### PR TITLE
refactor: type plugin/album builder outputs from generated GraphQL types

### DIFF
--- a/utils/albumUpdateInput.ts
+++ b/utils/albumUpdateInput.ts
@@ -1,8 +1,17 @@
+import type {
+  DiscussionUpdateInput,
+  AlbumImagesConnectFieldInput,
+  AlbumImagesUpdateFieldInput,
+} from '@/__generated__/graphql';
+
 /**
  * Pure builder extracted from the download edit page
  * (pages/forums/[forumId]/downloads/edit/[discussionId].vue). Produces the
  * `Album` portion of a discussion update input, choosing between creating a new
  * album and updating an existing one (connect/update/disconnect images).
+ *
+ * The return type is `Pick<DiscussionUpdateInput, 'Album'>`, so the generated
+ * GraphQL schema validates the produced shape at compile time.
  */
 
 export type AlbumFormImage = {
@@ -20,11 +29,13 @@ export type AlbumFormData = {
 
 export type ExistingAlbumImage = { id?: string | null };
 
+export type AlbumUpdatePortion = Pick<DiscussionUpdateInput, 'Album'>;
+
 export function buildAlbumUpdateInput(params: {
   albumData: AlbumFormData;
   existingAlbumId?: string | null;
   existingImages?: ExistingAlbumImage[];
-}) {
+}): AlbumUpdatePortion {
   const { albumData, existingAlbumId, existingImages = [] } = params;
 
   if (
@@ -45,30 +56,31 @@ export function buildAlbumUpdateInput(params: {
       return {}; // No valid images to connect
     }
 
-    const albumNode: {
-      imageOrder: string[];
-      Images: { connect: { where: { node: { id: string } } }[] };
-    } = {
-      imageOrder: albumData.imageOrder || [],
-      Images: {
-        connect: validImages.map((img) => ({
-          where: { node: { id: img.id } },
-        })),
+    const connect: AlbumImagesConnectFieldInput[] = validImages.map((img) => ({
+      where: { node: { id: img.id } },
+    }));
+
+    return {
+      Album: {
+        create: {
+          node: {
+            imageOrder: albumData.imageOrder || [],
+            Images: { connect },
+          },
+        },
       },
     };
-
-    return { Album: { create: { node: albumNode } } };
   }
 
-  // Existing album: build connect/update/disconnect arrays.
+  // Existing album: build connect/update/disconnect operations.
   const oldImages = existingImages;
   const newImages = albumData.images || [];
 
-  const connectImageArray = newImages
+  const connectImageArray: AlbumImagesUpdateFieldInput[] = newImages
     .filter((img) => img.id && !oldImages.some((old) => old.id === img.id))
     .map((img) => ({ connect: [{ where: { node: { id: img.id } } }] }));
 
-  const updateImageArray = newImages
+  const updateImageArray: AlbumImagesUpdateFieldInput[] = newImages
     .filter((img) => img.id && oldImages.some((old) => old.id === img.id))
     .map((img) => ({
       where: { node: { id: img.id } },
@@ -82,11 +94,11 @@ export function buildAlbumUpdateInput(params: {
       },
     }));
 
-  const disconnectImageArray = oldImages
+  const disconnectImageArray: AlbumImagesUpdateFieldInput[] = oldImages
     .filter((old) => !newImages.some((img) => img.id === old.id))
     .map((old) => ({ disconnect: [{ where: { node: { id: old.id } } }] }));
 
-  const imagesOps = [
+  const imagesOps: AlbumImagesUpdateFieldInput[] = [
     ...connectImageArray,
     ...updateImageArray,
     ...disconnectImageArray,

--- a/utils/pluginManifestUtils.ts
+++ b/utils/pluginManifestUtils.ts
@@ -1,4 +1,8 @@
 import type { PluginFormSection } from '@/types/pluginForms';
+import type {
+  ChannelEnabledPluginsUpdateFieldInput,
+  PluginVersionWhere,
+} from '@/__generated__/graphql';
 
 /**
  * Pure helpers shared by the server- and channel-scoped plugin configuration
@@ -214,19 +218,23 @@ export interface EnabledPluginsInputParams {
 /**
  * Build the `enabledPlugins` mutation input for connecting, updating, or
  * disconnecting a plugin on a channel. Returns `[]` when there is nothing to
- * do (disabling a plugin that has no edge).
+ * do (disabling a plugin that has no edge). The return type is tied to the
+ * generated `ChannelEnabledPluginsUpdateFieldInput`, so the schema validates
+ * the produced shape at compile time.
  */
 export function buildEnabledPluginsInput(
   params: EnabledPluginsInputParams
-): unknown[] {
+): ChannelEnabledPluginsUpdateFieldInput[] {
   const { enabled, hasEdge, pluginId, version, settingsJson } = params;
-  const node = { Plugin: { id: pluginId }, version };
+  const node: PluginVersionWhere = { Plugin: { id: pluginId }, version };
 
   if (enabled) {
     if (hasEdge) {
       return [{ where: { node }, update: { edge: { settingsJson } } }];
     }
-    return [{ connect: [{ where: { node }, edge: { enabled: true, settingsJson } }] }];
+    return [
+      { connect: [{ where: { node }, edge: { enabled: true, settingsJson } }] },
+    ];
   }
   if (hasEdge) {
     return [{ disconnect: [{ where: { node } }] }];


### PR DESCRIPTION
Follow-up: these two typing improvements were added to #76 and #78 **after** those PRs had already been merged, so they never reached `main`. This brings them in (cherry-picked from the original commits).

## What changed
- **`utils/albumUpdateInput.ts`** — `buildAlbumUpdateInput` now returns `Pick<DiscussionUpdateInput, 'Album'>`, with image ops typed as `AlbumImagesConnectFieldInput[]` / `AlbumImagesUpdateFieldInput[]`.
- **`utils/pluginManifestUtils.ts`** — `buildEnabledPluginsInput` now returns `ChannelEnabledPluginsUpdateFieldInput[]` (the type the `UPDATE_CHANNEL_ENABLED_PLUGINS` mutation expects); the version-where node is typed `PluginVersionWhere`.

Both now have their output validated against the generated schema at compile time instead of relying on inferred literals / `unknown[]`.

## Verification
- `npm run tsc`: 0 errors
- Affected util specs: **50 passing**
- Lint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)