### PR TITLE
fix(map): restore map zoom (wheel, visible buttons, no clipping)

### DIFF
--- a/components/event/map/Map.vue
+++ b/components/event/map/Map.vue
@@ -125,8 +125,14 @@ const renderMap = async () => {
       currentTheme.value === 'dark'
         ? google.maps.ColorScheme.DARK
         : google.maps.ColorScheme.LIGHT,
+    // 'greedy' so a plain mouse wheel zooms the map. The default ('auto')
+    // resolves to 'cooperative' for a map that doesn't fill the viewport,
+    // which ignores the wheel unless ctrl/cmd is held (and on macOS the
+    // browser captures ctrl/cmd+wheel as page zoom before the map sees it).
+    gestureHandling: 'greedy',
+    disableDefaultUI: false,
     zoomControl: true,
-    zoomControlOptions: { position: google.maps.ControlPosition.RIGHT_TOP },
+    zoomControlOptions: { position: google.maps.ControlPosition.RIGHT_BOTTOM },
   };
 
   map.value = new google.maps.Map(

--- a/components/event/map/Map.vue
+++ b/components/event/map/Map.vue
@@ -400,7 +400,7 @@ watch(
       <div
         v-else-if="!useMobileStyles"
         ref="desktopMapDiv"
-        style="position: fixed; width: 50vw; height: 82vh; top: 170px; right: 0"
+        style="position: fixed; top: 200px; left: 0; width: calc(100% - 14px); height: calc(100vh - 214px)"
       />
     </div>
   </client-only>


### PR DESCRIPTION
## Summary

Restores zoom on the `/map/search` map, which regressed after the map became a vector (`mapId`) map. Three related fixes:

1. **Mouse wheel didn't zoom the map.** `gestureHandling` was unset, defaulting to `'auto'` → `'cooperative'` for a map that doesn't fill the viewport, so a plain wheel was ignored (needs ctrl/cmd, which macOS captures as page zoom). → `gestureHandling: 'greedy'`.
2. **Zoom buttons appeared gone.** They were rendering at `RIGHT_TOP`, underneath the fixed search/filter header. → moved to `RIGHT_BOTTOM`.
3. **Map clipped on the top, right, and bottom.** The desktop map div hardcoded `width: 50vw; height: 82vh; top: 170px; right: 0`. Because the fixed right-half wrapper is the containing block for the map's `position: fixed`, those values overflowed the panel (top under the header, zoom buttons under the scrollbar, bottom off-screen). → fill the panel with `left: 0` + `calc()` insets; this also adapts to the `lg:` sidebar width that `50vw` ignored.

## Verification

Confirmed live in a real session (the map renders blank in automated/throttled tabs, so this was verified by hand): wheel zooms the map, zoom +/− buttons are fully visible at bottom-right, and the map fills its panel with no clipping on any edge. `tsc`, ESLint, and unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)