### PR TITLE
feat(event search): apply default 50mi radius when a location is picked from autocomplete

### DIFF
--- a/components/event/list/filters/EventFilterBar.vue
+++ b/components/event/list/filters/EventFilterBar.vue
@@ -13,6 +13,7 @@ import {
   MilesOrKm,
 } from '@/components/event/list/filters/eventSearchOptions';
 import { LocationFilterTypes } from './locationFilterTypes';
+import { getLocationSelectFilterParams } from './locationSelectFilterParams';
 import { getFilterValuesFromParams } from '@/components/event/list/filters/getEventFilterValuesFromParams';
 import GenericButton from '@/components/GenericButton.vue';
 import FilterChip from '@/components/FilterChip.vue';
@@ -143,15 +144,12 @@ const radiusLabel = computed(() => {
 // Note: Route query watching is handled by useFilterBar composable
 
 const updateLocationInput = (placeData: UpdateLocationInput) => {
+  // Picking a place from the autocomplete activates the within-radius filter
+  // with a default 50-mile distance so the results update for that location.
   updateFilters({
     router,
     route,
-    params: {
-      latitude: placeData.lat,
-      longitude: placeData.lng,
-      placeName: placeData.name,
-      placeAddress: placeData.formatted_address,
-    },
+    params: getLocationSelectFilterParams(placeData),
   });
 };
 

--- a/components/event/list/filters/locationSelectFilterParams.spec.ts
+++ b/components/event/list/filters/locationSelectFilterParams.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getLocationSelectFilterParams,
+  DEFAULT_LOCATION_SELECT_RADIUS_KM,
+} from './locationSelectFilterParams';
+import { LocationFilterTypes } from './locationFilterTypes';
+
+const placeData = {
+  name: 'Tempe',
+  formatted_address: 'Tempe, AZ, USA',
+  lat: 33.4255,
+  lng: -111.94,
+};
+
+describe('getLocationSelectFilterParams', () => {
+  it('activates the within-radius location filter', () => {
+    expect(getLocationSelectFilterParams(placeData).locationFilter).toBe(
+      LocationFilterTypes.WITHIN_RADIUS
+    );
+  });
+
+  it('applies the default 50-mile (80.4672 km) radius', () => {
+    expect(getLocationSelectFilterParams(placeData).radius).toBe(80.4672);
+  });
+
+  it('uses the shared 50-mile distance option as the default radius', () => {
+    expect(getLocationSelectFilterParams(placeData).radius).toBe(
+      DEFAULT_LOCATION_SELECT_RADIUS_KM
+    );
+  });
+
+  it('carries through the selected place coordinates and name', () => {
+    expect(getLocationSelectFilterParams(placeData)).toMatchObject({
+      latitude: 33.4255,
+      longitude: -111.94,
+      placeName: 'Tempe',
+      placeAddress: 'Tempe, AZ, USA',
+    });
+  });
+});

--- a/components/event/list/filters/locationSelectFilterParams.ts
+++ b/components/event/list/filters/locationSelectFilterParams.ts
@@ -1,0 +1,27 @@
+import type { UpdateLocationInput } from '@/components/event/form/CreateEditEventFields.vue';
+import type { UpdateStateInput } from '@/utils/routerUtils';
+import { LocationFilterTypes } from './locationFilterTypes';
+import { distanceOptionsForMiles } from './eventSearchOptions';
+
+// Default radius applied when a user picks a place from the location
+// autocomplete: 50 miles. Radius values are stored in kilometers (the value the
+// GraphQL query expects), so we reuse the 50-mile distance option.
+export const DEFAULT_LOCATION_SELECT_RADIUS_KM = Number(
+  distanceOptionsForMiles.find((option) => option.label === '50')?.value ??
+    80.4672
+);
+
+// Builds the filter params to apply when a user selects a place from the
+// location autocomplete. Selecting a place activates the within-radius filter
+// with a sensible default distance so the results immediately reflect the
+// chosen location, instead of only setting the reference point.
+export const getLocationSelectFilterParams = (
+  placeData: UpdateLocationInput
+): UpdateStateInput => ({
+  latitude: placeData.lat,
+  longitude: placeData.lng,
+  placeName: placeData.name,
+  placeAddress: placeData.formatted_address,
+  radius: DEFAULT_LOCATION_SELECT_RADIUS_KM,
+  locationFilter: LocationFilterTypes.WITHIN_RADIUS,
+});


### PR DESCRIPTION
## Summary

Improves the event search location UX: when a user types an address/city into the location autocomplete and picks a result, the search now **activates the within-radius location filter with a default 50-mile distance**, so the results immediately update for that location.

Previously, selecting a place only set the reference point (lat/lng + name) and left the results unfiltered until the user separately chose a distance.

## Implementation

- New `getLocationSelectFilterParams(placeData)` ([locationSelectFilterParams.ts](components/event/list/filters/locationSelectFilterParams.ts)) maps a selected place to the filter params: reference point + `radius` (50 mi, reusing the shared 50-mile distance option = `80.4672` km) + `locationFilter: WITHIN_RADIUS`.
- `EventFilterBar.updateLocationInput` now uses it, so the existing `updateFilters` → URL query params → refetch flow applies the location filter. `getEventWhere` already turns `WITHIN_RADIUS` + radius + lat/lng into the `location_LTE` distance query.
- Logic extracted into a pure helper for testability (per the repo's guidance) with unit coverage.

## Testing

- New unit tests in [locationSelectFilterParams.spec.ts](components/event/list/filters/locationSelectFilterParams.spec.ts) (4 cases): filter activated, default 50-mile radius, shared-constant default, and place fields passed through. `tsc`, ESLint, and unit tests pass.
- :warning: **Not verified end-to-end in a browser by me** — my automated browser tab keeps freezing on the map page (the blank-map renderer issue), so I couldn't drive the autocomplete live. Please confirm in a normal session: type a city in the "Anywhere" search, click a suggestion, and verify the URL gains `radius`/`locationFilter`/`latitude`/`longitude` and the results narrow to ~50 mi.

## Note on behavior

Picking a place always (re)applies the 50-mile default — a new place selection is treated as a fresh search. If you'd rather preserve a distance the user already chose, that's a small tweak; let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)