### PR TITLE
test+fix: mount spec for DiscussionCommentsWrapper (+ optional-chain crash fix)

### DIFF
--- a/components/discussion/detail/DiscussionCommentsWrapper.spec.ts
+++ b/components/discussion/detail/DiscussionCommentsWrapper.spec.ts
@@ -122,4 +122,31 @@ describe('DiscussionCommentsWrapper', () => {
     await wrapper.find('.subscribe-stub').trigger('click');
     expect(subscribeMock.mutate).not.toHaveBeenCalled();
   });
+
+  // Regression: the user query result may lack a `users` array; the notify
+  // computed must not throw on it (was `?.users[0]`, now `?.users?.[0]`).
+  it('does not crash when the user query result has no users array', () => {
+    configureApolloMocks({
+      useQuery,
+      useMutation,
+      fallbackQuery: createQueryMock({}),
+      mutations: {
+        subscribeToDiscussionChannel: subscribeMock,
+        unsubscribeFromDiscussionChannel: unsubscribeMock,
+      },
+    });
+    expect(() =>
+      mountWithDefaults(DiscussionCommentsWrapper, {
+        props: {
+          aggregateCommentCount: 0,
+          discussionAuthor: 'bob',
+          reachedEndOfResults: false,
+          previousOffset: 0,
+          discussionChannel: makeChannel(),
+          comments: [],
+        },
+        global: { stubs },
+      })
+    ).not.toThrow();
+  });
 });

--- a/components/discussion/detail/DiscussionCommentsWrapper.spec.ts
+++ b/components/discussion/detail/DiscussionCommentsWrapper.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import {
+  asMock,
+  createMutationMock,
+  createQueryMock,
+  configureApolloMocks,
+} from '@/tests/utils/mockApollo';
+import type { Comment, DiscussionChannel } from '@/__generated__/graphql';
+
+import { useQuery, useMutation } from '@vue/apollo-composable';
+
+import DiscussionCommentsWrapper from '@/components/discussion/detail/DiscussionCommentsWrapper.vue';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: vi.fn(),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: vi.fn(() => ({ params: {}, query: {} })) }));
+vi.mock('@/cache', () => ({ usernameVar: { value: 'alice' } }));
+vi.mock('@/composables/useAutoUnsubscribe', () => ({ useAutoUnsubscribe: vi.fn() }));
+
+const CommentSectionStub = {
+  name: 'CommentSection',
+  props: ['comments'],
+  // Render the slots so slotted content (e.g. the subscribe button) appears.
+  template:
+    '<div class="comment-section-stub"><slot name="subscription-button" /><slot name="pre-header" /><slot /></div>',
+};
+const SubscribeButtonStub = {
+  name: 'SubscribeButton',
+  props: ['isSubscribed'],
+  emits: ['toggle'],
+  template: '<button class="subscribe-stub" @click="$emit(\'toggle\')" />',
+};
+
+const stubs = {
+  CommentSection: CommentSectionStub,
+  SubscribeButton: SubscribeButtonStub,
+  InlineCommentForm: { template: '<div />' },
+  DiscussionRootCommentFormWrapper: { template: '<div />' },
+  Notification: { template: '<div />' },
+};
+
+const makeComment = (id: string): Comment =>
+  ({ id, text: `comment ${id}`, __typename: 'Comment' }) as unknown as Comment;
+
+const makeChannel = (overrides: Record<string, unknown> = {}): DiscussionChannel =>
+  ({
+    id: 'dc1',
+    discussionId: 'd1',
+    channelUniqueName: 'cats',
+    SubscribedToNotifications: [],
+    __typename: 'DiscussionChannel',
+    ...overrides,
+  }) as unknown as DiscussionChannel;
+
+const subscribeMock = createMutationMock();
+const unsubscribeMock = createMutationMock();
+
+const mountWrapper = (props: Record<string, unknown> = {}) => {
+  configureApolloMocks({
+    useQuery,
+    useMutation,
+    // The only query (GET_USER) reads result.users[0]; give it an array shape.
+    fallbackQuery: createQueryMock({ users: [] }),
+    mutations: {
+      subscribeToDiscussionChannel: subscribeMock,
+      unsubscribeFromDiscussionChannel: unsubscribeMock,
+    },
+  });
+  return mountWithDefaults(DiscussionCommentsWrapper, {
+    props: {
+      aggregateCommentCount: 0,
+      discussionAuthor: 'bob',
+      reachedEndOfResults: false,
+      previousOffset: 0,
+      discussionChannel: makeChannel(),
+      comments: [makeComment('a'), makeComment('b')],
+      ...props,
+    },
+    global: { stubs },
+  });
+};
+
+describe('DiscussionCommentsWrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    asMock(useMutation).mockReset();
+    asMock(useQuery).mockReset();
+  });
+
+  it('passes the comments through to CommentSection in order', () => {
+    const wrapper = mountWrapper();
+    const passed = wrapper.findComponent(CommentSectionStub).props('comments') as Comment[];
+    expect(passed.map((c) => c.id)).toEqual(['a', 'b']);
+  });
+
+  it('renders the subscribe button', () => {
+    const wrapper = mountWrapper();
+    expect(wrapper.find('.subscribe-stub').exists()).toBe(true);
+  });
+
+  it('subscribes when toggled while not subscribed', async () => {
+    const wrapper = mountWrapper();
+    await wrapper.find('.subscribe-stub').trigger('click');
+    expect(subscribeMock.mutate).toHaveBeenCalledWith({ discussionChannelId: 'dc1' });
+  });
+
+  it('unsubscribes when toggled while subscribed', async () => {
+    const wrapper = mountWrapper({
+      discussionChannel: makeChannel({
+        SubscribedToNotifications: [{ username: 'alice' }],
+      }),
+    });
+    await wrapper.find('.subscribe-stub').trigger('click');
+    expect(unsubscribeMock.mutate).toHaveBeenCalledWith({ discussionChannelId: 'dc1' });
+  });
+
+  it('does nothing when there is no discussion channel id', async () => {
+    const wrapper = mountWrapper({ discussionChannel: makeChannel({ id: '' }) });
+    await wrapper.find('.subscribe-stub').trigger('click');
+    expect(subscribeMock.mutate).not.toHaveBeenCalled();
+  });
+});

