### PR TITLE
refactor: extract DownloadEditForm pure helpers into tested util

### DIFF
--- a/components/discussion/form/DownloadEditForm.vue
+++ b/components/discussion/form/DownloadEditForm.vue
@@ -5,9 +5,6 @@ import type {
   Discussion,
   DownloadableFile,
   DiscussionUpdateInput,
-  DiscussionDownloadableFilesConnectFieldInput,
-  DiscussionDownloadableFilesDisconnectFieldInput,
-  DiscussionDownloadableFilesUpdateFieldInput,
   FilterGroup,
 } from '@/__generated__/graphql';
 // Using string literals instead of importing enums from massive generated file
@@ -28,6 +25,12 @@ import {
   validateDownloadFileSize,
   MAX_DOWNLOAD_FILE_SIZE_MB,
 } from '@/utils/downloadFileValidation';
+import {
+  getDownloadFileMimeType,
+  getDownloadFileKind,
+  buildDownloadAcceptAttribute,
+  buildDownloadableFilesUpdateInput,
+} from '@/utils/downloadFileHelpers';
 
 type DownloadableFileSupportFields = {
   attributionOverride?: string | null;
@@ -186,25 +189,9 @@ onDone(() => {
 });
 
 // Generate accept attribute from channel allowed file types
-const acceptAttribute = computed(() => {
-  const allowedTypes = props.channelData?.allowedFileTypes || [];
-  if (allowedTypes.length === 0) {
-    return undefined; // No restriction if no types specified
-  }
-
-  // Convert file types to file extensions for accept attribute
-  const extensions = allowedTypes.map((type) => {
-    const lowerType = type.toLowerCase();
-    // If it's already an extension (starts with .), use as-is
-    if (lowerType.startsWith('.')) {
-      return lowerType;
-    }
-    // Otherwise add a dot prefix
-    return `.${lowerType}`;
-  });
-
-  return extensions.join(',');
-});
+const acceptAttribute = computed(() =>
+  buildDownloadAcceptAttribute(props.channelData?.allowedFileTypes)
+);
 
 const downloadsDisabled = computed(() => {
   return props.channelData?.downloadsEnabled === false;
@@ -375,53 +362,10 @@ const uploadFile = async (file: File): Promise<boolean> => {
   }
 };
 
-const getFileTypeFromName = (filename: string): string | null => {
-  if (!filename) return null;
+const getFileTypeFromName = (filename: string): string | null =>
+  getDownloadFileMimeType(filename);
 
-  const extension = filename.toLowerCase().split('.').pop();
-  if (!extension) return null;
-
-  const mimeTypes: Record<string, string> = {
-    zip: 'application/zip',
-    rar: 'application/x-rar-compressed',
-    '7z': 'application/x-7z-compressed',
-    tar: 'application/x-tar',
-    gz: 'application/gzip',
-    pdf: 'application/pdf',
-    doc: 'application/msword',
-    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    exe: 'application/x-msdownload',
-    dmg: 'application/x-apple-diskimage',
-    pkg: 'application/x-newton-compatible-pkg',
-    deb: 'application/vnd.debian.binary-package',
-    rpm: 'application/x-rpm',
-  };
-
-  return mimeTypes[extension] || 'application/octet-stream';
-};
-
-const getFileKind = (file: File): string => {
-  const extension = file.name.toLowerCase().split('.').pop();
-
-  // Map to actual FileKind enum values: ZIP, RAR, PNG, JPG, BLEND, STL, GLB, OTHER
-  if (extension === 'zip') {
-    return 'ZIP';
-  } else if (extension === 'rar') {
-    return 'RAR';
-  } else if (['png'].includes(extension || '')) {
-    return 'PNG';
-  } else if (['jpg', 'jpeg'].includes(extension || '')) {
-    return 'JPG';
-  } else if (extension === 'blend') {
-    return 'BLEND';
-  } else if (extension === 'stl') {
-    return 'STL';
-  } else if (extension === 'glb') {
-    return 'GLB';
-  }
-
-  return 'OTHER';
-};
+const getFileKind = (file: File): string => getDownloadFileKind(file.name);
 
 // Remove file
 const removeFile = (index: number) => {
@@ -457,68 +401,10 @@ const updateFileSupportField = (
 };
 
 function getUpdateDiscussionInputForDownloadableFiles(): DiscussionUpdateInput {
-  // 1) If no downloadable files exist yet in the original discussion, CREATE connections
-  if (
-    !props.discussion?.DownloadableFiles ||
-    props.discussion.DownloadableFiles?.length === 0
-  ) {
-    const newFiles = formValues.value.downloadableFiles || [];
-
-    // Build connect array for new files
-    const connectArray: DiscussionDownloadableFilesConnectFieldInput[] =
-      newFiles
-        .filter((file) => file.id) // Only connect files that have database IDs
-        .map((file) => ({
-          where: { node: { id: file.id } },
-        }));
-
-    return {
-      hasDownload: newFiles.length > 0,
-      DownloadableFiles:
-        connectArray.length > 0
-          ? [
-              {
-                connect: connectArray,
-              },
-            ]
-          : undefined,
-    };
-  }
-
-  // 2) If downloadable files already exist, we build the connect/disconnect arrays
-  const oldFiles = props.discussion.DownloadableFiles ?? [];
-  const newFiles = formValues.value.downloadableFiles;
-
-  // CONNECT array: any new file in `newFiles` that has NO matching ID in `oldFiles`
-  const connectArray: DiscussionDownloadableFilesConnectFieldInput[] = newFiles
-    .filter((file) => file.id && !oldFiles.some((old) => old.id === file.id))
-    .map((file) => ({
-      where: { node: { id: file.id } },
-    }));
-
-  // DISCONNECT array: any old file that is no longer present in `newFiles`
-  const disconnectArray: DiscussionDownloadableFilesDisconnectFieldInput[] =
-    oldFiles
-      .filter((old) => !newFiles.some((file) => file.id === old.id))
-      .map((old) => ({
-        where: { node: { id: old.id } },
-      }));
-
-  // Build the update field input object
-  const updateFieldInput: DiscussionDownloadableFilesUpdateFieldInput = {};
-  if (connectArray.length > 0) {
-    updateFieldInput.connect = connectArray;
-  }
-  if (disconnectArray.length > 0) {
-    updateFieldInput.disconnect = disconnectArray;
-  }
-
-  // Return the update input
-  return {
-    hasDownload: newFiles.length > 0,
-    DownloadableFiles:
-      Object.keys(updateFieldInput).length > 0 ? [updateFieldInput] : undefined,
-  };
+  return buildDownloadableFilesUpdateInput({
+    originalFiles: props.discussion?.DownloadableFiles,
+    currentFiles: formValues.value.downloadableFiles,
+  });
 }
 
 // For handling save

--- a/tests/unit/utils/downloadFileHelpers.spec.ts
+++ b/tests/unit/utils/downloadFileHelpers.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getDownloadFileMimeType,
+  getDownloadFileKind,
+  buildDownloadAcceptAttribute,
+  buildDownloadableFilesUpdateInput,
+} from '@/utils/downloadFileHelpers';
+
+describe('getDownloadFileMimeType', () => {
+  it('returns null for an empty name', () => {
+    expect(getDownloadFileMimeType('')).toBeNull();
+  });
+
+  it('maps a known extension to its mime type', () => {
+    expect(getDownloadFileMimeType('archive.zip')).toBe('application/zip');
+  });
+
+  it('is case-insensitive', () => {
+    expect(getDownloadFileMimeType('Model.STL'.replace('STL', 'PDF'))).toBe('application/pdf');
+  });
+
+  it('falls back to octet-stream for unknown extensions', () => {
+    expect(getDownloadFileMimeType('file.xyz')).toBe('application/octet-stream');
+  });
+});
+
+describe('getDownloadFileKind', () => {
+  it.each([
+    ['model.zip', 'ZIP'],
+    ['model.rar', 'RAR'],
+    ['pic.png', 'PNG'],
+    ['pic.jpeg', 'JPG'],
+    ['pic.jpg', 'JPG'],
+    ['model.blend', 'BLEND'],
+    ['model.stl', 'STL'],
+    ['model.glb', 'GLB'],
+    ['notes.txt', 'OTHER'],
+  ])('maps %s to %s', (filename, kind) => {
+    expect(getDownloadFileKind(filename)).toBe(kind);
+  });
+});
+
+describe('buildDownloadAcceptAttribute', () => {
+  it('returns undefined when no types are allowed', () => {
+    expect(buildDownloadAcceptAttribute([])).toBeUndefined();
+  });
+
+  it('returns undefined for nullish input', () => {
+    expect(buildDownloadAcceptAttribute(null)).toBeUndefined();
+  });
+
+  it('prefixes bare extensions with a dot', () => {
+    expect(buildDownloadAcceptAttribute(['zip', 'stl'])).toBe('.zip,.stl');
+  });
+
+  it('leaves already-dotted extensions untouched', () => {
+    expect(buildDownloadAcceptAttribute(['.zip', 'STL'])).toBe('.zip,.stl');
+  });
+});
+
+describe('buildDownloadableFilesUpdateInput', () => {
+  it('connects new files when there are no original files', () => {
+    const result = buildDownloadableFilesUpdateInput({
+      originalFiles: [],
+      currentFiles: [{ id: 'f1' }, { id: 'f2' }],
+    });
+    expect(result.DownloadableFiles).toEqual([
+      { connect: [{ where: { node: { id: 'f1' } } }, { where: { node: { id: 'f2' } } }] },
+    ]);
+  });
+
+  it('sets hasDownload false when there are no files at all', () => {
+    const result = buildDownloadableFilesUpdateInput({ originalFiles: [], currentFiles: [] });
+    expect(result.hasDownload).toBe(false);
+  });
+
+  it('omits DownloadableFiles when no files have ids', () => {
+    const result = buildDownloadableFilesUpdateInput({
+      originalFiles: [],
+      currentFiles: [{ id: null }],
+    });
+    expect(result.DownloadableFiles).toBeUndefined();
+  });
+
+  it('connects only newly added files when originals exist', () => {
+    const result = buildDownloadableFilesUpdateInput({
+      originalFiles: [{ id: 'f1' }],
+      currentFiles: [{ id: 'f1' }, { id: 'f2' }],
+    });
+    expect(result.DownloadableFiles).toEqual([
+      { connect: [{ where: { node: { id: 'f2' } } }] },
+    ]);
+  });
+
+  it('disconnects files removed from the current set', () => {
+    const result = buildDownloadableFilesUpdateInput({
+      originalFiles: [{ id: 'f1' }, { id: 'f2' }],
+      currentFiles: [{ id: 'f1' }],
+    });
+    expect(result.DownloadableFiles).toEqual([
+      { disconnect: [{ where: { node: { id: 'f2' } } }] },
+    ]);
+  });
+
+  it('omits DownloadableFiles when the set is unchanged', () => {
+    const result = buildDownloadableFilesUpdateInput({
+      originalFiles: [{ id: 'f1' }],
+      currentFiles: [{ id: 'f1' }],
+    });
+    expect(result.DownloadableFiles).toBeUndefined();
+  });
+});

--- a/utils/downloadFileHelpers.ts
+++ b/utils/downloadFileHelpers.ts
@@ -1,0 +1,127 @@
+import type {
+  DiscussionUpdateInput,
+  DiscussionDownloadableFilesConnectFieldInput,
+  DiscussionDownloadableFilesDisconnectFieldInput,
+  DiscussionDownloadableFilesUpdateFieldInput,
+} from '@/__generated__/graphql';
+
+/**
+ * Pure helpers for the download edit form
+ * (components/discussion/form/DownloadEditForm.vue). Extracted from the
+ * component so the mime/kind/accept/update-input logic is unit-testable.
+ */
+
+const DOWNLOAD_MIME_TYPES: Record<string, string> = {
+  zip: 'application/zip',
+  rar: 'application/x-rar-compressed',
+  '7z': 'application/x-7z-compressed',
+  tar: 'application/x-tar',
+  gz: 'application/gzip',
+  pdf: 'application/pdf',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  exe: 'application/x-msdownload',
+  dmg: 'application/x-apple-diskimage',
+  pkg: 'application/x-newton-compatible-pkg',
+  deb: 'application/vnd.debian.binary-package',
+  rpm: 'application/x-rpm',
+};
+
+/**
+ * Guess a MIME type from a file name. Returns `null` when there is no name or
+ * extension, and `application/octet-stream` for unknown extensions.
+ */
+export function getDownloadFileMimeType(filename: string): string | null {
+  if (!filename) return null;
+  const extension = filename.toLowerCase().split('.').pop();
+  if (!extension) return null;
+  return DOWNLOAD_MIME_TYPES[extension] || 'application/octet-stream';
+}
+
+/** Map a file name to a FileKind enum value (ZIP/RAR/PNG/.../OTHER). */
+export function getDownloadFileKind(filename: string): string {
+  const extension = filename.toLowerCase().split('.').pop();
+  if (extension === 'zip') return 'ZIP';
+  if (extension === 'rar') return 'RAR';
+  if (extension === 'png') return 'PNG';
+  if (['jpg', 'jpeg'].includes(extension || '')) return 'JPG';
+  if (extension === 'blend') return 'BLEND';
+  if (extension === 'stl') return 'STL';
+  if (extension === 'glb') return 'GLB';
+  return 'OTHER';
+}
+
+/**
+ * Build the `accept` attribute for the file input from a channel's allowed file
+ * types. Returns `undefined` when there is no restriction.
+ */
+export function buildDownloadAcceptAttribute(
+  allowedFileTypes: string[] | null | undefined
+): string | undefined {
+  const allowedTypes = allowedFileTypes || [];
+  if (allowedTypes.length === 0) {
+    return undefined;
+  }
+  const extensions = allowedTypes.map((type) => {
+    const lowerType = type.toLowerCase();
+    return lowerType.startsWith('.') ? lowerType : `.${lowerType}`;
+  });
+  return extensions.join(',');
+}
+
+type FileRef = { id?: string | null };
+
+/**
+ * Build the discussion update input that connects newly added downloadable
+ * files and disconnects removed ones, mirroring the create-vs-update branching
+ * of the form. Only files with database IDs are connected.
+ */
+export function buildDownloadableFilesUpdateInput(params: {
+  originalFiles: FileRef[] | null | undefined;
+  currentFiles: FileRef[] | null | undefined;
+}): DiscussionUpdateInput {
+  const originalFiles = params.originalFiles ?? [];
+  const currentFiles = params.currentFiles ?? [];
+
+  // No pre-existing files: only build a connect array.
+  if (originalFiles.length === 0) {
+    const connectArray: DiscussionDownloadableFilesConnectFieldInput[] =
+      currentFiles
+        .filter((file) => file.id)
+        .map((file) => ({ where: { node: { id: file.id } } }));
+
+    return {
+      hasDownload: currentFiles.length > 0,
+      DownloadableFiles:
+        connectArray.length > 0 ? [{ connect: connectArray }] : undefined,
+    };
+  }
+
+  // Connect new files that aren't already linked.
+  const connectArray: DiscussionDownloadableFilesConnectFieldInput[] =
+    currentFiles
+      .filter(
+        (file) => file.id && !originalFiles.some((old) => old.id === file.id)
+      )
+      .map((file) => ({ where: { node: { id: file.id } } }));
+
+  // Disconnect old files no longer present.
+  const disconnectArray: DiscussionDownloadableFilesDisconnectFieldInput[] =
+    originalFiles
+      .filter((old) => !currentFiles.some((file) => file.id === old.id))
+      .map((old) => ({ where: { node: { id: old.id } } }));
+
+  const updateFieldInput: DiscussionDownloadableFilesUpdateFieldInput = {};
+  if (connectArray.length > 0) {
+    updateFieldInput.connect = connectArray;
+  }
+  if (disconnectArray.length > 0) {
+    updateFieldInput.disconnect = disconnectArray;
+  }
+
+  return {
+    hasDownload: currentFiles.length > 0,
+    DownloadableFiles:
+      Object.keys(updateFieldInput).length > 0 ? [updateFieldInput] : undefined,
+  };
+}


### PR DESCRIPTION
Continuation of the coverage push. While finishing "Tier 1", I found the remaining named targets (TextEditor, DownloadEditForm, AddToListPopover) are all composable/upload-heavy — their pure logic is already in composables/utils or belongs there, so there's no clean mount-as-is path. For **DownloadEditForm** (171 uncov), the reliable move is the same extract-then-test pattern as Tier 2.

## What changed
New `utils/downloadFileHelpers.ts` (23 assertions), with DownloadEditForm refactored to consume it (behavior-preserving):
- `getDownloadFileMimeType(name)` — extension → MIME type
- `getDownloadFileKind(name)` — extension → FileKind enum (ZIP/RAR/PNG/…/OTHER)
- `buildDownloadAcceptAttribute(allowedTypes)` — channel types → input `accept`
- `buildDownloadableFilesUpdateInput({ originalFiles, currentFiles })` — the connect/disconnect discussion-update builder

~130 lines of inline logic removed from `DownloadEditForm.vue`.

## Verification
- New util spec: **23 passing**
- `npm run tsc`: 0 errors
- Lint: clean

## Note on TextEditor / AddToListPopover
Both are dominated by composable wiring (`useImageUpload`, `useEmojiPicker`, `useCollectionMutations`, `usePopoverPositioning`, …) and their pure logic is already extracted (e.g. AddToListPopover uses `utils/collectionFilters`). Mounting them would mean mocking 4–6 composables for little net coverage. Better next targets are the heavy edit pages (Tier 2 extraction) and the still-untested composables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)