### PR TITLE
test: mount specs for filter managers + sitewide lists (Tier 1 coverage)

### DIFF
--- a/components/discussion/list/SitewideDiscussionList.spec.ts
+++ b/components/discussion/list/SitewideDiscussionList.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import {
+  asMock,
+  createQueryMock,
+  mockByDocument,
+} from '@/tests/utils/mockApollo';
+
+import { useQuery } from '@vue/apollo-composable';
+import { useRoute } from 'nuxt/app';
+
+// Import after mocks are declared (hoisted) so the component picks them up.
+import SitewideDiscussionList from '@/components/discussion/list/SitewideDiscussionList.vue';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: vi.fn(),
+}));
+vi.mock('@/composables/useTheme', () => ({
+  useAppTheme: () => ({ theme: ref('light') }),
+}));
+
+const SERVER_CONFIG = { serverConfigs: [{ serverName: 'Test', __typename: 'ServerConfig' }] };
+
+const makeDiscussion = (id: string, overrides: Record<string, unknown> = {}) => ({
+  id,
+  title: `Discussion ${id}`,
+  score: 0,
+  DiscussionChannels: [
+    { channelUniqueName: 'cats', CommentsAggregate: { count: 2 }, __typename: 'DiscussionChannel' },
+  ],
+  __typename: 'Discussion',
+  ...overrides,
+});
+
+const listResult = (discussions: ReturnType<typeof makeDiscussion>[], aggregate?: number) => ({
+  getSiteWideDiscussionList: {
+    discussions,
+    aggregateDiscussionCount: aggregate ?? discussions.length,
+    __typename: 'DiscussionListResponse',
+  },
+});
+
+const stubs = {
+  SitewideDiscussionListItem: {
+    name: 'SitewideDiscussionListItem',
+    props: ['discussion'],
+    emits: ['filterByTag', 'filterByChannel'],
+    template: '<li class="item-stub" />',
+  },
+  SitewideDiscussionSidebar: { template: '<div />' },
+  DiscussionDetailContent: { template: '<div class="detail-stub" />' },
+  DiscussionDetailEmptyState: { template: '<div class="empty-state-stub" />' },
+  LoadMore: {
+    name: 'LoadMore',
+    props: ['loading', 'reachedEndOfResults'],
+    emits: ['loadMore'],
+    template: '<button class="load-more-stub" @click="$emit(\'loadMore\')" />',
+  },
+  ErrorBanner: { props: ['text'], template: '<div class="error-stub">{{ text }}</div>' },
+  'v-skeleton-loader': { template: '<div class="skeleton-stub" />' },
+  NuxtLink: { template: '<a><slot /></a>' },
+};
+
+const setupQueries = (discussionMock: ReturnType<typeof createQueryMock>) => {
+  asMock(useQuery).mockImplementation(
+    mockByDocument(
+      {
+        getSiteWideDiscussionList: discussionMock,
+        serverConfigs: createQueryMock(SERVER_CONFIG),
+      },
+      createQueryMock({})
+    )
+  );
+};
+
+const mountList = (route: Record<string, unknown> = {}) => {
+  asMock(useRoute).mockReturnValue({ params: {}, query: {}, ...route });
+  return mountWithDefaults(SitewideDiscussionList, { global: { stubs } });
+};
+
+describe('SitewideDiscussionList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a list item per discussion', () => {
+    setupQueries(createQueryMock(listResult([makeDiscussion('1'), makeDiscussion('2')])));
+    const wrapper = mountList();
+    expect(wrapper.findAll('.item-stub')).toHaveLength(2);
+  });
+
+  it('shows the empty message when there are no discussions', () => {
+    setupQueries(createQueryMock(listResult([])));
+    const wrapper = mountList();
+    expect(wrapper.text()).toContain('There are no discussions to show.');
+  });
+
+  it('renders the error banner when the query errors', () => {
+    setupQueries(
+      createQueryMock(listResult([]), { error: ref(new Error('boom')) })
+    );
+    const wrapper = mountList();
+    expect(wrapper.find('.error-stub').text()).toContain('boom');
+  });
+
+  it('shows the skeleton loader while loading with no results', () => {
+    setupQueries(createQueryMock(null, { loading: ref(true) }));
+    const wrapper = mountList();
+    expect(wrapper.find('.skeleton-stub').exists()).toBe(true);
+  });
+
+  it('calls fetchMore when LoadMore emits loadMore', async () => {
+    const fetchMore = vi.fn();
+    setupQueries(
+      createQueryMock(listResult([makeDiscussion('1')], 5), {
+        // fetchMore isn't part of the canonical mock; attach it.
+        ...({ fetchMore } as object),
+      })
+    );
+    const wrapper = mountList();
+    await wrapper.find('.load-more-stub').trigger('click');
+    expect(fetchMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-emits filterByTag from a list item', () => {
+    setupQueries(createQueryMock(listResult([makeDiscussion('1')])));
+    const wrapper = mountList();
+    wrapper.findComponent(stubs.SitewideDiscussionListItem).vm.$emit('filterByTag', 'vue');
+    expect(wrapper.emitted('filterByTag')?.[0]).toEqual(['vue']);
+  });
+
+  it('builds comment-section links for the selected discussion', () => {
+    setupQueries(createQueryMock(listResult([makeDiscussion('1')])));
+    const wrapper = mountList({ query: { selectedDiscussionId: '1' } });
+    expect(wrapper.text()).toContain('2 comments');
+  });
+});

