### PR TITLE
fix(auth): defer username restore to post-mount to stop hydration flash

### DIFF
--- a/plugins/username-cache.client.ts
+++ b/plugins/username-cache.client.ts
@@ -7,17 +7,34 @@ import {
   TOKEN_STORAGE_KEY,
 } from '@/utils/authUtils';
 
-export default defineNuxtPlugin(() => {
-  // This plugin runs only on the client
-  if (typeof window !== 'undefined') {
-    // Restore the username from localStorage, but only when a token is also
-    // present. The username persists across sessions while the token does not,
-    // so restoring it alone would produce a "ghost login" (see authUtils).
+export default defineNuxtPlugin((nuxtApp) => {
+  // This plugin runs only on the client.
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  // Restore the username from localStorage, but only when a token is also
+  // present. The username persists across sessions while the token does not,
+  // so restoring it alone would produce a "ghost login" (see authUtils).
+  //
+  // IMPORTANT: this must NOT run before hydration. The server renders as
+  // logged-out (it cannot read the localStorage token), so if we populated
+  // usernameVar synchronously here the first client render would diverge from
+  // the SSR output and trigger a hydration mismatch ("Hydration completed but
+  // contains mismatches"). Vue then discards the server-rendered DOM and
+  // re-renders, which users see as the page flashing/reloading. Components such
+  // as DiscussionHeader read usernameVar directly, so they rely on it being
+  // empty during initial hydration (the same contract RequireAuth documents).
+  //
+  // By restoring on `app:mounted` (after hydration completes), the initial
+  // render matches SSR and the auth-gated UI then updates via a normal
+  // reactive re-render instead of a hydration bailout.
+  nuxtApp.hook('app:mounted', () => {
     const storedUsername = localStorage.getItem(USERNAME_STORAGE_KEY);
     const token = localStorage.getItem(TOKEN_STORAGE_KEY);
 
     if (shouldRestoreUsername(storedUsername, token)) {
       setUsername(storedUsername as string);
     }
-  }
+  });
 });


### PR DESCRIPTION
## Problem

Hard-refreshing a discussion detail page (e.g. a `/forums/:forumId/discussions/:id` URL) showed the page, then it blanked, then reappeared, with `Hydration completed but contains mismatches` in the console. That warning **is** the cause: when Vue finds the server-rendered DOM doesn't match the client's first render, it discards the SSR subtree and re-renders client-side — the visible flash.

## Root cause

Auth state was read from two inconsistent sources at hydration time:

| | Source | Result for a logged-in user |
|---|---|---|
| **Server** (`plugins/auth0.server.ts`) | `auth0.token` cookie → decode username | Auth0 runs in `cacheLocation: 'localstorage'`, so the token isn't in a readable cookie → SSR renders **logged-out** (`usernameVar = ''`) |
| **Client** (`plugins/username-cache.client.ts`) | `localStorage` token + username | Plugin ran **synchronously before hydration** → first client render was **logged-in** |

Components that gate UI directly on `usernameVar` then rendered different DOM on each side — e.g. `DiscussionHeader`'s author "Edit" button and action menu, and comment/vote buttons. Server: absent. Client first render: present. → mismatch → bailout → flash.

`RequireAuth.vue` already documents the correct contract (pretend logged-out during initial hydration to match SSR, then flip after mount via a normal re-render). It honors that with a cookie hint + `isMounted` guard, but the `username-cache` plugin broke the contract for every component reading `usernameVar` directly.

## Fix

Restore the username on the `app:mounted` hook (after hydration completes) instead of synchronously at plugin init. The initial client render now matches the logged-out SSR output — no hydration mismatch, no flash — and the auth-gated controls appear a tick later via an ordinary reactive update, identical to how `RequireAuth` already behaves.

Only `plugins/username-cache.client.ts` changes; the ghost-login guard (`shouldRestoreUsername`) is preserved, only its timing moves.

## Testing

- `npx vue-tsc --noEmit` clean for the changed file.
- Manual: log in, hard-refresh a discussion detail page — the mismatch warning and the flash should both be gone, with the Edit button / action menu appearing immediately after paint.

> Note: a deeper pre-existing issue remains — SSR is effectively always logged-out for real users because `auth0.server.ts` reads cookies the localStorage-mode SDK doesn't set. That's tracked separately (migration to the now-GA official `@auth0/auth0-nuxt` server-session SDK) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)