### PR TITLE
fix(forum): register useHead in setup to stop SSR unhandledRejection

### DIFF
--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -218,26 +218,58 @@ onGetChannelResult((result) => {
       },
     });
   }
+});
+
+// Derive SEO meta tags reactively from the query result so useHead is
+// registered during setup (not inside the async onResult callback, which
+// runs outside the Nuxt instance context during SSR).
+const metaData = computed(() => {
+  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME || 'Multiforum';
+  const baseUrl = import.meta.env.VITE_BASE_URL;
+  const loadedChannel = channel.value;
+
+  if (!loadedChannel) {
+    return {
+      title: serverName,
+      meta: [
+        {
+          name: 'description',
+          content: `Community forum on ${serverName}`,
+        },
+      ],
+    };
+  }
+
   const forumName = loadedChannel.displayName || loadedChannel.uniqueName;
   const forumDescription = loadedChannel.description
     ? loadedChannel.description.substring(0, 160) +
       (loadedChannel.description.length > 160 ? '...' : '')
     : `${forumName} - Community Forum`;
-  const baseUrl = import.meta.env.VITE_BASE_URL;
-  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME || 'Multiforum';
   const imageUrl =
     loadedChannel.channelIconURL || loadedChannel.channelBannerURL || '';
 
-  // Set basic SEO meta tags
-  useHead({
+  return {
     title: `${forumName} | ${serverName}`,
-    description: forumDescription,
-    image: imageUrl,
-    type: 'website',
-  });
+    meta: [
+      { name: 'description', content: forumDescription },
 
-  // Add structured data for rich results
-  useHead({
+      // OpenGraph tags
+      { property: 'og:title', content: forumName },
+      { property: 'og:description', content: forumDescription },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:url', content: `${baseUrl}/forums/${channelId.value}` },
+      { property: 'og:site_name', content: serverName },
+      ...(imageUrl ? [{ property: 'og:image', content: imageUrl }] : []),
+
+      // Twitter Card tags
+      {
+        name: 'twitter:card',
+        content: imageUrl ? 'summary_large_image' : 'summary',
+      },
+      { name: 'twitter:title', content: forumName },
+      { name: 'twitter:description', content: forumDescription },
+      ...(imageUrl ? [{ name: 'twitter:image', content: imageUrl }] : []),
+    ],
     script: [
       {
         type: 'application/ld+json',
@@ -256,8 +288,11 @@ onGetChannelResult((result) => {
         }),
       },
     ],
-  });
+  };
 });
+
+// Set meta tags reactively
+useHead(metaData);
 const adminList = computed(() => {
   return channel.value?.Admins?.map((user: User) => user?.username) || [];
 });


### PR DESCRIPTION
## What changed

In `pages/forums/[forumId].vue`, `useHead(...)` was being called twice **inside** the `onGetChannelResult` Apollo result callback. That callback fires asynchronously after component setup, so during SSR it runs outside the Nuxt instance context and throws:

```
[nuxt] A composable that requires access to the Nuxt instance was called
outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function.
  at useNuxtApp → injectHead → useHead → pages/forums/[forumId].vue
```

This fix mirrors the working pattern already used by the discussion-detail page (`pages/forums/[forumId]/discussions/[discussionId].vue`):

- `onGetChannelResult` now only performs the side effects that belong in a result callback — the `recentForums` localStorage write and the root-route redirect to `/discussions`.
- A new `metaData` computed derives title / description / OpenGraph / Twitter Card / JSON-LD tags from the existing `channel` ref, with a sensible fallback for when the channel hasn't loaded yet.
- `useHead(metaData)` is called **once during setup**, so the head composable is registered in setup context and updates reactively when channel data resolves.

## Why

Currently this only logs an `unhandledRejection` in dev (the page still renders), but it means the forum page's SEO meta tags may not be set reliably during SSR. Calling `useHead` in setup with a reactive source is the correct Nuxt pattern.

## Notes for reviewers

- Pre-existing bug, unrelated to auth — surfaced while testing the auth0-nuxt server-session spike.
- The old code set top-level `image` and `type` keys on `useHead`, which aren't valid `useHead` options. The new `metaData` expands these into proper `og:*` / `twitter:*` meta entries, so the SEO tags are now actually emitted.
- `npm run tsc` passes (exit 0, no type errors); pre-commit lint + unit tests ran on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)