--- a/components/discussion/list/SitewideDownloadList.spec.ts
+++ b/components/discussion/list/SitewideDownloadList.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import {
+  asMock,
+  createQueryMock,
+  mockByDocument,
+} from '@/tests/utils/mockApollo';
+
+import { useQuery } from '@vue/apollo-composable';
+import { useRoute, useRouter } from 'nuxt/app';
+
+import SitewideDownloadList from '@/components/discussion/list/SitewideDownloadList.vue';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: vi.fn(),
+  useRouter: vi.fn(),
+}));
+
+const SERVER_CONFIG = { serverConfigs: [{ serverName: 'Test', __typename: 'ServerConfig' }] };
+
+const makeDownload = (id: string) => ({
+  id,
+  title: `Download ${id}`,
+  Author: { username: 'alice', __typename: 'User' },
+  __typename: 'Discussion',
+});
+
+const listResult = (discussions: ReturnType<typeof makeDownload>[], aggregate?: number) => ({
+  getSiteWideDiscussionList: {
+    discussions,
+    aggregateDiscussionCount: aggregate ?? discussions.length,
+    __typename: 'DiscussionListResponse',
+  },
+});
+
+const stubs = {
+  SitewideDownloadListItem: {
+    name: 'SitewideDownloadListItem',
+    props: ['discussion'],
+    emits: ['filterByTag', 'openAlbum'],
+    template: '<li class="item-stub" />',
+  },
+  SitewideDiscussionSidebar: { template: '<div />' },
+  DiscussionAlbum: { props: ['album'], template: '<div class="album-stub" />' },
+  DownloadSkeletonCard: { template: '<div class="skeleton-stub" />' },
+  LoadMore: {
+    name: 'LoadMore',
+    props: ['loading', 'reachedEndOfResults'],
+    emits: ['loadMore'],
+    template: '<button class="load-more-stub" @click="$emit(\'loadMore\')" />',
+  },
+  ErrorBanner: { props: ['text'], template: '<div class="error-stub">{{ text }}</div>' },
+  NuxtLink: { template: '<a><slot /></a>' },
+};
+
+const replace = vi.fn();
+
+const setupQueries = (discussionMock: ReturnType<typeof createQueryMock>) => {
+  asMock(useQuery).mockImplementation(
+    mockByDocument(
+      {
+        getSiteWideDiscussionList: discussionMock,
+        serverConfigs: createQueryMock(SERVER_CONFIG),
+      },
+      createQueryMock({})
+    )
+  );
+};
+
+const mountList = (route: Record<string, unknown> = {}) => {
+  asMock(useRoute).mockReturnValue({ params: {}, query: {}, ...route });
+  asMock(useRouter).mockReturnValue({ replace });
+  return mountWithDefaults(SitewideDownloadList, { global: { stubs } });
+};
+
+describe('SitewideDownloadList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a card per download', () => {
+    setupQueries(createQueryMock(listResult([makeDownload('1'), makeDownload('2')])));
+    const wrapper = mountList();
+    expect(wrapper.findAll('.item-stub')).toHaveLength(2);
+  });
+
+  it('shows the empty message when there are no downloads', () => {
+    setupQueries(createQueryMock(listResult([])));
+    const wrapper = mountList();
+    expect(wrapper.text()).toContain('There are no downloads to show.');
+  });
+
+  it('renders the error banner when the query errors', () => {
+    setupQueries(createQueryMock(listResult([]), { error: ref(new Error('kaboom')) }));
+    const wrapper = mountList();
+    expect(wrapper.find('.error-stub').text()).toContain('kaboom');
+  });
+
+  it('shows skeleton cards during the initial load', () => {
+    setupQueries(createQueryMock(null, { loading: ref(true) }));
+    const wrapper = mountList();
+    expect(wrapper.find('.skeleton-stub').exists()).toBe(true);
+  });
+
+  it('calls fetchMore when LoadMore emits', async () => {
+    const fetchMore = vi.fn();
+    setupQueries(createQueryMock(listResult([makeDownload('1')], 5), { ...({ fetchMore } as object) }));
+    const wrapper = mountList();
+    await wrapper.find('.load-more-stub').trigger('click');
+    expect(fetchMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds the tag to the query when filtering by a new tag', () => {
+    setupQueries(createQueryMock(listResult([makeDownload('1')])));
+    const wrapper = mountList({ query: {} });
+    wrapper.findComponent(stubs.SitewideDownloadListItem).vm.$emit('filterByTag', 'vue');
+    expect(replace).toHaveBeenCalledWith({ query: { tags: ['vue'] } });
+  });
+
+  it('clears the tag when already filtering by only that tag', () => {
+    setupQueries(createQueryMock(listResult([makeDownload('1')])));
+    const wrapper = mountList({ query: { tags: 'vue' } });
+    wrapper.findComponent(stubs.SitewideDownloadListItem).vm.$emit('filterByTag', 'vue');
+    const lastCall = replace.mock.calls.at(-1)?.[0];
+    expect(lastCall.query.tags).toBeUndefined();
+  });
+
+  it('opens the album lightbox when a child requests it', async () => {
+    setupQueries(createQueryMock(listResult([makeDownload('1')])));
+    const wrapper = mountList();
+    wrapper.findComponent(stubs.SitewideDownloadListItem).vm.$emit('openAlbum', {
+      discussion: makeDownload('1'),
+      album: { id: 'a1', __typename: 'Album' },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.album-stub').exists()).toBe(true);
+  });
+});

--- a/components/filter/FilterGroupManager.spec.ts
+++ b/components/filter/FilterGroupManager.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import { FilterMode } from '@/__generated__/graphql';
+import type { FilterGroup } from '@/__generated__/graphql';
+
+import FilterGroupManager from '@/components/filter/FilterGroupManager.vue';
+
+// The child manager is exercised by its own spec; stub it so these tests stay
+// focused on FilterGroupManager's own add/remove/move/YAML logic. The stub
+// re-emits the events the parent listens for.
+const FilterOptionManagerStub = {
+  name: 'FilterOptionManager',
+  props: ['filterGroup', 'groupIndex', 'canMoveUp', 'canMoveDown', 'disabled', 'existingKeys'],
+  emits: ['updateGroup', 'removeGroup', 'moveGroup'],
+  template: '<div class="fom-stub" />',
+};
+
+const makeGroup = (overrides: Partial<FilterGroup> = {}): FilterGroup =>
+  ({
+    id: 'g1',
+    key: 'lot_size',
+    displayName: 'Lot Size',
+    mode: FilterMode.Include,
+    order: 0,
+    options: [],
+    __typename: 'FilterGroup',
+    ...overrides,
+  } as unknown as FilterGroup);
+
+const mountManager = (filterGroups: FilterGroup[] = [], disabled = false) =>
+  mountWithDefaults(FilterGroupManager, {
+    props: { filterGroups, disabled },
+    global: { stubs: { FilterOptionManager: FilterOptionManagerStub } },
+  });
+
+const openNewGroupForm = async (wrapper: ReturnType<typeof mountManager>) => {
+  await wrapper.findAll('button').find((b) => b.text() === 'Add New Filter Group')!.trigger('click');
+};
+
+describe('FilterGroupManager', () => {
+  it('shows the empty state when there are no groups', () => {
+    const wrapper = mountManager([]);
+    expect(wrapper.text()).toContain('No filter groups configured.');
+  });
+
+  it('renders one option manager per existing group', () => {
+    const wrapper = mountManager([makeGroup(), makeGroup({ id: 'g2', key: 'color' })]);
+    expect(wrapper.findAllComponents(FilterOptionManagerStub)).toHaveLength(2);
+  });
+
+  it('opens the new-group form when Add New Filter Group is clicked', async () => {
+    const wrapper = mountManager([]);
+    await openNewGroupForm(wrapper);
+    expect(wrapper.find('select').exists()).toBe(true);
+  });
+
+  it('disables the Add Group button until key and display name are valid', async () => {
+    const wrapper = mountManager([]);
+    await openNewGroupForm(wrapper);
+    const addBtn = wrapper.findAll('button').find((b) => b.text() === 'Add Group')!;
+    expect(addBtn.attributes('disabled')).toBeDefined();
+  });
+
+  it('rejects a key with invalid characters', async () => {
+    const wrapper = mountManager([]);
+    await openNewGroupForm(wrapper);
+    await wrapper.get('input[placeholder="e.g. lot_size"]').setValue('bad key!');
+    expect(wrapper.text()).toContain('Key can only contain letters, numbers, and underscores.');
+  });
+
+  it('flags a duplicate key', async () => {
+    const wrapper = mountManager([makeGroup({ id: 'g1', key: 'color' })]);
+    await openNewGroupForm(wrapper);
+    await wrapper.get('input[placeholder="e.g. lot_size"]').setValue('color');
+    expect(wrapper.text()).toContain('This key is already used by another filter group.');
+  });
+
+  it('emits updateFilterGroups with the new group when added', async () => {
+    const wrapper = mountManager([]);
+    await openNewGroupForm(wrapper);
+    await wrapper.get('input[placeholder="e.g. lot_size"]').setValue('lot_size');
+    await wrapper.get('input[placeholder="e.g. Lot Size"]').setValue('Lot Size');
+    await wrapper.findAll('button').find((b) => b.text() === 'Add Group')!.trigger('click');
+    expect(wrapper.emitted('updateFilterGroups')?.[0]?.[0]).toHaveLength(1);
+  });
+
+  it('emits the filtered list when a group is removed', () => {
+    const wrapper = mountManager([makeGroup({ id: 'g1' }), makeGroup({ id: 'g2', key: 'color' })]);
+    wrapper.findAllComponents(FilterOptionManagerStub)[0].vm.$emit('removeGroup', 'g1');
+    const emitted = wrapper.emitted('updateFilterGroups')?.[0]?.[0] as FilterGroup[];
+    expect(emitted.map((g) => g.id)).toEqual(['g2']);
+  });
+
+  it('applies an updated group field when a child requests it', () => {
+    const wrapper = mountManager([makeGroup({ id: 'g1', displayName: 'Old' })]);
+    wrapper.findComponent(FilterOptionManagerStub).vm.$emit('updateGroup', 'g1', { displayName: 'New' });
+    const emitted = wrapper.emitted('updateFilterGroups')?.[0]?.[0] as FilterGroup[];
+    expect(emitted[0].displayName).toBe('New');
+  });
+
+  it('reorders groups when a child requests a move down', () => {
+    const wrapper = mountManager([makeGroup({ id: 'g1' }), makeGroup({ id: 'g2', key: 'color' })]);
+    wrapper.findAllComponents(FilterOptionManagerStub)[0].vm.$emit('moveGroup', 'g1', 'down');
+    const emitted = wrapper.emitted('updateFilterGroups')?.[0]?.[0] as FilterGroup[];
+    expect(emitted.map((g) => g.id)).toEqual(['g2', 'g1']);
+  });
+
+  it('switches to the YAML editor and serializes the current groups', async () => {
+    const wrapper = mountManager([makeGroup({ id: 'g1', key: 'lot_size' })]);
+    await wrapper.findAll('button').find((b) => b.text() === 'YAML Editor')!.trigger('click');
+    expect(wrapper.get('textarea').element.value).toContain('lot_size');
+  });
+
+  it('shows a YAML error when applying invalid YAML', async () => {
+    const wrapper = mountManager([]);
+    await wrapper.findAll('button').find((b) => b.text() === 'YAML Editor')!.trigger('click');
+    await wrapper.get('textarea').setValue('not: [valid yaml');
+    await wrapper.findAll('button').find((b) => b.text() === 'Apply Changes')!.trigger('click');
+    expect(wrapper.text()).toContain('YAML Error:');
+  });
+});

--- a/components/filter/FilterOptionManager.spec.ts
+++ b/components/filter/FilterOptionManager.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import { FilterMode } from '@/__generated__/graphql';
+import type { FilterGroup, FilterOption } from '@/__generated__/graphql';
+
+import FilterOptionManager from '@/components/filter/FilterOptionManager.vue';
+
+const makeOption = (overrides: Partial<FilterOption> = {}): FilterOption =>
+  ({
+    id: 'o1',
+    value: '10x20',
+    displayName: '10 x 20',
+    order: 0,
+    __typename: 'FilterOption',
+    ...overrides,
+  } as unknown as FilterOption);
+
+const makeGroup = (overrides: Partial<FilterGroup> = {}): FilterGroup =>
+  ({
+    id: 'g1',
+    key: 'lot_size',
+    displayName: 'Lot Size',
+    mode: FilterMode.Include,
+    order: 0,
+    options: [],
+    __typename: 'FilterGroup',
+    ...overrides,
+  } as unknown as FilterGroup);
+
+const mountOM = (props: Record<string, unknown> = {}) =>
+  mountWithDefaults(FilterOptionManager, {
+    props: { filterGroup: makeGroup(), groupIndex: 1, ...props },
+  });
+
+const byText = (wrapper: ReturnType<typeof mountOM>, text: string) =>
+  wrapper.findAll('button').find((b) => b.text() === text)!;
+
+describe('FilterOptionManager', () => {
+  it('renders the group index in the header', () => {
+    const wrapper = mountOM({ groupIndex: 3 });
+    expect(wrapper.text()).toContain('Group #3');
+  });
+
+  it('shows the mode label in read mode', () => {
+    const wrapper = mountOM({ filterGroup: makeGroup({ mode: FilterMode.Exclude }) });
+    expect(wrapper.text()).toContain('Exclusion');
+  });
+
+  it('emits moveGroup up when Move Up is clicked', async () => {
+    const wrapper = mountOM({ canMoveUp: true });
+    await byText(wrapper, '↑ Move Up').trigger('click');
+    expect(wrapper.emitted('moveGroup')?.[0]).toEqual(['g1', 'up']);
+  });
+
+  it('hides the Move Up button when canMoveUp is false', () => {
+    const wrapper = mountOM({ canMoveUp: false });
+    expect(wrapper.findAll('button').some((b) => b.text() === '↑ Move Up')).toBe(false);
+  });
+
+  it('emits removeGroup when Remove Group is clicked', async () => {
+    const wrapper = mountOM();
+    await byText(wrapper, 'Remove Group').trigger('click');
+    expect(wrapper.emitted('removeGroup')?.[0]).toEqual(['g1']);
+  });
+
+  it('reveals the edit form when Edit Group Settings is clicked', async () => {
+    const wrapper = mountOM();
+    await byText(wrapper, 'Edit Group Settings').trigger('click');
+    expect(wrapper.find('select').exists()).toBe(true);
+  });
+
+  it('emits updateGroup with edited fields when saved', async () => {
+    const wrapper = mountOM();
+    await byText(wrapper, 'Edit Group Settings').trigger('click');
+    await wrapper.get('input[type="text"]').setValue('new_key');
+    await byText(wrapper, 'Save Changes').trigger('click');
+    expect(wrapper.emitted('updateGroup')?.[0]?.[1]).toMatchObject({ key: 'new_key' });
+  });
+
+  it('disables Save Changes for an invalid key', async () => {
+    const wrapper = mountOM();
+    await byText(wrapper, 'Edit Group Settings').trigger('click');
+    await wrapper.get('input[type="text"]').setValue('bad key!');
+    expect(byText(wrapper, 'Save Changes').attributes('disabled')).toBeDefined();
+  });
+
+  it('leaves edit mode when cancelled', async () => {
+    const wrapper = mountOM();
+    await byText(wrapper, 'Edit Group Settings').trigger('click');
+    await byText(wrapper, 'Cancel').trigger('click');
+    expect(wrapper.find('select').exists()).toBe(false);
+  });
+
+  it('shows the empty-options state when there are no options', () => {
+    const wrapper = mountOM();
+    expect(wrapper.text()).toContain('No options configured. Add an option above.');
+  });
+
+  it('emits updateGroup with the new option when added', async () => {
+    const wrapper = mountOM();
+    await byText(wrapper, '+ Add New Option').trigger('click');
+    await wrapper.get('input[placeholder="e.g. 10x20"]').setValue('5x5');
+    await wrapper.get('input[placeholder="e.g. 10 × 20"]').setValue('5 by 5');
+    await byText(wrapper, 'Add Option').trigger('click');
+    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as { options: FilterOption[] };
+    expect(payload.options).toHaveLength(1);
+  });
+
+  it('flags a duplicate option value', async () => {
+    const wrapper = mountOM({ filterGroup: makeGroup({ options: [makeOption({ value: '5x5' })] }) });
+    await byText(wrapper, '+ Add New Option').trigger('click');
+    await wrapper.get('input[placeholder="e.g. 10x20"]').setValue('5x5');
+    expect(wrapper.text()).toContain('This value already exists in this group.');
+  });
+
+  it('emits updateGroup with the option removed', async () => {
+    const wrapper = mountOM({
+      filterGroup: makeGroup({ options: [makeOption({ id: 'o1' }), makeOption({ id: 'o2', value: 'x' })] }),
+    });
+    await byText(wrapper, 'Remove').trigger('click');
+    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as { options: FilterOption[] };
+    expect(payload.options.map((o) => o.id)).toEqual(['o2']);
+  });
+
+  it('reorders options when moved down', async () => {
+    const wrapper = mountOM({
+      filterGroup: makeGroup({ options: [makeOption({ id: 'o1' }), makeOption({ id: 'o2', value: 'x' })] }),
+    });
+    await wrapper.get('button[title="Move down"]').trigger('click');
+    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as { options: FilterOption[] };
+    expect(payload.options.map((o) => o.id)).toEqual(['o2', 'o1']);
+  });
+});


### PR DESCRIPTION
First batch of the "Tier 1" coverage push identified in the coverage analysis — high-ROI targets that need **no source refactoring** because they mount cleanly with the existing `mountWithDefaults` / `mockApollo` helpers.

## What's covered (41 new assertions, source unchanged)

| Component | Prev stmt cov | Tests | What's exercised |
|---|---|---|---|
| `components/filter/FilterGroupManager.vue` | 0% | 12 | add/remove/move/update groups, key validity + uniqueness, form↔YAML view switching, YAML apply errors |
| `components/filter/FilterOptionManager.vue` | 0% | 14 | edit group + save/cancel, add/remove/move/validate options, move/remove-group emits |
| `components/discussion/list/SitewideDiscussionList.vue` | 0% | 7 | list render, empty/error/loading states, `fetchMore`, filter re-emit, selected-discussion comment links |
| `components/discussion/list/SitewideDownloadList.vue` | 0% | 8 | card render, states, `fetchMore`, tag-filter routing (`router.replace`), album lightbox |

The query-backed lists mock `@vue/apollo-composable` + `nuxt/app` via the shared helpers (`createQueryMock`, `mockByDocument`) and stub heavy children, keeping the tests focused on each component's own logic.

## Verification
- New specs: **41 passing**
- `npm run tsc`: 0 errors
- Lint: clean

Part of the incremental coverage effort (statements were ~30.3% before this batch). Next up: the plugin-page logic extraction (Tier 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)