### PR TITLE
test: mount harness helpers + first heavy-component mount spec (EventDetail)

### DIFF
--- a/components/event/detail/EventDetail.spec.ts
+++ b/components/event/detail/EventDetail.spec.ts
@@ -6,6 +6,8 @@ import {
   createQueryMock,
   configureApolloMocks,
 } from '@/tests/utils/mockApollo';
+import { makeEvent } from '@/tests/utils/factories';
+import type { Event, EventChannel } from '@/__generated__/graphql';
 
 import { useQuery } from '@vue/apollo-composable';
 
@@ -21,29 +23,13 @@ vi.mock('@/cache', () => ({
   usernameVar: { value: '' },
 }));
 
-const makeEvent = (overrides: Record<string, unknown> = {}) => ({
-  id: 'e1',
-  title: 'Test Event',
-  description: 'An event',
-  startTime: '2099-01-01T10:00:00.000Z',
-  endTime: '2099-01-01T12:00:00.000Z',
-  updatedAt: null,
-  Poster: { username: 'alice', __typename: 'User' },
-  EventChannels: [
-    { id: 'ec1', channelUniqueName: 'cats', __typename: 'EventChannel' },
-  ],
-  Tags: [],
-  __typename: 'Event',
-  ...overrides,
-});
-
 const eventChannel = {
   id: 'ec1',
   channelUniqueName: 'cats',
   archived: false,
   Channel: { uniqueName: 'cats', displayName: 'Cats', __typename: 'Channel' },
   __typename: 'EventChannel',
-};
+} as unknown as EventChannel;
 
 const stubs = {
   ErrorBanner: { props: ['text'], template: '<div class="error-stub">{{ text }}</div>' },
@@ -60,7 +46,7 @@ const stubs = {
 };
 
 const setup = (params: {
-  event?: ReturnType<typeof makeEvent> | null;
+  event?: Event | null;
   eventLoading?: boolean;
   eventError?: Error | null;
 } = {}) => {

--- a/components/event/detail/EventDetail.spec.ts
+++ b/components/event/detail/EventDetail.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import {
+  asMock,
+  createQueryMock,
+  configureApolloMocks,
+} from '@/tests/utils/mockApollo';
+
+import { useQuery } from '@vue/apollo-composable';
+
+import EventDetail from '@/components/event/detail/EventDetail.vue';
+
+vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+vi.mock('nuxt/app', () => ({
+  useRoute: vi.fn(() => ({ params: {}, query: {} })),
+  useHead: vi.fn(),
+}));
+vi.mock('@/cache', () => ({
+  modProfileNameVar: { value: '' },
+  usernameVar: { value: '' },
+}));
+
+const makeEvent = (overrides: Record<string, unknown> = {}) => ({
+  id: 'e1',
+  title: 'Test Event',
+  description: 'An event',
+  startTime: '2099-01-01T10:00:00.000Z',
+  endTime: '2099-01-01T12:00:00.000Z',
+  updatedAt: null,
+  Poster: { username: 'alice', __typename: 'User' },
+  EventChannels: [
+    { id: 'ec1', channelUniqueName: 'cats', __typename: 'EventChannel' },
+  ],
+  Tags: [],
+  __typename: 'Event',
+  ...overrides,
+});
+
+const eventChannel = {
+  id: 'ec1',
+  channelUniqueName: 'cats',
+  archived: false,
+  Channel: { uniqueName: 'cats', displayName: 'Cats', __typename: 'Channel' },
+  __typename: 'EventChannel',
+};
+
+const stubs = {
+  ErrorBanner: { props: ['text'], template: '<div class="error-stub">{{ text }}</div>' },
+  EventHeader: { template: '<div class="event-header-stub" />' },
+  EventBody: { template: '<div class="event-body-stub" />' },
+  EventFooter: { template: '<div class="event-footer-stub" />' },
+  ExpandableImage: { template: '<div />' },
+  EventCommentsWrapper: { template: '<div class="event-comments-stub" />' },
+  EventRootCommentFormWrapper: { template: '<div />' },
+  EventChannelLinks: { template: '<div class="event-channel-links-stub" />' },
+  AddToCalendarButton: { template: '<div />' },
+  ArchivedEventInfoBanner: { template: '<div class="archived-banner-stub" />' },
+  Tag: { template: '<span />' },
+};
+
+const setup = (params: {
+  event?: ReturnType<typeof makeEvent> | null;
+  eventLoading?: boolean;
+  eventError?: Error | null;
+} = {}) => {
+  const { event = makeEvent(), eventLoading = false, eventError = null } = params;
+  configureApolloMocks({
+    useQuery,
+    queries: {
+      'getEvent(': createQueryMock(
+        { events: event ? [event] : [] },
+        { loading: ref(eventLoading), error: ref(eventError) }
+      ),
+      getEventComments: {
+        ...createQueryMock({ getEventComments: { Comments: [], Event: event } }),
+        fetchMore: vi.fn(),
+      } as ReturnType<typeof createQueryMock>,
+      getEventChannelID: createQueryMock({ eventChannels: [eventChannel] }),
+      getEventRootCommentAggregate: createQueryMock({
+        events: [{ CommentsAggregate: { count: 0 } }],
+      }),
+    },
+  });
+  return mountWithDefaults(EventDetail, {
+    props: { eventId: 'e1', channelUniqueName: 'cats' },
+    global: { stubs },
+  });
+};
+
+describe('EventDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    asMock(useQuery).mockReset();
+  });
+
+  it('shows the loading state before the event arrives', () => {
+    const wrapper = setup({ event: null, eventLoading: true });
+    expect(wrapper.text()).toContain('Loading...');
+  });
+
+  it('renders the error banner when the event query errors', () => {
+    const wrapper = setup({ event: null, eventError: new Error('boom') });
+    expect(wrapper.find('.error-stub').text()).toContain('boom');
+  });
+
+  it('shows the not-found message when the event is missing', () => {
+    const wrapper = setup({ event: null, eventLoading: false });
+    expect(wrapper.text()).toContain("Can't find the content that was reported");
+  });
+
+  it('renders the event header once the event loads', () => {
+    const wrapper = setup();
+    expect(wrapper.find('.event-header-stub').exists()).toBe(true);
+  });
+
+  it('renders the event body for a loaded event', () => {
+    const wrapper = setup();
+    expect(wrapper.find('.event-body-stub').exists()).toBe(true);
+  });
+});

