### PR TITLE
fix: improve Apollo cache handling for Album.Images

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -134,6 +134,9 @@ export const inMemoryCacheOptions: InMemoryCacheConfig = {
         Channel: {
           merge: true,
         },
+        Album: {
+          merge: true,
+        },
       },
     },
     Comment: {
@@ -224,19 +227,25 @@ export const inMemoryCacheOptions: InMemoryCacheConfig = {
       merge: true,
       fields: {
         Images: {
-          merge: (_existing = [], incoming) => {
+          merge: (existing = [], incoming) => {
             // Handle case where incoming is an empty object instead of array
             if (incoming && typeof incoming === 'object' && !Array.isArray(incoming)) {
               const keys = Object.keys(incoming);
               if (keys.length === 0) {
-                return [];
+                // Preserve existing images when incoming is empty object
+                return existing;
               }
               // Convert object with numeric keys to array
               if (keys.every(k => !isNaN(Number(k)))) {
                 return keys.sort((a, b) => Number(a) - Number(b)).map(k => incoming[k]);
               }
             }
-            return Array.isArray(incoming) ? [...incoming] : [];
+            // If incoming is an empty array but we have existing images, preserve them
+            // This prevents cache updates from wiping out existing image data
+            if (Array.isArray(incoming) && incoming.length === 0 && existing.length > 0) {
+              return existing;
+            }
+            return Array.isArray(incoming) ? [...incoming] : existing;
           },
         },
       },


### PR DESCRIPTION
## Summary
- Add `Album` merge policy to `Discussion` type for proper nested merging
- Update `Album.Images` merge function to preserve existing images when incoming data is empty

## Problem
Cache updates could potentially overwrite existing image data with empty arrays, causing images to disappear from the UI.

## Solution
- Added defensive merge logic that preserves existing images when incoming data is empty
- Added Album to Discussion's field merge policies for proper cache normalization

## Related
- Backend PR: https://github.com/gennit-project/multiforum-backend/pull/12

## Test plan
- [x] Verified images display correctly on discussion list
- [x] Verified images persist when navigating between views

🤖 Generated with [Claude Code](https://claude.com/claude-code)