### PR TITLE
fix(ssr): enable Vuetify ssr mode to stop responsive-nav hydration mismatch

### DIFF
--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -5,6 +5,15 @@ import { aliases, mdi } from 'vuetify/iconsets/mdi';
 
 export default defineNuxtPlugin((nuxtApp) => {
   const vuetify = createVuetify({
+    // REQUIRED for SSR. Without it, useDisplay() (lgAndUp / mdAndUp / smAndDown,
+    // used for responsive nav rendering in layouts/default.vue, TopNav.vue,
+    // ChannelTabs.vue, etc.) resolves to an inconsistent viewport width between
+    // the server render and the client's first hydration render, so the
+    // responsive `v-if` branches flip and Vue reports "Hydration completed but
+    // contains mismatches" — the cascading nav/layout mismatch on discussion
+    // pages. With ssr:true Vuetify renders a stable default on both server and
+    // first client render, then updates the real breakpoints after mount.
+    ssr: true,
     icons: {
       defaultSet: 'mdi',
       aliases,


### PR DESCRIPTION
## Problem

Production discussion pages flash (content loads → black screen → reload) with `Hydration completed but contains mismatches`. After the previous NuxtRouteAnnouncer fix the error persisted; a structural diff of prod SSR vs the live DOM showed the real divergences are in the **nav/layout** — SSR renders `#comment` placeholders where the client renders `<nav>` elements.

## Root cause

`plugins/vuetify.ts` called `createVuetify()` **without `ssr: true`**. Vuetify's SSR docs require it. Without it, `useDisplay()` (`lgAndUp` / `mdAndUp` / `smAndDown`, used for responsive nav rendering in `layouts/default.vue`, `components/nav/TopNav.vue`, `components/channel/ChannelTabs.vue`, etc.) resolves to an inconsistent viewport width between the server render and the client's first hydration render. The responsive `v-if` branches flip → hydration mismatch → full client re-render (the flash).

Only manifested on the Vercel runtime; a local Node build of the same commit happened to hydrate cleanly, so it didn't reproduce locally.

## Fix

`createVuetify({ ssr: true, ... })`. Vuetify renders a stable default breakpoint on both server and first client render, then updates the real viewport after mount — no hydration mismatch.

## Verification

Verified on production after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)