### PR TITLE
test: mount spec for DiscussionDetailContent

### DIFF
--- a/components/discussion/detail/DiscussionDetailContent.spec.ts
+++ b/components/discussion/detail/DiscussionDetailContent.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import {
+  asMock,
+  createQueryMock,
+  configureApolloMocks,
+} from '@/tests/utils/mockApollo';
+import type { Comment, Discussion } from '@/__generated__/graphql';
+
+import { useQuery } from '@vue/apollo-composable';
+
+import DiscussionDetailContent from '@/components/discussion/detail/DiscussionDetailContent.vue';
+
+vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+vi.mock('nuxt/app', () => ({ useRoute: vi.fn(() => ({ params: {}, query: {} })) }));
+vi.mock('@/cache', () => ({
+  isAuthenticatedVar: { value: false },
+  modProfileNameVar: { value: '' },
+  usernameVar: { value: '' },
+}));
+vi.mock('@/composables/useForumRoleMembership', () => ({
+  provideForumRoleMembership: vi.fn(),
+}));
+
+const DiscussionCommentsWrapperStub = {
+  name: 'DiscussionCommentsWrapper',
+  props: ['comments'],
+  template: '<div class="comments-wrapper-stub" />',
+};
+
+const stubs = {
+  DiscussionHeader: { template: '<div class="discussion-header-stub" />' },
+  DiscussionCommentsWrapper: DiscussionCommentsWrapperStub,
+  DiscussionChannelLinks: { template: '<div />' },
+  PageNotFound: { template: '<div class="page-not-found-stub" />' },
+  InfoBanner: { template: '<div />' },
+  ErrorBanner: { template: '<div />' },
+  DiscussionBodyEditForm: { template: '<div />' },
+  AlbumEditForm: { template: '<div />' },
+  ArchivedDiscussionInfoBanner: { template: '<div />' },
+  DiscussionLayoutManager: { template: '<div class="layout-stub"><slot /></div>' },
+  FeedbackModalManager: { template: '<div />' },
+};
+
+const makeDiscussion = (overrides: Record<string, unknown> = {}): Discussion =>
+  ({
+    id: 'd1',
+    title: 'Test Discussion',
+    body: 'body',
+    DiscussionChannels: [
+      { channelUniqueName: 'cats', __typename: 'DiscussionChannel' },
+    ],
+    __typename: 'Discussion',
+    ...overrides,
+  }) as unknown as Discussion;
+
+const makeComment = (id: string): Comment =>
+  ({ id, __typename: 'Comment' }) as unknown as Comment;
+
+const commentSection = (comments: Comment[]) => ({
+  getCommentSection: {
+    DiscussionChannel: {
+      id: 'dc1',
+      channelUniqueName: 'cats',
+      Answers: [],
+      __typename: 'DiscussionChannel',
+    },
+    Comments: comments,
+  },
+});
+
+const setup = (params: {
+  discussions?: Discussion[];
+  comments?: Comment[];
+  hasCommentSection?: boolean;
+} = {}) => {
+  const { discussions = [makeDiscussion()], comments = [], hasCommentSection = true } = params;
+  configureApolloMocks({
+    useQuery,
+    queries: {
+      'getDiscussion(': createQueryMock({ discussions }),
+      getCommentSection: {
+        ...createQueryMock(hasCommentSection ? commentSection(comments) : { getCommentSection: null }),
+        fetchMore: vi.fn(),
+      } as ReturnType<typeof createQueryMock>,
+    },
+    // Both comment-aggregate queries read result.discussionChannels[0].
+    fallbackQuery: createQueryMock({ discussionChannels: [] }),
+  });
+  return mountWithDefaults(DiscussionDetailContent, {
+    props: { discussionId: 'd1', channelId: 'cats' },
+    global: { stubs },
+  });
+};
+
+describe('DiscussionDetailContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    asMock(useQuery).mockReset();
+  });
+
+  it('renders the discussion header for a loaded discussion', () => {
+    const wrapper = setup();
+    expect(wrapper.find('.discussion-header-stub').exists()).toBe(true);
+  });
+
+  it('does not show page-not-found for a loaded discussion', () => {
+    const wrapper = setup();
+    expect(wrapper.find('.page-not-found-stub').exists()).toBe(false);
+  });
+
+  it('shows page-not-found when the discussion and channel are absent', () => {
+    const wrapper = setup({ discussions: [], hasCommentSection: false });
+    expect(wrapper.find('.page-not-found-stub').exists()).toBe(true);
+  });
+
+  it('passes the comment-section comments through in order', () => {
+    const wrapper = setup({ comments: [makeComment('a'), makeComment('b')] });
+    const passed = wrapper
+      .findComponent(DiscussionCommentsWrapperStub)
+      .props('comments') as Comment[];
+    expect(passed.map((c) => c.id)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
Next on the mount harness. `DiscussionDetailContent` was ~5% covered (5 `useQuery`s).

## Spec
Mounts the real component with all five queries wired via `configureApolloMocks` (dispatched by document substring), `provideForumRoleMembership` stubbed, and heavy children stubbed. Covers:
- **loaded** state — `DiscussionHeader` renders, no `PageNotFound`
- **not-found** state — no discussion + no comment-section channel + not loading → `PageNotFound`
- comment-section comments passed through to `DiscussionCommentsWrapper` — asserted by **id + order**

4 assertions. tsc 0; lint clean.

Note: this component has the same `?.<arr>[0]` pattern (`getDiscussionResult.value?.discussions[0]`, and `?.discussionChannels[0]` in the aggregates) as the one fixed in #84 — the spec works around it with array-shaped query mocks. Worth a follow-up safety pass, but kept out of this test-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)