### PR TITLE
feat(map): sync Google Map color scheme with app theme

### DIFF
--- a/components/event/map/Map.spec.ts
+++ b/components/event/map/Map.spec.ts
@@ -55,6 +55,11 @@ global.google = {
     ControlPosition: {
       RIGHT_TOP: 1,
     },
+    ColorScheme: {
+      LIGHT: 'LIGHT',
+      DARK: 'DARK',
+      FOLLOW_SYSTEM: 'FOLLOW_SYSTEM',
+    },
   },
 } as any;
 

--- a/components/event/map/Map.vue
+++ b/components/event/map/Map.vue
@@ -121,6 +121,10 @@ const renderMap = async () => {
     zoom: 7,
     mapTypeId: 'terrain',
     mapId: config.googleMapId,
+    colorScheme:
+      currentTheme.value === 'dark'
+        ? google.maps.ColorScheme.DARK
+        : google.maps.ColorScheme.LIGHT,
     zoomControl: true,
     zoomControlOptions: { position: google.maps.ControlPosition.RIGHT_TOP },
   };


### PR DESCRIPTION
## Summary

Makes the map on `/map/search` follow the active app theme (dark/light) instead of always rendering in light mode.

The map component already tracked the theme via `useAppTheme()` and a `MutationObserver` on the `dark` class, and already re-rendered the map whenever the theme changed — but it never told Google Maps to actually switch appearance. This connects that signal by setting Google Maps' `colorScheme` (`DARK`/`LIGHT`) at map construction time, derived from `currentTheme`.

Since `colorScheme` can only be set when the map is constructed, the existing `watch(currentTheme, …) → renderMap()` rebuild is exactly what's needed to apply it on toggle. `colorScheme` is compatible with the cloud-based `mapId` (unlike the JSON `styles` array, which is ignored when a `mapId` is present).

## Changes

- `components/event/map/Map.vue`: add `colorScheme` to `mapConfig`.

## Testing

- `npm run tsc` passes (exit 0, no type errors); `google.maps.ColorScheme` is in the type defs.
- Recommend a manual check at `/map/search` toggling the theme to confirm the Google dark basemap renders as expected.

## Notes

- This uses Google's built-in dark basemap rather than the custom `components/event/map/nightModeMapStyles.ts` palette, which remains unused on this path. Can be removed in a follow-up, or we can switch to the custom palette instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)