### PR TITLE
chore: exclude presentational/glue code from coverage report

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -53,14 +53,22 @@ export default defineConfig({
         '.eslintrc.*',
         'cache.ts',
         'config.ts',
+        // Presentational-only: icons are pure <svg> markup with no logic.
+        'components/icons/**',
+        // Test scaffolding (E2E mock auth), not production behavior.
+        'composables/useTestAuth.ts',
+        'composables/useTestAuthHelpers.ts',
+        // Test helpers should not count as covered source.
+        'tests/**',
       ],
+      // Coverage targets app logic. layouts/ and plugins/ are framework
+      // integration glue (Nuxt registration, layout shells) that is exercised
+      // by the E2E suite rather than unit tests, so they are not included here.
       include: [
         'components/**/*.vue',
         'composables/**/*.ts',
         'utils/**/*.ts',
         'pages/**/*.vue',
-        'layouts/**/*.vue',
-        'plugins/**/*.ts',
       ],
       // Cleanup coverage results before each run
       clean: true,


### PR DESCRIPTION
Make the coverage report reflect code with logic worth testing, rather than presentational markup and framework glue.

## Excluded
- **`components/icons/**`** — verified pure `<svg>` (85 of 87 have an empty `<script>`). Icons don't need unit tests.
- **`composables/useTestAuth.ts` + `useTestAuthHelpers.ts`** — E2E mock-auth scaffolding, not production behavior.
- **`tests/**`** — test helpers shouldn't count as covered source.
- **`layouts/` and `plugins/`** dropped from the coverage `include` — Nuxt registration glue and layout shells.

## Kept (deliberately)
- **`components/scratchpad/`** — despite the name, it's a real feature (mutations + computed logic). It should be *tested*, not hidden.

## Effect
Removes **366 statements** of non-app-logic from the denominator (icons 88 + test-auth 92 + tests/utils 43 + plugins ~101 + layouts 42). Statement coverage now reads **35.1%** (was ~33.3%); note the headline also reflects the EventDetail/DiscussionCommentsWrapper specs that merged since the prior measurement. The bigger value is signal: ~90 permanently-red, logic-free files no longer clutter the report.

`npm run tsc`: 0 errors; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)