### PR TITLE
refactor: extract image lightbox zoom/pan into a tested composable

### DIFF
--- a/composables/useImageZoomPan.spec.ts
+++ b/composables/useImageZoomPan.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useImageZoomPan } from '@/composables/useImageZoomPan';
+
+const mouse = (overrides: Partial<MouseEvent> = {}) =>
+  ({ button: 0, clientX: 0, clientY: 0, preventDefault: vi.fn(), ...overrides } as unknown as MouseEvent);
+
+const key = (k: string) => ({ key: k } as KeyboardEvent);
+
+describe('useImageZoomPan', () => {
+  it('starts at zoom level 1 and not zoomed', () => {
+    const z = useImageZoomPan();
+    expect(z.isZoomed.value).toBe(false);
+  });
+
+  it('zooms in by the step up to the max', () => {
+    const z = useImageZoomPan();
+    z.zoomIn();
+    z.zoomIn();
+    z.zoomIn();
+    z.zoomIn(); // would exceed max (3), should clamp
+    expect(z.zoomLevel.value).toBe(3);
+  });
+
+  it('marks isZoomed once above 1', () => {
+    const z = useImageZoomPan();
+    z.zoomIn();
+    expect(z.isZoomed.value).toBe(true);
+  });
+
+  it('does not zoom out below the minimum', () => {
+    const z = useImageZoomPan();
+    z.zoomOut();
+    expect(z.zoomLevel.value).toBe(1);
+  });
+
+  it('resets zoom and translation', () => {
+    const z = useImageZoomPan();
+    z.zoomIn();
+    z.resetZoom();
+    expect(z.zoomLevel.value).toBe(1);
+  });
+
+  it('opens the lightbox when the guard allows it', () => {
+    const z = useImageZoomPan({ canOpenLightbox: () => true });
+    z.openLightbox();
+    expect(z.isLightboxOpen.value).toBe(true);
+  });
+
+  it('does not open the lightbox when the guard denies it', () => {
+    const z = useImageZoomPan({ canOpenLightbox: () => false });
+    z.openLightbox();
+    expect(z.isLightboxOpen.value).toBe(false);
+  });
+
+  it('closes the lightbox and resets zoom', () => {
+    const z = useImageZoomPan();
+    z.openLightbox();
+    z.zoomIn();
+    z.closeLightbox();
+    expect(z.isLightboxOpen.value).toBe(false);
+  });
+
+  it('ignores drag start when not zoomed', () => {
+    const z = useImageZoomPan();
+    z.startDrag(mouse());
+    expect(z.isDragging.value).toBe(false);
+  });
+
+  it('ignores non-left-button drag start', () => {
+    const z = useImageZoomPan();
+    z.zoomIn();
+    z.startDrag(mouse({ button: 1 }));
+    expect(z.isDragging.value).toBe(false);
+  });
+
+  it('begins dragging on a left click when zoomed', () => {
+    const z = useImageZoomPan();
+    z.zoomIn();
+    z.startDrag(mouse({ clientX: 10, clientY: 20 }));
+    expect(z.isDragging.value).toBe(true);
+  });
+
+  it('updates the translation while dragging', () => {
+    const z = useImageZoomPan();
+    z.zoomIn();
+    z.startDrag(mouse({ clientX: 10, clientY: 20 }));
+    z.onDrag(mouse({ clientX: 30, clientY: 50 }));
+    expect({ x: z.translateX.value, y: z.translateY.value }).toEqual({ x: 20, y: 30 });
+  });
+
+  it('does not update translation when not dragging', () => {
+    const z = useImageZoomPan();
+    z.onDrag(mouse({ clientX: 30, clientY: 50 }));
+    expect(z.translateX.value).toBe(0);
+  });
+
+  it('stops dragging', () => {
+    const z = useImageZoomPan();
+    z.zoomIn();
+    z.startDrag(mouse());
+    z.stopDrag();
+    expect(z.isDragging.value).toBe(false);
+  });
+
+  it('ignores key presses when the lightbox is closed', () => {
+    const z = useImageZoomPan();
+    z.handleKeyDown(key('+'));
+    expect(z.zoomLevel.value).toBe(1);
+  });
+
+  it('zooms in on "+" when the lightbox is open', () => {
+    const z = useImageZoomPan({ canOpenLightbox: () => true });
+    z.openLightbox();
+    z.handleKeyDown(key('+'));
+    expect(z.zoomLevel.value).toBe(1.5);
+  });
+
+  it('closes on Escape when the lightbox is open', () => {
+    const z = useImageZoomPan({ canOpenLightbox: () => true });
+    z.openLightbox();
+    z.handleKeyDown(key('Escape'));
+    expect(z.isLightboxOpen.value).toBe(false);
+  });
+});

