### PR TITLE
test: extract logic from the heaviest components + more coverage

### DIFF
--- a/components/MarkdownPreview.spec.ts
+++ b/components/MarkdownPreview.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import { createMockRoute, createMockRouter } from '@/tests/utils/mockRouter';
+import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
+
+// uiStore (pulled in by MarkdownPreview) imports useCookie/useRoute/useRouter
+// from nuxt/app at module load.
+vi.mock('nuxt/app', () => ({
+  useCookie: () => ({ value: 'dark' }),
+  useRoute: () => createMockRoute(),
+  useRouter: () => createMockRouter(),
+}));
+
+import MarkdownPreview from '@/components/MarkdownPreview.vue';
+
+const mountPreview = (props: Record<string, unknown>) =>
+  mountWithDefaults(MarkdownPreview, {
+    props,
+    global: { stubs: { MarkdownRenderer: true, VueEasyLightbox: true } },
+  });
+
+const renderedText = (wrapper: ReturnType<typeof mountPreview>) =>
+  wrapper.findComponent(MarkdownRenderer).props('text') as string;
+
+describe('MarkdownPreview', () => {
+  it('passes the text through to the renderer', () => {
+    const wrapper = mountPreview({ text: 'just words' });
+    expect(renderedText(wrapper)).toContain('just words');
+  });
+
+  it('auto-links bare URLs in the rendered text', () => {
+    const wrapper = mountPreview({ text: 'see https://a.com/x here' });
+    expect(renderedText(wrapper)).toContain(
+      '[https://a.com/x](https://a.com/x)'
+    );
+  });
+
+  it('truncates to the word limit when "show more" is enabled', () => {
+    const wrapper = mountPreview({
+      text: 'one two three four five',
+      wordLimit: 3,
+      showShowMore: true,
+    });
+    // Truncated text keeps the first words and drops the rest.
+    expect(renderedText(wrapper)).not.toContain('five');
+  });
+});

--- a/components/MarkdownPreview.spec.ts
+++ b/components/MarkdownPreview.spec.ts
@@ -3,6 +3,8 @@ import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { createMockRoute, createMockRouter } from '@/tests/utils/mockRouter';
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
 
