### PR TITLE
test: real-mount spec for CommentSection

### DIFF
--- a/components/comments/CommentSection.realmount.spec.ts
+++ b/components/comments/CommentSection.realmount.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import {
+  asMock,
+  createQueryMock,
+  configureApolloMocks,
+} from '@/tests/utils/mockApollo';
+import { makeComment } from '@/tests/utils/factories';
+import type { Comment } from '@/__generated__/graphql';
+
+import { useQuery, useMutation } from '@vue/apollo-composable';
+
+import CommentSection from '@/components/comments/CommentSection.vue';
+
+// Mock only the low-level deps; let the real composables (notifications, modals,
+// feedback/crud mutations, suspension notice) run — they only need Apollo +
+// route mocked, and exercising them is a coverage bonus.
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: vi.fn(),
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: vi.fn(() => ({ params: {}, query: {} })),
+  useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+}));
+vi.mock('@/cache', () => ({ modProfileNameVar: { value: '' } }));
+
+const CommentStub = {
+  name: 'Comment',
+  props: ['commentData'],
+  template: '<div class="comment-stub" />',
+};
+const LoadMoreStub = { name: 'LoadMore', template: '<div class="load-more-stub" />' };
+
+const stubs = {
+  Comment: CommentStub,
+  LoadMore: LoadMoreStub,
+  SortButtons: { template: '<div class="sort-buttons-stub" />' },
+  PinnedAnswers: { template: '<div />' },
+  WarningModal: { template: '<div />' },
+  BrokenRulesModal: { template: '<div />' },
+  GenericFeedbackFormModal: { template: '<div />' },
+  Notification: { template: '<div />' },
+  ConfirmUndoCommentFeedbackModal: { template: '<div />' },
+  EditCommentFeedbackModal: { template: '<div />' },
+  UnarchiveModal: { template: '<div />' },
+  LockIcon: { template: '<i />' },
+  InfoBanner: { template: '<div />' },
+  ErrorBanner: { template: '<div />' },
+  SuspensionNotice: { template: '<div />' },
+};
+
+const baseProps = (overrides: Record<string, unknown> = {}) => ({
+  commentSectionQueryVariables: {
+    discussionId: 'd1',
+    channelUniqueName: 'cats',
+    limit: 50,
+    offset: 0,
+  },
+  createCommentInput: {},
+  createFormValues: { text: '', isRootComment: true, depth: 1 },
+  reachedEndOfResults: false,
+  previousOffset: 0,
+  originalPoster: 'bob',
+  aggregateCommentCount: 2,
+  comments: [makeComment({ id: 'a' }), makeComment({ id: 'b' })],
+  ...overrides,
+});
+
+const mountSection = (overrides: Record<string, unknown> = {}) => {
+  configureApolloMocks({
+    useQuery,
+    useMutation,
+    fallbackQuery: createQueryMock({}),
+  });
+  return mountWithDefaults(CommentSection, {
+    props: baseProps(overrides),
+    global: { stubs },
+  });
+};
+
+describe('CommentSection (real mount)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    asMock(useQuery).mockReset();
+    asMock(useMutation).mockReset();
+  });
+
+  it('renders one Comment per comment in order', () => {
+    const wrapper = mountSection();
+    const ids = wrapper
+      .findAllComponents(CommentStub)
+      .map((c) => (c.props('commentData') as Comment).id);
+    expect(ids).toEqual(['a', 'b']);
+  });
+
+  it('renders no Comment when the list is empty (and not loading)', () => {
+    const wrapper = mountSection({ comments: [], loading: false });
+    expect(wrapper.findAllComponents(CommentStub)).toHaveLength(0);
+  });
+
+  it('renders the sort buttons', () => {
+    const wrapper = mountSection();
+    expect(wrapper.find('.sort-buttons-stub').exists()).toBe(true);
+  });
+
+  it('renders the load-more control', () => {
+    const wrapper = mountSection();
+    expect(wrapper.find('.load-more-stub').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
The last big composable-heavy headliner — `CommentSection.vue` (937 lines, 5 composables + 15 children). Was ~35% from a util/double-only spec; the real component was never mounted.

## Approach
Its 5 composables expose ~60 destructured values, so stubbing them by hand is impractical. Instead, mock only the **low-level deps** (`@vue/apollo-composable`, `nuxt/app`, `@/cache`) and let the real composables run:
- `useCommentSectionNotifications` / `useCommentSectionModals` are pure local state
- `useCommentFeedbackMutation` / `useCommentCrudMutations` only need `useMutation` mocked
- `useChannelSuspensionNotice` only needs `useQuery` mocked (and uses safe optional chaining)

Exercising the real composables is a coverage bonus. The 15 child components are stubbed.

## Covered
- one `Comment` rendered per comment — asserted by **id + order**
- empty list renders no comments
- sort buttons render (gated on `aggregateCommentCount`)
- load-more control renders

4 assertions. tsc 0; lint clean. Named `CommentSection.realmount.spec.ts` to coexist with the existing spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)