--- a/components/discussion/detail/DiscussionCommentsWrapper.vue
+++ b/components/discussion/detail/DiscussionCommentsWrapper.vue
@@ -234,7 +234,7 @@ const { result: getUserResult } = useQuery(
 // Get user's notification preference for comment replies
 const notifyOnReplyToCommentByDefault = computed(() => {
   return (
-    getUserResult.value?.users[0]?.notifyOnReplyToCommentByDefault ?? false
+    getUserResult.value?.users?.[0]?.notifyOnReplyToCommentByDefault ?? false
   );
 });
 


### PR DESCRIPTION
Next on the mount harness. `DiscussionCommentsWrapper` was ~1% covered — and mounting the real component surfaced a latent crash, which this PR also fixes.

## Test
Mounts the real component (GET_USER query + subscribe/unsubscribe mutations via `configureApolloMocks`; `CommentSection`/`SubscribeButton` stubbed with slot passthrough). Covers:
- comments passed through to `CommentSection` — asserted by **id + order**
- subscribe button renders
- toggle routes to **subscribe** when not subscribed, **unsubscribe** when subscribed
- no-op when there's no discussion-channel id

## Fix
`notifyOnReplyToCommentByDefault` read `getUserResult.value?.users[0]` — the optional chain stops at `.value`, so a GET_USER result without a `users` array threw `Cannot read properties of undefined (reading '0')`. Changed to `?.users?.[0]`.

Added a **regression test** that mounts with a user-query result lacking `users` and asserts no throw — it fails before the fix and passes after (verified red-green).

6 assertions total. tsc 0; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)