### PR TITLE
perf: ISR-cache detail pages and flatten GraphQL query waves

### DIFF
--- a/components/discussion/detail/DiscussionDetailContent.vue
+++ b/components/discussion/detail/DiscussionDetailContent.vue
@@ -7,6 +7,15 @@ import {
   GET_DISCUSSION_CHANNEL_COMMENT_AGGREGATE,
   GET_DISCUSSION_CHANNEL_ROOT_COMMENT_AGGREGATE,
 } from '@/graphQLData/comment/queries';
+import {
+  CHECK_DISCUSSION_ISSUE_EXISTENCE,
+  CHECK_DISCUSSION_COMMENT_ISSUE_EXISTENCE,
+} from '@/graphQLData/issue/queries';
+import { GET_CHANNEL } from '@/graphQLData/channel/queries';
+import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
+import { DateTime } from 'luxon';
+import { config } from '@/config';
+import type { RouteLocationRaw } from 'vue-router';
 import type {
   Discussion,
   DiscussionChannel,
@@ -280,6 +289,90 @@ const { result: getDiscussionChannelRootCommentAggregateResult } = useQuery(
   }
 );
 
+// Issue-existence checks are hoisted to this always-mounted parent so they fire
+// on mount (keyed off the route's discussionId + channelId) in parallel with
+// GET_DISCUSSION, rather than waiting for the discussion to load and the gated
+// DiscussionHeader to mount. The resolved link is passed down to the header.
+const { result: getDiscussionIssueResult } = useQuery(
+  CHECK_DISCUSSION_ISSUE_EXISTENCE,
+  () => ({
+    discussionId: props.discussionId,
+    channelUniqueName: channelId.value,
+  }),
+  {
+    fetchPolicy: 'cache-first',
+    enabled: computed(() => !!props.discussionId && !!channelId.value),
+  }
+);
+
+const { result: getDiscussionCommentIssueResult } = useQuery(
+  CHECK_DISCUSSION_COMMENT_ISSUE_EXISTENCE,
+  () => ({
+    discussionId: props.discussionId,
+    channelUniqueName: channelId.value,
+  }),
+  {
+    fetchPolicy: 'cache-first',
+    enabled: computed(() => !!props.discussionId && !!channelId.value),
+  }
+);
+
+// Prefetch the channel + server config in this first query wave. The
+// DiscussionHeader issues these same queries, but it only mounts after the
+// discussion loads (it sits behind v-if="discussion"), so on client-side
+// navigation they would otherwise start a second request wave once the header
+// appears. Firing them here (cache-first, identical variables) warms the
+// Apollo cache so the header reads them instantly when it mounts. Results are
+// intentionally unused here — this is a cache-priming prefetch.
+useQuery(
+  GET_CHANNEL,
+  {
+    uniqueName: channelId.value,
+    now: DateTime.local().startOf('hour').toISO(),
+  },
+  {
+    fetchPolicy: 'cache-first',
+    enabled: computed(() => !!channelId.value),
+  }
+);
+
+useQuery(
+  GET_SERVER_CONFIG,
+  {
+    serverName: config.serverName,
+  },
+  {
+    fetchPolicy: 'cache-first',
+  }
+);
+
+const relatedIssueNumber = computed(() => {
+  const directIssueNumber =
+    getDiscussionIssueResult.value?.issues?.[0]?.issueNumber;
+  if (directIssueNumber != null) {
+    return directIssueNumber;
+  }
+
+  return (
+    getDiscussionCommentIssueResult.value?.discussionChannels?.[0]
+      ?.Comments?.[0]?.RelatedIssues?.[0]?.issueNumber ?? null
+  );
+});
+
+const relatedIssueLink = computed<RouteLocationRaw | null>(() => {
+  if (relatedIssueNumber.value == null || !channelId.value) {
+    return null;
+  }
+
+  return {
+    name: 'forums-forumId-issues-issueNumber',
+    params: {
+      forumId: channelId.value,
+      issueNumber: relatedIssueNumber.value,
+    },
+  };
+});
+
 const commentCount = computed(
   () => activeDiscussionChannel.value?.CommentsAggregate?.count || 0
 );
