### PR TITLE
test: mount specs for AlbumEditor + DiscussionAlbum (component batch)

### DIFF
--- a/components/discussion/detail/DiscussionAlbum.spec.ts
+++ b/components/discussion/detail/DiscussionAlbum.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+
+import { useMutation } from '@vue/apollo-composable';
+import { configureApolloMocks } from '@/tests/utils/mockApollo';
+import type { Album } from '@/__generated__/graphql';
+
+import DiscussionAlbum from '@/components/discussion/detail/DiscussionAlbum.vue';
+
+vi.mock('@vue/apollo-composable', () => ({ useMutation: vi.fn() }));
+vi.mock('nuxt/app', () => ({
+  useRoute: vi.fn(() => ({ params: { forumId: 'cats' } })),
+}));
+vi.mock('@/cache', () => ({ usernameVar: { value: 'alice' } }));
+
+const stubs = {
+  ModelViewer: { template: '<div class="model-viewer-stub" />' },
+  StlViewer: { template: '<div class="stl-viewer-stub" />' },
+  CarouselThumbnail: { template: '<div />' },
+  ImageLightbox: { template: '<div class="lightbox-stub" />' },
+  TextEditor: { template: '<div />' },
+  SaveButton: { template: '<button />' },
+  CancelButton: { template: '<button />' },
+  LeftArrowIcon: { template: '<i />' },
+  RightArrowIcon: { template: '<i />' },
+  PencilIcon: { template: '<i />' },
+};
+
+const makeImage = (id: string) => ({
+  id,
+  url: `https://example.com/${id}.jpg`,
+  alt: `alt-${id}`,
+  caption: '',
+  __typename: 'Image',
+});
+
+const makeAlbum = (imageIds: string[], imageOrder?: string[]): Album =>
+  ({
+    id: 'album-1',
+    Images: imageIds.map(makeImage),
+    imageOrder: imageOrder ?? imageIds,
+    __typename: 'Album',
+  }) as unknown as Album;
+
+const mountAlbum = (props: Record<string, unknown> = {}) => {
+  configureApolloMocks({ useMutation });
+  return mountWithDefaults(DiscussionAlbum, {
+    props: {
+      album: makeAlbum(['a', 'b', 'c']),
+      discussionId: 'd1',
+      discussionAuthor: 'alice',
+      ...props,
+    },
+    global: { stubs },
+  });
+};
+
+describe('DiscussionAlbum', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // One direct child div of the grid is rendered per ordered image.
+  const cells = (wrapper: ReturnType<typeof mountAlbum>) =>
+    wrapper.findAll('.grid-cols-3 > div');
+
+  it('renders one grid cell per album image', () => {
+    expect(cells(mountAlbum())).toHaveLength(3);
+  });
+
+  it('renders no cells for an empty album', () => {
+    expect(cells(mountAlbum({ album: makeAlbum([]) }))).toHaveLength(0);
+  });
+
+  it('falls back to Images order when imageOrder is empty', () => {
+    expect(cells(mountAlbum({ album: makeAlbum(['a', 'b'], []) }))).toHaveLength(2);
+  });
+
+  it('orders the cells according to imageOrder', () => {
+    const wrapper = mountAlbum({ album: makeAlbum(['a', 'b', 'c'], ['c', 'a', 'b']) });
+    const firstImg = cells(wrapper)[0].find('img');
+    expect(firstImg.attributes('src')).toContain('/c.jpg');
+  });
+
+  it('appends a synthetic cell for STL files', () => {
+    const wrapper = mountAlbum({
+      album: makeAlbum(['a']),
+      stlFiles: [{ id: 's1', url: 'https://example.com/m.stl', fileName: 'm.stl' }],
+    });
+    expect(cells(wrapper)).toHaveLength(2);
+  });
+});

--- a/components/discussion/detail/DiscussionAlbum.spec.ts
+++ b/components/discussion/detail/DiscussionAlbum.spec.ts
@@ -72,8 +72,13 @@ describe('DiscussionAlbum', () => {
     expect(cells(mountAlbum({ album: makeAlbum([]) }))).toHaveLength(0);
   });
 
