### PR TITLE
refactor: extract plugin-page logic into tested utils (Tier 2 coverage)

### DIFF
--- a/pages/admin/settings/plugins/[pluginId].vue
+++ b/pages/admin/settings/plugins/[pluginId].vue
@@ -13,15 +13,25 @@ import PluginSettingsSection from '@/components/admin/plugins/PluginSettingsSect
 import PluginManifestSection from '@/components/admin/plugins/PluginManifestSection.vue';
 import PluginReadmeSection from '@/components/admin/plugins/PluginReadmeSection.vue';
 import { useToast } from '@/composables/useToast';
-import {
-  compareVersionStrings,
-  resolveDefaultVersion,
-} from '@/utils/versionUtils';
+import { resolveDefaultVersion } from '@/utils/versionUtils';
 import {
   extractSecretKeys,
   filterOutSecrets,
   getSecretsToSave,
 } from '@/utils/pluginSettingsUtils';
+import {
+  resolvePluginMetadata,
+  resolvePluginReadme,
+  canEnablePlugin,
+  sortVersionsDescending,
+  hasNewerVersions as hasNewerVersionsUtil,
+  mapInstallErrorMessage,
+  validateRequiredSettings,
+} from '@/utils/pluginVersionUtils';
+import {
+  getPluginFormSections,
+  stringifyManifest,
+} from '@/utils/pluginManifestUtils';
 import type {
   PluginFormSection,
   PluginSecretStatus as PluginSecretStatusType,
@@ -192,41 +202,22 @@ const isInitialLoading = computed(
   () => (pluginsLoading.value || installedLoading.value) && !pluginsResult.value
 );
 
-// Plugin metadata computed properties
-const pluginDisplayName = computed(() => {
-  return (
-    installedPlugin.value?.plugin?.displayName ||
-    plugin.value?.displayName ||
-    plugin.value?.name ||
-    pluginId
-  );
-});
+// Plugin metadata, resolved with the installed-then-registry fallback chain.
+const pluginMeta = computed(() =>
+  resolvePluginMetadata({
+    installed: installedPlugin.value?.plugin,
+    registry: plugin.value,
+    pluginId,
+  })
+);
 
-const pluginDescription = computed(() => {
-  return (
-    installedPlugin.value?.plugin?.description || plugin.value?.description
-  );
-});
-
-const pluginAuthorName = computed(() => {
-  return installedPlugin.value?.plugin?.authorName || plugin.value?.authorName;
-});
-
-const pluginAuthorUrl = computed(() => {
-  return installedPlugin.value?.plugin?.authorUrl || plugin.value?.authorUrl;
-});
-
-const pluginHomepage = computed(() => {
-  return installedPlugin.value?.plugin?.homepage || plugin.value?.homepage;
-});
-
-const pluginLicense = computed(() => {
-  return installedPlugin.value?.plugin?.license || plugin.value?.license;
-});
-
-const pluginTags = computed(() => {
-  return installedPlugin.value?.plugin?.tags || plugin.value?.tags || [];
-});
+const pluginDisplayName = computed(() => pluginMeta.value.displayName);
+const pluginDescription = computed(() => pluginMeta.value.description);
+const pluginAuthorName = computed(() => pluginMeta.value.authorName);
+const pluginAuthorUrl = computed(() => pluginMeta.value.authorUrl);
+const pluginHomepage = computed(() => pluginMeta.value.homepage);
+const pluginLicense = computed(() => pluginMeta.value.license);
+const pluginTags = computed(() => pluginMeta.value.tags);
 
 // Get versions with full details from the plugin detail query
 const pluginDetailVersions = computed(() => {
@@ -235,39 +226,18 @@ const pluginDetailVersions = computed(() => {
   return pluginDetail?.Versions || [];
 });
 
-const pluginReadme = computed(() => {
-  // First, try installed plugin's readme
-  if (installedPlugin.value?.readmeMarkdown) {
-    return installedPlugin.value.readmeMarkdown;
-  }
-
-  // If not installed or no readme, try to get from the selected version in detail query
-  if (selectedVersion.value && pluginDetailVersions.value.length > 0) {
-    const versionDetail = pluginDetailVersions.value.find(
-      (v: { version: string; readmeMarkdown?: string }) =>
-        v.version === selectedVersion.value
-    );
-    if (versionDetail?.readmeMarkdown) {
-      return versionDetail.readmeMarkdown;
-    }
-  }
-
-  // Fallback: try first version with a readme
-  for (const v of pluginDetailVersions.value) {
-    if (v.readmeMarkdown) {
-      return v.readmeMarkdown;
-    }
-  }
-
-  return null;
-});
+const pluginReadme = computed(() =>
+  resolvePluginReadme({
+    installedReadme: installedPlugin.value?.readmeMarkdown,
+    selectedVersion: selectedVersion.value,
+    detailVersions: pluginDetailVersions.value,
+  })
+);
 
 // Extract server settings form sections from the plugin manifest
-const serverSettingsSections = computed((): PluginFormSection[] => {
-  const manifest = installedPlugin.value?.manifest;
-  if (!manifest?.ui?.forms?.server) return [];
-  return manifest.ui.forms.server;
-});
+const serverSettingsSections = computed((): PluginFormSection[] =>
+  getPluginFormSections(installedPlugin.value?.manifest, 'server')
+);
 
 // Convert secrets array to the format expected by PluginSecretField
 const secretStatusesForForm = computed((): PluginSecretStatusType[] => {
@@ -288,20 +258,13 @@ const pluginRepoUrl = computed(() => {
   return currentVersion?.repoUrl;
 });
 
-const canEnable = computed(() => {
-  if (!isInstalled.value) return false;
-  // Check if all secrets are valid or set (untested)
-  return secrets.value.every(
-    (s) => s.status === 'VALID' || s.status === 'SET_UNTESTED'
-  );
-});
+const canEnable = computed(() =>
+  canEnablePlugin({ isInstalled: isInstalled.value, secrets: secrets.value })
+);
 
-const availableVersions = computed(() => {
-  const versions = plugin.value?.Versions || [];
-  return [...versions].sort((a, b) =>
-    compareVersionStrings(b.version, a.version)
-  );
-});
+const availableVersions = computed(() =>
+  sortVersionsDescending(plugin.value?.Versions || [])
+);
 
 const installedVersion = computed(() => {
   return installedPlugin.value?.version;
@@ -311,12 +274,9 @@ const isSelectedVersionInstalled = computed(() => {
   return installedVersion.value === selectedVersion.value;
 });
 
-const hasNewerVersions = computed(() => {
-  if (!installedVersion.value) return true;
-  return availableVersions.value.some(
-    (v) => v.version !== installedVersion.value
-  );
-});
+const hasNewerVersions = computed(() =>
+  hasNewerVersionsUtil(installedVersion.value, availableVersions.value)
+);
 
 // Version update info from backend
 const hasUpdate = computed(() => installedPlugin.value?.hasUpdate ?? false);
@@ -333,11 +293,9 @@ const canInstall = computed(() => {
 });
 
 // Get full manifest JSON for display
-const manifestJson = computed(() => {
-  const manifest = installedPlugin.value?.manifest;
-  if (!manifest) return null;
-  return JSON.stringify(manifest, null, 2);
-});
+const manifestJson = computed(() =>
+  stringifyManifest(installedPlugin.value?.manifest)
+);
 
 // Set default version when plugin loads
 watch(
@@ -415,29 +373,7 @@ const handleInstall = async (versionOverride?: string) => {
   } catch (err: unknown) {
     console.error('Install error:', err);
     const errorMessage = err instanceof Error ? err.message : '';
-
-    if (
-      errorMessage.includes('PLUGIN_VERSION_NOT_FOUND') ||
-      errorMessage.includes('not found in registry')
-    ) {
-      installError.value =
-        'Plugin version not found in registry. Please check that this version exists in the configured plugin registry.';
-    } else if (
-      errorMessage.includes('INTEGRITY_MISMATCH') ||
-      errorMessage.includes('SHA-256 mismatch') ||
-      errorMessage.includes('integrity verification failed')
-    ) {
-      installError.value =
-        'Plugin tarball integrity check failed. The SHA-256 hash of the downloaded tarball does not match the hash in the registry. The registry may need to be updated with the correct hash.';
-    } else if (errorMessage.includes('Failed to fetch plugin registry')) {
-      installError.value =
-        'Could not connect to the plugin registry. Please check that the registry URL is correct and accessible.';
-    } else if (errorMessage.includes('Failed to download tarball')) {
-      installError.value =
-        'Could not download the plugin tarball. Please check that the tarball URL in the registry is correct and accessible.';
-    } else {
-      installError.value = `Installation failed: ${errorMessage || 'Unknown error'}`;
-    }
+    installError.value = mapInstallErrorMessage(errorMessage);
   }
 };
 
@@ -502,16 +438,10 @@ const handleSaveSettings = async () => {
 
   try {
     // Validate required fields
-    for (const section of serverSettingsSections.value) {
-      for (const field of section.fields) {
-        if (field.validation?.required) {
-          const value = settingsValues.value[field.key];
-          if (value === undefined || value === null || value === '') {
-            settingsErrors.value[field.key] = `${field.label} is required`;
-          }
-        }
-      }
-    }
+    settingsErrors.value = validateRequiredSettings(
+      serverSettingsSections.value,
+      settingsValues.value
+    );
 
     // If there are validation errors, don't save
     if (Object.keys(settingsErrors.value).length > 0) {

--- a/pages/forums/[forumId]/edit/plugins/[pluginId].vue
+++ b/pages/forums/[forumId]/edit/plugins/[pluginId].vue
@@ -14,6 +14,19 @@ import {
 } from '@/graphQLData/channel/queries';
 import { UPDATE_CHANNEL_ENABLED_PLUGINS } from '@/graphQLData/channel/mutations';
 import type { PluginFormSection } from '@/types/pluginForms';
+import {
+  getPluginFormSections,
+  getSettingsDefaults,
+  parseSettingsJson,
+  serializeSettingsJson,
+  stringifyManifest,
+  isBotPlugin as detectBotPlugin,
+  parseBotProfiles,
+  resolveServerBotName,
+  resolveServerProfiles,
+  filterChannelSectionsForBot,
+  buildEnabledPluginsInput,
+} from '@/utils/pluginManifestUtils';
 
 type PluginState = {
   enabled: boolean;
@@ -109,52 +122,12 @@ const isLoading = computed(
 
 const isEnabled = computed(() => pluginState.value.enabled);
 
-function getChannelDefaults(manifest: any): Record<string, any> {
-  const defaults = manifest?.settingsDefaults?.channel;
-  if (!defaults || typeof defaults !== 'object') {
-    return {};
-  }
-  return { ...defaults };
-}
-
-function getChannelSections(manifest: any): PluginFormSection[] {
-  if (!manifest?.ui?.forms?.channel) {
-    return [];
-  }
-  return manifest.ui.forms.channel;
-}
-
-function parseSettingsJson(settingsJson: unknown): Record<string, any> {
-  if (!settingsJson) {
-    return {};
-  }
-  if (typeof settingsJson === 'string') {
-    try {
-      const parsed = JSON.parse(settingsJson);
-      return parsed && typeof parsed === 'object' ? parsed : {};
-    } catch {
-      return {};
-    }
-  }
-  if (typeof settingsJson === 'object') {
-    return settingsJson as Record<string, any>;
-  }
-  return {};
-}
-
-function serializeSettingsJson(settings: unknown) {
-  if (typeof settings === 'string') {
-    return settings;
-  }
-  return JSON.stringify(settings ?? {});
-}
-
 function initializePluginState() {
   if (!plugin.value) return;
   const edge = enabledPluginsById.value.get(pluginId.value);
   const manifest = plugin.value.manifest;
   const settingsJson = edge?.properties?.settingsJson;
-  const defaults = getChannelDefaults(manifest);
+  const defaults = getSettingsDefaults(manifest, 'channel');
   pluginState.value = {
     enabled: !!edge,
     settings: {
@@ -199,58 +172,15 @@ async function handleToggleEnabled(enabled: boolean) {
     return;
   }
 
-  const enabledPluginsInput: any[] = [];
   const settingsJson = serializeSettingsJson(pluginState.value.settings);
-
-  if (enabled) {
-    if (edge) {
-      enabledPluginsInput.push({
-        where: {
-          node: {
-            Plugin: { id: pluginId.value },
-            version,
-          },
-        },
-        update: {
-          edge: {
-            settingsJson,
-          },
-        },
-      });
-    } else {
-      enabledPluginsInput.push({
-        connect: [
-          {
-            where: {
-              node: {
-                Plugin: { id: pluginId.value },
-                version,
-              },
-            },
-            edge: {
-              enabled: true,
-              settingsJson,
-            },
-          },
-        ],
-      });
-    }
-  } else if (edge) {
-    enabledPluginsInput.push({
-      disconnect: [
-        {
-          where: {
-            node: {
-              Plugin: { id: pluginId.value },
-              version,
-            },
-          },
-        },
-      ],
-    });
-  } else {
-    return;
-  }
+  const enabledPluginsInput = buildEnabledPluginsInput({
+    enabled,
+    hasEdge: !!edge,
+    pluginId: pluginId.value,
+    version,
+    settingsJson,
+  });
+  if (enabledPluginsInput.length === 0) return;
 
   try {
     await updateChannelEnabledPlugins({
@@ -281,58 +211,15 @@ async function handleSave() {
     return;
   }
 
-  const enabledPluginsInput: any[] = [];
   const settingsJson = serializeSettingsJson(pluginState.value.settings);
-
-  if (pluginState.value.enabled) {
-    if (edge) {
-      enabledPluginsInput.push({
-        where: {
-          node: {
-            Plugin: { id: pluginId.value },
-            version,
-          },
-        },
-        update: {
-          edge: {
-            settingsJson,
-          },
-        },
-      });
-    } else {
-      enabledPluginsInput.push({
-        connect: [
-          {
-            where: {
-              node: {
-                Plugin: { id: pluginId.value },
-                version,
-              },
-            },
-            edge: {
-              enabled: true,
-              settingsJson,
-            },
-          },
-        ],
-      });
-    }
-  } else if (edge) {
-    enabledPluginsInput.push({
-      disconnect: [
-        {
-          where: {
-            node: {
-              Plugin: { id: pluginId.value },
-              version,
-            },
-          },
-        },
-      ],
-    });
-  } else {
-    return;
-  }
+  const enabledPluginsInput = buildEnabledPluginsInput({
+    enabled: pluginState.value.enabled,
+    hasEdge: !!edge,
+    pluginId: pluginId.value,
+    version,
+    settingsJson,
+  });
+  if (enabledPluginsInput.length === 0) return;
 
   saving.value = true;
   try {
@@ -355,36 +242,18 @@ async function handleSave() {
   }
 }
 
-const manifestJson = computed(() => {
-  const manifest = plugin.value?.manifest;
-  if (!manifest) return null;
-  return JSON.stringify(manifest, null, 2);
-});
+const manifestJson = computed(() => stringifyManifest(plugin.value?.manifest));
 
 // Bot plugin detection and handling
-const BOT_TAGS = ['bot', 'bots'];
-
-const isBotPlugin = computed(() => {
-  const tags = plugin.value?.plugin?.tags || [];
-  return tags.some((tag: string) => BOT_TAGS.includes(tag.toLowerCase()));
-});
+const isBotPlugin = computed(() => detectBotPlugin(plugin.value?.plugin?.tags));
 
 // Get bot name from server-level settings or manifest defaults
-const serverBotName = computed(() => {
-  // First check user-set server settings
-  if (plugin.value?.settingsJson) {
-    const settings = parseSettingsJson(plugin.value.settingsJson);
-    if (settings?.botName) {
-      return settings.botName;
-    }
-  }
-  // Fall back to manifest defaults
-  const manifest = plugin.value?.manifest;
-  if (manifest?.settingsDefaults?.server?.botName) {
-    return manifest.settingsDefaults.server.botName;
-  }
-  return '';
-});
+const serverBotName = computed(() =>
+  resolveServerBotName({
+    settingsJson: plugin.value?.settingsJson,
+    manifest: plugin.value?.manifest,
+  })
+);
 
 // Get existing bots for this channel
 const existingBots = computed<ExistingBot[]>(() => {
@@ -397,67 +266,17 @@ const existingBots = computed<ExistingBot[]>(() => {
 });
 
 // Get server-level profiles from settings or manifest defaults
-const serverProfiles = computed<BotProfile[]>(() => {
-  // First check user-set server settings
-  if (plugin.value?.settingsJson) {
-    const settings = parseSettingsJson(plugin.value.settingsJson);
-    // Check profilesJson first (user-configured)
-    if (settings?.profilesJson) {
-      try {
-        const parsed = typeof settings.profilesJson === 'string'
-          ? JSON.parse(settings.profilesJson)
-          : settings.profilesJson;
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          return parsed.map((p: any) => ({
-            id: p.id || '',
-            label: p.label || p.displayName || '',
-            prompt: p.prompt || '',
-          }));
-        }
-      } catch {
-        // Fall through to other sources
-      }
-    }
-    // Check profiles array
-    if (Array.isArray(settings?.profiles) && settings.profiles.length > 0) {
-      return settings.profiles.map((p: any) => ({
-        id: p.id || '',
-        label: p.label || p.displayName || '',
-        prompt: p.prompt || '',
-      }));
-    }
-  }
-  // Fall back to manifest defaults
-  const manifest = plugin.value?.manifest;
-  if (manifest?.settingsDefaults?.server?.profiles) {
-    const profiles = manifest.settingsDefaults.server.profiles;
-    if (Array.isArray(profiles) && profiles.length > 0) {
-      return profiles.map((p: any) => ({
-        id: p.id || '',
-        label: p.label || p.displayName || '',
-        prompt: p.prompt || '',
-      }));
-    }
-  }
-  return [];
-});
+const serverProfiles = computed<BotProfile[]>(() =>
+  resolveServerProfiles({
+    settingsJson: plugin.value?.settingsJson,
+    manifest: plugin.value?.manifest,
+  })
+);
 
 // Parse channel-level profiles from settings
-const botProfiles = computed<BotProfile[]>(() => {
-  const profilesJson = pluginState.value.settings?.profilesJson;
-  if (!profilesJson) return [];
-  try {
-    const parsed = typeof profilesJson === 'string' ? JSON.parse(profilesJson) : profilesJson;
-    if (!Array.isArray(parsed)) return [];
-    return parsed.map((p: any) => ({
-      id: p.id || '',
-      label: p.label || '',
-      prompt: p.prompt || '',
-    }));
-  } catch {
-    return [];
-  }
-});
+const botProfiles = computed<BotProfile[]>(() =>
+  parseBotProfiles(pluginState.value.settings?.profilesJson)
+);
 
 function updateBotProfiles(profiles: BotProfile[]) {
   pluginState.value.settings = {
@@ -471,15 +290,8 @@ function updateBotProfiles(profiles: BotProfile[]) {
 // since we handle it with the custom editor
 const filteredChannelSections = computed<PluginFormSection[]>(() => {
   if (!plugin.value?.manifest) return [];
-  const sections = getChannelSections(plugin.value.manifest);
-
-  if (!isBotPlugin.value) return sections;
-
-  // Filter out profilesJson field from sections
-  return sections.map((section) => ({
-    ...section,
-    fields: section.fields.filter((field) => field.key !== 'profilesJson'),
-  })).filter((section) => section.fields.length > 0);
+  const sections = getPluginFormSections(plugin.value.manifest, 'channel');
+  return filterChannelSectionsForBot(sections, isBotPlugin.value);
 });
 
 const hasFilteredChannelSettings = computed(() => {

--- a/tests/unit/utils/pluginManifestUtils.spec.ts
+++ b/tests/unit/utils/pluginManifestUtils.spec.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPluginFormSections,
+  getSettingsDefaults,
+  parseSettingsJson,
+  serializeSettingsJson,
+  stringifyManifest,
+  isBotPlugin,
+  normalizeBotProfiles,
+  parseBotProfiles,
+  resolveServerBotName,
+  resolveServerProfiles,
+  filterChannelSectionsForBot,
+  buildEnabledPluginsInput,
+} from '@/utils/pluginManifestUtils';
+import type { PluginFormSection } from '@/types/pluginForms';
+
+const section = (key: string, extra: Partial<PluginFormSection> = {}): PluginFormSection => ({
+  title: 'Section',
+  fields: [{ key, type: 'text', label: key }],
+  ...extra,
+});
+
+describe('getPluginFormSections', () => {
+  it('returns the server sections when present', () => {
+    const manifest = { ui: { forms: { server: [section('a')] } } };
+    expect(getPluginFormSections(manifest, 'server')).toHaveLength(1);
+  });
+
+  it('returns the channel sections when present', () => {
+    const manifest = { ui: { forms: { channel: [section('a'), section('b')] } } };
+    expect(getPluginFormSections(manifest, 'channel')).toHaveLength(2);
+  });
+
+  it('returns an empty array when the scope is missing', () => {
+    expect(getPluginFormSections({ ui: { forms: {} } }, 'server')).toEqual([]);
+  });
+
+  it('returns an empty array for a null manifest', () => {
+    expect(getPluginFormSections(null, 'channel')).toEqual([]);
+  });
+});
+
+describe('getSettingsDefaults', () => {
+  it('returns a copy of the scope defaults', () => {
+    const manifest = { settingsDefaults: { channel: { a: 1 } } };
+    expect(getSettingsDefaults(manifest, 'channel')).toEqual({ a: 1 });
+  });
+
+  it('does not return the same reference', () => {
+    const defaults = { a: 1 };
+    const manifest = { settingsDefaults: { channel: defaults } };
+    expect(getSettingsDefaults(manifest, 'channel')).not.toBe(defaults);
+  });
+
+  it('returns an empty object when defaults are absent', () => {
+    expect(getSettingsDefaults({}, 'server')).toEqual({});
+  });
+});
+
+describe('parseSettingsJson', () => {
+  it('returns an empty object for nullish input', () => {
+    expect(parseSettingsJson(null)).toEqual({});
+  });
+
+  it('parses a JSON string', () => {
+    expect(parseSettingsJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('returns an empty object for invalid JSON', () => {
+    expect(parseSettingsJson('{bad')).toEqual({});
+  });
+
+  it('returns an empty object when JSON parses to a non-object', () => {
+    expect(parseSettingsJson('5')).toEqual({});
+  });
+
+  it('passes through an object', () => {
+    expect(parseSettingsJson({ a: 1 })).toEqual({ a: 1 });
+  });
+});
+
+describe('serializeSettingsJson', () => {
+  it('passes through a string', () => {
+    expect(serializeSettingsJson('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('stringifies an object', () => {
+    expect(serializeSettingsJson({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it('serializes nullish to an empty object', () => {
+    expect(serializeSettingsJson(null)).toBe('{}');
+  });
+});
+
+describe('stringifyManifest', () => {
+  it('returns null for a missing manifest', () => {
+    expect(stringifyManifest(null)).toBeNull();
+  });
+
+  it('pretty-prints the manifest', () => {
+    expect(stringifyManifest({ settingsDefaults: { a: 1 } })).toBe(
+      '{\n  "settingsDefaults": {\n    "a": 1\n  }\n}'
+    );
+  });
+});
+
+describe('isBotPlugin', () => {
+  it('detects a bot tag case-insensitively', () => {
+    expect(isBotPlugin(['AI', 'Bot'])).toBe(true);
+  });
+
+  it('returns false without a bot tag', () => {
+    expect(isBotPlugin(['ai', 'tool'])).toBe(false);
+  });
+
+  it('returns false for a non-array', () => {
+    expect(isBotPlugin(undefined)).toBe(false);
+  });
+});
+
+describe('normalizeBotProfiles', () => {
+  it('maps id, label, and prompt with defaults', () => {
+    expect(normalizeBotProfiles([{ id: '1', prompt: 'hi' }])).toEqual([
+      { id: '1', label: '', prompt: 'hi' },
+    ]);
+  });
+
+  it('falls back to displayName for the label when enabled', () => {
+    expect(
+      normalizeBotProfiles([{ displayName: 'Bot' }], { displayNameFallback: true })
+    ).toEqual([{ id: '', label: 'Bot', prompt: '' }]);
+  });
+
+  it('ignores displayName when the fallback is off', () => {
+    expect(normalizeBotProfiles([{ displayName: 'Bot' }])).toEqual([
+      { id: '', label: '', prompt: '' },
+    ]);
+  });
+
+  it('returns an empty array for a non-array', () => {
+    expect(normalizeBotProfiles('nope')).toEqual([]);
+  });
+});
+
+describe('parseBotProfiles', () => {
+  it('parses a JSON string of profiles', () => {
+    expect(parseBotProfiles('[{"id":"1","label":"A"}]')).toEqual([
+      { id: '1', label: 'A', prompt: '' },
+    ]);
+  });
+
+  it('accepts an already-parsed array', () => {
+    expect(parseBotProfiles([{ id: '2' }])).toEqual([{ id: '2', label: '', prompt: '' }]);
+  });
+
+  it('returns an empty array for invalid JSON', () => {
+    expect(parseBotProfiles('[bad')).toEqual([]);
+  });
+
+  it('returns an empty array for nullish', () => {
+    expect(parseBotProfiles(null)).toEqual([]);
+  });
+});
+
+describe('resolveServerBotName', () => {
+  it('prefers the user-set bot name', () => {
+    expect(
+      resolveServerBotName({ settingsJson: { botName: 'Custom' }, manifest: {} })
+    ).toBe('Custom');
+  });
+
+  it('falls back to the manifest default', () => {
+    expect(
+      resolveServerBotName({
+        settingsJson: {},
+        manifest: { settingsDefaults: { server: { botName: 'Default' } } },
+      })
+    ).toBe('Default');
+  });
+
+  it('returns an empty string when neither is set', () => {
+    expect(resolveServerBotName({ settingsJson: {}, manifest: {} })).toBe('');
+  });
+});
+
+describe('resolveServerProfiles', () => {
+  it('reads profilesJson from settings', () => {
+    expect(
+      resolveServerProfiles({
+        settingsJson: { profilesJson: '[{"id":"1","displayName":"A"}]' },
+        manifest: {},
+      })
+    ).toEqual([{ id: '1', label: 'A', prompt: '' }]);
+  });
+
+  it('falls back to a settings profiles array', () => {
+    expect(
+      resolveServerProfiles({
+        settingsJson: { profiles: [{ id: '2', label: 'B' }] },
+        manifest: {},
+      })
+    ).toEqual([{ id: '2', label: 'B', prompt: '' }]);
+  });
+
+  it('falls back to manifest server defaults', () => {
+    expect(
+      resolveServerProfiles({
+        settingsJson: {},
+        manifest: { settingsDefaults: { server: { profiles: [{ id: '3' }] } } },
+      })
+    ).toEqual([{ id: '3', label: '', prompt: '' }]);
+  });
+
+  it('returns an empty array when no profiles exist', () => {
+    expect(resolveServerProfiles({ settingsJson: {}, manifest: {} })).toEqual([]);
+  });
+});
+
+describe('filterChannelSectionsForBot', () => {
+  it('passes sections through unchanged for non-bot plugins', () => {
+    const sections = [section('profilesJson')];
+    expect(filterChannelSectionsForBot(sections, false)).toBe(sections);
+  });
+
+  it('removes the profilesJson field for bot plugins', () => {
+    const sections: PluginFormSection[] = [
+      { title: 'S', fields: [{ key: 'profilesJson', type: 'text', label: 'p' }, { key: 'other', type: 'text', label: 'o' }] },
+    ];
+    expect(filterChannelSectionsForBot(sections, true)[0]!.fields.map((f) => f.key)).toEqual(['other']);
+  });
+
+  it('drops sections that become empty after filtering', () => {
+    const sections: PluginFormSection[] = [
+      { title: 'S', fields: [{ key: 'profilesJson', type: 'text', label: 'p' }] },
+    ];
+    expect(filterChannelSectionsForBot(sections, true)).toEqual([]);
+  });
+});
+
+describe('buildEnabledPluginsInput', () => {
+  const base = { pluginId: 'p1', version: '1.0.0', settingsJson: '{}' };
+
+  it('builds an update entry when enabling an existing edge', () => {
+    const [entry] = buildEnabledPluginsInput({ ...base, enabled: true, hasEdge: true }) as Record<string, unknown>[];
+    expect(entry).toHaveProperty('update');
+  });
+
+  it('builds a connect entry when enabling without an edge', () => {
+    const [entry] = buildEnabledPluginsInput({ ...base, enabled: true, hasEdge: false }) as Record<string, unknown>[];
+    expect(entry).toHaveProperty('connect');
+  });
+
+  it('builds a disconnect entry when disabling an existing edge', () => {
+    const [entry] = buildEnabledPluginsInput({ ...base, enabled: false, hasEdge: true }) as Record<string, unknown>[];
+    expect(entry).toHaveProperty('disconnect');
+  });
+
+  it('returns an empty array when disabling without an edge', () => {
+    expect(buildEnabledPluginsInput({ ...base, enabled: false, hasEdge: false })).toEqual([]);
+  });
+});

--- a/tests/unit/utils/pluginVersionUtils.spec.ts
+++ b/tests/unit/utils/pluginVersionUtils.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolvePluginMetadata,
+  resolvePluginReadme,
+  canEnablePlugin,
+  sortVersionsDescending,
+  hasNewerVersions,
+  mapInstallErrorMessage,
+  validateRequiredSettings,
+} from '@/utils/pluginVersionUtils';
+import type { PluginFormSection } from '@/types/pluginForms';
+
+describe('resolvePluginMetadata', () => {
+  it('prefers installed values over registry values', () => {
+    const meta = resolvePluginMetadata({
+      installed: { displayName: 'Installed' },
+      registry: { displayName: 'Registry' },
+      pluginId: 'p1',
+    });
+    expect(meta.displayName).toBe('Installed');
+  });
+
+  it('falls back to the registry name for the display name', () => {
+    const meta = resolvePluginMetadata({
+      installed: null,
+      registry: { name: 'reg-name' },
+      pluginId: 'p1',
+    });
+    expect(meta.displayName).toBe('reg-name');
+  });
+
+  it('falls back to the plugin id when nothing else is present', () => {
+    const meta = resolvePluginMetadata({ installed: null, registry: null, pluginId: 'p1' });
+    expect(meta.displayName).toBe('p1');
+  });
+
+  it('defaults tags to an empty array', () => {
+    const meta = resolvePluginMetadata({ installed: null, registry: null, pluginId: 'p1' });
+    expect(meta.tags).toEqual([]);
+  });
+});
+
+describe('resolvePluginReadme', () => {
+  it('returns the installed readme first', () => {
+    expect(
+      resolvePluginReadme({ installedReadme: 'INSTALLED', detailVersions: [] })
+    ).toBe('INSTALLED');
+  });
+
+  it('returns the selected version readme', () => {
+    expect(
+      resolvePluginReadme({
+        selectedVersion: '2.0.0',
+        detailVersions: [
+          { version: '1.0.0', readmeMarkdown: 'one' },
+          { version: '2.0.0', readmeMarkdown: 'two' },
+        ],
+      })
+    ).toBe('two');
+  });
+
+  it('falls back to the first version with a readme', () => {
+    expect(
+      resolvePluginReadme({
+        selectedVersion: '9.9.9',
+        detailVersions: [{ version: '1.0.0' }, { version: '2.0.0', readmeMarkdown: 'two' }],
+      })
+    ).toBe('two');
+  });
+
+  it('returns null when no readme is available', () => {
+    expect(resolvePluginReadme({ detailVersions: [{ version: '1.0.0' }] })).toBeNull();
+  });
+});
+
+describe('canEnablePlugin', () => {
+  it('returns false when not installed', () => {
+    expect(canEnablePlugin({ isInstalled: false, secrets: [] })).toBe(false);
+  });
+
+  it('returns true when all secrets are valid or set-untested', () => {
+    expect(
+      canEnablePlugin({
+        isInstalled: true,
+        secrets: [{ status: 'VALID' }, { status: 'SET_UNTESTED' }],
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when a secret is not set', () => {
+    expect(
+      canEnablePlugin({ isInstalled: true, secrets: [{ status: 'NOT_SET' }] })
+    ).toBe(false);
+  });
+});
+
+describe('sortVersionsDescending', () => {
+  it('sorts versions newest first', () => {
+    const sorted = sortVersionsDescending([
+      { version: '1.0.0' },
+      { version: '2.1.0' },
+      { version: '2.0.0' },
+    ]);
+    expect(sorted.map((v) => v.version)).toEqual(['2.1.0', '2.0.0', '1.0.0']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [{ version: '1.0.0' }, { version: '2.0.0' }];
+    sortVersionsDescending(input);
+    expect(input.map((v) => v.version)).toEqual(['1.0.0', '2.0.0']);
+  });
+});
+
+describe('hasNewerVersions', () => {
+  it('returns true when nothing is installed', () => {
+    expect(hasNewerVersions(undefined, [{ version: '1.0.0' }])).toBe(true);
+  });
+
+  it('returns true when an available version differs from installed', () => {
+    expect(hasNewerVersions('1.0.0', [{ version: '1.0.0' }, { version: '2.0.0' }])).toBe(true);
+  });
+
+  it('returns false when only the installed version is available', () => {
+    expect(hasNewerVersions('1.0.0', [{ version: '1.0.0' }])).toBe(false);
+  });
+});
+
+describe('mapInstallErrorMessage', () => {
+  it('maps a version-not-found error', () => {
+    expect(mapInstallErrorMessage('PLUGIN_VERSION_NOT_FOUND')).toContain('not found in registry');
+  });
+
+  it('maps an integrity mismatch error', () => {
+    expect(mapInstallErrorMessage('SHA-256 mismatch')).toContain('integrity check failed');
+  });
+
+  it('maps a registry fetch failure', () => {
+    expect(mapInstallErrorMessage('Failed to fetch plugin registry')).toContain('connect to the plugin registry');
+  });
+
+  it('maps a tarball download failure', () => {
+    expect(mapInstallErrorMessage('Failed to download tarball')).toContain('download the plugin tarball');
+  });
+
+  it('falls back to a generic message including the original text', () => {
+    expect(mapInstallErrorMessage('weird thing')).toBe('Installation failed: weird thing');
+  });
+
+  it('handles an empty message', () => {
+    expect(mapInstallErrorMessage('')).toBe('Installation failed: Unknown error');
+  });
+});
+
+describe('validateRequiredSettings', () => {
+  const sections: PluginFormSection[] = [
+    {
+      title: 'S',
+      fields: [
+        { key: 'apiKey', type: 'text', label: 'API Key', validation: { required: true } },
+        { key: 'optional', type: 'text', label: 'Optional' },
+      ],
+    },
+  ];
+
+  it('flags a missing required field', () => {
+    expect(validateRequiredSettings(sections, { apiKey: '' })).toEqual({
+      apiKey: 'API Key is required',
+    });
+  });
+
+  it('returns no errors when required fields are filled', () => {
+    expect(validateRequiredSettings(sections, { apiKey: 'set' })).toEqual({});
+  });
+
+  it('ignores optional empty fields', () => {
+    expect(validateRequiredSettings(sections, { apiKey: 'set', optional: '' })).toEqual({});
+  });
+});

--- a/utils/pluginManifestUtils.ts
+++ b/utils/pluginManifestUtils.ts
@@ -1,0 +1,235 @@
+import type { PluginFormSection } from '@/types/pluginForms';
+
+/**
+ * Pure helpers shared by the server- and channel-scoped plugin configuration
+ * pages. These were previously inlined in
+ * pages/admin/settings/plugins/[pluginId].vue and
+ * pages/forums/[forumId]/edit/plugins/[pluginId].vue; extracting them keeps the
+ * behavior identical while making the logic unit-testable.
+ */
+
+/** Loose manifest shape — the GraphQL type is `JSON`, so fields are optional. */
+export interface PluginManifestLike {
+  ui?: {
+    forms?: {
+      server?: PluginFormSection[];
+      channel?: PluginFormSection[];
+    };
+  };
+  settingsDefaults?: Record<string, unknown>;
+}
+
+export type PluginFormScope = 'server' | 'channel';
+
+export interface PluginBotProfile {
+  id: string;
+  label: string;
+  prompt: string;
+}
+
+/** Return the form sections for a given scope, or `[]` when absent. */
+export function getPluginFormSections(
+  manifest: PluginManifestLike | null | undefined,
+  scope: PluginFormScope
+): PluginFormSection[] {
+  const sections = manifest?.ui?.forms?.[scope];
+  return Array.isArray(sections) ? sections : [];
+}
+
+/** Return a shallow copy of the scope's settings defaults, or `{}`. */
+export function getSettingsDefaults(
+  manifest: PluginManifestLike | null | undefined,
+  scope: PluginFormScope
+): Record<string, unknown> {
+  const defaults = manifest?.settingsDefaults?.[scope];
+  if (!defaults || typeof defaults !== 'object') {
+    return {};
+  }
+  return { ...(defaults as Record<string, unknown>) };
+}
+
+/** Coerce a settingsJson value (string | object | nullish) into an object. */
+export function parseSettingsJson(settingsJson: unknown): Record<string, unknown> {
+  if (!settingsJson) {
+    return {};
+  }
+  if (typeof settingsJson === 'string') {
+    try {
+      const parsed = JSON.parse(settingsJson);
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  if (typeof settingsJson === 'object') {
+    return settingsJson as Record<string, unknown>;
+  }
+  return {};
+}
+
+/** Serialize settings to a JSON string, passing through existing strings. */
+export function serializeSettingsJson(settings: unknown): string {
+  if (typeof settings === 'string') {
+    return settings;
+  }
+  return JSON.stringify(settings ?? {});
+}
+
+/** Pretty-print a manifest for display, or `null` when there is none. */
+export function stringifyManifest(
+  manifest: PluginManifestLike | null | undefined
+): string | null {
+  if (!manifest) return null;
+  return JSON.stringify(manifest, null, 2);
+}
+
+const BOT_TAGS = ['bot', 'bots'];
+
+/** Whether a plugin's tag list marks it as a bot plugin. */
+export function isBotPlugin(tags: string[] | null | undefined): boolean {
+  if (!Array.isArray(tags)) return false;
+  return tags.some((tag) => BOT_TAGS.includes(String(tag).toLowerCase()));
+}
+
+/** Normalize raw profile objects into `{ id, label, prompt }` shape. */
+export function normalizeBotProfiles(
+  rawProfiles: unknown,
+  opts: { displayNameFallback?: boolean } = {}
+): PluginBotProfile[] {
+  if (!Array.isArray(rawProfiles)) return [];
+  return rawProfiles.map((p) => {
+    const profile = (p ?? {}) as Record<string, unknown>;
+    const label =
+      (profile.label as string) ||
+      (opts.displayNameFallback ? (profile.displayName as string) : '') ||
+      '';
+    return {
+      id: (profile.id as string) || '',
+      label,
+      prompt: (profile.prompt as string) || '',
+    };
+  });
+}
+
+/** Parse channel-level profiles from a settings `profilesJson` value. */
+export function parseBotProfiles(profilesJson: unknown): PluginBotProfile[] {
+  if (!profilesJson) return [];
+  try {
+    const parsed =
+      typeof profilesJson === 'string' ? JSON.parse(profilesJson) : profilesJson;
+    return normalizeBotProfiles(parsed);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Resolve the server-level bot name from user settings, falling back to the
+ * manifest's server defaults.
+ */
+export function resolveServerBotName(params: {
+  settingsJson?: unknown;
+  manifest?: PluginManifestLike | null;
+}): string {
+  const { settingsJson, manifest } = params;
+  if (settingsJson) {
+    const settings = parseSettingsJson(settingsJson);
+    if (settings?.botName) {
+      return settings.botName as string;
+    }
+  }
+  const serverDefaults = manifest?.settingsDefaults?.server as
+    | Record<string, unknown>
+    | undefined;
+  const defaultBotName = serverDefaults?.botName;
+  return typeof defaultBotName === 'string' ? defaultBotName : '';
+}
+
+/**
+ * Resolve server-level bot profiles, checking user settings (`profilesJson`
+ * then `profiles`) before falling back to the manifest server defaults.
+ */
+export function resolveServerProfiles(params: {
+  settingsJson?: unknown;
+  manifest?: PluginManifestLike | null;
+}): PluginBotProfile[] {
+  const { settingsJson, manifest } = params;
+  if (settingsJson) {
+    const settings = parseSettingsJson(settingsJson);
+    if (settings?.profilesJson) {
+      try {
+        const parsed =
+          typeof settings.profilesJson === 'string'
+            ? JSON.parse(settings.profilesJson as string)
+            : settings.profilesJson;
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          return normalizeBotProfiles(parsed, { displayNameFallback: true });
+        }
+      } catch {
+        // Fall through to other sources
+      }
+    }
+    if (Array.isArray(settings?.profiles) && settings.profiles.length > 0) {
+      return normalizeBotProfiles(settings.profiles, {
+        displayNameFallback: true,
+      });
+    }
+  }
+  const serverDefaults = manifest?.settingsDefaults?.server as
+    | Record<string, unknown>
+    | undefined;
+  const profiles = serverDefaults?.profiles;
+  if (Array.isArray(profiles) && profiles.length > 0) {
+    return normalizeBotProfiles(profiles, { displayNameFallback: true });
+  }
+  return [];
+}
+
+/**
+ * For bot plugins, drop the `profilesJson` field (handled by a custom editor)
+ * and any sections left empty. Non-bot plugins pass through unchanged.
+ */
+export function filterChannelSectionsForBot(
+  sections: PluginFormSection[],
+  isBot: boolean
+): PluginFormSection[] {
+  if (!isBot) return sections;
+  return sections
+    .map((section) => ({
+      ...section,
+      fields: section.fields.filter((field) => field.key !== 'profilesJson'),
+    }))
+    .filter((section) => section.fields.length > 0);
+}
+
+export interface EnabledPluginsInputParams {
+  enabled: boolean;
+  /** Whether an existing enabled-plugin edge is present. */
+  hasEdge: boolean;
+  pluginId: string;
+  version: string;
+  settingsJson: string;
+}
+
+/**
+ * Build the `enabledPlugins` mutation input for connecting, updating, or
+ * disconnecting a plugin on a channel. Returns `[]` when there is nothing to
+ * do (disabling a plugin that has no edge).
+ */
+export function buildEnabledPluginsInput(
+  params: EnabledPluginsInputParams
+): unknown[] {
+  const { enabled, hasEdge, pluginId, version, settingsJson } = params;
+  const node = { Plugin: { id: pluginId }, version };
+
+  if (enabled) {
+    if (hasEdge) {
+      return [{ where: { node }, update: { edge: { settingsJson } } }];
+    }
+    return [{ connect: [{ where: { node }, edge: { enabled: true, settingsJson } }] }];
+  }
+  if (hasEdge) {
+    return [{ disconnect: [{ where: { node } }] }];
+  }
+  return [];
+}

--- a/utils/pluginVersionUtils.ts
+++ b/utils/pluginVersionUtils.ts
@@ -1,0 +1,172 @@
+import { compareVersionStrings } from '@/utils/versionUtils';
+import type { PluginFormSection } from '@/types/pluginForms';
+
+/**
+ * Pure helpers for the server-scoped plugin detail page
+ * (pages/admin/settings/plugins/[pluginId].vue). Extracted from the component
+ * so the version/metadata/validation/error logic can be unit-tested directly.
+ */
+
+export interface PluginVersionLike {
+  version: string;
+  repoUrl?: string;
+  readmeMarkdown?: string;
+}
+
+export interface PluginSecretLike {
+  status: 'NOT_SET' | 'SET_UNTESTED' | 'VALID' | 'INVALID';
+}
+
+interface PluginMetaSource {
+  displayName?: string;
+  name?: string;
+  description?: string;
+  authorName?: string;
+  authorUrl?: string;
+  homepage?: string;
+  license?: string;
+  tags?: string[];
+}
+
+export interface ResolvedPluginMetadata {
+  displayName: string;
+  description?: string;
+  authorName?: string;
+  authorUrl?: string;
+  homepage?: string;
+  license?: string;
+  tags: string[];
+}
+
+/**
+ * Resolve plugin metadata, preferring the installed plugin's values and
+ * falling back to the registry plugin, then the route id for display name.
+ */
+export function resolvePluginMetadata(params: {
+  installed?: PluginMetaSource | null;
+  registry?: PluginMetaSource | null;
+  pluginId: string;
+}): ResolvedPluginMetadata {
+  const { installed, registry, pluginId } = params;
+  return {
+    displayName:
+      installed?.displayName ||
+      registry?.displayName ||
+      registry?.name ||
+      pluginId,
+    description: installed?.description || registry?.description,
+    authorName: installed?.authorName || registry?.authorName,
+    authorUrl: installed?.authorUrl || registry?.authorUrl,
+    homepage: installed?.homepage || registry?.homepage,
+    license: installed?.license || registry?.license,
+    tags: installed?.tags || registry?.tags || [],
+  };
+}
+
+/**
+ * Resolve the README to display: the installed plugin's README, else the
+ * selected version's README, else the first version that has one, else null.
+ */
+export function resolvePluginReadme(params: {
+  installedReadme?: string | null;
+  selectedVersion?: string;
+  detailVersions: PluginVersionLike[];
+}): string | null {
+  const { installedReadme, selectedVersion, detailVersions } = params;
+  if (installedReadme) {
+    return installedReadme;
+  }
+  if (selectedVersion && detailVersions.length > 0) {
+    const versionDetail = detailVersions.find(
+      (v) => v.version === selectedVersion
+    );
+    if (versionDetail?.readmeMarkdown) {
+      return versionDetail.readmeMarkdown;
+    }
+  }
+  for (const v of detailVersions) {
+    if (v.readmeMarkdown) {
+      return v.readmeMarkdown;
+    }
+  }
+  return null;
+}
+
+/** A plugin can be enabled only when installed and all secrets are usable. */
+export function canEnablePlugin(params: {
+  isInstalled: boolean;
+  secrets: PluginSecretLike[];
+}): boolean {
+  const { isInstalled, secrets } = params;
+  if (!isInstalled) return false;
+  return secrets.every(
+    (s) => s.status === 'VALID' || s.status === 'SET_UNTESTED'
+  );
+}
+
+/** Sort versions newest-first using semantic version comparison. */
+export function sortVersionsDescending<T extends { version: string }>(
+  versions: T[]
+): T[] {
+  return [...versions].sort((a, b) =>
+    compareVersionStrings(b.version, a.version)
+  );
+}
+
+/** Whether any available version differs from the installed one. */
+export function hasNewerVersions(
+  installedVersion: string | undefined,
+  availableVersions: { version: string }[]
+): boolean {
+  if (!installedVersion) return true;
+  return availableVersions.some((v) => v.version !== installedVersion);
+}
+
+/**
+ * Map a raw install error message to a user-facing explanation. Falls back to a
+ * generic message that includes the original text.
+ */
+export function mapInstallErrorMessage(errorMessage: string): string {
+  if (
+    errorMessage.includes('PLUGIN_VERSION_NOT_FOUND') ||
+    errorMessage.includes('not found in registry')
+  ) {
+    return 'Plugin version not found in registry. Please check that this version exists in the configured plugin registry.';
+  }
+  if (
+    errorMessage.includes('INTEGRITY_MISMATCH') ||
+    errorMessage.includes('SHA-256 mismatch') ||
+    errorMessage.includes('integrity verification failed')
+  ) {
+    return 'Plugin tarball integrity check failed. The SHA-256 hash of the downloaded tarball does not match the hash in the registry. The registry may need to be updated with the correct hash.';
+  }
+  if (errorMessage.includes('Failed to fetch plugin registry')) {
+    return 'Could not connect to the plugin registry. Please check that the registry URL is correct and accessible.';
+  }
+  if (errorMessage.includes('Failed to download tarball')) {
+    return 'Could not download the plugin tarball. Please check that the tarball URL in the registry is correct and accessible.';
+  }
+  return `Installation failed: ${errorMessage || 'Unknown error'}`;
+}
+
+/**
+ * Validate required settings fields, returning a map of field key to error
+ * message for any required field that is empty.
+ */
+export function validateRequiredSettings(
+  sections: PluginFormSection[],
+  values: Record<string, unknown>
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+  for (const section of sections) {
+    for (const field of section.fields) {
+      if (field.validation?.required) {
+        const value = values[field.key];
+        if (value === undefined || value === null || value === '') {
+          errors[field.key] = `${field.label} is required`;
+        }
+      }
+    }
+  }
+  return errors;
+}


### PR DESCRIPTION
"Tier 2" of the coverage push: the two plugin configuration pages were the worst-covered files in the repo (0%) and entangle their pure logic with Apollo/router, so they're poor mount targets. This extracts that logic into two unit-tested util modules and refactors both pages to consume them — **behavior-preserving**. Extraction moves statements out of the untested `.vue` pages and into tested utils, improving coverage on both ends.

## New utils (67 assertions)

**`utils/pluginManifestUtils.ts`** (shared / forum page)
- `getPluginFormSections(manifest, scope)`, `getSettingsDefaults(manifest, scope)`
- `parseSettingsJson`, `serializeSettingsJson`, `stringifyManifest`
- `isBotPlugin`, `normalizeBotProfiles`, `parseBotProfiles`, `resolveServerBotName`, `resolveServerProfiles`
- `filterChannelSectionsForBot`
- `buildEnabledPluginsInput` — the connect/update/disconnect mutation input that was **duplicated** across the forum page's toggle and save handlers

**`utils/pluginVersionUtils.ts`** (admin page)
- `resolvePluginMetadata`, `resolvePluginReadme`, `canEnablePlugin`
- `sortVersionsDescending`, `hasNewerVersions`
- `mapInstallErrorMessage` — the install-error → user-message mapping
- `validateRequiredSettings`

## Page changes
- `pages/admin/settings/plugins/[pluginId].vue` and `pages/forums/[forumId]/edit/plugins/[pluginId].vue` now import the helpers; **~363 lines of inline logic removed** from the two `.vue` files (net `+953 / -363` including new utils + specs).
- Edge cases preserved (e.g. forum toggle/save early-return when disabling a plugin with no existing edge → `buildEnabledPluginsInput` returns `[]`).

## Verification
- New util specs: **67 passing**
- `npm run tsc`: 0 errors
- Lint: clean (pre-existing `any` warnings in the forum page unchanged)

There is no page-level test for these pages, so correctness rests on a 1:1 mechanical extraction + tsc + the util specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)