--- a/tests/utils/mockApollo.ts
+++ b/tests/utils/mockApollo.ts
@@ -99,3 +99,47 @@ export function mockByDocument<T>(
     return fallback;
   };
 }
+
+/**
+ * Wire a component's mocked `useQuery`/`useMutation` in one call, dispatching by
+ * GraphQL document substring. This collapses the per-spec boilerplate of
+ * `asMock(useQuery).mockImplementation(mockByDocument({...}, createQueryMock({})))`.
+ *
+ * Pass the *mocked imports* (from a `vi.mock('@vue/apollo-composable', ...)`
+ * block) plus name→mock maps. Query values are full `QueryMock`s (build with
+ * `createQueryMock`); mutation values are `MutationMock`s.
+ *
+ *   vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn(), useMutation: vi.fn() }));
+ *   import { useQuery, useMutation } from '@vue/apollo-composable';
+ *   configureApolloMocks({
+ *     useQuery, useMutation,
+ *     queries: { getEvent: createQueryMock({ events: [event] }) },
+ *     mutations: { DeleteEvent: createMutationMock() },
+ *   });
+ */
+export function configureApolloMocks(params: {
+  useQuery?: unknown;
+  useMutation?: unknown;
+  queries?: Record<string, QueryMock>;
+  mutations?: Record<string, MutationMock>;
+  fallbackQuery?: QueryMock;
+  fallbackMutation?: MutationMock;
+}): void {
+  const {
+    useQuery,
+    useMutation,
+    queries = {},
+    mutations = {},
+    fallbackQuery = createQueryMock({}),
+    fallbackMutation = createMutationMock(),
+  } = params;
+
+  if (useQuery) {
+    asMock(useQuery).mockImplementation(mockByDocument(queries, fallbackQuery));
+  }
+  if (useMutation) {
+    asMock(useMutation).mockImplementation(
+      mockByDocument(mutations, fallbackMutation)
+    );
+  }
+}

--- a/tests/utils/mountWithDefaults.ts
+++ b/tests/utils/mountWithDefaults.ts
@@ -23,10 +23,30 @@ const slotPassthrough = (slotName = 'default') =>
     },
   });
 
+/** Renders an <a> so NuxtLink content stays visible and href is assertable. */
+const linkPassthrough = defineComponent({
+  name: 'NuxtLinkStub',
+  props: { to: { type: [String, Object], default: '' } },
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'a',
+        { href: typeof props.to === 'string' ? props.to : undefined },
+        slots.default?.()
+      );
+  },
+});
+
 export const defaultStubs: Record<string, Component> = {
   NuxtLayout: slotPassthrough(),
   // RequireAuth exposes a `has-auth` slot for the authenticated branch.
   RequireAuth: slotPassthrough('has-auth'),
+  // ClientOnly should render its content in unit tests.
+  ClientOnly: slotPassthrough(),
+  // Routing links render as transparent anchors.
+  NuxtLink: linkPassthrough,
+  'nuxt-link': linkPassthrough,
+  'router-link': linkPassthrough,
 };
 
 export const defaultMocks: Record<string, unknown> = {


### PR DESCRIPTION
Implements the highest-leverage step from the coverage plan: lower the per-spec cost of mounting query/router-backed components, then prove it on a heavy component.

## Harness additions
- **`mountWithDefaults`** now ships transparent default stubs for `NuxtLink` / `nuxt-link` / `router-link` (anchor passthrough, so link text + `href` are assertable) and `ClientOnly` (renders its slot). Specs no longer need to redeclare these.
- **`mockApollo`** gains `configureApolloMocks({ useQuery, useMutation, queries, mutations })` — wires document-dispatched query/mutation mocks in a single call, collapsing the per-spec `asMock(...).mockImplementation(mockByDocument(...))` boilerplate.

## First component on the harness
`components/event/detail/EventDetail.spec.ts` mounts the **real** `EventDetail.vue` (4 `useQuery`s + `useRoute`/`useHead` mocked, 10 heavy children stubbed) and covers the loading / error / not-found / loaded states. EventDetail was ~8% covered.

## Verification
- New spec: **5 passing**
- **Full unit suite: 220 files / 2360 tests passing** (confirms the shared `defaultStubs` change is safe across all existing specs)
- `npm run tsc`: 0 errors; lint clean

## Next
With the harness in place, the follow-up batch is cheap: mount the other partially-covered heavy components (`Comment`, `CommentSection`, `InlineCommentForm`, `IssueDetail`, `BrokenRulesModal`) the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)