### PR TITLE
fix: prevent ghost login from stale username in localStorage

### DIFF
--- a/composables/useAuthManager.ts
+++ b/composables/useAuthManager.ts
@@ -15,6 +15,7 @@ import {
   setProfilePicURL,
 } from '@/cache';
 import { useSSRAuth } from '@/composables/useSSRAuth';
+import { persistUsername, clearPersistedAuth } from '@/utils/authUtils';
 
 // Type for Auth0 error objects
 interface Auth0Error {
@@ -123,6 +124,9 @@ export function useAuthManager() {
     setModProfileName('');
     setNotificationCount(0);
     setProfilePicURL('');
+    // Clear persisted auth so a stale username can't be restored on the next
+    // load and produce a "ghost login" (username present, but no valid token).
+    clearPersistedAuth();
     // Clear auth hint cookies
     clearAuthHints();
   };
@@ -142,6 +146,9 @@ export function useAuthManager() {
     if (userData && !userData.loading) {
       // User found, set all data
       setUsername(userData.username);
+      // Persist the username so it can be restored on the next load alongside
+      // the session token (the token is written separately by RequireAuth).
+      persistUsername(userData.username);
       setIsLoadingAuth(false);
       setIsAuthenticated(true);
       setModProfileName(modProfileData?.displayName || '');

--- a/plugins/username-cache.client.ts
+++ b/plugins/username-cache.client.ts
@@ -1,16 +1,23 @@
 // plugins/username-cache.client.ts
 import { defineNuxtPlugin } from 'nuxt/app';
 import { setUsername } from '@/cache';
+import {
+  shouldRestoreUsername,
+  USERNAME_STORAGE_KEY,
+  TOKEN_STORAGE_KEY,
+} from '@/utils/authUtils';
 
 export default defineNuxtPlugin(() => {
   // This plugin runs only on the client
   if (typeof window !== 'undefined') {
-    // Try to load username from localStorage
-    const storedUsername = localStorage.getItem('username');
+    // Restore the username from localStorage, but only when a token is also
+    // present. The username persists across sessions while the token does not,
+    // so restoring it alone would produce a "ghost login" (see authUtils).
+    const storedUsername = localStorage.getItem(USERNAME_STORAGE_KEY);
+    const token = localStorage.getItem(TOKEN_STORAGE_KEY);
 
-    if (storedUsername) {
-      // Set the username in the reactive state
-      setUsername(storedUsername);
+    if (shouldRestoreUsername(storedUsername, token)) {
+      setUsername(storedUsername as string);
     }
   }
 });

--- a/tests/unit/utils/authUtils.spec.ts
+++ b/tests/unit/utils/authUtils.spec.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ApolloError } from '@apollo/client/errors';
 import { GraphQLError } from 'graphql';
-import { handleAuthError } from '@/utils/authUtils';
+import {
+  handleAuthError,
+  shouldRestoreUsername,
+  persistUsername,
+  clearPersistedAuth,
+  USERNAME_STORAGE_KEY,
+  TOKEN_STORAGE_KEY,
+} from '@/utils/authUtils';
 
 describe('authUtils', () => {
   const originalRefresh = (window as any).refreshAuthToken;
@@ -120,5 +127,87 @@ describe('authUtils', () => {
     await expect(handleAuthError(error, retryFn)).rejects.toBe(error);
 
     expect(retryFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldRestoreUsername', () => {
+  it.each([
+    ['username + token', 'cluse', 'jwt-token', true],
+    ['username, no token', 'cluse', null, false],
+    ['token, no username', null, 'jwt-token', false],
+    ['neither', null, null, false],
+    ['empty username + token', '', 'jwt-token', false],
+    ['username + empty token', 'cluse', '', false],
+  ])(
+    'returns %s -> %s',
+    (_label, storedUsername, token, expected) => {
+      expect(
+        shouldRestoreUsername(
+          storedUsername as string | null,
+          token as string | null
+        )
+      ).toBe(expected);
+    }
+  );
+});
+
+describe('persistUsername', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('writes the username to localStorage', () => {
+    persistUsername('cluse');
+
+    expect(window.localStorage.getItem(USERNAME_STORAGE_KEY)).toBe('cluse');
+  });
+
+  it.each([['empty string', ''], ['null', null], ['undefined', undefined]])(
+    'does not write when username is %s',
+    (_label, value) => {
+      persistUsername(value as string | null | undefined);
+
+      expect(window.localStorage.getItem(USERNAME_STORAGE_KEY)).toBeNull();
+    }
+  );
+});
+
+describe('clearPersistedAuth', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('removes the persisted username', () => {
+    window.localStorage.setItem(USERNAME_STORAGE_KEY, 'cluse');
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, 'jwt-token');
+
+    clearPersistedAuth();
+
+    expect(window.localStorage.getItem(USERNAME_STORAGE_KEY)).toBeNull();
+  });
+
+  it('removes the persisted token', () => {
+    window.localStorage.setItem(USERNAME_STORAGE_KEY, 'cluse');
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, 'jwt-token');
+
+    clearPersistedAuth();
+
+    expect(window.localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+  });
+
+  it('leaves unrelated keys intact', () => {
+    window.localStorage.setItem('theme', 'dark');
+
+    clearPersistedAuth();
+
+    expect(window.localStorage.getItem('theme')).toBe('dark');
   });
 });

--- a/utils/authUtils.ts
+++ b/utils/authUtils.ts
@@ -1,6 +1,51 @@
 import type { FetchResult } from '@apollo/client';
 import type { ApolloError } from '@apollo/client/errors';
 
+export const USERNAME_STORAGE_KEY = 'username';
+export const TOKEN_STORAGE_KEY = 'token';
+
+/**
+ * Decide whether a username persisted in localStorage should be restored into
+ * reactive auth state on app load.
+ *
+ * The username is written at signup and never expires, but the auth token is
+ * only present while a valid Auth0 session exists. Restoring the username
+ * without a token produces a "ghost login": the UI looks authenticated while
+ * every backend mutation is rejected with "You must be logged in to do that."
+ * Only restore when both the username and a token are present.
+ */
+export function shouldRestoreUsername(
+  storedUsername: string | null,
+  token: string | null
+): boolean {
+  return Boolean(storedUsername && token);
+}
+
+/**
+ * Persist the logged-in username so it can be restored on the next page load
+ * (alongside the token written by the Auth0 session). No-op on the server or
+ * when given an empty username.
+ */
+export function persistUsername(username: string | null | undefined): void {
+  if (typeof window === 'undefined' || !username) {
+    return;
+  }
+  window.localStorage.setItem(USERNAME_STORAGE_KEY, username);
+}
+
+/**
+ * Remove persisted auth (username + token) from localStorage. Called when auth
+ * state is cleared (logout, invalid/expired refresh token) so a stale username
+ * can't be restored on the next load and produce a ghost login.
+ */
+export function clearPersistedAuth(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.removeItem(USERNAME_STORAGE_KEY);
+  window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+}
+
 /**
  * Helper function to handle GraphQL errors related to authentication
  * and automatically retry operations after refreshing the token


### PR DESCRIPTION
## Problem

While driving the app logged in as `gennitdev`, creating a post and upvoting both failed with **"You must be logged in to do that."** even though the header showed a logged-in user (avatar + "Log Out").

Root cause: a **ghost login**. The `username` localStorage key is written once at signup ([`CreateUsernameForm.vue`](https://github.com/gennit-project/multiforum-nuxt/blob/main/components/auth/CreateUsernameForm.vue)) and **never expires**, but the auth `token` is only written while a valid Auth0 session exists ([`RequireAuth.vue`'s `storeToken`](https://github.com/gennit-project/multiforum-nuxt/blob/main/components/auth/RequireAuth.vue)). On every load, [`username-cache.client.ts`](https://github.com/gennit-project/multiforum-nuxt/blob/main/plugins/username-cache.client.ts) restored the username **unconditionally**:

```js
const storedUsername = localStorage.getItem('username');
if (storedUsername) setUsername(storedUsername);   // no token check
```

So once a session ended (cleared cookies / expired refresh token), `usernameVar` was repopulated → the UI rendered as authenticated → but `isAuthenticatedVar` was `false` and no `Authorization` header was sent, so the backend's `isAuthenticated` rule threw on every mutation. `clearAuthState()` also never removed the `username` key, so logout couldn't fix it either.

Verified live: `__DEBUG_AUTH_STATE__()` returned `{ username: "gennitdev", authenticated: false, hasToken: false }`.

## Changes

- **Only restore the cached username when a token is also present** (`shouldRestoreUsername`).
- **Clear persisted username + token on `clearAuthState()`** (`clearPersistedAuth`) so logout / invalid-refresh-token can't leave a ghost behind.
- **Persist the username on successful login** (`persistUsername`) so genuine returning users keep it cached across reloads alongside the token.
- Logic extracted into [`utils/authUtils.ts`](https://github.com/gennit-project/multiforum-nuxt/blob/main/utils/authUtils.ts) and covered by unit tests (real code, not reimplemented).

## Testing

- `npm run test:unit -- tests/unit/utils/authUtils.spec.ts` — 22 passed (13 new).
- `npm run tsc` — clean.
- Manually verified in-browser: after the fix, a session with a stale `username` but no token correctly renders **"Log In"**, and `usernameVar` is empty. Logging in as a real user works and the super-upvote button correctly hides on your own posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)