### PR TITLE
ci: harden E2E coverage workflow + keep combined badge stable

### DIFF
--- a/.github/workflows/e2e-coverage.yml
+++ b/.github/workflows/e2e-coverage.yml
@@ -1,11 +1,12 @@
 name: Combined Coverage (unit + E2E)
 
 # Opt-in: the coverage build emits source maps and is slower than the normal
-# suite, so this runs on demand (or on a schedule) rather than on every PR.
+# suite, so this runs on demand or weekly (not on every PR). The weekly run
+# refreshes the carried-forward `e2e` flag so the combined badge stays current.
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: '0 6 * * 1' # weekly, Mondays 06:00 UTC
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Mondays 06:00 UTC
 
 jobs:
   combined-coverage:
@@ -46,8 +47,12 @@ jobs:
       - name: Build app (mock mode + source maps)
         run: npm run coverage:e2e:build
 
+      # Coverage is the goal, not pass/fail: collecting V8 adds overhead that can
+      # push a couple of interaction-heavy specs past their timeout. Those tests
+      # still write their coverage in teardown, so don't fail the job on them.
       - name: Collect E2E coverage
         run: npm run coverage:e2e:collect
+        continue-on-error: true
 
       - name: Build E2E coverage report
         run: npm run coverage:e2e:report

--- a/.github/workflows/unit-tests-ci.yml
+++ b/.github/workflows/unit-tests-ci.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
+          flags: unit
           fail_ci_if_error: false
           verbose: true
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,6 +16,20 @@ coverage:
         # Set to informational initially while building coverage
         informational: true
 
+# Flag management.
+# - unit: uploaded on every PR/push by the Tests CI workflow.
+# - e2e:  uploaded only by the opt-in "Combined Coverage" workflow.
+#         carryforward reuses the most recent e2e report on commits where it
+#         isn't uploaded, so the combined number/badge doesn't drop back to
+#         unit-only between e2e runs. (Re-run / schedule that workflow to keep
+#         the e2e portion fresh.)
+flag_management:
+  individual_flags:
+    - name: unit
+      carryforward: false
+    - name: e2e
+      carryforward: true
+
 # Comment settings for PR coverage reports
 comment:
   layout: "reach,diff,flags,files"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coverage:open": "npm run coverage && open coverage/index.html",
     "coverage:e2e:build": "E2E_COVERAGE=true NITRO_PRESET=node-server VITE_E2E_MOCK_MODE=true VITE_GRAPHQL_URL=http://127.0.0.1:4100/graphql VITE_SERVER_NAME='Playwright Test Server' VITE_SENTRY_AUTH_TOKEN='' nuxt build",
     "coverage:e2e:collect": "E2E_COVERAGE=true playwright test --config playwright.build.config.ts",
-    "coverage:e2e:report": "node tests/playwright/coverage/report.mjs",
+    "coverage:e2e:report": "node --max-old-space-size=6144 tests/playwright/coverage/report.mjs",
     "knip": "knip",
     "tsc": "vue-tsc --noEmit",
     "verify": "npm run tsc && npm run test:unit:run",


### PR DESCRIPTION
Follow-up to the combined-coverage feature (#91). Fixes two ways the opt-in workflow would fail at full scale, and keeps the combined badge from reverting to unit-only between E2E runs.

## Reliability (the workflow as merged would go red)
Validated locally on the **full 64-test suite**:
- **Collect step**: collecting V8 adds overhead that pushed 2 interaction-heavy specs (`nestedComments`, `createEditDeleteDiscussions`) past their timeout (~2.4 min) → non-zero exit. Those tests still write their coverage in teardown, so → `continue-on-error: true` (coverage is the goal, not pass/fail).
- **Report step**: ~648 MB of raw V8 OOMs Node's default heap → bumped `--max-old-space-size` in `coverage:e2e:report`.

With these, the full run completes and produces real numbers: **E2E TOTAL ≈ 43%** app-source (pages 50%, components 42%, composables 42%, utils 43%).

## Badge stability (the question this answers)
Without this, the next normal PR merge uploads only unit coverage, so the badge drops back to ~unit-only. Fix:
- `unit-tests-ci.yml`: upload unit coverage under **`flags: unit`**.
- `codecov.yml`: declare flags — `unit` (carryforward off) and **`e2e` (`carryforward: true`)**. On commits without an e2e upload, Codecov reuses the latest e2e report, so the combined number persists.
- `e2e-coverage.yml`: enable the **weekly schedule** so the carried-forward e2e flag refreshes automatically (carried-forward data is only as fresh as the last run).

## Verification
All changed YAML/JSON validated; full-suite collect + report validated locally end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)