### PR TITLE
fix(ssr): authenticate SSR Apollo queries to stop auth-data hydration mismatch

### DIFF
--- a/plugins/apollo-ssr-auth.ts
+++ b/plugins/apollo-ssr-auth.ts
@@ -1,0 +1,43 @@
+// plugins/apollo-ssr-auth.ts
+//
+// SPIKE (auth0-nuxt server-session migration) — SSR auth for Apollo.
+//
+// Makes server-side GraphQL queries AUTHENTICATED, matching the client.
+//
+// @nuxtjs/apollo resolves the auth token via the `apollo:auth` hook first, then
+// falls back to `localStorage[tokenName]` — which is client-only. So without
+// this hook, SSR runs every query anonymously while the client (which has the
+// token in localStorage, kept in sync by plugins/apollo-auth.client.ts) runs
+// them authenticated. For permission-gated data (e.g. moderator/owner discussion
+// controls, feedback/answer state) the anonymous SSR result differs from the
+// authenticated client result, so the client's first hydration render does not
+// match the server HTML — a hydration mismatch ("server rendered more child
+// nodes than client vdom") that re-renders the content subtree.
+//
+// The session access token is already resolved server-side in
+// server/middleware/2.auth-session.ts and stashed on `event.context.accessToken`.
+// Here we hand it to Apollo on the server. On the client we set nothing, so the
+// module falls through to its existing localStorage behavior.
+//
+// This is the SSR counterpart of plugins/apollo-auth.client.ts and the reason we
+// can authenticate SSR without the cookieless `/api/auth/token` fetch that the
+// `apollo:auth` hook would otherwise trigger during SSR: the token is read
+// directly from the request context, no internal fetch involved.
+//
+// Per-request safety: forum detail pages are NOT route-cached (see the routeRules
+// note in nuxt.config.ts), so each SSR render is for exactly one user — one
+// user's token never authenticates another user's server render.
+import { defineNuxtPlugin } from 'nuxt/app';
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hook('apollo:auth', ({ token }) => {
+    if (!import.meta.server) {
+      // Client: leave unset so @nuxtjs/apollo reads localStorage[tokenName].
+      return;
+    }
+    const accessToken = nuxtApp.ssrContext?.event?.context?.accessToken;
+    if (accessToken) {
+      token.value = accessToken;
+    }
+  });
+});

--- a/server/middleware/2.auth-session.ts
+++ b/server/middleware/2.auth-session.ts
@@ -44,6 +44,9 @@ type AuthSessionContext = {
 declare module 'h3' {
   interface H3EventContext {
     authSession?: AuthSessionContext;
+    // API access token from the session, used to authenticate SSR Apollo
+    // queries (see plugins/apollo-ssr-auth.ts).
+    accessToken?: string;
   }
 }
 
@@ -182,6 +185,17 @@ export default defineEventHandler(async (event) => {
       try {
         const tokenSet = await auth0.getAccessToken();
         const accessToken = tokenSet?.accessToken;
+        // Expose the API access token to the SSR Apollo client (read back in
+        // plugins/apollo-ssr-auth.ts via the `apollo:auth` hook) so server-side
+        // GraphQL queries run AUTHENTICATED, exactly like the client's queries.
+        // Without this the SSR is anonymous (the token lives only in client
+        // localStorage), so permission-gated data renders differently on the
+        // server than on the client's first hydration render — a hydration
+        // mismatch. Safe per-request because forum detail pages are not
+        // route-cached (no shared SSR), so one user's token never serves another.
+        if (accessToken) {
+          event.context.accessToken = accessToken;
+        }
         const graphqlUrl =
           useRuntimeConfig(event).public?.apollo?.clients?.default
             ?.httpEndpoint;


### PR DESCRIPTION
## Problem

Authenticated users still saw a hydration mismatch on discussion pages (the content subtree re-rendered) after the announcer/Vuetify fixes. The detail-flag build pinned it to the discussion content wrapper: *"server rendered more child nodes than client vdom."*

## Root cause

The auth migration keeps the API access token **client-side only** (localStorage, synced by `plugins/apollo-auth.client.ts`). `@nuxtjs/apollo` resolves the token via the `apollo:auth` hook, then falls back to `localStorage` — which is client-only. So **SSR ran every GraphQL query anonymously while the client ran them authenticated**. For permission-gated discussion data (mod/owner controls, options menu, feedback/answer state), the anonymous server result differs from the authenticated client result → the client's first hydration render doesn't match the server HTML.

Confirmed: the prod client has a token in localStorage (`clientHasToken: true`), and the SSR is anonymous by design.

## Fix

The session access token is already resolved server-side in `server/middleware/2.auth-session.ts`. Stash it on `event.context.accessToken` and hand it to Apollo on the server via the `apollo:auth` hook (new `plugins/apollo-ssr-auth.ts`). The client is unchanged. SSR and client now run queries with the same auth → data and render match. Also fixes a real correctness gap (SSR previously rendered anonymous data for logged-in users).

**Safety:** forum detail pages are not route-cached (see `routeRules`), so a server render serves exactly one user — no token authenticates another user's page.

## Verification

Verified on production after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)