-  it('falls back to Images order when imageOrder is empty', () => {
-    expect(cells(mountAlbum({ album: makeAlbum(['a', 'b'], []) }))).toHaveLength(2);
+  it('falls back to the Images array (in order) when imageOrder is empty', () => {
+    const wrapper = mountAlbum({ album: makeAlbum(['a', 'b'], []) });
+    const srcs = cells(wrapper).map((cell) => cell.find('img').attributes('src'));
+    expect(srcs).toEqual([
+      'https://example.com/a.jpg',
+      'https://example.com/b.jpg',
+    ]);
   });
 
   it('orders the cells according to imageOrder', () => {

--- a/components/discussion/form/AlbumEditor.spec.ts
+++ b/components/discussion/form/AlbumEditor.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+
+import AlbumEditor from '@/components/discussion/form/AlbumEditor.vue';
+
+vi.mock('@/cache', () => ({ usernameVar: { value: 'alice' } }));
+vi.mock('@/composables/useAlbumImageUpload', () => ({
+  useAlbumImageUpload: () => ({
+    loadingStates: ref({}),
+    uploadStatus: ref({}),
+    createSignedStorageUrlError: ref(null),
+    createImageError: ref(null),
+    handleMultipleFiles: vi.fn(),
+    handleDrop: vi.fn(),
+    createImageFromUrl: vi.fn(),
+  }),
+}));
+vi.mock('@/composables/useAlbumAutoSave', () => ({
+  useAlbumAutoSave: () => ({
+    isAutoSaving: ref(false),
+    autoSaveSuccess: ref(false),
+    updateDiscussionError: ref(null),
+    debouncedAutoSave: vi.fn(),
+  }),
+}));
+
+const AlbumImageItemStub = {
+  name: 'AlbumImageItem',
+  props: ['image', 'index', 'isFirst', 'isLast'],
+  emits: ['update-field', 'delete', 'move-up', 'move-down'],
+  template: '<div class="image-item-stub" />',
+};
+
+const stubs = {
+  AlbumImageItem: AlbumImageItemStub,
+  AlbumDropZone: { template: '<div class="drop-zone-stub" />' },
+  AlbumUrlInputForm: { template: '<div />' },
+  ErrorBanner: { props: ['text'], template: '<div />' },
+  LoadingSpinner: { template: '<div />' },
+};
+
+const makeImage = (id: string) => ({
+  id,
+  url: `https://example.com/${id}.jpg`,
+  alt: `alt-${id}`,
+  caption: '',
+  copyright: '',
+});
+
+const mountEditor = (
+  images = [makeImage('a'), makeImage('b'), makeImage('c')],
+  imageOrder = ['a', 'b', 'c']
+) =>
+  mountWithDefaults(AlbumEditor, {
+    props: { formValues: { album: { images, imageOrder } } },
+    global: { stubs },
+  });
+
+const lastEmit = (wrapper: ReturnType<typeof mountEditor>) => {
+  const calls = wrapper.emitted('updateFormValues');
+  return (calls?.[calls.length - 1]?.[0] as { album: { images: { id: string }[]; imageOrder: string[] } }).album;
+};
+
+describe('AlbumEditor', () => {
+  it('renders one image item per ordered image', () => {
+    const wrapper = mountEditor();
+    expect(wrapper.findAllComponents(AlbumImageItemStub)).toHaveLength(3);
+  });
+
+  it('emits the album without the deleted image', async () => {
+    const wrapper = mountEditor();
+    wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('delete');
+    expect(lastEmit(wrapper).images.map((i) => i.id)).toEqual(['b', 'c']);
+  });
+
+  it('reorders imageOrder when an image moves up', () => {
+    const wrapper = mountEditor();
+    wrapper.findAllComponents(AlbumImageItemStub)[1].vm.$emit('move-up');
+    expect(lastEmit(wrapper).imageOrder).toEqual(['b', 'a', 'c']);
+  });
+
+  it('reorders imageOrder when an image moves down', () => {
+    const wrapper = mountEditor();
+    wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('move-down');
+    expect(lastEmit(wrapper).imageOrder).toEqual(['b', 'a', 'c']);
+  });
+
+  it('updates a field on the targeted image', () => {
+    const wrapper = mountEditor();
+    wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('update-field', 'alt', 'new alt');
+    const updated = lastEmit(wrapper).images.find((i) => i.id === 'a') as { alt: string };
+    expect(updated.alt).toBe('new alt');
+  });
+});


### PR DESCRIPTION
Next batch on the mount harness (from #82, now in main). Two more real heavy components mounted and exercised — both were near-0% covered.

## Specs
- **`AlbumEditor`** (was ~4%) — composables (`useAlbumImageUpload`, `useAlbumAutoSave`) stubbed; covers ordered-image rendering, delete, move up/down, and field-update emits via child events. (5 assertions)
- **`DiscussionAlbum`** (was ~5%) — covers image ordering by `imageOrder`, empty album, the `Images`-order fallback, ordering correctness (asserts cell `src`), and STL synthetic cells. (5 assertions)

Both mount the real components using the shared `mountWithDefaults` defaults + `configureApolloMocks`; fixtures use generated types (`Album`).

## Verification
- New specs: **10 passing**
- `npm run tsc`: 0 errors; lint clean

## Pattern note
`AlbumEditor` shows the clean way to mount a composable-heavy component: stub the composables it consumes (returning the destructured refs/fns) rather than mocking Apollo deeply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)