+import MarkdownPreview from '@/components/MarkdownPreview.vue';
+
 // uiStore (pulled in by MarkdownPreview) imports useCookie/useRoute/useRouter
 // from nuxt/app at module load.
 vi.mock('nuxt/app', () => ({
@@ -10,8 +12,6 @@ vi.mock('nuxt/app', () => ({
   useRoute: () => createMockRoute(),
   useRouter: () => createMockRouter(),
 }));
-
-import MarkdownPreview from '@/components/MarkdownPreview.vue';
 
 const mountPreview = (props: Record<string, unknown>) =>
   mountWithDefaults(MarkdownPreview, {

--- a/components/auth/CreateUsernameForm.vue
+++ b/components/auth/CreateUsernameForm.vue
@@ -16,6 +16,13 @@ import {
   setIsLoadingAuth,
 } from '@/cache';
 import { MAX_CHARS_IN_USERNAME } from '@/utils/constants';
+import {
+  isValidUsername,
+  getUsernameValidationMessage,
+  calculateAge,
+  getBirthdayValidationMessage,
+  MIN_SIGNUP_AGE,
+} from '@/utils/usernameValidation';
 
 const props = defineProps({
   email: {
@@ -63,45 +70,17 @@ const usernameIsEmpty = computed(() => {
   return newUsername.value.length === 0;
 });
 
-const isValidUsername = (username: string) => {
-  return /^[a-zA-Z0-9_]+$/.test(username);
-};
-
-const validationErrorMessage = computed(() => {
-  if (usernameIsEmpty.value) {
-    return 'Username cannot be empty.';
-  }
-  if (usernameIsTaken.value) {
-    return 'The username is already taken.';
-  }
-  if (usernameIsInvalid.value) {
-    return 'Username can only contain letters, numbers, and underscores.';
-  }
-  if (newUsername.value && newUsername.value.length > MAX_CHARS_IN_USERNAME) {
-    return `Username must be less than ${MAX_CHARS_IN_USERNAME} characters.`;
-  }
-  return '';
-});
+const validationErrorMessage = computed(() =>
+  getUsernameValidationMessage({
+    username: newUsername.value || '',
+    isEmpty: usernameIsEmpty.value,
+    isTaken: usernameIsTaken.value,
+  })
+);
 
 const usernameIsInvalid = computed(
   () => !isValidUsername(newUsername.value || '')
 );
-
-// Age validation logic
-const calculateAge = (birthDate: string): number => {
-  if (!birthDate) return 0;
-
-  const today = new Date();
-  const birth = new Date(birthDate);
-  let age = today.getFullYear() - birth.getFullYear();
-  const monthDiff = today.getMonth() - birth.getMonth();
-
-  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
-    age--;
-  }
-
-  return age;
-};
 
 const userAge = computed(() => calculateAge(birthday.value));
 
@@ -111,18 +90,12 @@ const birthdayIsEmpty = computed(
 
 const isUnderAge = computed(() => {
   if (birthdayIsEmpty.value) return false;
-  return userAge.value < 13;
+  return userAge.value < MIN_SIGNUP_AGE;
 });
 
-const birthdayValidationMessage = computed(() => {
-  if (birthdayIsEmpty.value) {
-    return 'Birthday is required.';
-  }
-  if (isUnderAge.value) {
-    return 'You must be at least 13 years old to create an account.';
-  }
-  return '';
-});
+const birthdayValidationMessage = computed(() =>
+  getBirthdayValidationMessage({ birthday: birthday.value })
+);
 
 const confirmedAvailable = computed(
   () =>

--- a/components/comments/CommentSection.vue
+++ b/components/comments/CommentSection.vue
@@ -29,6 +29,10 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
 import { hasBotMention, type BotSuggestion } from '@/utils/botMentions';
+import {
+  filterCommentsBySearch,
+  resolveChannelUniqueName,
+} from '@/utils/commentSection';
 import type { ModSuggestion } from '@/utils/modMentions';
 
 // Import new composables
@@ -218,15 +222,12 @@ const editFormOpenAtCommentID = ref('');
 const searchText = ref('');
 
 // Filter comments by search text (client-side filtering)
-const filteredComments = computed(() => {
-  if (!searchText.value.trim()) {
-    return props.comments || [];
-  }
-  const searchLower = searchText.value.toLowerCase().trim();
-  return (props.comments || []).filter((comment) =>
-    comment?.text?.toLowerCase().includes(searchLower)
-  );
-});
+const filteredComments = computed(() =>
+  filterCommentsBySearch({
+    comments: props.comments,
+    searchText: searchText.value,
+  })
+);
 const locked = ref(props.locked);
 const showModProfileModal = ref(false);
 
@@ -339,24 +340,13 @@ onDoneUpdatingComment(() => {
   };
 });
 
-const fallbackChannelUniqueName = computed(() => {
-  const firstComment = (props.comments || []).find(
-    (comment) => !!comment?.id
-  );
-  return (
-    firstComment?.DiscussionChannel?.channelUniqueName ||
-    firstComment?.Channel?.uniqueName ||
-    ''
-  );
-});
-
-const effectiveChannelUniqueName = computed(() => {
-  return (
-    props.commentSectionQueryVariables.channelUniqueName ||
-    fallbackChannelUniqueName.value ||
-    ''
-  );
-});
+const effectiveChannelUniqueName = computed(() =>
+  resolveChannelUniqueName({
+    comments: props.comments,
+    explicitChannelUniqueName:
+      props.commentSectionQueryVariables.channelUniqueName,
+  })
+);
 
 const {
   issueNumber: suspensionIssueNumber,

--- a/components/discussion/detail/AlbumEditForm.vue
+++ b/components/discussion/detail/AlbumEditForm.vue
@@ -3,9 +3,12 @@ import { ref, computed, onMounted } from 'vue';
 import type { PropType } from 'vue';
 import type {
   Discussion,
-  Image,
   DiscussionUpdateInput,
 } from '@/__generated__/graphql';
+import {
+  mapAlbumImagesToForm,
+  getInitialImageOrder,
+} from '@/utils/albumImages';
 import PrimaryButton from '@/components/PrimaryButton.vue';
 import GenericButton from '@/components/GenericButton.vue';
 import { useMutation } from '@vue/apollo-composable';
@@ -93,41 +96,16 @@ const albumId = computed(() => {
   return props.discussion?.Album?.id || '';
 });
 
-const images = computed(() => {
-  if (!props.discussion?.Album?.Images) return [];
-  return props.discussion.Album.Images.map((image: Image) => {
-    return {
-      id: image.id || '',
-      url: image.url || '',
-      alt: image.alt || '',
-      caption: image.caption || '',
-      isCoverImage: false,
-      hasSensitiveContent: false,
-      hasSpoiler: false,
-      copyright: image.copyright || '',
-    };
-  });
-});
+const images = computed(() =>
+  mapAlbumImagesToForm(props.discussion?.Album?.Images)
+);
 
-const initialImageOrder = computed<string[]>(() => {
-  // If there's an existing order, use it
-  if (props.discussion?.Album?.imageOrder?.length) {
-    // Filter out any null or undefined values to ensure string[]
-    return props.discussion.Album.imageOrder.filter(
-      (id): id is string => typeof id === 'string'
-    );
-  }
-
-  // If no order exists, create one from the images array
-  if (images.value.length > 0) {
-    // Create an order from the image IDs
-    return images.value
-      .filter((img): img is (typeof images.value)[number] => Boolean(img.id))
-      .map((img) => img.id);
-  }
-
-  return [];
-});
+const initialImageOrder = computed<string[]>(() =>
+  getInitialImageOrder({
+    albumImageOrder: props.discussion?.Album?.imageOrder,
+    images: images.value,
+  })
+);
 
 // Create reactive form values based on the computed props
 const formValues = ref<AlbumFormData>({

--- a/components/discussion/form/AlbumEditor.vue
+++ b/components/discussion/form/AlbumEditor.vue
@@ -8,6 +8,12 @@ import AlbumDropZone from './AlbumDropZone.vue';
 import AlbumUrlInputForm from './AlbumUrlInputForm.vue';
 import { useAlbumImageUpload } from '@/composables/useAlbumImageUpload';
 import { useAlbumAutoSave } from '@/composables/useAlbumAutoSave';
+import {
+  orderImagesByOrder,
+  getImageIdOrder,
+  moveImageOrderUp,
+  moveImageOrderDown,
+} from '@/utils/albumImageOrder';
 import type { Album } from '@/__generated__/graphql';
 
 const MAX_IMAGES = 25;
@@ -40,31 +46,16 @@ const isImageLimitReached = computed(() => {
 });
 
 // Ordered images based on imageOrder field
-const orderedImages = computed(() => {
-  if (!props.formValues.album?.images) {
-    return [];
-  }
-
-  if (
-    !props.formValues.album.imageOrder ||
-    props.formValues.album.imageOrder.length === 0
-  ) {
-    return props.formValues.album.images;
-  }
-
-  return props.formValues.album.imageOrder
-    .map((imageId) => {
-      return props.formValues.album.images?.find(
-        (image) => image.id === imageId
-      );
-    })
-    .filter((image) => image !== undefined);
-});
+const orderedImages = computed(() =>
+  orderImagesByOrder({
+    images: props.formValues.album?.images,
+    imageOrder: props.formValues.album?.imageOrder,
+  })
+);
 
 // Helper to update imageOrder after changes
-const updateImageOrderAfterChange = (images: ImageInput[]) => {
-  return images.map((img) => img.id).filter((id) => id !== undefined);
-};
+const updateImageOrderAfterChange = (images: ImageInput[]) =>
+  getImageIdOrder(images);
 
 // Helper to add a new image to the album
 const addNewImage = (input: Partial<ImageInput>) => {
@@ -196,21 +187,10 @@ const deleteImage = (index: number) => {
 const moveImageUp = (index: number) => {
   if (index <= 0) return;
 
-  const updatedImageOrder = [...props.formValues.album.imageOrder];
-  const currentItem = updatedImageOrder[index];
-  const previousItem = updatedImageOrder[index - 1];
-
-  if (currentItem && previousItem) {
-    [updatedImageOrder[index], updatedImageOrder[index - 1]] = [
-      previousItem,
-      currentItem,
-    ];
-  }
-
   emit('updateFormValues', {
     album: {
       images: props.formValues.album.images,
-      imageOrder: updatedImageOrder,
+      imageOrder: moveImageOrderUp(props.formValues.album.imageOrder, index),
     },
   });
 
@@ -222,21 +202,10 @@ const moveImageDown = (index: number) => {
   const imageOrder = props.formValues.album.imageOrder;
   if (index >= imageOrder.length - 1) return;
 
-  const updatedImageOrder = [...imageOrder];
-  const currentItem = updatedImageOrder[index];
-  const nextItem = updatedImageOrder[index + 1];
-
-  if (currentItem && nextItem) {
-    [updatedImageOrder[index], updatedImageOrder[index + 1]] = [
-      nextItem,
-      currentItem,
-    ];
-  }
-
   emit('updateFormValues', {
     album: {
       images: props.formValues.album.images,
-      imageOrder: updatedImageOrder,
+      imageOrder: moveImageOrderDown(imageOrder, index),
     },
   });
 

--- a/components/discussion/form/CreateEditDiscussionFields.vue
+++ b/components/discussion/form/CreateEditDiscussionFields.vue
@@ -14,6 +14,10 @@ import {
   MAX_CHARS_IN_DISCUSSION_BODY,
   DISCUSSION_TITLE_CHAR_LIMIT,
 } from '@/utils/constants';
+import {
+  discussionFormNeedsChanges,
+  getDiscussionFormValidationMessage,
+} from '@/utils/discussionFormValidation';
 import AlbumEditForm from '../detail/AlbumEditForm.vue';
 import DownloadEditForm from './DownloadEditForm.vue';
 import type { Channel, Discussion } from '@/__generated__/graphql';
@@ -60,15 +64,15 @@ const formTitle = computed(() => {
 const touched = ref(false);
 const titleInputRef = ref<HTMLElement | null>(null);
 
-const needsChanges = computed(() => {
-  return !(
-    props.formValues?.selectedChannels &&
-    props.formValues.selectedChannels.length > 0 &&
-    props.formValues?.title &&
-    props.formValues?.body?.length <= MAX_CHARS_IN_DISCUSSION_BODY &&
-    props.formValues?.title.length <= DISCUSSION_TITLE_CHAR_LIMIT
-  );
-});
+const discussionFormValidationInput = computed(() => ({
+  selectedChannelsCount: props.formValues?.selectedChannels?.length || 0,
+  title: props.formValues?.title || '',
+  body: props.formValues?.body || '',
+}));
+
+const needsChanges = computed(() =>
+  discussionFormNeedsChanges(discussionFormValidationInput.value)
+);
 
 const embeddedCrosspost = computed<Discussion | null>(() => {
   return (
@@ -86,18 +90,9 @@ const showCrosspostSection = computed(() => {
   );
 });
 
-const changesRequiredMessage = computed(() => {
-  if (!props.formValues?.title) {
-    return 'A title is required.';
-  } else if (props.formValues?.selectedChannels?.length === 0) {
-    return 'Must select at least one forum.';
-  } else if (props.formValues?.body?.length > MAX_CHARS_IN_DISCUSSION_BODY) {
-    return `Body cannot exceed ${MAX_CHARS_IN_DISCUSSION_BODY} characters.`;
-  } else if (props.formValues?.title.length > DISCUSSION_TITLE_CHAR_LIMIT) {
-    return `Title cannot exceed ${DISCUSSION_TITLE_CHAR_LIMIT} characters.`;
-  }
-  return '';
-});
+const changesRequiredMessage = computed(() =>
+  getDiscussionFormValidationMessage(discussionFormValidationInput.value)
+);
 
 const showCreateDiscussionError = computed(() => {
   return !(

--- a/components/discussion/form/DownloadEditForm.vue
+++ b/components/discussion/form/DownloadEditForm.vue
@@ -23,9 +23,11 @@ import Notification from '@/components/NotificationComponent.vue';
 import { uploadAndGetEmbeddedLink, getUploadFileName } from '@/utils';
 import { usernameVar } from '@/cache';
 import DownloadLabelPicker from '@/components/download/DownloadLabelPicker.vue';
-
-const MAX_DOWNLOAD_FILE_SIZE_MB = 50;
-const MAX_DOWNLOAD_FILE_SIZE_BYTES = MAX_DOWNLOAD_FILE_SIZE_MB * 1024 * 1024;
+import {
+  validateDownloadFileType,
+  validateDownloadFileSize,
+  MAX_DOWNLOAD_FILE_SIZE_MB,
+} from '@/utils/downloadFileValidation';
 
 type DownloadableFileSupportFields = {
   attributionOverride?: string | null;
@@ -223,46 +225,15 @@ onMounted(() => {
 });
 
 // File validation
-const validateFileType = (file: File): { valid: boolean; message: string } => {
-  if (downloadsDisabled.value) {
-    return {
-      valid: false,
-      message: 'Downloads are disabled in this channel.',
-    };
-  }
+const validateFileType = (file: File) =>
+  validateDownloadFileType({
+    fileName: file.name,
+    fileType: file.type,
+    allowedFileTypes: props.channelData?.allowedFileTypes || [],
+    downloadsDisabled: downloadsDisabled.value,
+  });
 
-  const allowedTypes = props.channelData?.allowedFileTypes || [];
-
-  if (allowedTypes.length === 0) {
-    return { valid: true, message: '' };
-  }
-
-  const fileExtension = file.name.toLowerCase().split('.').pop();
-  const isAllowed = allowedTypes.some(
-    (type) =>
-      type.toLowerCase().includes(fileExtension || '') ||
-      file.type.toLowerCase().includes(type.toLowerCase())
-  );
-
-  if (!isAllowed) {
-    return {
-      valid: false,
-      message: `File type not allowed. Allowed types: ${allowedTypes.join(', ')}`,
-    };
-  }
-
-  return { valid: true, message: '' };
-};
-
-const validateFileSize = (file: File): { valid: boolean; message: string } => {
-  if (file.size > MAX_DOWNLOAD_FILE_SIZE_BYTES) {
-    return {
-      valid: false,
-      message: `File size must be less than ${MAX_DOWNLOAD_FILE_SIZE_MB}MB. Current file is ${(file.size / (1024 * 1024)).toFixed(1)}MB.`,
-    };
-  }
-  return { valid: true, message: '' };
-};
+const validateFileSize = (file: File) => validateDownloadFileSize(file.size);
 
 // File upload handling
 const handleFileUpload = async (event: Event) => {

--- a/components/discussion/list/ChannelDiscussionListItem.spec.ts
+++ b/components/discussion/list/ChannelDiscussionListItem.spec.ts
@@ -12,6 +12,8 @@ import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { makeDiscussion } from '@/tests/utils/factories';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 
+import ChannelDiscussionListItem from '@/components/discussion/list/ChannelDiscussionListItem.vue';
+
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
   useMutation: () => createMutationMock(),
@@ -34,8 +36,6 @@ vi.mock('nuxt/app', () => ({
 }));
 vi.mock('@/cache', () => createCacheMock({ username: 'alice' }));
 vi.mock('@/composables/useSSRAuth', () => createSSRAuthMock());
-
-import ChannelDiscussionListItem from '@/components/discussion/list/ChannelDiscussionListItem.vue';
 
 const mountItem = (title: string) => {
   asMock(useQuery).mockReturnValue(createQueryMock({ users: [] }));

--- a/components/discussion/list/ChannelDiscussionListItem.spec.ts
+++ b/components/discussion/list/ChannelDiscussionListItem.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useQuery } from '@vue/apollo-composable';
+import {
+  asMock,
+  createQueryMock,
+  createMutationMock,
+} from '@/tests/utils/mockApollo';
+import { createMockRoute, createMockRouter } from '@/tests/utils/mockRouter';
+import { createCacheMock } from '@/tests/utils/mockAuth';
+import { createSSRAuthMock } from '@/tests/utils/mockSSRAuth';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import { makeDiscussion } from '@/tests/utils/factories';
+import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: () => createMutationMock(),
+}));
+// A child imports the Transition family from @headlessui/vue, which the global
+// setup mock omits; provide passthrough stubs.
+vi.mock('@headlessui/vue', () => {
+  const passthrough = { template: '<div><slot /></div>' };
+  return {
+    TransitionRoot: passthrough,
+    TransitionChild: passthrough,
+    Dialog: passthrough,
+    DialogPanel: passthrough,
+    DialogTitle: passthrough,
+  };
+});
+vi.mock('nuxt/app', () => ({
+  useRoute: () => createMockRoute(),
+  useRouter: () => createMockRouter(),
+}));
+vi.mock('@/cache', () => createCacheMock({ username: 'alice' }));
+vi.mock('@/composables/useSSRAuth', () => createSSRAuthMock());
+
+import ChannelDiscussionListItem from '@/components/discussion/list/ChannelDiscussionListItem.vue';
+
+const mountItem = (title: string) => {
+  asMock(useQuery).mockReturnValue(createQueryMock({ users: [] }));
+  const discussion = makeDiscussion({
+    title,
+    Author: { username: 'alice' },
+  } as Partial<Discussion>);
+  const discussionChannel = {
+    __typename: 'DiscussionChannel',
+    channelUniqueName: 'cats',
+    Discussion: discussion,
+    CommentsAggregate: { count: 0 },
+  } as unknown as DiscussionChannel;
+
+  return mountWithDefaults(ChannelDiscussionListItem, {
+    props: { discussionChannel, discussion },
+    global: {
+      stubs: {
+        AddToDiscussionFavorites: true,
+        MarkdownPreview: true,
+        UsernameWithTooltip: true,
+        TagComponent: true,
+        ErrorBanner: true,
+        CheckCircleIcon: true,
+        DiscussionVotes: true,
+        DiscussionAlbum: true,
+      },
+    },
+  });
+};
+
+describe('ChannelDiscussionListItem', () => {
+  it('renders the discussion title', () => {
+    expect(mountItem('My Discussion').text()).toContain('My Discussion');
+  });
+
+  it('reflects an overridden title', () => {
+    expect(mountItem('Another One').text()).toContain('Another One');
+  });
+});

--- a/components/discussion/list/SitewideDiscussionListItem.spec.ts
+++ b/components/discussion/list/SitewideDiscussionListItem.spec.ts
@@ -8,12 +8,12 @@ import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { makeDiscussion } from '@/tests/utils/factories';
 import type { Discussion } from '@/__generated__/graphql';
 
+import SitewideDiscussionListItem from '@/components/discussion/list/SitewideDiscussionListItem.vue';
+
 vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
 vi.mock('nuxt/app', () => ({ useRoute: () => createMockRoute() }));
 vi.mock('@/cache', () => createCacheMock({ username: 'alice' }));
 vi.mock('@/composables/useSSRAuth', () => createSSRAuthMock());
-
-import SitewideDiscussionListItem from '@/components/discussion/list/SitewideDiscussionListItem.vue';
 
 const mountItem = (discussion: Discussion) => {
   asMock(useQuery).mockReturnValue(createQueryMock({ users: [] }));

--- a/components/discussion/list/SitewideDiscussionListItem.spec.ts
+++ b/components/discussion/list/SitewideDiscussionListItem.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useQuery } from '@vue/apollo-composable';
+import { asMock, createQueryMock } from '@/tests/utils/mockApollo';
+import { createMockRoute } from '@/tests/utils/mockRouter';
+import { createCacheMock } from '@/tests/utils/mockAuth';
+import { createSSRAuthMock } from '@/tests/utils/mockSSRAuth';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import { makeDiscussion } from '@/tests/utils/factories';
+import type { Discussion } from '@/__generated__/graphql';
+
+vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+vi.mock('nuxt/app', () => ({ useRoute: () => createMockRoute() }));
+vi.mock('@/cache', () => createCacheMock({ username: 'alice' }));
+vi.mock('@/composables/useSSRAuth', () => createSSRAuthMock());
+
+import SitewideDiscussionListItem from '@/components/discussion/list/SitewideDiscussionListItem.vue';
+
+const mountItem = (discussion: Discussion) => {
+  asMock(useQuery).mockReturnValue(createQueryMock({ users: [] }));
+  return mountWithDefaults(SitewideDiscussionListItem, {
+    props: { discussion },
+    global: {
+      stubs: {
+        AddToDiscussionFavorites: true,
+        MarkdownPreview: true,
+        UsernameWithTooltip: true,
+        TagComponent: true,
+        ChevronDownIcon: true,
+      },
+    },
+  });
+};
+
+const discussion = (overrides: Record<string, unknown> = {}): Discussion =>
+  makeDiscussion({
+    Author: { username: 'alice' },
+    DiscussionChannels: [],
+    ...overrides,
+  } as Partial<Discussion>);
+
+describe('SitewideDiscussionListItem', () => {
+  it('renders the discussion title', () => {
+    const wrapper = mountItem(discussion({ title: 'My Discussion' }));
+    expect(wrapper.text()).toContain('My Discussion');
+  });
+
+  it('reflects an overridden title', () => {
+    const wrapper = mountItem(discussion({ title: 'Another One' }));
+    expect(wrapper.text()).toContain('Another One');
+  });
+});

--- a/components/discussion/list/SitewideDownloadListItem.spec.ts
+++ b/components/discussion/list/SitewideDownloadListItem.spec.ts
@@ -6,14 +6,14 @@ import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { makeDiscussion } from '@/tests/utils/factories';
 import type { Discussion } from '@/__generated__/graphql';
 
+import SitewideDownloadListItem from '@/components/discussion/list/SitewideDownloadListItem.vue';
+
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: () => createQueryMock({}),
   useMutation: () => createMutationMock(),
 }));
 vi.mock('nuxt/app', () => ({ useRoute: () => createMockRoute() }));
 vi.mock('@/composables/useSSRAuth', () => createSSRAuthMock());
-
-import SitewideDownloadListItem from '@/components/discussion/list/SitewideDownloadListItem.vue';
 
 const mountItem = (title: string) =>
   mountWithDefaults(SitewideDownloadListItem, {

--- a/components/discussion/list/SitewideDownloadListItem.spec.ts
+++ b/components/discussion/list/SitewideDownloadListItem.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockRoute } from '@/tests/utils/mockRouter';
+import { createSSRAuthMock } from '@/tests/utils/mockSSRAuth';
+import { createQueryMock, createMutationMock } from '@/tests/utils/mockApollo';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import { makeDiscussion } from '@/tests/utils/factories';
+import type { Discussion } from '@/__generated__/graphql';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => createQueryMock({}),
+  useMutation: () => createMutationMock(),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => createMockRoute() }));
+vi.mock('@/composables/useSSRAuth', () => createSSRAuthMock());
+
+import SitewideDownloadListItem from '@/components/discussion/list/SitewideDownloadListItem.vue';
+
+const mountItem = (title: string) =>
+  mountWithDefaults(SitewideDownloadListItem, {
+    props: {
+      discussion: makeDiscussion({
+        title,
+        hasDownload: true,
+        Author: { username: 'alice' },
+        DiscussionChannels: [
+          { channelUniqueName: 'cats' },
+        ] as Discussion['DiscussionChannels'],
+      } as Partial<Discussion>),
+    },
+    global: {
+      stubs: {
+        AddToDiscussionFavorites: true,
+        UsernameWithTooltip: true,
+        ImageIcon: true,
+        ChevronDownIcon: true,
+      },
+    },
+  });
+
+describe('SitewideDownloadListItem', () => {
+  it('renders the download title', () => {
+    expect(mountItem('Cool Model').text()).toContain('Cool Model');
+  });
+
+  it('reflects an overridden title', () => {
+    expect(mountItem('Another Model').text()).toContain('Another Model');
+  });
+});

--- a/components/event/detail/EventDetail.vue
+++ b/components/event/detail/EventDetail.vue
@@ -13,8 +13,13 @@ import type {
   EventChannel,
   Event as EventData,
 } from '@/__generated__/graphql';
-import { DateTime } from 'luxon';
 import { stableRelativeTime } from '@/utils';
+import { isEventInThePast, hasEventStarted } from '@/utils/eventTiming';
+import {
+  formatEventDate,
+  buildEventSeoMeta,
+  buildEventStructuredData,
+} from '@/utils/eventSeo';
 import 'md-editor-v3/lib/style.css';
 import EventFooter from '@/components/event/detail/EventFooter.vue';
 import EventHeader from '@/components/event/detail/EventHeader.vue';
@@ -30,9 +35,7 @@ import AddToCalendarButton from '../AddToCalendarButton.vue';
 import ArchivedEventInfoBanner from './ArchivedEventInfoBanner.vue';
 import { getOriginalPoster } from '@/utils/originalPoster';
 
-const formatDate = (date: string) => {
-  return DateTime.fromISO(date).toLocaleString(DateTime.DATE_FULL);
-};
+const formatDate = formatEventDate;
 
 const COMMENT_LIMIT = 50;
 
@@ -274,18 +277,9 @@ const channelsExceptCurrent = computed(() => {
   );
 });
 
-const eventIsInThePast = computed(() => {
-  if (!event.value) return false;
-  return DateTime.fromISO(event.value.endTime) < DateTime.now();
-});
+const eventIsInThePast = computed(() => isEventInThePast(event.value));
 
-const eventHasStarted = computed(() => {
-  if (!event.value) return false;
-  return (
-    DateTime.fromISO(event.value.startTime) < DateTime.now() &&
-    !eventIsInThePast.value
-  );
-});
+const eventHasStarted = computed(() => hasEventStarted(event.value));
 
 const originalPoster = computed(() => event.value?.Poster?.username || '');
 
@@ -302,79 +296,32 @@ const handleClickEditEventDescription = () => {
 
 // Add SEO metadata for the event
 watchEffect(() => {
-  if (!event.value) {
-    useHead({
-      title: `Event Not Found${channelId.value ? ` | ${channelId.value}` : ''}`,
-      description: 'The requested event could not be found.',
-    });
-    return;
-  }
-
-  const title = event.value.title || 'Event';
   const forumName =
     activeEventChannel.value?.Channel?.displayName || channelId.value || '';
-  const description = event.value.description
-    ? event.value.description.substring(0, 160) +
-      (event.value.description.length > 160 ? '...' : '')
-    : `${title} - Event on ${formatDate(event.value.startTime)}`;
-  const baseUrl = import.meta.env.VITE_BASE_URL;
   const serverDisplayName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
-  const imageUrl = event.value.coverImageURL || '';
 
-  // Set basic SEO meta tags
-  useHead({
-    title: forumName
-      ? `${title} | ${forumName} | ${serverDisplayName}`
-      : `${title} | ${serverDisplayName}`,
-    description: description,
-    image: imageUrl,
-    type: 'event',
-  });
+  useHead(
+    buildEventSeoMeta({
+      event: event.value,
+      channelId: channelId.value,
+      forumName,
+      serverDisplayName,
+    })
+  );
+
+  if (!event.value) return;
 
   // Add structured data for rich results
   useHead({
     script: [
       {
         type: 'application/ld+json',
-        children: JSON.stringify({
-          '@context': 'https://schema.org',
-          '@type': 'Event',
-          name: title,
-          description: description,
-          startDate: event.value.startTime,
-          endDate: event.value.endTime,
-          image: imageUrl,
-          location: event.value.address
-            ? {
-                '@type': 'Place',
-                name: event.value.address,
-                address: {
-                  '@type': 'PostalAddress',
-                  streetAddress: event.value.address,
-                },
-              }
-            : {
-                '@type': 'VirtualLocation',
-                url:
-                  event.value.virtualEventUrl ??
-                  `${baseUrl}/events/list/search/${event.value.id}`,
-              },
-          organizer: {
-            '@type': 'Person',
-            name:
-              event.value.Poster?.displayName ||
-              event.value.Poster?.username ||
-              'Anonymous',
-          },
-          eventStatus: event.value.canceled
-            ? 'https://schema.org/EventCancelled'
-            : eventIsInThePast.value
-              ? 'https://schema.org/EventScheduled'
-              : 'https://schema.org/EventScheduled',
-          eventAttendanceMode: event.value.virtualEventUrl
-            ? 'https://schema.org/OnlineEventAttendanceMode'
-            : 'https://schema.org/OfflineEventAttendanceMode',
-        }),
+        children: JSON.stringify(
+          buildEventStructuredData({
+            event: event.value,
+            baseUrl: import.meta.env.VITE_BASE_URL,
+          })
+        ),
       },
     ],
   });

--- a/components/event/detail/EventHeader.vue
+++ b/components/event/detail/EventHeader.vue
@@ -24,6 +24,7 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import { getDuration } from '@/utils';
 import { getEventHeaderMenuItems } from '@/utils/headerPermissionUtils';
+import { formatEventDateString } from '@/utils/eventDateFormat';
 import GenericFeedbackFormModal from '@/components/GenericFeedbackFormModal.vue';
 import BrokenRulesModal from '@/components/mod/BrokenRulesModal.vue';
 import { modProfileNameVar, usernameVar } from '@/cache';
@@ -425,19 +426,11 @@ const menuItems = computed(() => {
 });
 
 function getFormattedDateString(startTime: string) {
-  // if the event is all day and spans multiple days,
-  // include start and end date but not time
-  if (props.eventData.isAllDay && props.eventData.endTime) {
-    const start = DateTime.fromISO(startTime);
-    const end = DateTime.fromISO(props.eventData.endTime);
-    if (start.hasSame(end, 'day')) {
-      return start.toFormat('cccc LLLL d yyyy');
-    }
-    return `${start.toFormat('cccc LLLL d yyyy')} - ${end.toFormat(
-      'cccc LLLL d yyyy'
-    )}`;
-  }
-  return DateTime.fromISO(startTime).toFormat('cccc LLLL d yyyy h:mm a');
+  return formatEventDateString({
+    startTime,
+    isAllDay: props.eventData.isAllDay,
+    endTime: props.eventData.endTime,
+  });
 }
 
 const feedbackText = ref('');

--- a/components/event/form/CreateEditEventFields.vue
+++ b/components/event/form/CreateEditEventFields.vue
@@ -36,6 +36,10 @@ import {
   EVENT_TITLE_CHAR_LIMIT,
   MAX_CHARS_IN_EVENT_DESCRIPTION,
 } from '@/utils/constants';
+import {
+  eventFormNeedsChanges,
+  getEventFormValidationMessage,
+} from '@/utils/eventFormValidation';
 import type { PropType } from 'vue';
 import { isFileSizeValid } from '@/utils/index';
 
@@ -278,40 +282,22 @@ const duration = computed(() => {
   );
 });
 
-const needsChanges = computed(() => {
-  const hasValidVirtualEventUrl = props.formValues.virtualEventUrl
-    ? urlIsValid.value && !!props.formValues.virtualEventUrl
-    : true;
+const eventFormValidationInput = computed(() => ({
+  selectedChannelsCount: props.formValues.selectedChannels.length,
+  title: props.formValues.title,
+  description: props.formValues.description,
+  virtualEventUrl: props.formValues.virtualEventUrl,
+  urlIsValid: urlIsValid.value,
+  startBeforeEnd: startTime.value < endTime.value,
+}));
 
-  return !(
-    props.formValues.selectedChannels.length > 0 &&
-    props.formValues.title.length > 0 &&
-    startTime.value < endTime.value &&
-    props.formValues.title.length <= EVENT_TITLE_CHAR_LIMIT &&
-    props.formValues.description.length <= MAX_CHARS_IN_EVENT_DESCRIPTION &&
-    (urlIsValid.value || !props.formValues.virtualEventUrl) &&
-    hasValidVirtualEventUrl
-  );
-});
+const needsChanges = computed(() =>
+  eventFormNeedsChanges(eventFormValidationInput.value)
+);
 
-const changesRequiredMessage = computed(() => {
-  if (props.formValues.selectedChannels.length === 0) {
-    return 'At least one channel must be selected.';
-  }
-  if (!props.formValues.title) {
-    return 'A title is required.';
-  }
-  if (props.formValues.title.length > EVENT_TITLE_CHAR_LIMIT) {
-    return `Title cannot exceed ${EVENT_TITLE_CHAR_LIMIT} characters.`;
-  }
-  if (props.formValues.description.length > MAX_CHARS_IN_EVENT_DESCRIPTION) {
-    return `Description cannot exceed ${MAX_CHARS_IN_EVENT_DESCRIPTION} characters.`;
-  }
-  if (props.formValues.virtualEventUrl && !urlIsValid.value) {
-    return 'Virtual event URL must be valid.';
-  }
-  return '';
-});
+const changesRequiredMessage = computed(() =>
+  getEventFormValidationMessage(eventFormValidationInput.value)
+);
 
 const urlIsValid = computed(() => {
   return checkUrl(props.formValues.virtualEventUrl || '');

--- a/components/filter/FilterGroupManager.vue
+++ b/components/filter/FilterGroupManager.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
-import yaml from 'js-yaml';
+import {
+  serializeFilterGroupsToYaml,
+  parseFilterGroupsYaml,
+} from '@/utils/filterGroupYaml';
 import type {
   FilterGroup,
   Channel,
@@ -54,105 +57,45 @@ const filterModeOptions = [
   },
 ];
 
-// YAML conversion utilities
-type YamlFilterGroup = {
-  key: string;
-  displayName: string;
-  mode: 'INCLUDE' | 'EXCLUDE';
-  order: number;
-  options: {
-    value: string;
-    displayName: string;
-    order: number;
-  }[];
-};
-
-const convertFilterGroupsToYaml = (filterGroups: FilterGroup[]): string => {
-  const cleanGroups: YamlFilterGroup[] = filterGroups.map((group) => ({
-    key: group.key,
-    displayName: group.displayName,
-    mode: group.mode,
-    order: group.order,
-    options: (group.options || []).map((option) => ({
-      value: option.value,
-      displayName: option.displayName,
-      order: option.order,
-    })),
-  }));
-
-  try {
-    return yaml.dump(cleanGroups, {
-      indent: 2,
-      lineWidth: -1,
-      noRefs: true,
-      sortKeys: false,
-    });
-  } catch (error) {
-    console.error('Error converting to YAML:', error);
-    return '';
-  }
-};
+const convertFilterGroupsToYaml = (filterGroups: FilterGroup[]): string =>
+  serializeFilterGroupsToYaml(filterGroups);
 
 const convertYamlToFilterGroups = (
   yamlString: string
 ): { success: boolean; filterGroups?: FilterGroup[]; error?: string } => {
-  try {
-    const parsed = yaml.load(yamlString) as YamlFilterGroup[];
-
-    if (!Array.isArray(parsed)) {
-      return {
-        success: false,
-        error: 'YAML must contain an array of filter groups',
-      };
-    }
-
-    const filterGroups: FilterGroup[] = parsed.map((group, index) => {
-      if (!group.key || !group.displayName) {
-        throw new Error(
-          `Group at index ${index} is missing required fields (key, displayName)`
-        );
-      }
-
-      if (!['INCLUDE', 'EXCLUDE'].includes(group.mode)) {
-        throw new Error(
-          `Group "${group.key}" has invalid mode. Must be INCLUDE or EXCLUDE`
-        );
-      }
-
-      return {
-        id: '', // Empty ID for new/edited groups - server will handle
-        key: group.key,
-        displayName: group.displayName,
-        mode: group.mode as FilterMode,
-        order: group.order ?? index,
-        options: (group.options || []).map((option, optionIndex) => ({
-          id: '', // Empty ID for new/edited options - server will handle
-          value: option.value,
-          displayName: option.displayName,
-          order: option.order ?? optionIndex,
-          // Required GraphQL fields
-          __typename: 'FilterOption' as const,
-          group: emptyFilterGroup, // Will be populated by parent
-          groupAggregate: null,
-          groupConnection: emptyGroupConnection,
-        })),
-        // Required GraphQL fields
-        __typename: 'FilterGroup' as const,
-        channel: emptyChannel,
-        channelAggregate: null,
-        channelConnection: emptyChannelConnection,
-        optionsAggregate: null,
-        optionsConnection: emptyOptionsConnection,
-      };
-    });
-
-    return { success: true, filterGroups };
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Invalid YAML format',
-    };
+  const result = parseFilterGroupsYaml(yamlString);
+  if (!result.success || !result.groups) {
+    return { success: false, error: result.error };
   }
+
+  // Map the validated plain groups onto full GraphQL FilterGroup objects.
+  const filterGroups: FilterGroup[] = result.groups.map((group, index) => ({
+    id: '', // Empty ID for new/edited groups - server will handle
+    key: group.key,
+    displayName: group.displayName,
+    mode: group.mode as FilterMode,
+    order: group.order ?? index,
+    options: (group.options || []).map((option, optionIndex) => ({
+      id: '', // Empty ID for new/edited options - server will handle
+      value: option.value,
+      displayName: option.displayName,
+      order: option.order ?? optionIndex,
+      // Required GraphQL fields
+      __typename: 'FilterOption' as const,
+      group: emptyFilterGroup, // Will be populated by parent
+      groupAggregate: null,
+      groupConnection: emptyGroupConnection,
+    })),
+    // Required GraphQL fields
+    __typename: 'FilterGroup' as const,
+    channel: emptyChannel,
+    channelAggregate: null,
+    channelConnection: emptyChannelConnection,
+    optionsAggregate: null,
+    optionsConnection: emptyOptionsConnection,
+  }));
+
+  return { success: true, filterGroups };
 };
 
 const addNewGroup = () => {

--- a/tests/unit/utils/albumImageOrder.spec.ts
+++ b/tests/unit/utils/albumImageOrder.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  orderImagesByOrder,
+  getImageIdOrder,
+  moveImageOrderUp,
+  moveImageOrderDown,
+} from '@/utils/albumImageOrder';
+
+const img = (id: string) => ({ id });
+
+describe('orderImagesByOrder', () => {
+  it('returns an empty array when there are no images', () => {
+    expect(orderImagesByOrder({ images: null, imageOrder: ['a'] })).toEqual([]);
+  });
+
+  it('returns the original order when no imageOrder is set', () => {
+    const images = [img('a'), img('b')];
+    expect(orderImagesByOrder({ images, imageOrder: [] })).toBe(images);
+  });
+
+  it('orders images according to imageOrder', () => {
+    const images = [img('a'), img('b'), img('c')];
+    expect(
+      orderImagesByOrder({ images, imageOrder: ['c', 'a', 'b'] }).map(
+        (i) => i.id
+      )
+    ).toEqual(['c', 'a', 'b']);
+  });
+
+  it('drops order ids that have no matching image', () => {
+    const images = [img('a')];
+    expect(
+      orderImagesByOrder({ images, imageOrder: ['missing', 'a'] }).map(
+        (i) => i.id
+      )
+    ).toEqual(['a']);
+  });
+});
+
+describe('getImageIdOrder', () => {
+  it('extracts the ids in order', () => {
+    expect(getImageIdOrder([img('a'), img('b')])).toEqual(['a', 'b']);
+  });
+
+  it('skips images without an id', () => {
+    expect(getImageIdOrder([{ id: 'a' }, {}, { id: null }])).toEqual(['a']);
+  });
+});
+
+describe('moveImageOrderUp', () => {
+  it('swaps the item with the previous one', () => {
+    expect(moveImageOrderUp(['a', 'b', 'c'], 1)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('is a no-op at the start', () => {
+    expect(moveImageOrderUp(['a', 'b'], 0)).toEqual(['a', 'b']);
+  });
+
+  it('does not mutate the input', () => {
+    const order = ['a', 'b'];
+    moveImageOrderUp(order, 1);
+    expect(order).toEqual(['a', 'b']);
+  });
+});
+
+describe('moveImageOrderDown', () => {
+  it('swaps the item with the next one', () => {
+    expect(moveImageOrderDown(['a', 'b', 'c'], 1)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('is a no-op at the end', () => {
+    expect(moveImageOrderDown(['a', 'b'], 1)).toEqual(['a', 'b']);
+  });
+});

--- a/tests/unit/utils/albumImages.spec.ts
+++ b/tests/unit/utils/albumImages.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mapAlbumImagesToForm,
+  getInitialImageOrder,
+  type AlbumFormImage,
+} from '@/utils/albumImages';
+
+const formImage = (id: string): AlbumFormImage => ({
+  id,
+  url: '',
+  alt: '',
+  caption: '',
+  isCoverImage: false,
+  hasSensitiveContent: false,
+  hasSpoiler: false,
+  copyright: '',
+});
+
+describe('mapAlbumImagesToForm', () => {
+  it('returns an empty array when there are no images', () => {
+    expect(mapAlbumImagesToForm(null)).toEqual([]);
+  });
+
+  it('maps source fields and defaults missing ones', () => {
+    expect(
+      mapAlbumImagesToForm([{ id: 'a', url: 'u', caption: 'c' }])
+    ).toEqual([
+      {
+        id: 'a',
+        url: 'u',
+        alt: '',
+        caption: 'c',
+        isCoverImage: false,
+        hasSensitiveContent: false,
+        hasSpoiler: false,
+        copyright: '',
+      },
+    ]);
+  });
+});
+
+describe('getInitialImageOrder', () => {
+  it('uses the existing album order when present', () => {
+    expect(
+      getInitialImageOrder({
+        albumImageOrder: ['b', 'a'],
+        images: [formImage('a'), formImage('b')],
+      })
+    ).toEqual(['b', 'a']);
+  });
+
+  it('filters non-string ids out of the existing order', () => {
+    expect(
+      getInitialImageOrder({
+        albumImageOrder: ['a', null, undefined],
+        images: [formImage('a')],
+      })
+    ).toEqual(['a']);
+  });
+
+  it('falls back to image ids when no order is stored', () => {
+    expect(
+      getInitialImageOrder({
+        albumImageOrder: [],
+        images: [formImage('a'), formImage('b')],
+      })
+    ).toEqual(['a', 'b']);
+  });
+
+  it('skips images with an empty id in the fallback', () => {
+    expect(
+      getInitialImageOrder({
+        albumImageOrder: null,
+        images: [formImage(''), formImage('b')],
+      })
+    ).toEqual(['b']);
+  });
+});

--- a/tests/unit/utils/commentSection.spec.ts
+++ b/tests/unit/utils/commentSection.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterCommentsBySearch,
+  resolveChannelUniqueName,
+} from '@/utils/commentSection';
+
+describe('filterCommentsBySearch', () => {
+  const comments = [
+    { text: 'Hello world' },
+    { text: 'Goodbye' },
+    { text: null },
+  ];
+
+  it('returns all comments when the search text is empty', () => {
+    expect(filterCommentsBySearch({ comments, searchText: '  ' })).toEqual(
+      comments
+    );
+  });
+
+  it('filters comments by a case-insensitive text match', () => {
+    expect(
+      filterCommentsBySearch({ comments, searchText: 'WORLD' })
+    ).toEqual([{ text: 'Hello world' }]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterCommentsBySearch({ comments, searchText: 'zzz' })).toEqual([]);
+  });
+
+  it('handles a null comments list', () => {
+    expect(
+      filterCommentsBySearch({ comments: null, searchText: 'x' })
+    ).toEqual([]);
+  });
+});
+
+describe('resolveChannelUniqueName', () => {
+  it('prefers the explicit channel name', () => {
+    expect(
+      resolveChannelUniqueName({
+        comments: [{ id: '1', Channel: { uniqueName: 'dogs' } }],
+        explicitChannelUniqueName: 'cats',
+      })
+    ).toBe('cats');
+  });
+
+  it('falls back to the first comment DiscussionChannel name', () => {
+    expect(
+      resolveChannelUniqueName({
+        comments: [
+          { id: '1', DiscussionChannel: { channelUniqueName: 'cats' } },
+        ],
+      })
+    ).toBe('cats');
+  });
+
+  it('falls back to the first comment Channel name', () => {
+    expect(
+      resolveChannelUniqueName({
+        comments: [{ id: '1', Channel: { uniqueName: 'dogs' } }],
+      })
+    ).toBe('dogs');
+  });
+
+  it('skips comments without an id when finding the fallback', () => {
+    expect(
+      resolveChannelUniqueName({
+        comments: [
+          { Channel: { uniqueName: 'ignored' } },
+          { id: '2', Channel: { uniqueName: 'cats' } },
+        ],
+      })
+    ).toBe('cats');
+  });
+
+  it('returns an empty string when nothing resolves', () => {
+    expect(resolveChannelUniqueName({ comments: [] })).toBe('');
+  });
+});

--- a/tests/unit/utils/discussionFormValidation.spec.ts
+++ b/tests/unit/utils/discussionFormValidation.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  discussionFormNeedsChanges,
+  getDiscussionFormValidationMessage,
+  type DiscussionFormValidationInput,
+} from '@/utils/discussionFormValidation';
+
+const validInput = (
+  overrides: Partial<DiscussionFormValidationInput> = {}
+): DiscussionFormValidationInput => ({
+  selectedChannelsCount: 1,
+  title: 'My Discussion',
+  body: 'Some body text',
+  ...overrides,
+});
+
+describe('discussionFormNeedsChanges', () => {
+  it('is false for a valid form', () => {
+    expect(discussionFormNeedsChanges(validInput())).toBe(false);
+  });
+
+  it('is true with no channel selected', () => {
+    expect(
+      discussionFormNeedsChanges(validInput({ selectedChannelsCount: 0 }))
+    ).toBe(true);
+  });
+
+  it('is true with an empty title', () => {
+    expect(discussionFormNeedsChanges(validInput({ title: '' }))).toBe(true);
+  });
+
+  it('is true when the title is over the limit', () => {
+    expect(
+      discussionFormNeedsChanges(validInput({ title: 'a'.repeat(200) }))
+    ).toBe(true);
+  });
+});
+
+describe('getDiscussionFormValidationMessage', () => {
+  it('returns no message for a valid form', () => {
+    expect(getDiscussionFormValidationMessage(validInput())).toBe('');
+  });
+
+  it('asks for a title first', () => {
+    expect(getDiscussionFormValidationMessage(validInput({ title: '' }))).toBe(
+      'A title is required.'
+    );
+  });
+
+  it('asks for a forum when none selected', () => {
+    expect(
+      getDiscussionFormValidationMessage(
+        validInput({ selectedChannelsCount: 0 })
+      )
+    ).toBe('Must select at least one forum.');
+  });
+
+  it('flags an over-long body', () => {
+    expect(
+      getDiscussionFormValidationMessage(
+        validInput({ body: 'a'.repeat(18001) })
+      )
+    ).toContain('Body cannot exceed');
+  });
+});

--- a/tests/unit/utils/downloadFileValidation.spec.ts
+++ b/tests/unit/utils/downloadFileValidation.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateDownloadFileType,
+  validateDownloadFileSize,
+  MAX_DOWNLOAD_FILE_SIZE_BYTES,
+} from '@/utils/downloadFileValidation';
+
+describe('validateDownloadFileType', () => {
+  it('rejects when downloads are disabled', () => {
+    expect(
+      validateDownloadFileType({
+        fileName: 'a.stl',
+        fileType: 'model/stl',
+        allowedFileTypes: ['stl'],
+        downloadsDisabled: true,
+      }).valid
+    ).toBe(false);
+  });
+
+  it('allows any type when no allow-list is configured', () => {
+    expect(
+      validateDownloadFileType({
+        fileName: 'a.xyz',
+        fileType: 'application/xyz',
+        allowedFileTypes: [],
+        downloadsDisabled: false,
+      }).valid
+    ).toBe(true);
+  });
+
+  it('allows a file whose extension is in the allow-list', () => {
+    expect(
+      validateDownloadFileType({
+        fileName: 'model.stl',
+        fileType: 'application/octet-stream',
+        allowedFileTypes: ['stl'],
+        downloadsDisabled: false,
+      }).valid
+    ).toBe(true);
+  });
+
+  it('rejects a file whose type is not in the allow-list', () => {
+    const result = validateDownloadFileType({
+      fileName: 'doc.pdf',
+      fileType: 'application/pdf',
+      allowedFileTypes: ['stl'],
+      downloadsDisabled: false,
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('lists the allowed types in the rejection message', () => {
+    const result = validateDownloadFileType({
+      fileName: 'doc.pdf',
+      fileType: 'application/pdf',
+      allowedFileTypes: ['stl', 'obj'],
+      downloadsDisabled: false,
+    });
+    expect(result.message).toContain('stl, obj');
+  });
+});
+
+describe('validateDownloadFileSize', () => {
+  it('accepts a file within the size limit', () => {
+    expect(validateDownloadFileSize(1024).valid).toBe(true);
+  });
+
+  it('rejects a file over the size limit', () => {
+    expect(
+      validateDownloadFileSize(MAX_DOWNLOAD_FILE_SIZE_BYTES + 1).valid
+    ).toBe(false);
+  });
+
+  it('reports the file size in the rejection message', () => {
+    expect(
+      validateDownloadFileSize(MAX_DOWNLOAD_FILE_SIZE_BYTES + 1).message
+    ).toContain('less than 50MB');
+  });
+});

--- a/tests/unit/utils/eventDateFormat.spec.ts
+++ b/tests/unit/utils/eventDateFormat.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { formatEventDateString } from '@/utils/eventDateFormat';
+
+// Naive ISO strings (no zone) parse and format in the same local zone, so the
+// time portion is stable across environments.
+
+describe('formatEventDateString', () => {
+  it('includes the time for a timed event', () => {
+    const result = formatEventDateString({
+      startTime: '2024-06-01T18:30:00',
+    });
+    expect(result).toContain('6:30 PM');
+  });
+
+  it('includes the weekday and date for a timed event', () => {
+    const result = formatEventDateString({
+      startTime: '2024-06-01T18:30:00',
+    });
+    expect(result).toContain('Saturday June 1 2024');
+  });
+
+  it('omits the time for an all-day single-day event', () => {
+    const result = formatEventDateString({
+      startTime: '2024-06-01T00:00:00',
+      isAllDay: true,
+      endTime: '2024-06-01T23:00:00',
+    });
+    expect(result).toBe('Saturday June 1 2024');
+  });
+
+  it('shows a date range for a multi-day all-day event', () => {
+    const result = formatEventDateString({
+      startTime: '2024-06-01T00:00:00',
+      isAllDay: true,
+      endTime: '2024-06-03T00:00:00',
+    });
+    expect(result).toBe('Saturday June 1 2024 - Monday June 3 2024');
+  });
+
+  it('falls back to the timed format when all-day has no end time', () => {
+    const result = formatEventDateString({
+      startTime: '2024-06-01T18:30:00',
+      isAllDay: true,
+    });
+    expect(result).toContain('6:30 PM');
+  });
+});

--- a/tests/unit/utils/eventFormValidation.spec.ts
+++ b/tests/unit/utils/eventFormValidation.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  eventFormNeedsChanges,
+  getEventFormValidationMessage,
+  type EventFormValidationInput,
+} from '@/utils/eventFormValidation';
+
+const validInput = (
+  overrides: Partial<EventFormValidationInput> = {}
+): EventFormValidationInput => ({
+  selectedChannelsCount: 1,
+  title: 'My Event',
+  description: 'A description',
+  virtualEventUrl: '',
+  urlIsValid: true,
+  startBeforeEnd: true,
+  ...overrides,
+});
+
+describe('eventFormNeedsChanges', () => {
+  it('is false for a fully valid form', () => {
+    expect(eventFormNeedsChanges(validInput())).toBe(false);
+  });
+
+  it('is true when no channel is selected', () => {
+    expect(
+      eventFormNeedsChanges(validInput({ selectedChannelsCount: 0 }))
+    ).toBe(true);
+  });
+
+  it('is true when the title is empty', () => {
+    expect(eventFormNeedsChanges(validInput({ title: '' }))).toBe(true);
+  });
+
+  it('is true when the start is not before the end', () => {
+    expect(
+      eventFormNeedsChanges(validInput({ startBeforeEnd: false }))
+    ).toBe(true);
+  });
+
+  it('is true when a virtual url is present but invalid', () => {
+    expect(
+      eventFormNeedsChanges(
+        validInput({ virtualEventUrl: 'not-a-url', urlIsValid: false })
+      )
+    ).toBe(true);
+  });
+
+  it('is false when there is no virtual url even if urlIsValid is false', () => {
+    expect(
+      eventFormNeedsChanges(
+        validInput({ virtualEventUrl: '', urlIsValid: false })
+      )
+    ).toBe(false);
+  });
+});
+
+describe('getEventFormValidationMessage', () => {
+  it('returns no message for a valid form', () => {
+    expect(getEventFormValidationMessage(validInput())).toBe('');
+  });
+
+  it('asks for a channel first', () => {
+    expect(
+      getEventFormValidationMessage(validInput({ selectedChannelsCount: 0 }))
+    ).toBe('At least one channel must be selected.');
+  });
+
+  it('asks for a title when missing', () => {
+    expect(getEventFormValidationMessage(validInput({ title: '' }))).toBe(
+      'A title is required.'
+    );
+  });
+
+  it('flags an over-long title', () => {
+    expect(
+      getEventFormValidationMessage(validInput({ title: 'a'.repeat(200) }))
+    ).toContain('Title cannot exceed');
+  });
+
+  it('flags an invalid virtual url', () => {
+    expect(
+      getEventFormValidationMessage(
+        validInput({ virtualEventUrl: 'x', urlIsValid: false })
+      )
+    ).toBe('Virtual event URL must be valid.');
+  });
+});

--- a/tests/unit/utils/eventSeo.spec.ts
+++ b/tests/unit/utils/eventSeo.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  truncateDescription,
+  buildEventSeoMeta,
+  buildEventStructuredData,
+  type EventSeoData,
+} from '@/utils/eventSeo';
+
+const baseEvent: EventSeoData = {
+  id: 'e1',
+  title: 'Trivia Night',
+  description: 'Come play trivia',
+  startTime: '2024-06-01T18:00:00Z',
+  endTime: '2024-06-01T20:00:00Z',
+  coverImageURL: 'https://img/x.png',
+  Poster: { username: 'alice', displayName: 'Alice' },
+};
+
+describe('truncateDescription', () => {
+  it('leaves short text unchanged', () => {
+    expect(truncateDescription('short', 160)).toBe('short');
+  });
+
+  it('truncates long text and appends an ellipsis', () => {
+    expect(truncateDescription('a'.repeat(200), 160)).toBe(
+      `${'a'.repeat(160)}...`
+    );
+  });
+});
+
+describe('buildEventSeoMeta', () => {
+  it('returns not-found meta when there is no event', () => {
+    expect(
+      buildEventSeoMeta({
+        event: null,
+        channelId: 'cats',
+        forumName: '',
+        serverDisplayName: 'Server',
+      }).title
+    ).toBe('Event Not Found | cats');
+  });
+
+  it('includes the forum and server in the title', () => {
+    expect(
+      buildEventSeoMeta({
+        event: baseEvent,
+        channelId: 'cats',
+        forumName: 'Cats',
+        serverDisplayName: 'Server',
+      }).title
+    ).toBe('Trivia Night | Cats | Server');
+  });
+
+  it('omits the forum from the title when none is given', () => {
+    expect(
+      buildEventSeoMeta({
+        event: baseEvent,
+        channelId: '',
+        forumName: '',
+        serverDisplayName: 'Server',
+      }).title
+    ).toBe('Trivia Night | Server');
+  });
+
+  it('falls back to a generated description when the event has none', () => {
+    const meta = buildEventSeoMeta({
+      event: { ...baseEvent, description: '' },
+      channelId: 'cats',
+      forumName: 'Cats',
+      serverDisplayName: 'Server',
+    });
+    expect(meta.description).toContain('Trivia Night - Event on');
+  });
+});
+
+describe('buildEventStructuredData', () => {
+  it('uses a Place location when an address is present', () => {
+    const data = buildEventStructuredData({
+      event: { ...baseEvent, address: '123 Main St' },
+      baseUrl: 'https://x',
+    });
+    expect((data.location as { '@type': string })['@type']).toBe('Place');
+  });
+
+  it('uses a VirtualLocation with a fallback url when there is no address', () => {
+    const data = buildEventStructuredData({
+      event: { ...baseEvent, address: '', virtualEventUrl: null },
+      baseUrl: 'https://x',
+    });
+    expect((data.location as { url: string }).url).toBe(
+      'https://x/events/list/search/e1'
+    );
+  });
+
+  it('marks a canceled event with EventCancelled status', () => {
+    const data = buildEventStructuredData({
+      event: { ...baseEvent, canceled: true },
+      baseUrl: 'https://x',
+    });
+    expect(data.eventStatus).toBe('https://schema.org/EventCancelled');
+  });
+
+  it('falls back to Anonymous when there is no poster', () => {
+    const data = buildEventStructuredData({
+      event: { ...baseEvent, Poster: null },
+      baseUrl: 'https://x',
+    });
+    expect((data.organizer as { name: string }).name).toBe('Anonymous');
+  });
+});

--- a/tests/unit/utils/eventTiming.spec.ts
+++ b/tests/unit/utils/eventTiming.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { DateTime } from 'luxon';
+import { isEventInThePast, hasEventStarted } from '@/utils/eventTiming';
+
+const NOW = DateTime.fromISO('2024-06-15T12:00:00.000Z');
+
+describe('isEventInThePast', () => {
+  it('is true when the end time is before now', () => {
+    expect(isEventInThePast({ endTime: '2024-01-01T00:00:00Z' }, NOW)).toBe(
+      true
+    );
+  });
+
+  it('is false when the end time is in the future', () => {
+    expect(isEventInThePast({ endTime: '2024-12-01T00:00:00Z' }, NOW)).toBe(
+      false
+    );
+  });
+
+  it('is false when there is no event', () => {
+    expect(isEventInThePast(null, NOW)).toBe(false);
+  });
+
+  it('is false when there is no end time', () => {
+    expect(isEventInThePast({ startTime: '2024-01-01T00:00:00Z' }, NOW)).toBe(
+      false
+    );
+  });
+});
+
+describe('hasEventStarted', () => {
+  it('is true when the event has started but not ended', () => {
+    expect(
+      hasEventStarted(
+        { startTime: '2024-06-01T00:00:00Z', endTime: '2024-12-01T00:00:00Z' },
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('is false when the event has not started yet', () => {
+    expect(
+      hasEventStarted(
+        { startTime: '2024-07-01T00:00:00Z', endTime: '2024-08-01T00:00:00Z' },
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it('is false when the event is already over', () => {
+    expect(
+      hasEventStarted(
+        { startTime: '2024-01-01T00:00:00Z', endTime: '2024-02-01T00:00:00Z' },
+        NOW
+      )
+    ).toBe(false);
+  });
+});

--- a/tests/unit/utils/filterGroupYaml.spec.ts
+++ b/tests/unit/utils/filterGroupYaml.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  serializeFilterGroupsToYaml,
+  parseFilterGroupsYaml,
+} from '@/utils/filterGroupYaml';
+
+describe('serializeFilterGroupsToYaml', () => {
+  it('serializes a group to YAML containing its key', () => {
+    const yaml = serializeFilterGroupsToYaml([
+      {
+        key: 'color',
+        displayName: 'Color',
+        mode: 'INCLUDE',
+        order: 0,
+        options: [{ value: 'red', displayName: 'Red', order: 0 }],
+      },
+    ]);
+    expect(yaml).toContain('key: color');
+  });
+
+  it('round-trips through parse back to the same data', () => {
+    const groups = [
+      {
+        key: 'color',
+        displayName: 'Color',
+        mode: 'INCLUDE',
+        order: 0,
+        options: [{ value: 'red', displayName: 'Red', order: 0 }],
+      },
+    ];
+    const result = parseFilterGroupsYaml(serializeFilterGroupsToYaml(groups));
+    expect(result.groups).toEqual(groups);
+  });
+});
+
+describe('parseFilterGroupsYaml', () => {
+  it('fails when the YAML is not an array', () => {
+    const result = parseFilterGroupsYaml('key: value');
+    expect(result).toEqual({
+      success: false,
+      error: 'YAML must contain an array of filter groups',
+    });
+  });
+
+  it('fails when a group is missing required fields', () => {
+    const result = parseFilterGroupsYaml('- displayName: No Key\n  mode: INCLUDE');
+    expect(result.error).toContain('missing required fields');
+  });
+
+  it('fails when a group has an invalid mode', () => {
+    const result = parseFilterGroupsYaml(
+      '- key: color\n  displayName: Color\n  mode: MAYBE'
+    );
+    expect(result.error).toContain('invalid mode');
+  });
+
+  it('defaults missing order values to the index', () => {
+    const result = parseFilterGroupsYaml(
+      '- key: a\n  displayName: A\n  mode: INCLUDE\n- key: b\n  displayName: B\n  mode: EXCLUDE'
+    );
+    expect(result.groups?.map((g) => g.order)).toEqual([0, 1]);
+  });
+
+  it('returns an error for malformed YAML', () => {
+    const result = parseFilterGroupsYaml(':\n  - [unbalanced');
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/utils/usernameValidation.spec.ts
+++ b/tests/unit/utils/usernameValidation.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidUsername,
+  getUsernameValidationMessage,
+  calculateAge,
+  getBirthdayValidationMessage,
+} from '@/utils/usernameValidation';
+
+const NOW = new Date('2024-06-15T00:00:00Z');
+
+describe('isValidUsername', () => {
+  it('accepts letters, numbers and underscores', () => {
+    expect(isValidUsername('cool_user_99')).toBe(true);
+  });
+
+  it('rejects spaces and punctuation', () => {
+    expect(isValidUsername('cool user!')).toBe(false);
+  });
+});
+
+describe('getUsernameValidationMessage', () => {
+  it('reports an empty username first', () => {
+    expect(
+      getUsernameValidationMessage({ username: '', isEmpty: true, isTaken: false })
+    ).toBe('Username cannot be empty.');
+  });
+
+  it('reports a taken username', () => {
+    expect(
+      getUsernameValidationMessage({
+        username: 'taken',
+        isEmpty: false,
+        isTaken: true,
+      })
+    ).toBe('The username is already taken.');
+  });
+
+  it('reports invalid characters', () => {
+    expect(
+      getUsernameValidationMessage({
+        username: 'bad name',
+        isEmpty: false,
+        isTaken: false,
+      })
+    ).toContain('letters, numbers, and underscores');
+  });
+
+  it('reports an over-long username', () => {
+    expect(
+      getUsernameValidationMessage({
+        username: 'a'.repeat(60),
+        isEmpty: false,
+        isTaken: false,
+      })
+    ).toContain('must be less than');
+  });
+
+  it('returns no message for a valid username', () => {
+    expect(
+      getUsernameValidationMessage({
+        username: 'valid_name',
+        isEmpty: false,
+        isTaken: false,
+      })
+    ).toBe('');
+  });
+});
+
+describe('calculateAge', () => {
+  it('returns 0 for an empty birth date', () => {
+    expect(calculateAge('', NOW)).toBe(0);
+  });
+
+  it('computes age before the birthday this year', () => {
+    expect(calculateAge('2000-12-01', NOW)).toBe(23);
+  });
+
+  it('computes age after the birthday this year', () => {
+    expect(calculateAge('2000-01-01', NOW)).toBe(24);
+  });
+});
+
+describe('getBirthdayValidationMessage', () => {
+  it('requires a birthday', () => {
+    expect(getBirthdayValidationMessage({ birthday: '', now: NOW })).toBe(
+      'Birthday is required.'
+    );
+  });
+
+  it('rejects under-13 users', () => {
+    expect(
+      getBirthdayValidationMessage({ birthday: '2015-01-01', now: NOW })
+    ).toContain('at least 13 years old');
+  });
+
+  it('accepts users 13 and older', () => {
+    expect(
+      getBirthdayValidationMessage({ birthday: '2000-01-01', now: NOW })
+    ).toBe('');
+  });
+});

--- a/utils/albumImageOrder.ts
+++ b/utils/albumImageOrder.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure album image-ordering helpers, extracted from AlbumEditor. The album
+ * stores images plus an `imageOrder` array of image ids; these compute the
+ * displayed order and reorder the id list.
+ */
+
+export type OrderableImage = { id?: string | null };
+
+export type OrderImagesParams<T> = {
+  images: T[] | null | undefined;
+  imageOrder: string[] | null | undefined;
+};
+
+/**
+ * Return images sorted by `imageOrder`. Falls back to the original order when
+ * no `imageOrder` is set; drops ids in the order that have no matching image.
+ */
+export function orderImagesByOrder<T extends OrderableImage>(
+  params: OrderImagesParams<T>
+): T[] {
+  const { images, imageOrder } = params;
+  if (!images) return [];
+  if (!imageOrder || imageOrder.length === 0) return images;
+
+  return imageOrder
+    .map((imageId) => images.find((image) => image.id === imageId))
+    .filter((image): image is T => image !== undefined);
+}
+
+/** The list of image ids, used to persist a new order. */
+export function getImageIdOrder<T extends OrderableImage>(
+  images: T[]
+): string[] {
+  return images
+    .map((image) => image.id)
+    .filter((id): id is string => id !== undefined && id !== null);
+}
+
+const swap = (order: string[], a: number, b: number): string[] => {
+  const next = [...order];
+  const itemA = next[a];
+  const itemB = next[b];
+  if (itemA !== undefined && itemB !== undefined) {
+    next[a] = itemB;
+    next[b] = itemA;
+  }
+  return next;
+};
+
+/** Move the id at `index` one position earlier; no-op at the start. */
+export function moveImageOrderUp(
+  imageOrder: string[],
+  index: number
+): string[] {
+  if (index <= 0) return [...imageOrder];
+  return swap(imageOrder, index, index - 1);
+}
+
+/** Move the id at `index` one position later; no-op at the end. */
+export function moveImageOrderDown(
+  imageOrder: string[],
+  index: number
+): string[] {
+  if (index >= imageOrder.length - 1) return [...imageOrder];
+  return swap(imageOrder, index, index + 1);
+}

--- a/utils/albumImages.ts
+++ b/utils/albumImages.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure helpers for turning an album's stored images into the editor form's
+ * shape and deriving the initial image order, extracted from AlbumEditForm.
+ */
+
+export type AlbumImageSource = {
+  id?: string | null;
+  url?: string | null;
+  alt?: string | null;
+  caption?: string | null;
+  copyright?: string | null;
+};
+
+export type AlbumFormImage = {
+  id: string;
+  url: string;
+  alt: string;
+  caption: string;
+  isCoverImage: boolean;
+  hasSensitiveContent: boolean;
+  hasSpoiler: boolean;
+  copyright: string;
+};
+
+export function mapAlbumImagesToForm(
+  albumImages: AlbumImageSource[] | null | undefined
+): AlbumFormImage[] {
+  if (!albumImages) return [];
+  return albumImages.map((image) => ({
+    id: image.id || '',
+    url: image.url || '',
+    alt: image.alt || '',
+    caption: image.caption || '',
+    isCoverImage: false,
+    hasSensitiveContent: false,
+    hasSpoiler: false,
+    copyright: image.copyright || '',
+  }));
+}
+
+export type InitialImageOrderParams = {
+  albumImageOrder: (string | null | undefined)[] | null | undefined;
+  images: AlbumFormImage[];
+};
+
+/**
+ * Use the album's stored order when present (string ids only); otherwise build
+ * an order from the images that have a (truthy) id.
+ */
+export function getInitialImageOrder(
+  params: InitialImageOrderParams
+): string[] {
+  const { albumImageOrder, images } = params;
+
+  const existing = (albumImageOrder || []).filter(
+    (id): id is string => typeof id === 'string'
+  );
+  if (existing.length) {
+    return existing;
+  }
+
+  return images.filter((image) => Boolean(image.id)).map((image) => image.id);
+}

--- a/utils/commentSection.ts
+++ b/utils/commentSection.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure helpers extracted from CommentSection: filtering comments by a search
+ * term and resolving the effective channel unique name from an explicit value
+ * with a fallback to the first comment's channel.
+ */
+
+export type ChannelResolvableComment = {
+  id?: string | null;
+  DiscussionChannel?: { channelUniqueName?: string | null } | null;
+  Channel?: { uniqueName?: string | null } | null;
+};
+
+export type FilterCommentsParams<T> = {
+  comments: T[] | null | undefined;
+  searchText: string;
+};
+
+export function filterCommentsBySearch<T extends { text?: string | null }>(
+  params: FilterCommentsParams<T>
+): T[] {
+  const { comments, searchText } = params;
+  const list = comments || [];
+  const term = searchText.trim().toLowerCase();
+  if (!term) return list;
+  return list.filter((comment) =>
+    comment?.text?.toLowerCase().includes(term)
+  );
+}
+
+export type ResolveChannelParams = {
+  comments: ChannelResolvableComment[] | null | undefined;
+  explicitChannelUniqueName?: string | null;
+};
+
+export function resolveChannelUniqueName(
+  params: ResolveChannelParams
+): string {
+  const { comments, explicitChannelUniqueName } = params;
+  if (explicitChannelUniqueName) return explicitChannelUniqueName;
+  const firstComment = (comments || []).find((comment) => !!comment?.id);
+  return (
+    firstComment?.DiscussionChannel?.channelUniqueName ||
+    firstComment?.Channel?.uniqueName ||
+    ''
+  );
+}

--- a/utils/discussionFormValidation.ts
+++ b/utils/discussionFormValidation.ts
@@ -1,0 +1,47 @@
+import {
+  DISCUSSION_TITLE_CHAR_LIMIT,
+  MAX_CHARS_IN_DISCUSSION_BODY,
+} from '@/utils/constants';
+
+/**
+ * Pure validation for the discussion create/edit form, extracted from
+ * CreateEditDiscussionFields.
+ */
+export type DiscussionFormValidationInput = {
+  selectedChannelsCount: number;
+  title: string;
+  body: string;
+};
+
+/** True when the form is NOT yet submittable. */
+export function discussionFormNeedsChanges(
+  input: DiscussionFormValidationInput
+): boolean {
+  const { selectedChannelsCount, title, body } = input;
+  return !(
+    selectedChannelsCount > 0 &&
+    !!title &&
+    body.length <= MAX_CHARS_IN_DISCUSSION_BODY &&
+    title.length <= DISCUSSION_TITLE_CHAR_LIMIT
+  );
+}
+
+/** The first applicable validation message, or '' when valid. */
+export function getDiscussionFormValidationMessage(
+  input: DiscussionFormValidationInput
+): string {
+  const { selectedChannelsCount, title, body } = input;
+  if (!title) {
+    return 'A title is required.';
+  }
+  if (selectedChannelsCount === 0) {
+    return 'Must select at least one forum.';
+  }
+  if (body.length > MAX_CHARS_IN_DISCUSSION_BODY) {
+    return `Body cannot exceed ${MAX_CHARS_IN_DISCUSSION_BODY} characters.`;
+  }
+  if (title.length > DISCUSSION_TITLE_CHAR_LIMIT) {
+    return `Title cannot exceed ${DISCUSSION_TITLE_CHAR_LIMIT} characters.`;
+  }
+  return '';
+}

--- a/utils/downloadFileValidation.ts
+++ b/utils/downloadFileValidation.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure file-validation helpers for the download upload form, extracted from
+ * DownloadEditForm. They take primitive file fields (name/type/size) rather
+ * than a File object so they can be unit-tested without the DOM.
+ */
+export const MAX_DOWNLOAD_FILE_SIZE_MB = 50;
+export const MAX_DOWNLOAD_FILE_SIZE_BYTES =
+  MAX_DOWNLOAD_FILE_SIZE_MB * 1024 * 1024;
+
+export type FileValidationResult = { valid: boolean; message: string };
+
+export type ValidateFileTypeParams = {
+  fileName: string;
+  fileType: string;
+  allowedFileTypes: string[];
+  downloadsDisabled: boolean;
+};
+
+export function validateDownloadFileType(
+  params: ValidateFileTypeParams
+): FileValidationResult {
+  const { fileName, fileType, allowedFileTypes, downloadsDisabled } = params;
+
+  if (downloadsDisabled) {
+    return { valid: false, message: 'Downloads are disabled in this channel.' };
+  }
+
+  if (allowedFileTypes.length === 0) {
+    return { valid: true, message: '' };
+  }
+
+  const fileExtension = fileName.toLowerCase().split('.').pop();
+  const isAllowed = allowedFileTypes.some(
+    (type) =>
+      type.toLowerCase().includes(fileExtension || '') ||
+      fileType.toLowerCase().includes(type.toLowerCase())
+  );
+
+  if (!isAllowed) {
+    return {
+      valid: false,
+      message: `File type not allowed. Allowed types: ${allowedFileTypes.join(', ')}`,
+    };
+  }
+
+  return { valid: true, message: '' };
+}
+
+export function validateDownloadFileSize(
+  fileSize: number
+): FileValidationResult {
+  if (fileSize > MAX_DOWNLOAD_FILE_SIZE_BYTES) {
+    return {
+      valid: false,
+      message: `File size must be less than ${MAX_DOWNLOAD_FILE_SIZE_MB}MB. Current file is ${(
+        fileSize /
+        (1024 * 1024)
+      ).toFixed(1)}MB.`,
+    };
+  }
+  return { valid: true, message: '' };
+}

--- a/utils/eventDateFormat.ts
+++ b/utils/eventDateFormat.ts
@@ -1,0 +1,30 @@
+import { DateTime } from 'luxon';
+
+/**
+ * Formats an event's date for display, extracted from EventHeader. All-day
+ * events show date(s) without a time; multi-day all-day events show a range;
+ * timed events include the start time. Pure, so it can be unit-tested.
+ */
+export type FormatEventDateParams = {
+  startTime: string;
+  isAllDay?: boolean | null;
+  endTime?: string | null;
+};
+
+const DATE_FORMAT = 'cccc LLLL d yyyy';
+const DATE_TIME_FORMAT = 'cccc LLLL d yyyy h:mm a';
+
+export function formatEventDateString(params: FormatEventDateParams): string {
+  const { startTime, isAllDay, endTime } = params;
+
+  if (isAllDay && endTime) {
+    const start = DateTime.fromISO(startTime);
+    const end = DateTime.fromISO(endTime);
+    if (start.hasSame(end, 'day')) {
+      return start.toFormat(DATE_FORMAT);
+    }
+    return `${start.toFormat(DATE_FORMAT)} - ${end.toFormat(DATE_FORMAT)}`;
+  }
+
+  return DateTime.fromISO(startTime).toFormat(DATE_TIME_FORMAT);
+}

--- a/utils/eventFormValidation.ts
+++ b/utils/eventFormValidation.ts
@@ -1,0 +1,71 @@
+import {
+  EVENT_TITLE_CHAR_LIMIT,
+  MAX_CHARS_IN_EVENT_DESCRIPTION,
+} from '@/utils/constants';
+
+/**
+ * Pure validation for the event create/edit form, extracted from
+ * CreateEditEventFields. The component still derives `urlIsValid` (via checkUrl)
+ * and `startBeforeEnd` from its date pickers and passes them in.
+ */
+export type EventFormValidationInput = {
+  selectedChannelsCount: number;
+  title: string;
+  description: string;
+  virtualEventUrl?: string | null;
+  urlIsValid: boolean;
+  startBeforeEnd: boolean;
+};
+
+/** True when the form is NOT yet submittable. */
+export function eventFormNeedsChanges(
+  input: EventFormValidationInput
+): boolean {
+  const {
+    selectedChannelsCount,
+    title,
+    description,
+    virtualEventUrl,
+    urlIsValid,
+    startBeforeEnd,
+  } = input;
+
+  const hasValidVirtualEventUrl = virtualEventUrl
+    ? urlIsValid && !!virtualEventUrl
+    : true;
+
+  return !(
+    selectedChannelsCount > 0 &&
+    title.length > 0 &&
+    startBeforeEnd &&
+    title.length <= EVENT_TITLE_CHAR_LIMIT &&
+    description.length <= MAX_CHARS_IN_EVENT_DESCRIPTION &&
+    (urlIsValid || !virtualEventUrl) &&
+    hasValidVirtualEventUrl
+  );
+}
+
+/** The first applicable validation message, or '' when valid. */
+export function getEventFormValidationMessage(
+  input: EventFormValidationInput
+): string {
+  const { selectedChannelsCount, title, description, virtualEventUrl, urlIsValid } =
+    input;
+
+  if (selectedChannelsCount === 0) {
+    return 'At least one channel must be selected.';
+  }
+  if (!title) {
+    return 'A title is required.';
+  }
+  if (title.length > EVENT_TITLE_CHAR_LIMIT) {
+    return `Title cannot exceed ${EVENT_TITLE_CHAR_LIMIT} characters.`;
+  }
+  if (description.length > MAX_CHARS_IN_EVENT_DESCRIPTION) {
+    return `Description cannot exceed ${MAX_CHARS_IN_EVENT_DESCRIPTION} characters.`;
+  }
+  if (virtualEventUrl && !urlIsValid) {
+    return 'Virtual event URL must be valid.';
+  }
+  return '';
+}

--- a/utils/eventSeo.ts
+++ b/utils/eventSeo.ts
@@ -1,0 +1,123 @@
+import { DateTime } from 'luxon';
+
+/**
+ * Pure builders for EventDetail's SEO metadata and schema.org structured data,
+ * extracted from a watchEffect so they can be unit-tested without mounting the
+ * component or wiring up useHead.
+ */
+
+export type EventSeoData = {
+  id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  startTime?: string | null;
+  endTime?: string | null;
+  address?: string | null;
+  virtualEventUrl?: string | null;
+  coverImageURL?: string | null;
+  canceled?: boolean | null;
+  Poster?: { username?: string | null; displayName?: string | null } | null;
+};
+
+export const DESCRIPTION_MAX_LENGTH = 160;
+
+export function formatEventDate(iso: string): string {
+  return DateTime.fromISO(iso).toLocaleString(DateTime.DATE_FULL);
+}
+
+export function truncateDescription(
+  text: string,
+  max: number = DESCRIPTION_MAX_LENGTH
+): string {
+  return text.length > max ? `${text.substring(0, max)}...` : text;
+}
+
+const eventTitle = (event: EventSeoData): string => event.title || 'Event';
+
+const eventDescription = (event: EventSeoData): string => {
+  if (event.description) {
+    return truncateDescription(event.description);
+  }
+  return `${eventTitle(event)} - Event on ${formatEventDate(event.startTime || '')}`;
+};
+
+export type EventSeoMeta = {
+  title: string;
+  description: string;
+  image?: string;
+  type?: string;
+};
+
+export type BuildEventSeoMetaParams = {
+  event: EventSeoData | null | undefined;
+  channelId: string;
+  forumName: string;
+  serverDisplayName: string;
+};
+
+export function buildEventSeoMeta(params: BuildEventSeoMetaParams): EventSeoMeta {
+  const { event, channelId, forumName, serverDisplayName } = params;
+  if (!event) {
+    return {
+      title: `Event Not Found${channelId ? ` | ${channelId}` : ''}`,
+      description: 'The requested event could not be found.',
+    };
+  }
+
+  const title = eventTitle(event);
+  return {
+    title: forumName
+      ? `${title} | ${forumName} | ${serverDisplayName}`
+      : `${title} | ${serverDisplayName}`,
+    description: eventDescription(event),
+    image: event.coverImageURL || '',
+    type: 'event',
+  };
+}
+
+export type BuildEventStructuredDataParams = {
+  event: EventSeoData;
+  baseUrl: string;
+};
+
+/** schema.org Event JSON-LD object. */
+export function buildEventStructuredData(
+  params: BuildEventStructuredDataParams
+): Record<string, unknown> {
+  const { event, baseUrl } = params;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: eventTitle(event),
+    description: eventDescription(event),
+    startDate: event.startTime,
+    endDate: event.endTime,
+    image: event.coverImageURL || '',
+    location: event.address
+      ? {
+          '@type': 'Place',
+          name: event.address,
+          address: {
+            '@type': 'PostalAddress',
+            streetAddress: event.address,
+          },
+        }
+      : {
+          '@type': 'VirtualLocation',
+          url:
+            event.virtualEventUrl ??
+            `${baseUrl}/events/list/search/${event.id}`,
+        },
+    organizer: {
+      '@type': 'Person',
+      name:
+        event.Poster?.displayName || event.Poster?.username || 'Anonymous',
+    },
+    eventStatus: event.canceled
+      ? 'https://schema.org/EventCancelled'
+      : 'https://schema.org/EventScheduled',
+    eventAttendanceMode: event.virtualEventUrl
+      ? 'https://schema.org/OnlineEventAttendanceMode'
+      : 'https://schema.org/OfflineEventAttendanceMode',
+  };
+}

--- a/utils/eventTiming.ts
+++ b/utils/eventTiming.ts
@@ -1,0 +1,28 @@
+import { DateTime } from 'luxon';
+
+/**
+ * Pure event date-status helpers, extracted from EventDetail. `now` is
+ * injectable so the logic can be unit-tested deterministically.
+ */
+export type EventTimes = {
+  startTime?: string | null;
+  endTime?: string | null;
+};
+
+export function isEventInThePast(
+  event: EventTimes | null | undefined,
+  now: DateTime = DateTime.now()
+): boolean {
+  if (!event?.endTime) return false;
+  return DateTime.fromISO(event.endTime) < now;
+}
+
+export function hasEventStarted(
+  event: EventTimes | null | undefined,
+  now: DateTime = DateTime.now()
+): boolean {
+  if (!event?.startTime) return false;
+  return (
+    DateTime.fromISO(event.startTime) < now && !isEventInThePast(event, now)
+  );
+}

--- a/utils/filterGroupYaml.ts
+++ b/utils/filterGroupYaml.ts
@@ -1,0 +1,102 @@
+import yaml from 'js-yaml';
+
+/**
+ * Pure YAML serialize/parse for the filter-group editor, extracted from
+ * FilterGroupManager. Works with a plain shape (no GraphQL placeholder fields);
+ * the component maps the parsed plain groups onto full FilterGroup objects.
+ */
+export type PlainFilterOption = {
+  value: string;
+  displayName: string;
+  order?: number;
+};
+
+export type PlainFilterGroup = {
+  key: string;
+  displayName: string;
+  mode: string;
+  order?: number;
+  options?: PlainFilterOption[];
+};
+
+export type ParseFilterGroupsResult = {
+  success: boolean;
+  groups?: PlainFilterGroup[];
+  error?: string;
+};
+
+/** Serialize filter groups to YAML, picking only the persisted fields. */
+export function serializeFilterGroupsToYaml(
+  filterGroups: PlainFilterGroup[]
+): string {
+  const cleanGroups = filterGroups.map((group) => ({
+    key: group.key,
+    displayName: group.displayName,
+    mode: group.mode,
+    order: group.order,
+    options: (group.options || []).map((option) => ({
+      value: option.value,
+      displayName: option.displayName,
+      order: option.order,
+    })),
+  }));
+
+  try {
+    return yaml.dump(cleanGroups, {
+      indent: 2,
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: false,
+    });
+  } catch (error) {
+    console.error('Error converting to YAML:', error);
+    return '';
+  }
+}
+
+/** Parse and validate a YAML string into plain filter groups. */
+export function parseFilterGroupsYaml(
+  yamlString: string
+): ParseFilterGroupsResult {
+  try {
+    const parsed = yaml.load(yamlString) as PlainFilterGroup[];
+
+    if (!Array.isArray(parsed)) {
+      return {
+        success: false,
+        error: 'YAML must contain an array of filter groups',
+      };
+    }
+
+    const groups: PlainFilterGroup[] = parsed.map((group, index) => {
+      if (!group.key || !group.displayName) {
+        throw new Error(
+          `Group at index ${index} is missing required fields (key, displayName)`
+        );
+      }
+      if (!['INCLUDE', 'EXCLUDE'].includes(group.mode)) {
+        throw new Error(
+          `Group "${group.key}" has invalid mode. Must be INCLUDE or EXCLUDE`
+        );
+      }
+      return {
+        key: group.key,
+        displayName: group.displayName,
+        mode: group.mode,
+        order: group.order ?? index,
+        options: (group.options || []).map((option, optionIndex) => ({
+          value: option.value,
+          displayName: option.displayName,
+          order: option.order ?? optionIndex,
+        })),
+      };
+    });
+
+    return { success: true, groups };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Invalid YAML format',
+    };
+  }
+}

--- a/utils/usernameValidation.ts
+++ b/utils/usernameValidation.ts
@@ -1,0 +1,65 @@
+import { MAX_CHARS_IN_USERNAME } from '@/utils/constants';
+
+/**
+ * Pure username/age validation for CreateUsernameForm. `now` is injectable so
+ * age math is deterministic in tests.
+ */
+export const MIN_SIGNUP_AGE = 13;
+
+export function isValidUsername(username: string): boolean {
+  return /^[a-zA-Z0-9_]+$/.test(username);
+}
+
+export type UsernameValidationParams = {
+  username: string;
+  isEmpty: boolean;
+  isTaken: boolean;
+};
+
+export function getUsernameValidationMessage(
+  params: UsernameValidationParams
+): string {
+  const { username, isEmpty, isTaken } = params;
+  if (isEmpty) {
+    return 'Username cannot be empty.';
+  }
+  if (isTaken) {
+    return 'The username is already taken.';
+  }
+  if (!isValidUsername(username || '')) {
+    return 'Username can only contain letters, numbers, and underscores.';
+  }
+  if (username && username.length > MAX_CHARS_IN_USERNAME) {
+    return `Username must be less than ${MAX_CHARS_IN_USERNAME} characters.`;
+  }
+  return '';
+}
+
+export function calculateAge(birthDate: string, now: Date = new Date()): number {
+  if (!birthDate) return 0;
+  const birth = new Date(birthDate);
+  let age = now.getFullYear() - birth.getFullYear();
+  const monthDiff = now.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) {
+    age--;
+  }
+  return age;
+}
+
+export type BirthdayValidationParams = {
+  birthday: string;
+  now?: Date;
+};
+
+export function getBirthdayValidationMessage(
+  params: BirthdayValidationParams
+): string {
+  const { birthday, now = new Date() } = params;
+  if (!birthday || birthday.length === 0) {
+    return 'Birthday is required.';
+  }
+  if (calculateAge(birthday, now) < MIN_SIGNUP_AGE) {
+    return 'You must be at least 13 years old to create an account.';
+  }
+  return '';
+}


### PR DESCRIPTION
## Summary

Round 3 of the coverage effort, building on the merged #71 infra. The strategy for the heaviest components (650–1130 lines, many Apollo queries + children) is to **extract their trapped pure logic into tested utils** rather than mount the whole component — plus a few mount specs where cheap.

## Logic extractions (components refactored to consume tested utils)
| Component | New util |
|---|---|
| EventDetail | `eventTiming`, `eventSeo` (SEO meta + schema.org JSON-LD) |
| EventHeader | `eventDateFormat` |
| CommentSection | `commentSection` (search filter + channel resolution) |
| CreateEditEventFields | `eventFormValidation` |
| CreateEditDiscussionFields | `discussionFormValidation` |
| DownloadEditForm | `downloadFileValidation` |
| AlbumEditor | `albumImageOrder` |
| AlbumEditForm | `albumImages` |
| CreateUsernameForm | `usernameValidation` (username + age) |
| FilterGroupManager | `filterGroupYaml` (serialize + parse/validate) |

## Mount specs (previously 0%-covered components)
SitewideDiscussionListItem, ChannelDiscussionListItem, MarkdownPreview, SitewideDownloadListItem.

## Verification
- `vue-tsc`: **0 errors**; `eslint`: **0 errors**; full `vitest`: **2146 passing**.
- All extractions are behavior-preserving (components import the new utils; computeds/handlers unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)