--- a/composables/useImageZoomPan.ts
+++ b/composables/useImageZoomPan.ts
@@ -1,0 +1,131 @@
+import { ref, computed } from 'vue';
+
+/**
+ * Lightbox zoom + pan state for the image detail page
+ * (pages/u/[username]/images/[imageId].vue). Extracted from the component so
+ * the zoom/drag/keyboard logic is unit-testable.
+ *
+ * The lightbox open guard is injected via `canOpenLightbox` so the component
+ * can keep its url/format checks while the template binds `openLightbox`
+ * directly (any event argument is ignored).
+ */
+
+export type UseImageZoomPanOptions = {
+  canOpenLightbox?: () => boolean;
+  /** Min/max zoom and step; defaults mirror the original component. */
+  minZoom?: number;
+  maxZoom?: number;
+  step?: number;
+};
+
+const setBodyOverflow = (value: string) => {
+  if (typeof document !== 'undefined' && document.body) {
+    document.body.style.overflow = value;
+  }
+};
+
+export function useImageZoomPan(options: UseImageZoomPanOptions = {}) {
+  const minZoom = options.minZoom ?? 1;
+  const maxZoom = options.maxZoom ?? 3;
+  const step = options.step ?? 0.5;
+
+  const isLightboxOpen = ref(false);
+  const zoomLevel = ref(minZoom);
+  const isZoomed = computed(() => zoomLevel.value > 1);
+
+  const isDragging = ref(false);
+  const startX = ref(0);
+  const startY = ref(0);
+  const translateX = ref(0);
+  const translateY = ref(0);
+
+  const resetTranslation = () => {
+    translateX.value = 0;
+    translateY.value = 0;
+  };
+
+  const startDrag = (event: MouseEvent) => {
+    if (!isZoomed.value) return;
+    if (event.button !== 0) return;
+    event.preventDefault();
+    isDragging.value = true;
+    startX.value = event.clientX - translateX.value;
+    startY.value = event.clientY - translateY.value;
+  };
+
+  const onDrag = (event: MouseEvent) => {
+    if (!isDragging.value) return;
+    event.preventDefault();
+    translateX.value = event.clientX - startX.value;
+    translateY.value = event.clientY - startY.value;
+  };
+
+  const stopDrag = () => {
+    isDragging.value = false;
+  };
+
+  const openLightbox = () => {
+    const allowed = options.canOpenLightbox ? options.canOpenLightbox() : true;
+    if (!allowed) return;
+    isLightboxOpen.value = true;
+    zoomLevel.value = minZoom;
+    resetTranslation();
+    setBodyOverflow('hidden');
+  };
+
+  const closeLightbox = () => {
+    isLightboxOpen.value = false;
+    zoomLevel.value = minZoom;
+    resetTranslation();
+    setBodyOverflow('');
+  };
+
+  const zoomIn = () => {
+    if (zoomLevel.value < maxZoom) {
+      zoomLevel.value += step;
+    }
+  };
+
+  const zoomOut = () => {
+    if (zoomLevel.value > minZoom) {
+      zoomLevel.value -= step;
+    }
+  };
+
+  const resetZoom = () => {
+    zoomLevel.value = minZoom;
+    resetTranslation();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (!isLightboxOpen.value) return;
+    if (e.key === 'Escape') {
+      closeLightbox();
+    } else if (e.key === '+') {
+      zoomIn();
+    } else if (e.key === '-') {
+      zoomOut();
+    } else if (e.key === '0') {
+      resetZoom();
+    }
+  };
+
+  return {
+    isLightboxOpen,
+    zoomLevel,
+    isZoomed,
+    isDragging,
+    translateX,
+    translateY,
+    startDrag,
+    onDrag,
+    stopDrag,
+    resetTranslation,
+    openLightbox,
+    closeLightbox,
+    zoomIn,
+    zoomOut,
+    resetZoom,
+    handleKeyDown,
+  };
+}

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -19,6 +19,7 @@ import SaveButton from '@/components/SaveButton.vue';
 import CancelButton from '@/components/CancelButton.vue';
 import PencilIcon from '@/components/icons/PencilIcon.vue';
 import AlbumThumbnailGrid from '@/components/album/AlbumThumbnailGrid.vue';