@@ -484,6 +577,7 @@ const handleEditAlbum = () => {
                 :discussion-channel-id="activeDiscussionChannel?.id"
                 :discussion-is-archived="isArchived || false"
                 :download-mode="downloadMode"
+                :related-issue-link="relatedIssueLink"
                 :show-action-menu="true"
                 @cancel-edit-discussion-body="discussionBodyEditMode = false"
                 @handle-click-add-album="handleClickAddAlbum"

--- a/components/discussion/detail/DiscussionHeader.vue
+++ b/components/discussion/detail/DiscussionHeader.vue
@@ -19,15 +19,12 @@ import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavo
 import UnarchiveModal from '@/components/mod/UnarchiveModal.vue';
 import { GET_CHANNEL } from '@/graphQLData/channel/queries';
 import { USER_IS_MOD_OR_OWNER_IN_CHANNEL } from '@/graphQLData/user/queries';
-import {
-  CHECK_DISCUSSION_ISSUE_EXISTENCE,
-  CHECK_DISCUSSION_COMMENT_ISSUE_EXISTENCE,
-} from '@/graphQLData/issue/queries';
 import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
 import { config } from '@/config';
 import LinkIcon from '@/components/icons/LinkIcon.vue';
 import EditsDropdown from './activityFeed/EditsDropdown.vue';
 import type { Discussion } from '@/__generated__/graphql';
+import type { RouteLocationRaw } from 'vue-router';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import { getServerRoleBadge } from '@/utils/serverRoleBadges';
 import { useModerationOutcomeUI } from '@/composables/useModerationOutcomeUI';
@@ -42,6 +39,7 @@ const props = defineProps<{
   discussionBodyEditMode?: boolean;
   discussionIsArchived?: boolean | undefined | null;
   downloadMode?: boolean;
+  relatedIssueLink?: RouteLocationRaw | null;
 }>();
 
 const emit = defineEmits([
@@ -121,10 +119,10 @@ const handleToggleSensitiveContent = async () => {
   }
 };
 
+// Derive the channel from the route first so channel-scoped queries can fire
+// immediately on mount, rather than waiting for the parent's GET_DISCUSSION
+// result to populate `props.discussion` (which created a query waterfall).
 const defaultChannel = computed(() => {
-  if (!props.discussion) {
-    return '';
-  }
   const channelInRoute = Array.isArray(route.params.forumId)
     ? route.params.forumId[0]
     : typeof route.params.forumId === 'string'
@@ -132,7 +130,8 @@ const defaultChannel = computed(() => {
       : '';
   return (
     channelInRoute ||
-    props.discussion?.DiscussionChannels?.[0]?.channelUniqueName
+    props.discussion?.DiscussionChannels?.[0]?.channelUniqueName ||
+    ''
   );
 });
 
@@ -150,57 +149,6 @@ const { result: getChannelResult } = useQuery(
     enabled: computed(() => !!props.channelId || !!defaultChannel.value),
   }
 );
-
-const { result: getDiscussionIssueResult } = useQuery(
-  CHECK_DISCUSSION_ISSUE_EXISTENCE,
-  () => ({
-    discussionId: props.discussion?.id,
-    channelUniqueName: defaultChannel.value,
-  }),
-  {
-    fetchPolicy: 'cache-first',
-    enabled: computed(() => !!props.discussion?.id && !!defaultChannel.value),
-  }
-);
-
-const { result: getDiscussionCommentIssueResult } = useQuery(
-  CHECK_DISCUSSION_COMMENT_ISSUE_EXISTENCE,
-  () => ({
-    discussionId: props.discussion?.id,
-    channelUniqueName: defaultChannel.value,
-  }),
-  {
-    fetchPolicy: 'cache-first',
-    enabled: computed(() => !!props.discussion?.id && !!defaultChannel.value),
-  }
-);
-
-const relatedIssueNumber = computed(() => {
-  const directIssueNumber =
-    getDiscussionIssueResult.value?.issues?.[0]?.issueNumber;
-  if (directIssueNumber != null) {
-    return directIssueNumber;
-  }
-
-  return (
-    getDiscussionCommentIssueResult.value?.discussionChannels?.[0]
-      ?.Comments?.[0]?.RelatedIssues?.[0]?.issueNumber ?? null
-  );
-});
-
-const relatedIssueLink = computed(() => {
-  if (relatedIssueNumber.value == null || !defaultChannel.value) {
-    return null;
-  }
-
-  return {
-    name: 'forums-forumId-issues-issueNumber',
-    params: {
-      forumId: defaultChannel.value,
-      issueNumber: relatedIssueNumber.value,
-    },
-  };
-});
 
 // Query server config to get default roles
 const { result: getServerResult } = useQuery(
@@ -364,7 +312,7 @@ const menuItems = computed(() => {
     feedbackEnabled:
       getChannelResult.value?.channels?.[0]?.feedbackEnabled ?? true,
     hasSensitiveContent: !!props.discussion?.hasSensitiveContent,
-    relatedIssueLink: relatedIssueLink.value,
+    relatedIssueLink: props.relatedIssueLink ?? null,
   });
 });
 

--- a/components/event/detail/EventDetail.vue
+++ b/components/event/detail/EventDetail.vue
@@ -8,6 +8,10 @@ import {
   GET_EVENT_ROOT_COMMENT_AGGREGATE,
 } from '@/graphQLData/comment/queries';
 import { GET_EVENT_CHANNEL } from '@/graphQLData/mod/queries';
+import { GET_CHANNEL } from '@/graphQLData/channel/queries';
+import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
+import { DateTime } from 'luxon';
+import { config } from '@/config';
 import type {
   Comment,
   EventChannel,
@@ -222,6 +226,35 @@ const {
 } = useQuery(GET_EVENT_ROOT_COMMENT_AGGREGATE, {
   eventId: eventId,
 });
+
+// Prefetch channel + server config in this first query wave. EventHeader issues
+// these same queries, but it only mounts after the event loads (it sits behind
+// v-if="event"), so on client-side navigation they would otherwise start a
+// second request wave once the header appears. Firing them here (cache-first,
+// identical variables) warms the Apollo cache so the header reads them
+// instantly. Results are intentionally unused here — this is a cache-priming
+// prefetch.
+useQuery(
+  GET_CHANNEL,
+  {
+    uniqueName: channelId.value,
+    now: DateTime.local().startOf('hour').toISO(),
+  },
+  {
+    fetchPolicy: 'cache-first',
+    enabled: computed(() => !!channelId.value),
+  }
+);
+
+useQuery(
+  GET_SERVER_CONFIG,
+  {
+    serverName: config.serverName,
+  },
+  {
+    fetchPolicy: 'cache-first',
+  }
+);
 
 watch([eventId, channelId], ([newEventId, newChannelId]) => {
   if (newEventId && newChannelId !== undefined) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -294,6 +294,21 @@ export default defineNuxtConfig({
     cdn: true,
     // Enable server-side caching
     routeRules: {
+      // Cache server-rendered discussion pages. The SSR output is anonymous
+      // (auth runs client-side only, so the server never personalizes the
+      // HTML), which makes it identical for every visitor and safe to cache.
+      // On Vercel this becomes ISR: the page renders on demand, is served
+      // from the edge (~5ms vs ~2s SSR), and revalidates in the background
+      // every 300s. Note: the single-segment glob is required — a mid-path
+      // `**` (e.g. /forums/**/discussions/**) corrupts Nitro's route matcher
+      // and 404s the route.
+      '/forums/*/discussions/*': { isr: 300 },
+      // Event and download detail pages render the same way: public, anonymous
+      // SSR (auth is client-side), so they cache identically for every visitor.
+      // Downloads are discussions with hasDownload=true and reuse the same
+      // components, so they also inherit the flattened query waves.
+      '/forums/*/events/*': { isr: 300 },
+      '/forums/*/downloads/*': { isr: 300 },
       // Cache API routes
       '/api/**': {
         cache: {

--- a/pages/forums/[forumId]/downloads/[discussionId]/comments.vue
+++ b/pages/forums/[forumId]/downloads/[discussionId]/comments.vue
@@ -14,9 +14,15 @@ import DiscussionRootCommentFormWrapper from '@/components/discussion/form/Discu
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import InfoBanner from '@/components/InfoBanner.vue';
-import type { Comment } from '@/__generated__/graphql';
+import type { Comment, Discussion } from '@/__generated__/graphql';
 
 const COMMENT_LIMIT = 50;
+
+// The parent download page passes the already-loaded discussion via <NuxtPage>,
+// so skip the redundant GET_DISCUSSION fetch when switching to this tab.
+const props = defineProps<{
+  discussion?: Discussion;
+}>();
 
 const route = useRoute();
 const offset = ref(0);
@@ -33,14 +39,20 @@ const channelId = computed(() => {
 
 const loggedInUserModName = computed(() => modProfileNameVar.value);
 
-const { result: getDiscussionResult } = useQuery(GET_DISCUSSION, {
-  id: discussionId,
-  loggedInModName: loggedInUserModName,
-  channelUniqueName: channelId.value,
-});
+const { result: getDiscussionResult } = useQuery(
+  GET_DISCUSSION,
+  () => ({
+    id: discussionId.value,
+    loggedInModName: loggedInUserModName.value,
+    channelUniqueName: channelId.value,
+  }),
+  {
+    enabled: !props.discussion,
+  }
+);
 
 const discussion = computed(
-  () => getDiscussionResult.value?.discussions?.[0] || null
+  () => props.discussion || getDiscussionResult.value?.discussions?.[0] || null
 );
 const activeDiscussionChannel = computed(() => {
   return discussion.value?.DiscussionChannels?.find(

--- a/pages/forums/[forumId]/downloads/index.vue
+++ b/pages/forums/[forumId]/downloads/index.vue
@@ -149,8 +149,14 @@ const filterGroups = computed<FilterGroup[]>(() => {
       </div>
     </div>
 
-    <!-- Downloads Content -->
-    <div v-else>
+    <!-- Downloads Content. Rendered with v-show (not v-else) so DownloadList
+         mounts immediately and its list query fires in parallel with the
+         channel/server-config checks instead of waiting for them — removing a
+         query wave on channel-scoped navigation. It stays hidden while loading
+         or when downloads are disabled. filterGroups (filter UI only) populate
+         once the channel query resolves; the list query doesn't depend on
+         them. -->
+    <div v-show="shouldShowDownloads">
       <DownloadFilterBar :filter-groups="filterGroups" />
 
       <!-- Desktop Layout with Sidebar -->

--- a/pages/forums/[forumId]/events/index.vue
+++ b/pages/forums/[forumId]/events/index.vue
@@ -97,6 +97,13 @@ const errorMessage = computed(() => {
 </script>
 <template>
   <div>
+    <!-- Mounted immediately (v-show, not v-if) so its GET_EVENTS query fires in
+         parallel with the channel/server-config checks instead of waiting for
+         them to resolve first. That removes a query wave on channel-scoped
+         navigation. Visibility is still gated so the list is hidden while
+         loading or when events are disabled for the forum/server. -->
+    <EventListView v-show="shouldShowEvents" />
+
     <!-- Loading State -->
     <div v-if="bothLoading" class="flex justify-center py-8">
       <div class="text-center">
@@ -142,8 +149,5 @@ const errorMessage = computed(() => {
         </div>
       </div>
     </div>
-
-    <!-- Events List -->
-    <EventListView v-else />
   </div>
 </template>


### PR DESCRIPTION
## Summary

Two performance levers applied across the detail and channel-list pages. Both are safe because **auth is entirely client-side** (token in `localStorage`), so the server renders every page anonymously — identical for all visitors, with personalization layered on during client hydration.

### 1. Server TTFB — ISR caching
Cache the public, anonymously-rendered **detail** pages at the edge:
```ts
'/forums/*/discussions/*': { isr: 300 },
'/forums/*/events/*':      { isr: 300 },
'/forums/*/downloads/*':   { isr: 300 },
```
TTFB drops **~2,000ms → ~5ms** on cache hits (validated locally via the equivalent Nitro SWR cache; ISR config confirmed in the Vercel-preset build with `expiration: 300`). Bonus: the GraphQL backend serves roughly one render per revalidation window per page instead of one per request.

> Note: single-segment globs (`/forums/*/...`) are required — a mid-path `**` corrupts Nitro's route matcher and 404s the route.

### 2. Client-side navigation — flatten GraphQL query waves
When navigating within the app there's no SSR/ISR, so the client fetches. Several pages issued queries in **serial waves** (a query gated on a prior query's result, or a component that doesn't mount until its parent's data loads). Flattened so queries fire in **one wave**:

| Page | Change |
|---|---|
| Discussion detail | Hoist issue-existence queries out of the discussion-gated header into the always-mounted parent (keyed off route params); prefetch channel + server config so the header reads them warm. **3 waves → 1.** |
| Event detail | Prefetch channel + server config in the parent (same `v-if="event"` mount-gate pattern). |
| Channel events / downloads lists | Render the list with `v-show` instead of `v-if` so its list query fires in parallel with the channel/server-config enabled-check instead of after it. |
| Download comments tab | Accept the `discussion` prop passed via `<NuxtPage>` to skip a redundant `GET_DISCUSSION` on tab switch. |

Download detail reuses the discussion detail components, so it inherits the flattening for free.

## Deliberately out of scope
- **List index pages are not ISR-cached** — query-param fragmentation (search/tags/filters) and event time-sensitivity make the hit rate poor; they rely on Apollo `cache-first`.
- **No `GET_USER` dedupe** — Apollo already deduplicates the two `cache-first` identical queries into one request.
- **Cache invalidation** not included — with `isr: 300`, content can be up to 5 min stale before background revalidation. The discussion content-refetch-on-mount for authenticated users already prevents a commenter's own comment from appearing lost. On-demand invalidation on mutations is a sensible follow-up if tighter freshness is wanted.

## Verification
- `vue-tsc --noEmit`: 0 errors. ESLint: 0 errors. Pre-commit hook (tsc + unit tests) passed.
- Discussion + download detail client-side nav confirmed **single-wave** in-browser; pages render correctly, no console errors.
- Channel events + downloads list pages confirmed rendering correctly (loading / disabled / enabled states + filter bars intact).
- ISR config confirmed in the Vercel-preset build output.

Caveat: absolute millisecond figures are noisy (local dev backend latency swings 260–2000ms); the reliable wins are structural (cache hit vs full render; 1 wave vs 3). Event-detail wave reduction wasn't measured empirically (no event seed data in the test channel) — it's a low-risk cache-priming prefetch structurally identical to the verified discussion change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)