### PR TITLE
fix: guard unsafe optional chains before array index access

### DIFF
--- a/components/admin/SelectBrokenRules.vue
+++ b/components/admin/SelectBrokenRules.vue
@@ -60,7 +60,7 @@ const getRules = (rulesJSON: string): RuleOption[] => {
 };
 
 const forumRuleOptions = computed<RuleOption[]>(() => {
-  const channel = channelRulesResult.value?.channels[0];
+  const channel = channelRulesResult.value?.channels?.[0];
   if (!channel) {
     return [];
   }
@@ -68,7 +68,7 @@ const forumRuleOptions = computed<RuleOption[]>(() => {
 });
 
 const serverRuleOptions = computed<RuleOption[]>(() => {
-  const serverConfig = serverRulesResult.value?.serverConfigs[0];
+  const serverConfig = serverRulesResult.value?.serverConfigs?.[0];
   if (!serverConfig) {
     return [];
   }

--- a/components/admin/ServerSuspendedModList.vue
+++ b/components/admin/ServerSuspendedModList.vue
@@ -16,11 +16,11 @@ const { result, loading, error } = useQuery(
 );
 
 const suspensions = computed(() => {
-  return result.value?.serverConfigs[0]?.SuspendedMods ?? [];
+  return result.value?.serverConfigs?.[0]?.SuspendedMods ?? [];
 });
 
 const aggregateCount = computed(() => {
-  return result.value?.serverConfigs[0]?.SuspendedModsAggregate?.count ?? 0;
+  return result.value?.serverConfigs?.[0]?.SuspendedModsAggregate?.count ?? 0;
 });
 
 const humanReadableDate = (dateISO?: string | null): string => {

--- a/components/admin/ServerSuspendedUserList.vue
+++ b/components/admin/ServerSuspendedUserList.vue
@@ -16,11 +16,11 @@ const { result, loading, error } = useQuery(
 );
 
 const suspendedUsers = computed(() => {
-  return result.value?.serverConfigs[0]?.SuspendedUsers ?? [];
+  return result.value?.serverConfigs?.[0]?.SuspendedUsers ?? [];
 });
 
 const aggregateCount = computed(() => {
-  return result.value?.serverConfigs[0]?.SuspendedUsersAggregate?.count ?? 0;
+  return result.value?.serverConfigs?.[0]?.SuspendedUsersAggregate?.count ?? 0;
 });
 
 const humanReadableDate = (dateISO?: string | null): string => {

--- a/components/channel/form/ForumOwnerList.vue
+++ b/components/channel/form/ForumOwnerList.vue
@@ -21,7 +21,7 @@ const { result, loading, error } = useQuery(
     fetchPolicy: 'cache-first',
   }
 );
-const admins = computed(() => result.value?.channels[0]?.Admins);
+const admins = computed(() => result.value?.channels?.[0]?.Admins);
 
 defineEmits(['click-remove-owner']);
 </script>

--- a/components/channel/form/ModList.vue
+++ b/components/channel/form/ModList.vue
@@ -21,7 +21,7 @@ const { result, loading, error } = useQuery(
     fetchPolicy: 'cache-first',
   }
 );
-const mods = computed(() => result.value?.channels[0]?.Moderators);
+const mods = computed(() => result.value?.channels?.[0]?.Moderators);
 
 defineEmits(['click-remove-mod']);
 </script>

--- a/components/channel/form/PendingForumModList.vue
+++ b/components/channel/form/PendingForumModList.vue
@@ -22,7 +22,7 @@ const { result, loading, error } = useQuery(
   }
 );
 const invites = computed(
-  () => result.value?.channels[0]?.PendingModInvites ?? []
+  () => result.value?.channels?.[0]?.PendingModInvites ?? []
 );
 
 defineEmits(['click-cancel-invite']);

--- a/components/channel/form/PendingForumOwnerList.vue
+++ b/components/channel/form/PendingForumOwnerList.vue
@@ -22,7 +22,7 @@ const { result, loading, error } = useQuery(
   }
 );
 const invites = computed(
-  () => result.value?.channels[0]?.PendingOwnerInvites ?? []
+  () => result.value?.channels?.[0]?.PendingOwnerInvites ?? []
 );
 
 defineEmits(['click-cancel-invite']);

--- a/components/channel/form/SuspendedModList.vue
+++ b/components/channel/form/SuspendedModList.vue
@@ -23,10 +23,10 @@ const { result, loading, error } = useQuery(
   }
 );
 const suspensions = computed(
-  () => result.value?.channels[0]?.SuspendedMods ?? []
+  () => result.value?.channels?.[0]?.SuspendedMods ?? []
 );
 const aggregateCount = computed(
-  () => result.value?.channels[0]?.SuspendedModsAggregate?.count ?? 0
+  () => result.value?.channels?.[0]?.SuspendedModsAggregate?.count ?? 0
 );
 
 const humanReadableDate = (dateISO: string): string => {

--- a/components/comments/ArchivedCommentText.vue
+++ b/components/comments/ArchivedCommentText.vue
@@ -21,7 +21,7 @@ const { result: getCommentIssueResult } = useQuery(GET_COMMENT_ISSUE, {
 });
 
 const issueNumber = computed(() => {
-  return getCommentIssueResult.value?.comments[0]?.RelatedIssues[0]
+  return getCommentIssueResult.value?.comments?.[0]?.RelatedIssues?.[0]
     ?.issueNumber;
 });
 

--- a/components/comments/CommentHeader.vue
+++ b/components/comments/CommentHeader.vue
@@ -83,7 +83,7 @@ const createdAtFormatted = computed(() => {
       ? ' in c/' +
         (props.commentData.DiscussionChannel?.channelUniqueName ||
           (props.commentData.Event?.EventChannels &&
-            props.commentData.Event?.EventChannels[0]?.channelUniqueName) ||
+            props.commentData.Event?.EventChannels?.[0]?.channelUniqueName) ||
           props.commentData.Channel?.uniqueName ||
           '')
       : ''
@@ -187,7 +187,7 @@ const contextLinkObject = computed(() => {
     });
   }
   return getPermalinkToEventComment({
-    forumId: Event?.EventChannels[0]?.channelUniqueName || '',
+    forumId: Event?.EventChannels?.[0]?.channelUniqueName || '',
     eventId: Event?.id || '',
     commentId: props.commentData.id,
   });

--- a/components/comments/LoggedInUserAvatar.vue
+++ b/components/comments/LoggedInUserAvatar.vue
@@ -16,7 +16,7 @@ const { result: getUserResult } = useQuery(
 );
 
 const profilePicURL = computed(() => {
-  return getUserResult.value?.users[0]?.profilePicURL || '';
+  return getUserResult.value?.users?.[0]?.profilePicURL || '';
 });
 </script>
 

--- a/components/comments/PermalinkedComment.vue
+++ b/components/comments/PermalinkedComment.vue
@@ -15,7 +15,7 @@ const {
 });
 
 const comment = computed(() => {
-  return commentResult.value?.comments[0];
+  return commentResult.value?.comments?.[0];
 });
 
 const parentCommentId = computed(() => {

--- a/components/discussion/detail/ArchivedDiscussionInfoBanner.vue
+++ b/components/discussion/detail/ArchivedDiscussionInfoBanner.vue
@@ -19,7 +19,7 @@ const { result: getDiscussionIssueResult } = useQuery(GET_DISCUSSION_ISSUE, {
 });
 
 const issueNumber = computed(() => {
-  return getDiscussionIssueResult.value?.discussionChannels[0]?.RelatedIssues[0]
+  return getDiscussionIssueResult.value?.discussionChannels?.[0]?.RelatedIssues?.[0]
     ?.issueNumber;
 });
 

--- a/components/discussion/detail/DiscussionDetailContent.vue
+++ b/components/discussion/detail/DiscussionDetailContent.vue
@@ -127,7 +127,7 @@ const albumEditMode = ref(false);
 const feedbackModalManager = ref();
 
 const discussion = computed<Discussion | null>(() => {
-  const currentDiscussion = getDiscussionResult.value?.discussions[0];
+  const currentDiscussion = getDiscussionResult.value?.discussions?.[0];
 
   return currentDiscussion || lastValidDiscussion.value;
 });
@@ -290,14 +290,14 @@ const imageUploadsEnabled = computed(
 
 const aggregateCommentCount = computed(() => {
   return (
-    getDiscussionChannelCommentAggregateResult.value?.discussionChannels[0]
+    getDiscussionChannelCommentAggregateResult.value?.discussionChannels?.[0]
       ?.CommentsAggregate?.count || 0
   );
 });
 
 const aggregateRootCommentCount = computed(() => {
   return (
-    getDiscussionChannelRootCommentAggregateResult.value?.discussionChannels[0]
+    getDiscussionChannelRootCommentAggregateResult.value?.discussionChannels?.[0]
       ?.CommentsAggregate?.count || 0
   );
 });

--- a/components/discussion/detail/DiscussionHeader.vue
+++ b/components/discussion/detail/DiscussionHeader.vue
@@ -362,7 +362,7 @@ const menuItems = computed(() => {
     discussionId: props.discussion.id,
     hasAlbum: !!props.discussion?.Album?.Images?.length,
     feedbackEnabled:
-      getChannelResult.value?.channels[0]?.feedbackEnabled ?? true,
+      getChannelResult.value?.channels?.[0]?.feedbackEnabled ?? true,
     hasSensitiveContent: !!props.discussion?.hasSensitiveContent,
     relatedIssueLink: relatedIssueLink.value,
   });

--- a/components/discussion/detail/DiscussionTitleEditForm.vue
+++ b/components/discussion/detail/DiscussionTitleEditForm.vue
@@ -44,7 +44,7 @@ const answered = computed(() => {
   if (isDiscussionAnsweredLoading.value) return false;
   if (isDiscussionAnsweredError.value) return false;
   return (
-    isDiscussionAnsweredResult.value?.discussionChannels[0]?.answered || false
+    isDiscussionAnsweredResult.value?.discussionChannels?.[0]?.answered || false
   );
 });
 
@@ -60,7 +60,7 @@ const {
 });
 
 const discussion = computed<Discussion | null>(() => {
-  const discussion = getDiscussionResult.value?.discussions[0];
+  const discussion = getDiscussionResult.value?.discussions?.[0];
   if (getDiscussionLoading.value && !discussion) {
     return null;
   }
@@ -79,7 +79,7 @@ const formValues = ref({
 });
 onGetDiscussionResult(
   (result) =>
-    (formValues.value.title = result?.data?.discussions[0]?.title || '')
+    (formValues.value.title = result?.data?.discussions?.[0]?.title || '')
 );
 
 const {

--- a/components/discussion/form/DiscussionRootCommentFormWrapper.vue
+++ b/components/discussion/form/DiscussionRootCommentFormWrapper.vue
@@ -76,7 +76,7 @@ const { result: getUserResult } = useQuery(
 // Get user's notification preference for comment replies
 const notifyOnReplyToCommentByDefault = computed(() => {
   return (
-    getUserResult.value?.users[0]?.notifyOnReplyToCommentByDefault ?? false
+    getUserResult.value?.users?.[0]?.notifyOnReplyToCommentByDefault ?? false
   );
 });
 
@@ -183,7 +183,7 @@ const {
     // the cache after replying to a comment, see the CommentSection
     // component.
     try {
-      const newComment: Comment = result.data?.createComments?.comments[0];
+      const newComment: Comment = result.data?.createComments?.comments?.[0];
       if (!newComment) {
         console.error('No new comment returned from createComments mutation');
         return;

--- a/components/discussion/form/InlineCommentForm.vue
+++ b/components/discussion/form/InlineCommentForm.vue
@@ -67,7 +67,7 @@ const { result: getUserResult } = useQuery(
 
 const notifyOnReplyToCommentByDefault = computed(() => {
   return (
-    getUserResult.value?.users[0]?.notifyOnReplyToCommentByDefault ?? false
+    getUserResult.value?.users?.[0]?.notifyOnReplyToCommentByDefault ?? false
   );
 });
 
@@ -157,7 +157,7 @@ const {
   },
   update: (cache: ApolloCache<NormalizedCacheObject>, result: FetchResult) => {
     try {
-      const newComment: Comment = result.data?.createComments?.comments[0];
+      const newComment: Comment = result.data?.createComments?.comments?.[0];
       if (!newComment) {
         console.error('No new comment returned from createComments mutation');
         return;

--- a/components/discussion/list/SitewideDiscussionList.vue
+++ b/components/discussion/list/SitewideDiscussionList.vue
@@ -114,7 +114,7 @@ const serverConfig = computed(() => {
   if (getServerError.value || !getServerResult.value?.serverConfigs) {
     return null;
   }
-  return getServerResult.value?.serverConfigs[0] || null;
+  return getServerResult.value?.serverConfigs?.[0] || null;
 });
 
 const discussions = computed<Discussion[]>(() => {

--- a/components/event/detail/ArchivedEventInfoBanner.vue
+++ b/components/event/detail/ArchivedEventInfoBanner.vue
@@ -19,7 +19,7 @@ const { result: getEventIssueResult } = useQuery(GET_EVENT_ISSUE, {
 });
 
 const issueNumber = computed(() => {
-  return getEventIssueResult.value?.eventChannels[0]?.RelatedIssues[0]
+  return getEventIssueResult.value?.eventChannels?.[0]?.RelatedIssues?.[0]
     ?.issueNumber;
 });
 

--- a/components/event/detail/EventCommentsWrapper.vue
+++ b/components/event/detail/EventCommentsWrapper.vue
@@ -118,7 +118,7 @@ const { result: getUserResult } = useQuery(
 // Get user's notification preference for comment replies
 const notifyOnReplyToCommentByDefault = computed(() => {
   return (
-    getUserResult.value?.users[0]?.notifyOnReplyToCommentByDefault ?? false
+    getUserResult.value?.users?.[0]?.notifyOnReplyToCommentByDefault ?? false
   );
 });
 

--- a/components/event/detail/EventHeader.vue
+++ b/components/event/detail/EventHeader.vue
@@ -208,7 +208,7 @@ const { userPermissions } = useResolvedModPermissions({
 });
 
 const feedbackEnabled = computed(() => {
-  return getChannelResult.value?.channels[0]?.feedbackEnabled !== false;
+  return getChannelResult.value?.channels?.[0]?.feedbackEnabled !== false;
 });
 
 const permalinkObject = computed(() => {

--- a/components/event/detail/EventRootCommentFormWrapper.vue
+++ b/components/event/detail/EventRootCommentFormWrapper.vue
@@ -49,7 +49,7 @@ const { result: getUserResult } = useQuery(
 // Get user's notification preference for comment replies
 const notifyOnReplyToCommentByDefault = computed(() => {
   return (
-    getUserResult.value?.users[0]?.notifyOnReplyToCommentByDefault ?? false
+    getUserResult.value?.users?.[0]?.notifyOnReplyToCommentByDefault ?? false
   );
 });
 

--- a/components/event/form/CreateEditEventFields.vue
+++ b/components/event/form/CreateEditEventFields.vue
@@ -308,7 +308,7 @@ const titleInputRef = ref<InstanceType<typeof TextInput> | null>(null);
 nextTick(() => {
   if (titleInputRef.value) {
     (
-      titleInputRef.value?.$el?.children[0].childNodes[0] as HTMLInputElement
+      titleInputRef.value?.$el?.children?.[0].childNodes[0] as HTMLInputElement
     ).focus();
   }
 });

--- a/components/event/form/CreateEvent.vue
+++ b/components/event/form/CreateEvent.vue
@@ -140,7 +140,7 @@ const {
 });
 onDone((response) => {
   createEventLoading.value = false;
-  const newEventId = response.data?.createEventWithChannelConnections[0]?.id;
+  const newEventId = response.data?.createEventWithChannelConnections?.[0]?.id;
   const redirectChannelId = formValues.value.selectedChannels[0];
   if (!newEventId) {
     submitError.value =

--- a/components/event/map/MapView.vue
+++ b/components/event/map/MapView.vue
@@ -272,10 +272,10 @@ const highlightEventOnMap = (input: HighlightEventInput) => {
   if (markerMap.markers[eventLocationId]) {
     const openSpecificInfowindow = () => {
       const eventTitle =
-        markerMap.markers[eventLocationId]?.events[highlightedEventId.value]
+        markerMap.markers[eventLocationId]?.events?.[highlightedEventId.value]
           ?.title;
       const eventLocation =
-        markerMap.markers[eventLocationId]?.events[highlightedEventId.value]
+        markerMap.markers[eventLocationId]?.events?.[highlightedEventId.value]
           ?.locationName;
 
       let infowindowContent = `<b>${eventTitle}</b>`;

--- a/components/mod/CommentDetails.vue
+++ b/components/mod/CommentDetails.vue
@@ -52,7 +52,7 @@ const originalComment = computed(() => {
     return null;
   }
 
-  return commentResult.value?.comments && commentResult.value?.comments[0];
+  return commentResult.value?.comments && commentResult.value?.comments?.[0];
 });
 
 const forumRoleBadge = computed(() => {

--- a/components/mod/IssueTitleEditForm.vue
+++ b/components/mod/IssueTitleEditForm.vue
@@ -47,7 +47,7 @@ const {
 );
 
 const issue = computed<Issue | null>(() => {
-  const issue = getIssueResult.value?.issues[0];
+  const issue = getIssueResult.value?.issues?.[0];
   if (getIssueLoading.value && !issue) {
     return null;
   }
@@ -65,7 +65,7 @@ const formValues = ref({
   title: getIssueResult.value?.issue?.title || '',
 });
 onGetIssueResult(
-  (result) => (formValues.value.title = result?.data?.issues[0]?.title || '')
+  (result) => (formValues.value.title = result?.data?.issues?.[0]?.title || '')
 );
 
 const {

--- a/components/mod/ModProfileSidebar.vue
+++ b/components/mod/ModProfileSidebar.vue
@@ -32,7 +32,7 @@ const { result, error: getModError } = useQuery(GET_MOD, () => ({
 }));
 
 const mod = computed(() => {
-  return result.value?.moderationProfiles[0] || null;
+  return result.value?.moderationProfiles?.[0] || null;
 });
 </script>
 

--- a/components/mod/PendingInvite.vue
+++ b/components/mod/PendingInvite.vue
@@ -57,11 +57,11 @@ const {
 } = useMutation(ACCEPT_FORUM_MOD_INVITE);
 
 const pendingOwnerInviteExists = computed(() => {
-  const channelData = pendingOwnerInviteResult.value?.channels[0];
+  const channelData = pendingOwnerInviteResult.value?.channels?.[0];
   if (!channelData) {
     return false;
   }
-  const pendingInvite = channelData?.PendingOwnerInvites[0];
+  const pendingInvite = channelData?.PendingOwnerInvites?.[0];
   if (usernameVar.value === pendingInvite?.username) {
     return true;
   }
@@ -69,11 +69,11 @@ const pendingOwnerInviteExists = computed(() => {
 });
 
 const pendingModInviteExists = computed(() => {
-  const channelData = pendingModInviteResult.value?.channels[0];
+  const channelData = pendingModInviteResult.value?.channels?.[0];
   if (!channelData) {
     return false;
   }
-  const pendingInvite = channelData?.PendingModInvites[0];
+  const pendingInvite = channelData?.PendingModInvites?.[0];
   if (usernameVar.value === pendingInvite?.username) {
     return true;
   }

--- a/components/mod/PermalinkedActivityFeedItem.vue
+++ b/components/mod/PermalinkedActivityFeedItem.vue
@@ -19,7 +19,7 @@ const {
 
 const moderationAction = computed(() => {
   if (!commentResult.value?.comments) return null;
-  return commentResult.value?.comments[0]?.ModerationAction;
+  return commentResult.value?.comments?.[0]?.ModerationAction;
 });
 </script>
 

--- a/components/mod/ReportChannelImageModal.vue
+++ b/components/mod/ReportChannelImageModal.vue
@@ -67,7 +67,7 @@ const getRules = (rulesJSON: string): RuleOption[] => {
 };
 
 const serverRuleOptions = computed<RuleOption[]>(() => {
-  const serverConfig = serverRulesResult.value?.serverConfigs[0];
+  const serverConfig = serverRulesResult.value?.serverConfigs?.[0];
   if (!serverConfig) {
     return [];
   }

--- a/components/mod/ReportChannelModal.vue
+++ b/components/mod/ReportChannelModal.vue
@@ -60,7 +60,7 @@ const getRules = (rulesJSON: string): RuleOption[] => {
 };
 
 const serverRuleOptions = computed<RuleOption[]>(() => {
-  const serverConfig = serverRulesResult.value?.serverConfigs[0];
+  const serverConfig = serverRulesResult.value?.serverConfigs?.[0];
   if (!serverConfig) {
     return [];
   }

--- a/components/mod/ReportProfilePictureModal.vue
+++ b/components/mod/ReportProfilePictureModal.vue
@@ -60,7 +60,7 @@ const getRules = (rulesJSON: string): RuleOption[] => {
 };
 
 const serverRuleOptions = computed<RuleOption[]>(() => {
-  const serverConfig = serverRulesResult.value?.serverConfigs[0];
+  const serverConfig = serverRulesResult.value?.serverConfigs?.[0];
   if (!serverConfig) {
     return [];
   }

--- a/components/nav/SiteSidenav.vue
+++ b/components/nav/SiteSidenav.vue
@@ -111,7 +111,7 @@ const { result: getUserResult } = useQuery(
   }
 );
 
-const user = computed(() => getUserResult.value?.users[0] || null);
+const user = computed(() => getUserResult.value?.users?.[0] || null);
 
 const profilePicURL = computed(() => user.value?.profilePicURL || '');
 

--- a/components/user/EditAccountSettingsFields.vue
+++ b/components/user/EditAccountSettingsFields.vue
@@ -115,7 +115,7 @@ const handleProfilePicChange = async (input: FileChangeInput) => {
 nextTick(() => {
   if (titleInputRef.value) {
     (
-      titleInputRef.value?.$el?.children[0].childNodes[0] as HTMLElement
+      titleInputRef.value?.$el?.children?.[0].childNodes[0] as HTMLElement
     ).focus();
   }
 });

--- a/components/user/UserProfileSidebar.vue
+++ b/components/user/UserProfileSidebar.vue
@@ -47,7 +47,7 @@ const user = computed(() => {
   if (getUserLoading.value || getUserError.value) {
     return null;
   }
-  return result.value?.users[0] || null;
+  return result.value?.users?.[0] || null;
 });
 
 // Use a computed property that prioritizes our global reactive state for profilePicURL

--- a/composables/useCommentCrudMutations.ts
+++ b/composables/useCommentCrudMutations.ts
@@ -55,7 +55,7 @@ export function useCommentCrudMutations(params: UseCommentCrudMutationsParams) {
   } = useMutation(CREATE_COMMENT, {
     errorPolicy: 'none',
     update: (cache, result) => {
-      const newComment: CommentType = result.data?.createComments?.comments[0];
+      const newComment: CommentType = result.data?.createComments?.comments?.[0];
       const newCommentParentId = newComment?.ParentComment?.id;
 
       // Handle root comments

--- a/pages/admin.vue
+++ b/pages/admin.vue
@@ -27,7 +27,7 @@ const serverConfig = computed(() => {
   if (getServerError.value || !getServerResult.value?.serverConfigs) {
     return null;
   }
-  return getServerResult.value?.serverConfigs[0] || null;
+  return getServerResult.value?.serverConfigs?.[0] || null;
 });
 
 const showIssueDetailPane = computed(() => {

--- a/pages/admin/about.vue
+++ b/pages/admin/about.vue
@@ -19,7 +19,7 @@ const serverConfig = computed(() => {
   if (getServerError.value || !getServerResult.value?.serverConfigs) {
     return null;
   }
-  return getServerResult.value?.serverConfigs[0] || null;
+  return getServerResult.value?.serverConfigs?.[0] || null;
 });
 </script>
 

--- a/pages/admin/roles.vue
+++ b/pages/admin/roles.vue
@@ -27,7 +27,7 @@ const serverConfig = computed(() => {
   if (getServerError.value || !getServerResult.value?.serverConfigs) {
     return null;
   }
-  return getServerResult.value?.serverConfigs[0] || null;
+  return getServerResult.value?.serverConfigs?.[0] || null;
 });
 </script>
 

--- a/pages/admin/settings.vue
+++ b/pages/admin/settings.vue
@@ -42,7 +42,7 @@ const formValues = ref<ServerConfigUpdateInput>({
 
 onGetServerResult((result) => {
   dataLoaded.value = true;
-  const serverConfig = result.data?.serverConfigs[0];
+  const serverConfig = result.data?.serverConfigs?.[0];
   if (!serverConfig) return;
 
   let rules = [];

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -204,7 +204,7 @@ const addForumToLocalStorage = (channel: Channel) => {
   setLocalStorageItem('recentForums', recentForums);
 };
 onGetChannelResult((result) => {
-  const loadedChannel = result.data?.channels[0];
+  const loadedChannel = result.data?.channels?.[0];
   if (!loadedChannel) {
     return;
   }

--- a/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].vue
+++ b/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].vue
@@ -39,7 +39,7 @@ const originalComment = computed<Comment | null>(() => {
   if (!getCommentResult.value || getCommentError.value) {
     return null;
   }
-  return getCommentResult.value?.comments[0] || null;
+  return getCommentResult.value?.comments?.[0] || null;
 });
 
 const contextOfFeedbackComment = computed(() => {

--- a/pages/forums/[forumId]/discussions/feedback/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/feedback/[discussionId].vue
@@ -60,7 +60,7 @@ const commentToRemoveFeedbackFrom = ref(null);
 const commentToGiveFeedbackOn = ref<Comment | null>(null);
 
 const discussion = computed(() => {
-  return getDiscussionResult.value?.discussions[0] || null;
+  return getDiscussionResult.value?.discussions?.[0] || null;
 });
 
 const stlFiles = computed(() => {
@@ -128,7 +128,7 @@ const {
 
 const originalComment = computed(() => {
   if (getCommentError.value) return null;
-  return getCommentResult.value?.comments[0] || null;
+  return getCommentResult.value?.comments?.[0] || null;
 });
 
 const contextOfFeedbackComment = computed(() => {
@@ -215,7 +215,7 @@ const {
           FeedbackComments: [...prevFeedbackComments, newFeedbackComment],
           FeedbackCommentsAggregate: {
             count:
-              (prevQueryResult?.discussions[0]?.FeedbackCommentsAggregate
+              (prevQueryResult?.discussions?.[0]?.FeedbackCommentsAggregate
                 ?.count || 0) + 1,
             __typename: 'FeedbackCommentsAggregate',
           },

--- a/pages/forums/[forumId]/downloads/[discussionId]/activity.vue
+++ b/pages/forums/[forumId]/downloads/[discussionId]/activity.vue
@@ -40,7 +40,7 @@ const { result: getDiscussionResult } = useQuery(
 );
 
 const discussion = computed<Discussion | null>(() => {
-  return props.discussion || getDiscussionResult.value?.discussions[0] || null;
+  return props.discussion || getDiscussionResult.value?.discussions?.[0] || null;
 });
 
 // Get the active discussion channel for this forum

--- a/pages/forums/[forumId]/downloads/[discussionId]/comments.vue
+++ b/pages/forums/[forumId]/downloads/[discussionId]/comments.vue
@@ -40,7 +40,7 @@ const { result: getDiscussionResult } = useQuery(GET_DISCUSSION, {
 });
 
 const discussion = computed(
-  () => getDiscussionResult.value?.discussions[0] || null
+  () => getDiscussionResult.value?.discussions?.[0] || null
 );
 const activeDiscussionChannel = computed(() => {
   return discussion.value?.DiscussionChannels?.find(
@@ -137,14 +137,14 @@ const commentCount = computed(
 
 const aggregateCommentCount = computed(() => {
   return (
-    getDiscussionChannelCommentAggregateResult.value?.discussionChannels[0]
+    getDiscussionChannelCommentAggregateResult.value?.discussionChannels?.[0]
       ?.CommentsAggregate?.count || 0
   );
 });
 
 const aggregateRootCommentCount = computed(() => {
   return (
-    getDiscussionChannelRootCommentAggregateResult.value?.discussionChannels[0]
+    getDiscussionChannelRootCommentAggregateResult.value?.discussionChannels?.[0]
       ?.CommentsAggregate?.count || 0
   );
 });

--- a/pages/forums/[forumId]/downloads/index.vue
+++ b/pages/forums/[forumId]/downloads/index.vue
@@ -49,7 +49,7 @@ const {
   }
 );
 
-const channel = computed(() => channelResult.value?.channels[0]);
+const channel = computed(() => channelResult.value?.channels?.[0]);
 
 const serverConfig = computed(() => {
   return serverConfigResult.value?.serverConfigs?.[0] || null;

--- a/pages/forums/[forumId]/edit.vue
+++ b/pages/forums/[forumId]/edit.vue
@@ -48,7 +48,7 @@ const formValues = ref<CreateEditChannelFormValues>({
 
 const dataLoaded = ref(false);
 
-const channel = computed(() => getChannelResult.value?.channels[0]);
+const channel = computed(() => getChannelResult.value?.channels?.[0]);
 
 watch(
   getChannelResult,

--- a/pages/forums/[forumId]/edit/roles.vue
+++ b/pages/forums/[forumId]/edit/roles.vue
@@ -19,7 +19,7 @@ const serverConfig = computed(() => {
   if (getServerError.value || !getServerResult.value?.serverConfigs) {
     return null;
   }
-  return getServerResult.value?.serverConfigs[0] || null;
+  return getServerResult.value?.serverConfigs?.[0] || null;
 });
 </script>
 

--- a/pages/forums/[forumId]/edit/suspended-users.vue
+++ b/pages/forums/[forumId]/edit/suspended-users.vue
@@ -23,12 +23,12 @@ const {
 });
 
 const suspendedUsers = computed(() => {
-  return suspendedUsersResult.value?.channels[0]?.SuspendedUsers ?? [];
+  return suspendedUsersResult.value?.channels?.[0]?.SuspendedUsers ?? [];
 });
 
 const aggregateCount = computed(() => {
   return (
-    suspendedUsersResult.value?.channels[0]?.SuspendedUsersAggregate?.count ?? 0
+    suspendedUsersResult.value?.channels?.[0]?.SuspendedUsersAggregate?.count ?? 0
   );
 });
 

--- a/pages/forums/[forumId]/events/feedback/[eventId].vue
+++ b/pages/forums/[forumId]/events/feedback/[eventId].vue
@@ -43,7 +43,7 @@ const event = computed<Event>(() => {
   if (getEventError.value) {
     return null;
   }
-  return getEventResult.value?.events[0] || null;
+  return getEventResult.value?.events?.[0] || null;
 });
 
 const feedbackComments = computed(() => {

--- a/pages/forums/[forumId]/wiki/[slug].vue
+++ b/pages/forums/[forumId]/wiki/[slug].vue
@@ -35,7 +35,7 @@ const {
 );
 
 // Computed property for the wiki page data
-const wikiPage = computed(() => wikiPageResult.value?.wikiPages[0]);
+const wikiPage = computed(() => wikiPageResult.value?.wikiPages?.[0]);
 
 // Query channel to check if wiki is enabled
 const {
@@ -45,7 +45,7 @@ const {
 } = useQuery(GET_CHANNEL, { uniqueName: forumId }, { errorPolicy: 'all' });
 
 // Computed property for the channel data
-const channel = computed(() => channelResult.value?.channels[0]);
+const channel = computed(() => channelResult.value?.channels?.[0]);
 
 // Check if wiki is enabled
 const wikiEnabled = computed(() => channel.value?.wikiEnabled);

--- a/pages/forums/[forumId]/wiki/create-child.vue
+++ b/pages/forums/[forumId]/wiki/create-child.vue
@@ -26,7 +26,7 @@ const {
 } = useQuery(GET_CHANNEL, { uniqueName: forumId }, { errorPolicy: 'all' });
 
 // Computed property for the channel data
-const channel = computed(() => channelResult.value?.channels[0]);
+const channel = computed(() => channelResult.value?.channels?.[0]);
 const wikiHomePage = computed(() => channel.value?.WikiHomePage);
 
 const {

--- a/pages/forums/[forumId]/wiki/edit/[slug].vue
+++ b/pages/forums/[forumId]/wiki/edit/[slug].vue
@@ -56,9 +56,9 @@ const {
 // Computed property for the wiki page data
 const wikiPage = computed(() => {
   if (isHomePage.value) {
-    return channelResult.value?.channels[0]?.WikiHomePage;
+    return channelResult.value?.channels?.[0]?.WikiHomePage;
   } else {
-    return wikiPageResult.value?.wikiPages[0];
+    return wikiPageResult.value?.wikiPages?.[0];
   }
 });
 

--- a/pages/forums/[forumId]/wiki/index.vue
+++ b/pages/forums/[forumId]/wiki/index.vue
@@ -32,7 +32,7 @@ const {
 } = useQuery(GET_CHANNEL, { uniqueName: forumId }, { errorPolicy: 'all' });
 
 // Computed property for the channel data
-const channel = computed(() => channelResult.value?.channels[0]);
+const channel = computed(() => channelResult.value?.channels?.[0]);
 
 // Check if wiki is enabled
 const wikiEnabled = computed(() => channel.value?.wikiEnabled);

--- a/pages/forums/[forumId]/wiki/revisions/[slug].vue
+++ b/pages/forums/[forumId]/wiki/revisions/[slug].vue
@@ -35,7 +35,7 @@ const {
 );
 
 // Computed property for the wiki page data
-const wikiPage = computed(() => wikiPageResult.value?.wikiPages[0] as WikiPage);
+const wikiPage = computed(() => wikiPageResult.value?.wikiPages?.[0] as WikiPage);
 
 // Total number of edits
 const totalEdits = computed(() => {

--- a/pages/forums/[forumId]/wiki/revisions/diff/[slug]/[revisionId].vue
+++ b/pages/forums/[forumId]/wiki/revisions/diff/[slug]/[revisionId].vue
@@ -50,7 +50,7 @@ const {
 );
 
 // Computed property for the wiki page data
-const wikiPage = computed(() => wikiPageResult.value?.wikiPages[0] as WikiPage);
+const wikiPage = computed(() => wikiPageResult.value?.wikiPages?.[0] as WikiPage);
 
 // Process all versions to find the specific revision
 const allEdits = computed(() => {

--- a/pages/forums/create.vue
+++ b/pages/forums/create.vue
@@ -109,7 +109,7 @@ const {
   onError,
 } = useMutation(CREATE_CHANNEL, () => ({
   update: (cache, result) => {
-    const newChannel: Channel = result.data?.createChannels?.channels[0];
+    const newChannel: Channel = result.data?.createChannels?.channels?.[0];
     if (!newChannel?.uniqueName) {
       return;
     }

--- a/pages/mod/[modId]/comments.vue
+++ b/pages/mod/[modId]/comments.vue
@@ -75,12 +75,12 @@ const loadMore = () => {
 
 const commentCount = computed(() => {
   return (
-    commentResult.value?.moderationProfiles[0]?.AuthoredComments?.length || 0
+    commentResult.value?.moderationProfiles?.[0]?.AuthoredComments?.length || 0
   );
 });
 
 const comments = computed(() => {
-  return commentResult.value?.moderationProfiles[0]?.AuthoredComments || [];
+  return commentResult.value?.moderationProfiles?.[0]?.AuthoredComments || [];
 });
 
 const {

--- a/pages/u/[username]/comments.vue
+++ b/pages/u/[username]/comments.vue
@@ -112,7 +112,7 @@ const isCommentOnDeletedEvent = (comment: CommentType) => {
     <div
       v-else-if="
         commentResult?.users?.length === 0 ||
-        commentResult?.users[0]?.Comments.length === 0
+        commentResult?.users?.[0]?.Comments.length === 0
       "
     >
       No comments yet
@@ -152,7 +152,7 @@ const isCommentOnDeletedEvent = (comment: CommentType) => {
       </div>
     </div>
     <div v-if="loading">Loading...</div>
-    <div v-if="commentResult?.users[0]?.Comments.length > 0">
+    <div v-if="commentResult?.users?.[0]?.Comments.length > 0">
       <LoadMore
         class="justify-self-center"
         :reached-end-of-results="

--- a/pages/u/[username]/events.vue
+++ b/pages/u/[username]/events.vue
@@ -44,7 +44,7 @@ const { result, loading, error } = useQuery(
     <div v-else-if="error">Error</div>
     <div
       v-else-if="
-        result?.users?.length === 0 || result?.users[0]?.Events.length === 0
+        result?.users?.length === 0 || result?.users?.[0]?.Events.length === 0
       "
     >
       No events yet


### PR DESCRIPTION
Codebase-wide sweep of the recurring crash bug first fixed in #84: `x?.arr[0]` where the optional chain stops *before* the array index, so when `arr` is `undefined` it throws `Cannot read properties of undefined (reading '0')`. Replaced with `x?.arr?.[0]`.

## Scope
**62 files** across `components/`, `pages/`, and `composables/` — e.g. `EventChannels[0]` → `EventChannels?.[0]`, `discussions[0]` → `discussions?.[0]`, `discussionChannels[0]` → `discussionChannels?.[0]`.

## Safety
- Purely mechanical: **87 one-line replacements, every added line adds `?.[`** (audited — nothing else changed).
- `npm run tsc`: **0 errors**
- Full unit suite: **2390 passing**
- Lint: clean

This is the bug class the component-mounting work surfaced (mounting `DiscussionCommentsWrapper` in #84 actually crashed on one of these). The sweep prevents the rest from biting when a query result comes back without the expected array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)