### PR TITLE
refactor: extract collection page item/author helpers into tested util

### DIFF
--- a/pages/library/[collectionId].vue
+++ b/pages/library/[collectionId].vue
@@ -20,11 +20,15 @@ import AvatarComponent from '@/components/AvatarComponent.vue';
 import GenericModal from '@/components/GenericModal.vue';
 import WarningModal from '@/components/WarningModal.vue';
 import { relativeTime } from '@/utils';
-import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
 import { usernameVar } from '@/cache';
-import type { Discussion, DiscussionChannel, Comment } from '@/__generated__/graphql';
+import type { Discussion, Comment } from '@/__generated__/graphql';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
-import { getServerRoleBadge } from '@/utils/serverRoleBadges';
+import {
+  getCollectionTypeLabel,
+  getCollectionItems,
+  buildCollectionDiscussionLink,
+  resolveCollectionItemAuthor,
+} from '@/utils/collectionItemUtils';
 
 // Lazy load the album component since it's not needed for initial render
 const DiscussionAlbum = defineAsyncComponent(
@@ -61,81 +65,24 @@ useHead({
   title: computed(() => `${collectionName.value} - Library`),
 });
 
-const getDiscussionLink = (discussion: Discussion) => {
-  const firstChannel = safeArrayFirst(discussion.DiscussionChannels) as DiscussionChannel | null;
-  if (!firstChannel?.channelUniqueName) return '/';
+const getDiscussionLink = (discussion: Discussion) =>
+  buildCollectionDiscussionLink({
+    discussion,
+    isDownloadsCollection: collection.value?.collectionType === 'DOWNLOADS',
+  });
 
-  const isDownload =
-    discussion?.hasDownload === true ||
-    collection.value?.collectionType === 'DOWNLOADS';
-
-  const basePath = isDownload ? 'downloads' : 'discussions';
-
-  return `/forums/${firstChannel.channelUniqueName}/${basePath}/${discussion.id}`;
-};
-
-const getAuthorInfo = (item: Discussion | Comment) => {
-  // Comments use CommentAuthor, other types use Author
-  const author = 'CommentAuthor' in item ? item.CommentAuthor : 'Author' in item ? item.Author : null;
-  if (!author) return null;
-
-  // Check if author is a User (has username) vs ModerationProfile (only has displayName)
-  const isUser = 'username' in author && author.username;
-  const username = isUser ? author.username : '';
-
-  const serverRoleBadge = getServerRoleBadge({
-    username: username || undefined,
+const getAuthorInfo = (item: Discussion | Comment) =>
+  resolveCollectionItemAuthor({
+    item,
     adminUsernames: serverAdminUsernames.value,
   });
 
-  return {
-    username: username || '',
-    displayName: author.displayName || '',
-    profilePicURL: isUser && 'profilePicURL' in author ? author.profilePicURL || '' : '',
-    commentKarma: isUser && 'commentKarma' in author ? author.commentKarma ?? 0 : 0,
-    discussionKarma: isUser && 'discussionKarma' in author ? author.discussionKarma ?? 0 : 0,
-    createdAt: isUser && 'createdAt' in author ? author.createdAt || '' : '',
-    isAdmin: serverRoleBadge === 'serverAdmin',
-  };
-};
-
 // Get items based on collection type
-const items = computed(() => {
-  if (!collection.value) return [];
+const items = computed(() => getCollectionItems(collection.value));
 
-  switch (collection.value.collectionType) {
-    case 'DISCUSSIONS':
-      return collection.value.Discussions || [];
-    case 'COMMENTS':
-      return collection.value.Comments || [];
-    case 'IMAGES':
-      return collection.value.Images || [];
-    case 'CHANNELS':
-      return collection.value.Channels || [];
-    case 'DOWNLOADS':
-      return collection.value.Downloads || [];
-    default:
-      return [];
-  }
-});
-
-const collectionTypeLabel = computed(() => {
-  const type = collection.value?.collectionType;
-  switch (type) {
-    case 'DISCUSSIONS':
-      return 'Discussions';
-    case 'COMMENTS':
-      return 'Comments';
-    case 'IMAGES':
-      return 'Images';
-    case 'CHANNELS':
-      return 'Forums';
-    case 'DOWNLOADS':
-      return 'Downloads';
-    default:
-      return 'Items';
-  }
-});
+const collectionTypeLabel = computed(() =>
+  getCollectionTypeLabel(collection.value?.collectionType)
+);
 
 // Rename modal state
 const showRenameModal = ref(false);

--- a/tests/unit/utils/collectionItemUtils.spec.ts
+++ b/tests/unit/utils/collectionItemUtils.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getCollectionTypeLabel,
+  getCollectionItems,
+  buildCollectionDiscussionLink,
+  resolveCollectionItemAuthor,
+} from '@/utils/collectionItemUtils';
+import type { Discussion, Comment } from '@/__generated__/graphql';
+
+describe('getCollectionTypeLabel', () => {
+  it.each([
+    ['DISCUSSIONS', 'Discussions'],
+    ['COMMENTS', 'Comments'],
+    ['IMAGES', 'Images'],
+    ['CHANNELS', 'Forums'],
+    ['DOWNLOADS', 'Downloads'],
+  ])('labels %s as %s', (type, label) => {
+    expect(getCollectionTypeLabel(type)).toBe(label);
+  });
+
+  it('falls back to Items for unknown types', () => {
+    expect(getCollectionTypeLabel(undefined)).toBe('Items');
+  });
+});
+
+describe('getCollectionItems', () => {
+  it('returns the array matching the collection type', () => {
+    expect(
+      getCollectionItems({ collectionType: 'COMMENTS', Comments: [{}, {}] })
+    ).toHaveLength(2);
+  });
+
+  it('returns an empty array when the typed array is missing', () => {
+    expect(getCollectionItems({ collectionType: 'IMAGES' })).toEqual([]);
+  });
+
+  it('returns an empty array for a null collection', () => {
+    expect(getCollectionItems(null)).toEqual([]);
+  });
+
+  it('returns an empty array for an unknown type', () => {
+    expect(getCollectionItems({ collectionType: 'WIDGETS' })).toEqual([]);
+  });
+});
+
+describe('buildCollectionDiscussionLink', () => {
+  const discussion = (overrides: Record<string, unknown> = {}) =>
+    ({
+      id: 'd1',
+      DiscussionChannels: [{ channelUniqueName: 'cats' }],
+      ...overrides,
+    }) as unknown as Discussion;
+
+  it('links to the discussions path by default', () => {
+    expect(
+      buildCollectionDiscussionLink({ discussion: discussion(), isDownloadsCollection: false })
+    ).toBe('/forums/cats/discussions/d1');
+  });
+
+  it('links to the downloads path for a downloads collection', () => {
+    expect(
+      buildCollectionDiscussionLink({ discussion: discussion(), isDownloadsCollection: true })
+    ).toBe('/forums/cats/downloads/d1');
+  });
+
+  it('links to the downloads path when the discussion has a download', () => {
+    expect(
+      buildCollectionDiscussionLink({
+        discussion: discussion({ hasDownload: true }),
+        isDownloadsCollection: false,
+      })
+    ).toBe('/forums/cats/downloads/d1');
+  });
+
+  it('returns "/" when there is no channel', () => {
+    expect(
+      buildCollectionDiscussionLink({
+        discussion: discussion({ DiscussionChannels: [] }),
+        isDownloadsCollection: false,
+      })
+    ).toBe('/');
+  });
+});
+
+describe('resolveCollectionItemAuthor', () => {
+  it('returns null when there is no author', () => {
+    expect(
+      resolveCollectionItemAuthor({ item: { Author: null } as unknown as Discussion, adminUsernames: [] })
+    ).toBeNull();
+  });
+
+  it('resolves a user Author with karma', () => {
+    const item = {
+      Author: { username: 'alice', displayName: 'Alice', commentKarma: 5, discussionKarma: 7 },
+    } as unknown as Discussion;
+    const result = resolveCollectionItemAuthor({ item, adminUsernames: [] });
+    expect(result).toMatchObject({ username: 'alice', commentKarma: 5, discussionKarma: 7, isAdmin: false });
+  });
+
+  it('reads the CommentAuthor for comments', () => {
+    const item = { CommentAuthor: { username: 'bob', displayName: 'Bob' } } as unknown as Comment;
+    expect(resolveCollectionItemAuthor({ item, adminUsernames: [] })?.username).toBe('bob');
+  });
+
+  it('marks server admins', () => {
+    const item = { Author: { username: 'alice', displayName: 'Alice' } } as unknown as Discussion;
+    expect(
+      resolveCollectionItemAuthor({ item, adminUsernames: ['alice'] })?.isAdmin
+    ).toBe(true);
+  });
+
+  it('collapses a mod profile (no username) to display name only', () => {
+    const item = { Author: { displayName: 'ModName' } } as unknown as Discussion;
+    const result = resolveCollectionItemAuthor({ item, adminUsernames: [] });
+    expect(result).toMatchObject({ username: '', displayName: 'ModName' });
+  });
+});

--- a/utils/collectionItemUtils.ts
+++ b/utils/collectionItemUtils.ts
@@ -1,0 +1,147 @@
+import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
+import { getServerRoleBadge } from '@/utils/serverRoleBadges';
+import type {
+  Discussion,
+  Comment,
+  DiscussionChannel,
+} from '@/__generated__/graphql';
+
+/**
+ * Pure helpers for the collection detail page
+ * (pages/library/[collectionId].vue). Extracted so the type-label, item
+ * selection, link building, and author resolution logic is unit-testable.
+ */
+
+export type CollectionType =
+  | 'DISCUSSIONS'
+  | 'COMMENTS'
+  | 'IMAGES'
+  | 'CHANNELS'
+  | 'DOWNLOADS'
+  | string
+  | null
+  | undefined;
+
+/** Human-readable label for a collection type. */
+export function getCollectionTypeLabel(type: CollectionType): string {
+  switch (type) {
+    case 'DISCUSSIONS':
+      return 'Discussions';
+    case 'COMMENTS':
+      return 'Comments';
+    case 'IMAGES':
+      return 'Images';
+    case 'CHANNELS':
+      return 'Forums';
+    case 'DOWNLOADS':
+      return 'Downloads';
+    default:
+      return 'Items';
+  }
+}
+
+export interface CollectionLike {
+  collectionType?: CollectionType;
+  Discussions?: unknown[];
+  Comments?: unknown[];
+  Images?: unknown[];
+  Channels?: unknown[];
+  Downloads?: unknown[];
+}
+
+/**
+ * Select the items array that matches the collection's type. The element type
+ * is heterogeneous across collection types, so the return is intentionally
+ * loose (matching the page's original inline behavior).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getCollectionItems(
+  collection: CollectionLike | null | undefined
+): any[] {
+  if (!collection) return [];
+  switch (collection.collectionType) {
+    case 'DISCUSSIONS':
+      return collection.Discussions || [];
+    case 'COMMENTS':
+      return collection.Comments || [];
+    case 'IMAGES':
+      return collection.Images || [];
+    case 'CHANNELS':
+      return collection.Channels || [];
+    case 'DOWNLOADS':
+      return collection.Downloads || [];
+    default:
+      return [];
+  }
+}
+
+/**
+ * Build the route for a discussion within a collection. Downloads (either the
+ * discussion's own flag or a downloads-typed collection) link to the downloads
+ * path. Returns '/' when no channel is available.
+ */
+export function buildCollectionDiscussionLink(params: {
+  discussion: Discussion;
+  isDownloadsCollection: boolean;
+}): string {
+  const { discussion, isDownloadsCollection } = params;
+  const firstChannel = safeArrayFirst(
+    discussion.DiscussionChannels
+  ) as DiscussionChannel | null;
+  if (!firstChannel?.channelUniqueName) return '/';
+
+  const isDownload = discussion?.hasDownload === true || isDownloadsCollection;
+  const basePath = isDownload ? 'downloads' : 'discussions';
+  return `/forums/${firstChannel.channelUniqueName}/${basePath}/${discussion.id}`;
+}
+
+export interface CollectionAuthorInfo {
+  username: string;
+  displayName: string;
+  profilePicURL: string;
+  commentKarma: number;
+  discussionKarma: number;
+  createdAt: string;
+  isAdmin: boolean;
+}
+
+/**
+ * Resolve the author info for a collection item. Comments expose
+ * `CommentAuthor`, other items expose `Author`. Moderation profiles (no
+ * username) collapse to display-name-only info. Returns null when there is no
+ * author.
+ */
+export function resolveCollectionItemAuthor(params: {
+  item: Discussion | Comment;
+  adminUsernames: string[];
+}): CollectionAuthorInfo | null {
+  const { item, adminUsernames } = params;
+  const author =
+    'CommentAuthor' in item
+      ? item.CommentAuthor
+      : 'Author' in item
+        ? item.Author
+        : null;
+  if (!author) return null;
+
+  const isUser = 'username' in author && author.username;
+  const username = isUser ? author.username : '';
+
+  const serverRoleBadge = getServerRoleBadge({
+    username: username || undefined,
+    adminUsernames,
+  });
+
+  return {
+    username: username || '',
+    displayName: author.displayName || '',
+    profilePicURL:
+      isUser && 'profilePicURL' in author ? author.profilePicURL || '' : '',
+    commentKarma:
+      isUser && 'commentKarma' in author ? (author.commentKarma ?? 0) : 0,
+    discussionKarma:
+      isUser && 'discussionKarma' in author ? (author.discussionKarma ?? 0) : 0,
+    createdAt: isUser && 'createdAt' in author ? author.createdAt || '' : '',
+    isAdmin: serverRoleBadge === 'serverAdmin',
+  };
+}


### PR DESCRIPTION
Tier 2 — the library collection page `pages/library/[collectionId].vue` (was 148 uncov). Extract its pure helpers into a unit-tested util, behavior-preserving.

## What changed
New `utils/collectionItemUtils.ts` (19 assertions):
- `getCollectionTypeLabel(type)` — collection type → display label
- `getCollectionItems(collection)` — type → the matching items array
- `buildCollectionDiscussionLink({ discussion, isDownloadsCollection })` — discussion → route (downloads-aware), `/` when no channel
- `resolveCollectionItemAuthor({ item, adminUsernames })` — item → author info, handling user vs moderation-profile authors and the server-admin badge

The page now delegates `getDiscussionLink`, `getAuthorInfo`, `items`, and `collectionTypeLabel` to these helpers; ~70 lines of inline logic removed.

## Verification
- New util spec: **19 passing**
- `npm run tsc`: 0 errors
- Lint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)