### PR TITLE
fix(ssr): wrap NuxtRouteAnnouncer in ClientOnly to stop app-root hydration mismatch

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -17,7 +17,22 @@ onMounted(() => {
 
 <template>
   <div>
-    <NuxtRouteAnnouncer />
+    <!--
+      NuxtRouteAnnouncer is rendered as a client-only component on the server
+      (an empty <div> placeholder, with no `nuxt-route-announcer` markup in the
+      SSR HTML) but mounts as a real <span class="nuxt-route-announcer"> on the
+      client. On the Vercel runtime that div->span swap at the app root is
+      treated as a hard hydration mismatch (the Node runtime swaps it cleanly),
+      which shifts every following sibling and forces Vue to re-render the whole
+      tree client-side — the "content loads, black screen, then reloads" flash.
+      Wrapping it in <ClientOnly> gives a deterministic SSR placeholder so the
+      announcer is mounted client-side without a hydration mismatch. It only
+      announces route changes to screen readers, which is a client-runtime
+      concern anyway, so there is no SSR/SEO cost.
+    -->
+    <ClientOnly>
+      <NuxtRouteAnnouncer />
+    </ClientOnly>
     <NuxtPage />
   </div>
 </template>


### PR DESCRIPTION
## Problem

Authenticated users on discussion detail pages (and likely all pages) see the content load, flash to a black screen, then re-render — with `Hydration completed but contains mismatches` in the console. Reproduced live on production (build `C7mRMxHp`).

## Root cause

The trigger is at the **app root**, not the auth code. In `app.vue` the first child is `<NuxtRouteAnnouncer />`. On the **Vercel runtime**:

- SSR emits an empty `<div></div>` placeholder there (the `nuxt-route-announcer` markup is entirely absent from the server HTML).
- The client mounts it as `<span class="nuxt-route-announcer">`.

That `div`→`span` tag mismatch on the app's first child shifts every following sibling, so Vue reports the mismatch, bails on hydration, and re-renders the whole tree client-side — the "black screen, then reload" flash.

Notably this is **Vercel-runtime-specific**: a local Node-runtime build of the identical commit (`199e87c2`, the same release running in prod) swaps the same placeholder cleanly with **no** mismatch. Confirmed it is not a caching issue (`x-vercel-cache: MISS`, `age: 0`).

## Fix

Wrap the announcer in `<ClientOnly>` so it gets a deterministic SSR placeholder and mounts client-side without a hydration mismatch. It only announces route changes to screen readers (a client-runtime concern), so there is no SSR/SEO cost.

## Verification

Verified on production after deploy (preview deployments are SSO-protected and couldn't be reached for pre-merge verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)