+import { useImageZoomPan } from '@/composables/useImageZoomPan';
 
 // @ts-ignore - definePageMeta is auto-imported by Nuxt
 definePageMeta({
@@ -184,102 +185,30 @@ const albumImages = computed(() => {
   return orderedImages.filter((img) => img.id !== image.value?.id);
 });
 
-// Custom lightbox state
-const isLightboxOpen = ref(false);
-
-// Zoom functionality
-const zoomLevel = ref(1);
-const isZoomed = computed(() => zoomLevel.value > 1);
-
-// Image panning
-const isDragging = ref(false);
-const startX = ref(0);
-const startY = ref(0);
-const translateX = ref(0);
-const translateY = ref(0);
-
-const startDrag = (event: MouseEvent) => {
-  if (!isZoomed.value) return;
-
-  if (event.button !== 0) return;
-
-  event.preventDefault();
-  isDragging.value = true;
-  startX.value = event.clientX - translateX.value;
-  startY.value = event.clientY - translateY.value;
-};
-
-const onDrag = (event: MouseEvent) => {
-  if (!isDragging.value) return;
-
-  event.preventDefault();
-  translateX.value = event.clientX - startX.value;
-  translateY.value = event.clientY - startY.value;
-};
-
-const stopDrag = () => {
-  isDragging.value = false;
-};
-
-// Reset translation when changing zoom
-const resetTranslation = () => {
-  translateX.value = 0;
-  translateY.value = 0;
-};
-
-// Lightbox functions
-const openLightbox = () => {
-  if (
-    image.value?.url &&
-    !hasGlbExtension(image.value.url) &&
-    !hasStlExtension(image.value.url)
-  ) {
-    isLightboxOpen.value = true;
-    zoomLevel.value = 1;
-    resetTranslation();
-    document.body.style.overflow = 'hidden';
-  }
-};
-
-const closeLightbox = () => {
-  isLightboxOpen.value = false;
-  zoomLevel.value = 1;
-  resetTranslation();
-  document.body.style.overflow = '';
-};
-
-// Zoom functions
-const zoomIn = () => {
-  if (zoomLevel.value < 3) {
-    zoomLevel.value += 0.5;
-  }
-};
-
-const zoomOut = () => {
-  if (zoomLevel.value > 1) {
-    zoomLevel.value -= 0.5;
-  }
-};
-
-const resetZoom = () => {
-  zoomLevel.value = 1;
-  resetTranslation();
-};
-
-// Keyboard navigation
-const handleKeyDown = (e: KeyboardEvent) => {
-  if (isLightboxOpen.value) {
-    if (e.key === 'Escape') {
-      closeLightbox();
-    } else if (e.key === '+') {
-      zoomIn();
-    } else if (e.key === '-') {
-      zoomOut();
-    } else if (e.key === '0') {
-      resetZoom();
-    }
-  }
-};
+// Lightbox zoom + pan state (extracted to a composable). The open guard keeps
+// the component's url/format checks.
+const {
+  isLightboxOpen,
+  zoomLevel,
+  isZoomed,
+  isDragging,
+  translateX,
+  translateY,
+  startDrag,
+  onDrag,
+  stopDrag,
+  openLightbox,
+  closeLightbox,
+  zoomIn,
+  zoomOut,
+  resetZoom,
+  handleKeyDown,
+} = useImageZoomPan({
+  canOpenLightbox: () =>
+    image.value?.url
+      ? !hasGlbExtension(image.value.url) && !hasStlExtension(image.value.url)
+      : false,
+});
 
 const downloadImage = (imageUrl: string) => {
   fetch(imageUrl)


### PR DESCRIPTION
Tier 2 — the image detail page `pages/u/[username]/images/[imageId].vue` (was 213 uncov) is dominated by lightbox zoom/pan/keyboard UI state. Extract that into a composable and refactor the page to consume it (behavior-preserving).

## What changed
- New **`composables/useImageZoomPan.ts`** — `isLightboxOpen`/`zoomLevel`/`isZoomed`/drag state + `startDrag`/`onDrag`/`stopDrag`/`openLightbox`/`closeLightbox`/`zoomIn`/`zoomOut`/`resetZoom`/`handleKeyDown`. Zoom clamps to [min,max]; drag requires left-button + zoomed; keyboard only acts when open.
- The open guard (url + GLB/STL format checks) is injected via `canOpenLightbox`, so the template's `@click="openLightbox"` binding is unchanged.
- ~95 lines removed from the page.

## Verification
- New composable spec: **17 passing**
- `npm run tsc`: 0 errors
- Lint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)