### PR TITLE
fix(auth): request-scope auth state (fixes cross-request leak + hydration mismatch)

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -103,41 +103,19 @@ const mergeByEntityKey: FieldMergeFunction<CacheEntity[]> = (
 const mergeModerators = mergeByEntityKey;
 const mergeAdmins = mergeByEntityKey;
 
-export const usernameVar = ref('');
-export const setUsername = (username: string) => {
-  usernameVar.value = username;
-};
-// The verified email from the server session. Seeded by plugins/auth-session.ts.
-// Used by the create-username flow (which keys the new User node off the email).
-export const emailVar = ref('');
-export const setEmail = (email: string) => {
-  emailVar.value = email;
-};
-export const profilePicURLVar = ref('');
-export const setProfilePicURL = (url: string) => {
-  profilePicURLVar.value = url;
-};
+// NOTE: the session-seeded auth state (isAuthenticatedVar, usernameVar,
+// emailVar, profilePicURLVar, modProfileNameVar, notificationCountVar) used to
+// live here as module-level refs. Module-level refs are SHARED across every
+// request on a server instance, so they leaked one user's auth state into
+// another user's SSR render (a privacy bug + hydration mismatch). They now live
+// in `composables/useAuthState.ts` as request-scoped `useState` values. Read
+// them with `const usernameVar = useUsername()` etc.
+
 export const userDataLoadingVar = ref(false);
-export const modProfileNameVar = ref('');
-export const setModProfileName = (modProfileName: string) => {
-  modProfileNameVar.value = modProfileName;
-};
-export const isAuthenticatedVar = ref(false);
-export const setIsAuthenticated = (status: boolean) => {
-  if (status === isAuthenticatedVar.value) {
-    return; // No change in authentication status, skip update
-  }
-  isAuthenticatedVar.value = status;
-};
 
 export const isLoadingAuthVar = ref(false);
 export const setIsLoadingAuth = (status: boolean) => {
   isLoadingAuthVar.value = status;
-};
-
-export const notificationCountVar = ref(0);
-export const setNotificationCount = (count: number) => {
-  notificationCountVar.value = count;
 };
 
 export const sideNavIsOpenVar = ref(false);

--- a/components/auth/CreateUsernameForm.vue
+++ b/components/auth/CreateUsernameForm.vue
@@ -13,8 +13,8 @@ import {
   setUsername,
   setModProfileName,
   setIsAuthenticated,
-  setIsLoadingAuth,
-} from '@/cache';
+} from '@/composables/useAuthState';
+import { setIsLoadingAuth } from '@/cache';
 import { MAX_CHARS_IN_USERNAME } from '@/utils/constants';
 import {
   isValidUsername,

--- a/components/auth/RequireAuth.spec.ts
+++ b/components/auth/RequireAuth.spec.ts
@@ -1,15 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { ref } from 'vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 
-// RequireAuth now reads auth state straight from the cache vars, which are
-// seeded from the server session (plugins/auth-session.ts) and are identical on
-// server and client. No auth-hint cookie shim, no @auth0/auth0-vue, no SSR vs
-// client branching — so the test just drives the two reactive vars.
-vi.mock('@/cache', () => ({
-  usernameVar: ref(''),
-  isAuthenticatedVar: ref(false),
+// RequireAuth now reads auth state straight from the useAuthState composables,
+// which are seeded from the server session (plugins/auth-session.ts) and are
+// identical on server and client. No auth-hint cookie shim, no @auth0/auth0-vue,
+// no SSR vs client branching — so the test just drives the two reactive refs.
+const { mockUsername, mockIsAuthenticated } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref } = require('vue');
+  return { mockUsername: ref(''), mockIsAuthenticated: ref(false) };
+});
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsername,
+  useIsAuthenticated: () => mockIsAuthenticated,
 }));
 
 const slots = {
@@ -25,9 +30,8 @@ const setAuthState = async ({
   authenticated: boolean;
   username: string;
 }) => {
-  const { usernameVar, isAuthenticatedVar } = await vi.importMock('@/cache');
-  isAuthenticatedVar.value = authenticated;
-  usernameVar.value = username;
+  mockIsAuthenticated.value = authenticated;
+  mockUsername.value = username;
 };
 
 describe('RequireAuth', () => {

--- a/components/auth/RequireAuth.vue
+++ b/components/auth/RequireAuth.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { isAuthenticatedVar, usernameVar } from '@/cache';
+import { useIsAuthenticated, useUsername } from '@/composables/useAuthState';
+
+const isAuthenticatedVar = useIsAuthenticated();
+const usernameVar = useUsername();
 
 /*
 Wrapper around content that requires authentication: renders the `has-auth`

--- a/components/channel/ChannelAboutPage.vue
+++ b/components/channel/ChannelAboutPage.vue
@@ -12,8 +12,11 @@ import LockChannelDialog from '@/components/mod/LockChannelDialog.vue';
 import UnlockChannelDialog from '@/components/mod/UnlockChannelDialog.vue';
 import { useRoute } from 'nuxt/app';
 import { config } from '@/config';
-import { usernameVar, modProfileNameVar } from '@/cache';
+import { useUsername, useModProfileName } from '@/composables/useAuthState';
 import { checkPermission } from '@/utils/permissionUtils';
+
+const usernameVar = useUsername();
+const modProfileNameVar = useModProfileName();
 
 const route = useRoute();
 const channelId = computed(() => {

--- a/components/channel/ChannelHeaderMobile.vue
+++ b/components/channel/ChannelHeaderMobile.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import AddToChannelFavorites from '@/components/favorites/AddToChannelFavorites.vue';
-import { isAuthenticatedVar } from '@/cache';
+import { useIsAuthenticated } from '@/composables/useAuthState';
+
+const isAuthenticatedVar = useIsAuthenticated();
 
 defineProps({
   channelId: {

--- a/components/channel/ChannelSidebar.vue
+++ b/components/channel/ChannelSidebar.vue
@@ -10,7 +10,9 @@ import { useRouter, useRoute } from 'nuxt/app';
 import FontSizeControl from '@/components/channel/FontSizeControl.vue';
 import BecomeAdminModal from '@/components/channel/BecomeAdminModal.vue';
 import AddToChannelFavorites from '@/components/favorites/AddToChannelFavorites.vue';
-import { isAuthenticatedVar } from '@/cache';
+import { useIsAuthenticated } from '@/composables/useAuthState';
+
+const isAuthenticatedVar = useIsAuthenticated();
 
 type BotSummary = {
   username: string;

--- a/components/channel/ChannelTabs.vue
+++ b/components/channel/ChannelTabs.vue
@@ -10,7 +10,11 @@ import InfoIcon from '@/components/icons/InfoIcon.vue';
 import BookIcon from '@/components/icons/BookIcon.vue';
 import UserIcon from '@/components/icons/UserIcon.vue';
 import type { Channel } from '@/__generated__/graphql';
-import { modProfileNameVar, usernameVar, isAuthenticatedVar } from '@/cache';
+import {
+  useModProfileName,
+  useUsername,
+  useIsAuthenticated,
+} from '@/composables/useAuthState';
 import { useRoute } from 'nuxt/app';
 import { useDisplay } from 'vuetify';
 import { useQuery } from '@vue/apollo-composable';
@@ -19,6 +23,10 @@ import { config } from '@/config';
 // Import Popper dynamically to avoid SSR issues with regeneratorRuntime
 import { defineAsyncComponent } from 'vue';
 const Popper = defineAsyncComponent(() => import('vue3-popper'));
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
+const isAuthenticatedVar = useIsAuthenticated();
 
 type Tab = {
   name: string;

--- a/components/channel/DownloadList.vue
+++ b/components/channel/DownloadList.vue
@@ -11,7 +11,7 @@ import ErrorBanner from '../ErrorBanner.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import DiscussionAlbum from '@/components/discussion/detail/DiscussionAlbum.vue';
 import { GET_DISCUSSIONS_WITH_DISCUSSION_CHANNEL_DATA } from '@/graphQLData/discussion/queries';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { getFilterValuesFromParams } from '@/components/event/list/filters/getEventFilterValuesFromParams';
 import {
   getSortFromQuery,
@@ -19,6 +19,8 @@ import {
 } from '@/components/comments/getSortFromQuery';
 import { convertUrlParamsToLabelFilters } from '@/utils/downloadFilters';
 import type { Discussion, Album, FilterGroup } from '@/__generated__/graphql';
+
+const usernameVar = useUsername();
 
 const DOWNLOAD_PAGE_LIMIT = 25;
 

--- a/components/channel/ForumPicker.spec.ts
+++ b/components/channel/ForumPicker.spec.ts
@@ -17,10 +17,10 @@ vi.mock('@/graphQLData/channel/queries', () => ({
   GET_USER_FAVORITE_CHANNELS: {},
 }));
 
-// Mock cache
-vi.mock('@/cache', () => ({
-  usernameVar: ref(''),
-  isAuthenticatedVar: ref(false),
+// Mock auth state
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref(''),
+  useIsAuthenticated: () => ref(false),
 }));
 
 // Use real MultiSelect component

--- a/components/channel/ForumPicker.vue
+++ b/components/channel/ForumPicker.vue
@@ -13,8 +13,11 @@ import type {
   MultiSelectSection,
 } from '@/components/MultiSelect.vue';
 import type { Channel, ChannelWhere, Collection } from '@/__generated__/graphql';
-import { usernameVar, isAuthenticatedVar } from '@/cache';
+import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
 import { createCaseInsensitivePattern } from '@/utils/searchUtils';
+
+const usernameVar = useUsername();
+const isAuthenticatedVar = useIsAuthenticated();
 
 type ChannelFlag = 'eventsEnabled';
 type ChannelOptionSource = Pick<

--- a/components/channel/SearchableForumList.spec.ts
+++ b/components/channel/SearchableForumList.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useQuery } from '@vue/apollo-composable';
 import { asMock, createQueryMock } from '@/tests/utils/mockApollo';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
-import { createCacheMock } from '@/tests/utils/mockAuth';
+import { createAuthStateMock } from '@/tests/utils/mockAuth';
 import SearchableForumListItem from '@/components/channel/SearchableForumListItem.vue';
 // vi.mock is hoisted above imports, so the component (imported below) picks up
 // the mocked modules.
@@ -12,7 +12,7 @@ vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
 }));
 
-vi.mock('@/cache', () => createCacheMock());
+vi.mock('@/composables/useAuthState', () => createAuthStateMock());
 
 const makeChannel = (uniqueName: string) => ({
   uniqueName,

--- a/components/channel/SearchableForumList.vue
+++ b/components/channel/SearchableForumList.vue
@@ -10,12 +10,15 @@ import { GET_USER_CHANNEL_COLLECTIONS_WITH_CHANNELS } from '@/graphQLData/collec
 import SearchBar from '@/components/SearchBar.vue';
 import type { PropType } from 'vue';
 import SearchableForumListItem from './SearchableForumListItem.vue';
-import { usernameVar, isAuthenticatedVar } from '@/cache';
+import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
 import {
   areAllChannelsSelected,
   getChannelsToToggle,
   filterChannelsBySearch,
 } from '@/utils/channelSelection';
+
+const usernameVar = useUsername();
+const isAuthenticatedVar = useIsAuthenticated();
 
 // Define props
 const props = defineProps({

--- a/components/channel/form/CreateEditChannelFields.spec.ts
+++ b/components/channel/form/CreateEditChannelFields.spec.ts
@@ -13,9 +13,12 @@ vi.mock('nuxt/app', () => ({
 }));
 
 vi.mock('@/cache', () => ({
-  isAuthenticatedVar: { value: true },
   isLoadingAuthVar: { value: false },
-  usernameVar: { value: 'alice' },
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => ({ value: true }),
+  useUsername: () => ({ value: 'alice' }),
 }));
 
 describe('CreateEditChannelFields', () => {

--- a/components/channel/form/CreateEditChannelFields.vue
+++ b/components/channel/form/CreateEditChannelFields.vue
@@ -8,7 +8,8 @@ import type { CreateEditChannelFormValues } from '@/types/Channel';
 import TailwindForm from '@/components/FormComponent.vue';
 import { useRoute, useRouter } from 'nuxt/app';
 import { MAX_CHARS_IN_CHANNEL_NAME } from '@/utils/constants';
-import { isAuthenticatedVar, isLoadingAuthVar, usernameVar } from '@/cache';
+import { isLoadingAuthVar } from '@/cache';
+import { useIsAuthenticated, useUsername } from '@/composables/useAuthState';
 // Server config query removed since individual settings pages handle validation
 
 // Import icons
@@ -21,6 +22,9 @@ import PencilIcon from '@/components/icons/PencilIcon.vue';
 import CalendarIcon from '@/components/icons/CalendarIcon.vue';
 import AnnotationIcon from '@/components/icons/AnnotationIcon.vue';
 import DownloadIcon from '@/components/icons/DownloadIcon.vue';
+
+const isAuthenticatedVar = useIsAuthenticated();
+const usernameVar = useUsername();
 
 interface TabItem {
   key: string;

--- a/components/collection/AddToListPopover.vue
+++ b/components/collection/AddToListPopover.vue
@@ -2,7 +2,7 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import type { PropType } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useToastStore } from '@/stores/toastStore';
 import type { CollectionVisibility, Collection } from '@/__generated__/graphql';
 import { useCollectionMutations } from '@/composables/useCollectionMutations';
@@ -15,6 +15,8 @@ import {
   isItemFavorited,
   filterCollectionsBySearch,
 } from '@/utils/collectionFilters';
+
+const usernameVar = useUsername();
 
 // Type for item types that can be added to collections
 type ItemType = 'discussion' | 'comment' | 'image' | 'channel' | 'download';

--- a/components/comments/Comment.autoUnsubscribe.spec.ts
+++ b/components/comments/Comment.autoUnsubscribe.spec.ts
@@ -41,8 +41,8 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'alice' },
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ({ value: 'alice' }),
 }));
 
 vi.mock('@/composables/useCommentPermissions', () => ({

--- a/components/comments/Comment.realmount.spec.ts
+++ b/components/comments/Comment.realmount.spec.ts
@@ -7,7 +7,9 @@ import type { Comment } from '@/__generated__/graphql';
 import Comment from '@/components/comments/Comment.vue';
 
 vi.mock('nuxt/app', () => ({ useRoute: () => ({ params: {} }) }));
-vi.mock('@/cache', () => ({ usernameVar: { value: 'alice' } }));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ({ value: 'alice' }),
+}));
 vi.mock('@vue/apollo-composable', () => ({
   useMutation: () => ({
     mutate: vi.fn(),

--- a/components/comments/Comment.vue
+++ b/components/comments/Comment.vue
@@ -14,7 +14,7 @@ import EllipsisHorizontal from '@/components/icons/EllipsisHorizontal.vue';
 import RightArrowIcon from '@/components/icons/RightArrowIcon.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import CommentHeader from './CommentHeader.vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { MAX_CHARS_IN_COMMENT } from '@/utils/constants';
 import type { BotSuggestion } from '@/utils/botMentions';
 import type { ModSuggestion } from '@/utils/modMentions';
@@ -30,6 +30,8 @@ import {
   SUBSCRIBE_TO_COMMENT,
   UNSUBSCRIBE_FROM_COMMENT,
 } from '@/graphQLData/comment/mutations';
+
+const usernameVar = useUsername();
 
 const MAX_COMMENT_DEPTH = 5;
 const SHOW_MORE_THRESHOLD = 1000;

--- a/components/comments/CommentButtons.spec.ts
+++ b/components/comments/CommentButtons.spec.ts
@@ -12,9 +12,9 @@ vi.mock('nuxt/app', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'alice' },
-  modProfileNameVar: { value: '' },
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ({ value: 'alice' }),
+  useModProfileName: () => ({ value: '' }),
 }));
 
 describe('CommentButtons', () => {

--- a/components/comments/CommentButtons.vue
+++ b/components/comments/CommentButtons.vue
@@ -16,8 +16,11 @@ import NewEmojiButton from './NewEmojiButton.vue';
 import AddToCommentFavorites from '@/components/favorites/AddToCommentFavorites.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
-import { usernameVar, modProfileNameVar } from '@/cache';
+import { useUsername, useModProfileName } from '@/composables/useAuthState';
 import { MAX_CHARS_IN_COMMENT } from '@/utils/constants';
+
+const usernameVar = useUsername();
+const modProfileNameVar = useModProfileName();
 
 const props = defineProps({
   commentData: {

--- a/components/comments/CommentOnFeedbackPage.vue
+++ b/components/comments/CommentOnFeedbackPage.vue
@@ -19,13 +19,16 @@ import type { Comment } from '@/__generated__/graphql';
 import type { ApolloCache, NormalizedCacheObject } from '@apollo/client/core';
 import type { MenuItemType } from '@/components/IconButtonDropdown.vue';
 import { timeAgo, ALLOWED_ICONS } from '@/utils';
-import { modProfileNameVar, usernameVar } from '@/cache';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
 import { getFeedbackPermalinkObject } from '@/utils/routerUtils';
 import ArchivedCommentText from '@/components/comments/ArchivedCommentText.vue';
 import BrokenRulesModal from '@/components/mod/BrokenRulesModal.vue';
 import Notification from '@/components/NotificationComponent.vue';
 import UnarchiveModal from '@/components/mod/UnarchiveModal.vue';
 import { useModerationOutcomeUI } from '@/composables/useModerationOutcomeUI';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 const props = defineProps({
   comment: {

--- a/components/comments/CommentSection.realmount.spec.ts
+++ b/components/comments/CommentSection.realmount.spec.ts
@@ -23,7 +23,10 @@ vi.mock('nuxt/app', () => ({
   useRoute: vi.fn(() => ({ params: {}, query: {} })),
   useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
 }));
-vi.mock('@/cache', () => ({ modProfileNameVar: { value: '' } }));
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ({ value: '' }),
+  useUsername: () => ({ value: '' }),
+}));
 
 const CommentStub = {
   name: 'Comment',

--- a/components/comments/CommentSection.spec.ts
+++ b/components/comments/CommentSection.spec.ts
@@ -13,10 +13,8 @@ vi.mock('@vue/apollo-composable', () => ({
   useMutation: vi.fn(),
 }));
 
-vi.mock('@/cache', () => ({
-  modProfileNameVar: {
-    value: 'testmod',
-  },
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ({ value: 'testmod' }),
 }));
 
 vi.mock('@/components/comments/getSortFromQuery', () => ({

--- a/components/comments/CommentSection.suspension.spec.ts
+++ b/components/comments/CommentSection.suspension.spec.ts
@@ -48,10 +48,8 @@ vi.mock('@/composables/useSuspensionNotice', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  modProfileNameVar: {
-    value: 'mod-one',
-  },
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ({ value: 'mod-one' }),
 }));
 
 vi.mock('@/components/comments/getSortFromQuery', async (importOriginal) => {

--- a/components/comments/CommentSection.vue
+++ b/components/comments/CommentSection.vue
@@ -19,7 +19,7 @@ import type {
   CreateReplyInputData,
 } from '@/types/Comment';
 import type { PropType } from 'vue';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import { useRouter, useRoute } from 'nuxt/app';
 import UnarchiveModal from '@/components/mod/UnarchiveModal.vue';
 import LockIcon from '@/components/icons/LockIcon.vue';
@@ -40,6 +40,8 @@ import { useCommentSectionNotifications } from '@/composables/useCommentSectionN
 import { useCommentSectionModals } from '@/composables/useCommentSectionModals';
 import { useCommentFeedbackMutation } from '@/composables/useCommentFeedbackMutation';
 import { useCommentCrudMutations } from '@/composables/useCommentCrudMutations';
+
+const modProfileNameVar = useModProfileName();
 
 type CommentSectionQueryVariablesType = {
   discussionId?: string;

--- a/components/comments/CreateRootCommentForm.spec.ts
+++ b/components/comments/CreateRootCommentForm.spec.ts
@@ -1,3 +1,4 @@
+import { ref } from 'vue';
 import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import CreateRootCommentForm from '@/components/comments/CreateRootCommentForm.vue';
@@ -7,6 +8,7 @@ vi.mock('nuxt/app', () => ({
     params: { forumId: 'cats' },
     query: {},
   }),
+  useState: (_k, init) => ref(init ? init() : undefined),
 }));
 
 describe('CreateRootCommentForm', () => {

--- a/components/comments/CreateRootCommentForm.vue
+++ b/components/comments/CreateRootCommentForm.vue
@@ -8,7 +8,7 @@ import ErrorBanner from '../ErrorBanner.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import type { ApolloError } from '@apollo/client/errors';
 import type { CreateEditCommentFormValues } from '@/types/Comment';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import LoggedInUserAvatar from './LoggedInUserAvatar.vue';
 import { MAX_CHARS_IN_COMMENT } from '@/utils/constants';
 import { hasBotMention, type BotSuggestion } from '@/utils/botMentions';
@@ -18,6 +18,8 @@ import type { ModSuggestion } from '@/utils/modMentions';
 const TextEditor = defineAsyncComponent(
   () => import('@/components/TextEditor.vue')
 );
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   createCommentError: {

--- a/components/comments/EmojiButtons.spec.ts
+++ b/components/comments/EmojiButtons.spec.ts
@@ -20,8 +20,8 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: ref('alice'),
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
 }));
 
 describe('EmojiButtons', () => {

--- a/components/comments/EmojiButtons.vue
+++ b/components/comments/EmojiButtons.vue
@@ -9,8 +9,10 @@ import {
   ADD_EMOJI_TO_DISCUSSION_CHANNEL,
   REMOVE_EMOJI_FROM_DISCUSSION_CHANNEL,
 } from '@/graphQLData/discussion/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { ref } from 'vue';
+
+const usernameVar = useUsername();
 
 // Props
 const props = defineProps({

--- a/components/comments/EmojiPicker.vue
+++ b/components/comments/EmojiPicker.vue
@@ -5,7 +5,9 @@ import { useMutation } from '@vue/apollo-composable';
 import { ADD_EMOJI_TO_COMMENT } from '@/graphQLData/comment/mutations';
 import { ADD_EMOJI_TO_DISCUSSION_CHANNEL } from '@/graphQLData/discussion/mutations';
 
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 // Mutation to add emoji to comment
 const { mutate: addEmojiToComment } = useMutation(ADD_EMOJI_TO_COMMENT);
 

--- a/components/comments/LoggedInUserAvatar.vue
+++ b/components/comments/LoggedInUserAvatar.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { GET_USER } from '@/graphQLData/user/queries';
 import AvatarComponent from '../AvatarComponent.vue';
-import { usernameVar } from '@/cache';
 import { useQuery } from '@vue/apollo-composable';
 import { computed } from 'vue';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const { result: getUserResult } = useQuery(
   GET_USER,

--- a/components/comments/VoteButtons.spec.ts
+++ b/components/comments/VoteButtons.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
-import { createCacheMock } from '@/tests/utils/mockAuth';
+import { createAuthStateMock } from '@/tests/utils/mockAuth';
 import { makeComment } from '@/tests/utils/factories';
 import VotesComponent from '@/components/comments/Votes.vue';
 import type { Comment } from '@/__generated__/graphql';
@@ -17,7 +17,9 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => createCacheMock({ username: 'alice' }));
+vi.mock('@/composables/useAuthState', () =>
+  createAuthStateMock({ username: 'alice' })
+);
 
 const comment = (overrides: Record<string, unknown>): Comment =>
   makeComment(overrides as Partial<Comment>);

--- a/components/comments/VoteButtons.vue
+++ b/components/comments/VoteButtons.vue
@@ -11,7 +11,10 @@ import type { Comment } from '@/__generated__/graphql';
 import VotesComponent from './Votes.vue';
 import SuperUpvoteModal from '@/components/superUpvote/SuperUpvoteModal.vue';
 import { UNDO_SUPER_UPVOTE } from '@/graphQLData/scratchpad/mutations';
-import { modProfileNameVar, usernameVar } from '@/cache';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 const props = defineProps({
   commentData: {

--- a/components/discussion/detail/DiscussionAlbum.spec.ts
+++ b/components/discussion/detail/DiscussionAlbum.spec.ts
@@ -11,7 +11,9 @@ vi.mock('@vue/apollo-composable', () => ({ useMutation: vi.fn() }));
 vi.mock('nuxt/app', () => ({
   useRoute: vi.fn(() => ({ params: { forumId: 'cats' } })),
 }));
-vi.mock('@/cache', () => ({ usernameVar: { value: 'alice' } }));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ({ value: 'alice' }),
+}));
 
 const stubs = {
   ModelViewer: { template: '<div class="model-viewer-stub" />' },

--- a/components/discussion/detail/DiscussionAlbum.vue
+++ b/components/discussion/detail/DiscussionAlbum.vue
@@ -11,12 +11,14 @@ import SaveButton from '@/components/SaveButton.vue';
 import CancelButton from '@/components/CancelButton.vue';
 import { useMutation } from '@vue/apollo-composable';
 import { UPDATE_IMAGE } from '@/graphQLData/discussion/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import ModelViewer from '@/components/ModelViewer.vue';
 import StlViewer from '@/components/download/StlViewer.vue';
 import CarouselThumbnail from '@/components/discussion/detail/CarouselThumbnail.vue';
 import ImageLightbox from '@/components/discussion/detail/ImageLightbox.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
+
+const usernameVar = useUsername();
 
 const route = useRoute();
 

--- a/components/discussion/detail/DiscussionBody.spec.ts
+++ b/components/discussion/detail/DiscussionBody.spec.ts
@@ -9,9 +9,15 @@ vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: ref(''),
-  isAuthenticatedVar: ref(false),
+const { mockUsername, mockIsAuthenticated } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref } = require('vue');
+  return { mockUsername: ref(''), mockIsAuthenticated: ref(false) };
+});
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsername,
+  useIsAuthenticated: () => mockIsAuthenticated,
 }));
 
 vi.mock('nuxt/app', () => ({
@@ -94,13 +100,12 @@ describe('DiscussionBody Sensitive Content', () => {
 
     // Get mocked modules
     const apolloComposable = await vi.importMock('@vue/apollo-composable');
-    const cache = await vi.importMock('@/cache');
 
     mockUseQuery = apolloComposable.useQuery;
-    mockUsernameVar = cache.usernameVar;
-    mockIsAuthenticatedVar = cache.isAuthenticatedVar;
+    mockUsernameVar = mockUsername;
+    mockIsAuthenticatedVar = mockIsAuthenticated;
 
-    // Reset cache values
+    // Reset auth state values
     mockUsernameVar.value = '';
     mockIsAuthenticatedVar.value = false;
   });

--- a/components/discussion/detail/DiscussionBody.vue
+++ b/components/discussion/detail/DiscussionBody.vue
@@ -10,9 +10,12 @@ import type { Discussion } from '@/__generated__/graphql';
 import { useRouter } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_USER } from '@/graphQLData/user/queries';
-import { usernameVar, isAuthenticatedVar } from '@/cache';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
+import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
+const isAuthenticatedVar = useIsAuthenticated();
 
 const router = useRouter();
 

--- a/components/discussion/detail/DiscussionCommentsWrapper.spec.ts
+++ b/components/discussion/detail/DiscussionCommentsWrapper.spec.ts
@@ -17,7 +17,9 @@ vi.mock('@vue/apollo-composable', () => ({
   useMutation: vi.fn(),
 }));
 vi.mock('nuxt/app', () => ({ useRoute: vi.fn(() => ({ params: {}, query: {} })) }));
-vi.mock('@/cache', () => ({ usernameVar: { value: 'alice' } }));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ({ value: 'alice' }),
+}));
 vi.mock('@/composables/useAutoUnsubscribe', () => ({ useAutoUnsubscribe: vi.fn() }));
 
 const CommentSectionStub = {

--- a/components/discussion/detail/DiscussionCommentsWrapper.vue
+++ b/components/discussion/detail/DiscussionCommentsWrapper.vue
@@ -10,7 +10,6 @@ import { computed, ref, onMounted } from 'vue';
 import { getSortFromQuery } from '@/components/comments/getSortFromQuery';
 import type { CreateEditCommentFormValues } from '@/types/Comment';
 import CommentSection from '@/components/comments/CommentSection.vue';
-import { usernameVar } from '@/cache';
 import { useRoute } from 'nuxt/app';
 import { useMutation, useQuery } from '@vue/apollo-composable';
 import {
@@ -25,6 +24,9 @@ import DiscussionRootCommentFormWrapper from '@/components/discussion/form/Discu
 import { buildBotMentionOptions } from '@/utils/botMentions';
 import { buildModMentionOptions } from '@/utils/modMentions';
 import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const COMMENT_LIMIT = 50;
 

--- a/components/discussion/detail/DiscussionDetailContent.spec.ts
+++ b/components/discussion/detail/DiscussionDetailContent.spec.ts
@@ -13,10 +13,10 @@ import DiscussionDetailContent from '@/components/discussion/detail/DiscussionDe
 
 vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
 vi.mock('nuxt/app', () => ({ useRoute: vi.fn(() => ({ params: {}, query: {} })) }));
-vi.mock('@/cache', () => ({
-  isAuthenticatedVar: { value: false },
-  modProfileNameVar: { value: '' },
-  usernameVar: { value: '' },
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => ({ value: false }),
+  useModProfileName: () => ({ value: '' }),
+  useUsername: () => ({ value: '' }),
 }));
 vi.mock('@/composables/useForumRoleMembership', () => ({
   provideForumRoleMembership: vi.fn(),

--- a/components/discussion/detail/DiscussionDetailContent.vue
+++ b/components/discussion/detail/DiscussionDetailContent.vue
@@ -27,7 +27,6 @@ import DiscussionCommentsWrapper from '@/components/discussion/detail/Discussion
 import DiscussionChannelLinks from '@/components/discussion/detail/DiscussionChannelLinks.vue';
 import PageNotFound from '@/components/PageNotFound.vue';
 import { getSortFromQuery } from '@/components/comments/getSortFromQuery';
-import { isAuthenticatedVar, modProfileNameVar, usernameVar } from '@/cache';
 import { useRoute } from 'nuxt/app';
 import DiscussionBodyEditForm from './DiscussionBodyEditForm.vue';
 import AlbumEditForm from './AlbumEditForm.vue';
@@ -35,6 +34,15 @@ import ArchivedDiscussionInfoBanner from './ArchivedDiscussionInfoBanner.vue';
 import DiscussionLayoutManager from './DiscussionLayoutManager.vue';
 import FeedbackModalManager from './FeedbackModalManager.vue';
 import { provideForumRoleMembership } from '@/composables/useForumRoleMembership';
+import {
+  useIsAuthenticated,
+  useModProfileName,
+  useUsername,
+} from '@/composables/useAuthState';
+
+const isAuthenticatedVar = useIsAuthenticated();
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 const COMMENT_LIMIT = 50;
 

--- a/components/discussion/detail/DiscussionHeader.spec.ts
+++ b/components/discussion/detail/DiscussionHeader.spec.ts
@@ -41,10 +41,15 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'viewer' },
-  modProfileNameVar: { value: '' },
-}));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return {
+    useUsername: () => ref('viewer'),
+    useModProfileName: () => ref(''),
+    setUsername: vi.fn(),
+    setModProfileName: vi.fn(),
+  };
+});
 
 vi.mock('@/composables/useServerRoleMembership', () => ({
   useServerRoleMembership: () => ({

--- a/components/discussion/detail/DiscussionHeader.vue
+++ b/components/discussion/detail/DiscussionHeader.vue
@@ -14,7 +14,7 @@ import Notification from '@/components/NotificationComponent.vue';
 import BrokenRulesModal from '@/components/mod/BrokenRulesModal.vue';
 import EllipsisHorizontal from '@/components/icons/EllipsisHorizontal.vue';
 import { getDiscussionHeaderMenuItems } from '@/utils/headerPermissionUtils';
-import { usernameVar, modProfileNameVar } from '@/cache';
+import { useUsername, useModProfileName } from '@/composables/useAuthState';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
 import UnarchiveModal from '@/components/mod/UnarchiveModal.vue';
 import { GET_CHANNEL } from '@/graphQLData/channel/queries';
@@ -29,6 +29,9 @@ import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import { getServerRoleBadge } from '@/utils/serverRoleBadges';
 import { useModerationOutcomeUI } from '@/composables/useModerationOutcomeUI';
 import { useResolvedModPermissions } from '@/composables/useResolvedModPermissions';
+
+const usernameVar = useUsername();
+const modProfileNameVar = useModProfileName();
 
 const props = defineProps<{
   discussion: Discussion | null;

--- a/components/discussion/detail/DiscussionTitleEditForm.vue
+++ b/components/discussion/detail/DiscussionTitleEditForm.vue
@@ -14,10 +14,13 @@ import {
   IS_DISCUSSION_ANSWERED,
 } from '@/graphQLData/discussion/queries';
 import { DISCUSSION_TITLE_CHAR_LIMIT } from '@/utils/constants';
-import { modProfileNameVar, usernameVar } from '@/cache';
 import { useAppTheme } from '@/composables/useTheme';
 import { useRoute } from 'nuxt/app';
 import CheckCircleIcon from '@/components/icons/CheckCircleIcon.vue';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 const { theme } = useAppTheme();
 

--- a/components/discussion/detail/DownloadModeLayout.vue
+++ b/components/discussion/detail/DownloadModeLayout.vue
@@ -6,8 +6,10 @@ import DiscussionVotes from '@/components/discussion/vote/DiscussionVotes.vue';
 import MarkAsAnsweredButton from '@/components/discussion/detail/MarkAsAnsweredButton.vue';
 import DownloadSidebar from '@/components/channel/DownloadSidebar.vue';
 import ImageIcon from '@/components/icons/ImageIcon.vue';
-import { usernameVar } from '@/cache';
 import CrosspostedDiscussionEmbed from '@/components/discussion/detail/CrosspostedDiscussionEmbed.vue';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const DiscussionAlbum = defineAsyncComponent(
   () => import('@/components/discussion/detail/DiscussionAlbum.vue')

--- a/components/discussion/detail/DownloadTabNavigation.vue
+++ b/components/discussion/detail/DownloadTabNavigation.vue
@@ -4,10 +4,12 @@ import { useRouter } from 'nuxt/app';
 import type { Discussion } from '@/__generated__/graphql';
 import MarkdownPreview from '@/components/MarkdownPreview.vue';
 import PencilIcon from '@/components/icons/PencilIcon.vue';
-import { usernameVar } from '@/cache';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_PUBLIC_COLLECTIONS_FOR_DOWNLOAD } from '@/graphQLData/collection/queries';
 import PublicCollectionListItem from '@/components/collection/PublicCollectionListItem.vue';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   discussionId: {

--- a/components/discussion/detail/RegularDiscussionLayout.vue
+++ b/components/discussion/detail/RegularDiscussionLayout.vue
@@ -5,8 +5,10 @@ import DiscussionBody from '@/components/discussion/detail/DiscussionBody.vue';
 import DiscussionVotes from '@/components/discussion/vote/DiscussionVotes.vue';
 import MarkAsAnsweredButton from '@/components/discussion/detail/MarkAsAnsweredButton.vue';
 import DiscussionTitleVersions from '@/components/discussion/detail/activityFeed/DiscussionTitleVersions.vue';
-import { usernameVar } from '@/cache';
 import CrosspostedDiscussionEmbed from '@/components/discussion/detail/CrosspostedDiscussionEmbed.vue';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const DiscussionAlbum = defineAsyncComponent(
   () => import('@/components/discussion/detail/DiscussionAlbum.vue')

--- a/components/discussion/form/AlbumEditor.spec.ts
+++ b/components/discussion/form/AlbumEditor.spec.ts
@@ -4,7 +4,10 @@ import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 
 import AlbumEditor from '@/components/discussion/form/AlbumEditor.vue';
 
-vi.mock('@/cache', () => ({ usernameVar: { value: 'alice' } }));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return { useUsername: () => ref('alice'), setUsername: vi.fn() };
+});
 vi.mock('@/composables/useAlbumImageUpload', () => ({
   useAlbumImageUpload: () => ({
     loadingStates: ref({}),

--- a/components/discussion/form/AlbumEditor.vue
+++ b/components/discussion/form/AlbumEditor.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { ref, computed } from 'vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import AlbumImageItem from './AlbumImageItem.vue';
@@ -15,6 +15,8 @@ import {
   moveImageOrderDown,
 } from '@/utils/albumImageOrder';
 import type { Album } from '@/__generated__/graphql';
+
+const usernameVar = useUsername();
 
 const MAX_IMAGES = 25;
 

--- a/components/discussion/form/CreateDiscussion.spec.ts
+++ b/components/discussion/form/CreateDiscussion.spec.ts
@@ -2,7 +2,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { ref } from 'vue';
 import CreateDiscussion from '@/components/discussion/form/CreateDiscussion.vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
+
+const { mockUsername } = vi.hoisted(() => {
+  const { ref } = require('vue');
+  return { mockUsername: ref('alice') };
+});
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsername,
+  setUsername: vi.fn(),
+}));
 
 const mockPush = vi.fn();
 const onDoneCallbacks: Array<(data: any) => void> = [];
@@ -45,7 +54,7 @@ describe('CreateDiscussion', () => {
   beforeEach(() => {
     onDoneCallbacks.length = 0;
     mockPush.mockReset();
-    usernameVar.value = 'alice';
+    useUsername().value = 'alice';
   });
 
   it('only shows suspension info after submit attempt', async () => {

--- a/components/discussion/form/CreateDiscussion.vue
+++ b/components/discussion/form/CreateDiscussion.vue
@@ -18,9 +18,11 @@ import {
   getSortFromQuery,
   getTimeFrameFromQuery,
 } from '@/components/comments/getSortFromQuery';
-import { usernameVar } from '@/cache';
 import { useRouter, useRoute } from 'nuxt/app';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const DISCUSSION_PAGE_LIMIT = 10;
 const route = useRoute();

--- a/components/discussion/form/DiscussionRootCommentFormWrapper.vue
+++ b/components/discussion/form/DiscussionRootCommentFormWrapper.vue
@@ -13,13 +13,15 @@ import type { NormalizedCacheObject, ApolloCache, FetchResult  } from '@apollo/c
 import { CREATE_COMMENT } from '@/graphQLData/comment/mutations';
 import { GET_DISCUSSION_COMMENTS } from '@/graphQLData/comment/queries';
 import { GET_USER } from '@/graphQLData/user/queries';
-import { usernameVar } from '@/cache';
 import { getSortFromQuery } from '@/components/comments/getSortFromQuery';
 import { useRoute } from 'nuxt/app';
 import { gql } from '@apollo/client/core';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
 import type { BotSuggestion } from '@/utils/botMentions';
 import type { ModSuggestion } from '@/utils/modMentions';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 defineOptions({ inheritAttrs: false });
 

--- a/components/discussion/form/DownloadEditForm.vue
+++ b/components/discussion/form/DownloadEditForm.vue
@@ -18,7 +18,6 @@ import {
 } from '@/graphQLData/discussion/mutations';
 import Notification from '@/components/NotificationComponent.vue';
 import { uploadAndGetEmbeddedLink, getUploadFileName } from '@/utils';
-import { usernameVar } from '@/cache';
 import DownloadLabelPicker from '@/components/download/DownloadLabelPicker.vue';
 import {
   validateDownloadFileType,
@@ -31,6 +30,9 @@ import {
   buildDownloadAcceptAttribute,
   buildDownloadableFilesUpdateInput,
 } from '@/utils/downloadFileHelpers';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 type DownloadableFileSupportFields = {
   attributionOverride?: string | null;

--- a/components/discussion/form/InlineCommentForm.spec.ts
+++ b/components/discussion/form/InlineCommentForm.spec.ts
@@ -24,9 +24,10 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'alice' },
-}));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return { useUsername: () => ref('alice'), setUsername: vi.fn() };
+});
 
 vi.mock('@/composables/useSuspensionNotice', () => ({
   useChannelSuspensionNotice: () => ({

--- a/components/discussion/form/InlineCommentForm.vue
+++ b/components/discussion/form/InlineCommentForm.vue
@@ -12,7 +12,7 @@ import type { NormalizedCacheObject, ApolloCache, FetchResult  } from '@apollo/c
 import { CREATE_COMMENT } from '@/graphQLData/comment/mutations';
 import { GET_DISCUSSION_COMMENTS } from '@/graphQLData/comment/queries';
 import { GET_USER } from '@/graphQLData/user/queries';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { getSortFromQuery } from '@/components/comments/getSortFromQuery';
 import { useRoute } from 'nuxt/app';
 import { gql } from '@apollo/client/core';
@@ -24,6 +24,8 @@ import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
 import { getBotMentionState, filterBotSuggestions, type BotSuggestion } from '@/utils/botMentions';
 import { getModMentionState, filterModSuggestions, type ModSuggestion } from '@/utils/modMentions';
+
+const usernameVar = useUsername();
 
 const COMMENT_LIMIT = 50;
 

--- a/components/discussion/list/ChannelDiscussionList.vue
+++ b/components/discussion/list/ChannelDiscussionList.vue
@@ -9,7 +9,7 @@ import LoadMore from '../../LoadMore.vue';
 import ErrorBanner from '../../ErrorBanner.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import { GET_DISCUSSIONS_WITH_DISCUSSION_CHANNEL_DATA } from '@/graphQLData/discussion/queries';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { getFilterValuesFromParams } from '@/components/discussion/list/getDiscussionFilterValuesFromParams';
 import {
   getSortFromQuery,
@@ -17,6 +17,8 @@ import {
 } from '@/components/comments/getSortFromQuery';
 import { useAppTheme } from '@/composables/useTheme';
 import type { DiscussionChannel } from '@/__generated__/graphql';
+
+const usernameVar = useUsername();
 
 const { theme } = useAppTheme();
 

--- a/components/discussion/list/ChannelDiscussionListItem.spec.ts
+++ b/components/discussion/list/ChannelDiscussionListItem.spec.ts
@@ -6,7 +6,7 @@ import {
   createMutationMock,
 } from '@/tests/utils/mockApollo';
 import { createMockRoute, createMockRouter } from '@/tests/utils/mockRouter';
-import { createCacheMock } from '@/tests/utils/mockAuth';
+import { createAuthStateMock } from '@/tests/utils/mockAuth';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { makeDiscussion } from '@/tests/utils/factories';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
@@ -33,7 +33,9 @@ vi.mock('nuxt/app', () => ({
   useRoute: () => createMockRoute(),
   useRouter: () => createMockRouter(),
 }));
-vi.mock('@/cache', () => createCacheMock({ username: 'alice' }));
+vi.mock('@/composables/useAuthState', () =>
+  createAuthStateMock({ username: 'alice' })
+);
 
 const mountItem = (title: string) => {
   asMock(useQuery).mockReturnValue(createQueryMock({ users: [] }));

--- a/components/discussion/list/ChannelDiscussionListItem.vue
+++ b/components/discussion/list/ChannelDiscussionListItem.vue
@@ -22,9 +22,12 @@ import { storeToRefs } from 'pinia';
 import { useUIStore } from '@/stores/uiStore';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_USER } from '@/graphQLData/user/queries';
-import { usernameVar, isAuthenticatedVar } from '@/cache';
+import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import { getServerRoleBadge } from '@/utils/serverRoleBadges';
+
+const usernameVar = useUsername();
+const isAuthenticatedVar = useIsAuthenticated();
 // UI state is now handled via props
 // Lazy load the album component since it's not needed for initial render
 const DiscussionAlbum = defineAsyncComponent(

--- a/components/discussion/list/SitewideDiscussionList.spec.ts
+++ b/components/discussion/list/SitewideDiscussionList.spec.ts
@@ -18,6 +18,7 @@ vi.mock('@vue/apollo-composable', () => ({
 }));
 vi.mock('nuxt/app', () => ({
   useRoute: vi.fn(),
+  useState: (_k, init) => ref(init ? init() : undefined),
 }));
 vi.mock('@/composables/useTheme', () => ({
   useAppTheme: () => ({ theme: ref('light') }),

--- a/components/discussion/list/SitewideDiscussionList.vue
+++ b/components/discussion/list/SitewideDiscussionList.vue
@@ -21,8 +21,10 @@ import { storeToRefs } from 'pinia';
 import { config } from '@/config';
 import { useAppTheme } from '@/composables/useTheme';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
+
+const usernameVar = useUsername();
 
 const { theme } = useAppTheme();
 

--- a/components/discussion/list/SitewideDiscussionListItem.spec.ts
+++ b/components/discussion/list/SitewideDiscussionListItem.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { useQuery } from '@vue/apollo-composable';
 import { asMock, createQueryMock } from '@/tests/utils/mockApollo';
 import { createMockRoute } from '@/tests/utils/mockRouter';
-import { createCacheMock } from '@/tests/utils/mockAuth';
+import { createAuthStateMock } from '@/tests/utils/mockAuth';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { makeDiscussion } from '@/tests/utils/factories';
 import type { Discussion } from '@/__generated__/graphql';
@@ -11,7 +11,9 @@ import SitewideDiscussionListItem from '@/components/discussion/list/SitewideDis
 
 vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
 vi.mock('nuxt/app', () => ({ useRoute: () => createMockRoute() }));
-vi.mock('@/cache', () => createCacheMock({ username: 'alice' }));
+vi.mock('@/composables/useAuthState', () =>
+  createAuthStateMock({ username: 'alice' })
+);
 
 const mountItem = (discussion: Discussion) => {
   asMock(useQuery).mockReturnValue(createQueryMock({ users: [] }));

--- a/components/discussion/list/SitewideDiscussionListItem.vue
+++ b/components/discussion/list/SitewideDiscussionListItem.vue
@@ -19,9 +19,12 @@ import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavo
 import { relativeTime } from '@/utils';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_USER } from '@/graphQLData/user/queries';
-import { usernameVar, isAuthenticatedVar } from '@/cache';
+import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import { getServerRoleBadge } from '@/utils/serverRoleBadges';
+
+const usernameVar = useUsername();
+const isAuthenticatedVar = useIsAuthenticated();
 // Lazy load the album component since it's not needed for initial render
 const DiscussionAlbum = defineAsyncComponent(
   () => import('@/components/discussion/detail/DiscussionAlbum.vue')

--- a/components/discussion/list/SitewideDownloadList.spec.ts
+++ b/components/discussion/list/SitewideDownloadList.spec.ts
@@ -18,6 +18,7 @@ vi.mock('@vue/apollo-composable', () => ({
 vi.mock('nuxt/app', () => ({
   useRoute: vi.fn(),
   useRouter: vi.fn(),
+  useState: (_k, init) => ref(init ? init() : undefined),
 }));
 
 const SERVER_CONFIG = { serverConfigs: [{ serverName: 'Test', __typename: 'ServerConfig' }] };

--- a/components/discussion/list/SitewideDownloadList.vue
+++ b/components/discussion/list/SitewideDownloadList.vue
@@ -17,9 +17,11 @@ import {
   getTimeFrameFromQuery,
 } from '@/components/comments/getSortFromQuery';
 import { config } from '@/config';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import type { SearchDiscussionValues } from '@/types/Discussion';
 import type { Album, Discussion } from '@/__generated__/graphql';
+
+const usernameVar = useUsername();
 
 const DISCUSSION_PAGE_LIMIT = 15;
 

--- a/components/discussion/vote/DiscussionVotes.spec.ts
+++ b/components/discussion/vote/DiscussionVotes.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { ref } from 'vue';
 import DiscussionVotes from '@/components/discussion/vote/DiscussionVotes.vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({
@@ -23,9 +23,15 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'alice' },
-  modProfileNameVar: { value: '' },
+const { mockUsername, mockModProfileName } = vi.hoisted(() => {
+  const { ref } = require('vue');
+  return { mockUsername: ref('alice'), mockModProfileName: ref('') };
+});
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsername,
+  useModProfileName: () => mockModProfileName,
+  setUsername: vi.fn(),
+  setModProfileName: vi.fn(),
 }));
 
 vi.mock('@/composables/useSuspensionNotice', () => ({
@@ -40,11 +46,11 @@ vi.mock('@/composables/useSuspensionNotice', () => ({
 describe('DiscussionVotes', () => {
   afterEach(() => {
     // Restore the default mocked username after tests that clear it.
-    usernameVar.value = 'alice';
+    useUsername().value = 'alice';
   });
 
   it('surfaces the auth error in the banner (not a throw) when upvoting without a username', async () => {
-    usernameVar.value = '';
+    useUsername().value = '';
 
     const wrapper = mount(DiscussionVotes, {
       props: {

--- a/components/discussion/vote/DiscussionVotes.vue
+++ b/components/discussion/vote/DiscussionVotes.vue
@@ -12,9 +12,12 @@ import NewEmojiButton from '@/components/comments/NewEmojiButton.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import SuperUpvoteModal from '@/components/superUpvote/SuperUpvoteModal.vue';
 import { UNDO_SUPER_UPVOTE } from '@/graphQLData/scratchpad/mutations';
-import { usernameVar, modProfileNameVar } from '@/cache';
+import { useUsername, useModProfileName } from '@/composables/useAuthState';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
+
+const usernameVar = useUsername();
+const modProfileNameVar = useModProfileName();
 
 const props = defineProps({
   discussionChannel: {

--- a/components/download/form/CreateDownload.vue
+++ b/components/download/form/CreateDownload.vue
@@ -12,8 +12,10 @@ import {
 import { GET_CHANNEL } from '@/graphQLData/channel/queries';
 import type { CreateEditDiscussionFormValues } from '@/types/Discussion';
 import type { FilterGroup, FilterOption } from '@/__generated__/graphql';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import ErrorBanner from '@/components/ErrorBanner.vue';
+
+const usernameVar = useUsername();
 
 const router = useRouter();
 const route = useRoute();

--- a/components/event/detail/EventBody.vue
+++ b/components/event/detail/EventBody.vue
@@ -2,8 +2,10 @@
 import type { PropType } from 'vue';
 import { computed } from 'vue';
 import type { Event } from '@/__generated__/graphql';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import EventDescriptionEditForm from './EventDescriptionEditForm.vue';
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   event: {

--- a/components/event/detail/EventCommentsWrapper.spec.ts
+++ b/components/event/detail/EventCommentsWrapper.spec.ts
@@ -34,10 +34,15 @@ vi.mock('@/composables/useToast', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'alice' },
-  isAuthenticatedVar: { value: true },
-}));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return {
+    useUsername: () => ref('alice'),
+    useIsAuthenticated: () => ref(true),
+    setUsername: vi.fn(),
+    setIsAuthenticated: vi.fn(),
+  };
+});
 
 vi.mock('@/components/comments/getSortFromQuery', async (importOriginal) => {
   const actual = await importOriginal();

--- a/components/event/detail/EventCommentsWrapper.vue
+++ b/components/event/detail/EventCommentsWrapper.vue
@@ -9,7 +9,7 @@ import type {
 import { getSortFromQuery } from '@/components/comments/getSortFromQuery';
 import CommentSection from '@/components/comments/CommentSection.vue';
 import type { CreateEditCommentFormValues } from '@/types/Comment';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useRoute } from 'nuxt/app';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 import type { ApolloCache } from '@apollo/client/core';
@@ -23,6 +23,8 @@ import {
 import Notification from '@/components/NotificationComponent.vue';
 import EventNotificationsMenu from './EventNotificationsMenu.vue';
 import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
+
+const usernameVar = useUsername();
 
 const COMMENT_LIMIT = 50;
 

--- a/components/event/detail/EventDetail.spec.ts
+++ b/components/event/detail/EventDetail.spec.ts
@@ -18,10 +18,15 @@ vi.mock('nuxt/app', () => ({
   useRoute: vi.fn(() => ({ params: {}, query: {} })),
   useHead: vi.fn(),
 }));
-vi.mock('@/cache', () => ({
-  modProfileNameVar: { value: '' },
-  usernameVar: { value: '' },
-}));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return {
+    useModProfileName: () => ref(''),
+    useUsername: () => ref(''),
+    setModProfileName: vi.fn(),
+    setUsername: vi.fn(),
+  };
+});
 
 const eventChannel = {
   id: 'ec1',

--- a/components/event/detail/EventDetail.vue
+++ b/components/event/detail/EventDetail.vue
@@ -34,10 +34,13 @@ import EventRootCommentFormWrapper from '@/components/event/detail/EventRootComm
 import { getSortFromQuery } from '@/components/comments/getSortFromQuery';
 import EventChannelLinks from '@/components/event/detail/EventChannelLinks.vue';
 import { useRoute, useHead } from 'nuxt/app';
-import { modProfileNameVar, usernameVar } from '@/cache';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
 import AddToCalendarButton from '../AddToCalendarButton.vue';
 import ArchivedEventInfoBanner from './ArchivedEventInfoBanner.vue';
 import { getOriginalPoster } from '@/utils/originalPoster';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 const formatDate = formatEventDate;
 

--- a/components/event/detail/EventHeader.spec.ts
+++ b/components/event/detail/EventHeader.spec.ts
@@ -39,10 +39,15 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'viewer' },
-  modProfileNameVar: { value: 'mod-alice' },
-}));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return {
+    useUsername: () => ref('viewer'),
+    useModProfileName: () => ref('mod-alice'),
+    setUsername: vi.fn(),
+    setModProfileName: vi.fn(),
+  };
+});
 
 vi.mock('@/composables/useServerRoleMembership', () => ({
   useServerRoleMembership: () => ({

--- a/components/event/detail/EventHeader.vue
+++ b/components/event/detail/EventHeader.vue
@@ -27,7 +27,7 @@ import { getEventHeaderMenuItems } from '@/utils/headerPermissionUtils';
 import { formatEventDateString } from '@/utils/eventDateFormat';
 import GenericFeedbackFormModal from '@/components/GenericFeedbackFormModal.vue';
 import BrokenRulesModal from '@/components/mod/BrokenRulesModal.vue';
-import { modProfileNameVar, usernameVar } from '@/cache';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
 import { useRoute, useRouter } from 'nuxt/app';
 import InfoBanner from '@/components/InfoBanner.vue';
 import UnarchiveModal from '@/components/mod/UnarchiveModal.vue';
@@ -40,6 +40,9 @@ import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import { getServerRoleBadge } from '@/utils/serverRoleBadges';
 import { useModerationOutcomeUI } from '@/composables/useModerationOutcomeUI';
 import { useResolvedModPermissions } from '@/composables/useResolvedModPermissions';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 const props = defineProps({
   eventData: {

--- a/components/event/detail/EventRootCommentFormWrapper.spec.ts
+++ b/components/event/detail/EventRootCommentFormWrapper.spec.ts
@@ -27,9 +27,10 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'alice' },
-}));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return { useUsername: () => ref('alice'), setUsername: vi.fn() };
+});
 
 vi.mock('@/composables/useSuspensionNotice', () => ({
   useChannelSuspensionNotice: () => ({

--- a/components/event/detail/EventRootCommentFormWrapper.vue
+++ b/components/event/detail/EventRootCommentFormWrapper.vue
@@ -11,8 +11,10 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import { getSortFromQuery } from '@/components/comments/getSortFromQuery';
 import type { Event, CommentCreateInput } from '@/__generated__/graphql';
 import type { CreateEditCommentFormValues } from '@/types/Comment';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
+
+const usernameVar = useUsername();
 
 const COMMENT_LIMIT = 50;
 const props = defineProps({

--- a/components/event/detail/EventTitleEditForm.vue
+++ b/components/event/detail/EventTitleEditForm.vue
@@ -9,10 +9,13 @@ import { UPDATE_EVENT_WITH_CHANNEL_CONNECTIONS } from '@/graphQLData/event/mutat
 import { useMutation, useQuery } from '@vue/apollo-composable';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import { GET_EVENT } from '@/graphQLData/event/queries';
-import { modProfileNameVar, usernameVar } from '@/cache';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
 import { EVENT_TITLE_CHAR_LIMIT } from '@/utils/constants';
 import { useAppTheme } from '@/composables/useTheme';
 import { useRoute } from 'nuxt/app';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 const route = useRoute();
 const titleEditMode = ref(false);

--- a/components/event/form/CreateEditEventFields.spec.ts
+++ b/components/event/form/CreateEditEventFields.spec.ts
@@ -140,10 +140,11 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-// Mock cache
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'testuser' },
-}));
+// Mock auth state
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return { useUsername: () => ref('testuser'), setUsername: vi.fn() };
+});
 
 describe('CreateEditEventFields Component', () => {
   // Default form values for testing

--- a/components/event/form/CreateEditEventFields.vue
+++ b/components/event/form/CreateEditEventFields.vue
@@ -31,7 +31,7 @@ import { useMutation } from '@vue/apollo-composable';
 import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
 import ForumPicker from '@/components/channel/ForumPicker.vue';
 import TagPicker from '@/components/TagPicker.vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import {
   EVENT_TITLE_CHAR_LIMIT,
   MAX_CHARS_IN_EVENT_DESCRIPTION,
@@ -42,6 +42,8 @@ import {
 } from '@/utils/eventFormValidation';
 import type { PropType } from 'vue';
 import { isFileSizeValid } from '@/utils/index';
+
+const usernameVar = useUsername();
 
 type FileChangeInput = {
   // event of HTMLInputElement;

--- a/components/event/form/CreateEvent.spec.ts
+++ b/components/event/form/CreateEvent.spec.ts
@@ -2,7 +2,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { ref } from 'vue';
 import CreateEvent from '@/components/event/form/CreateEvent.vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
+
+const { mockUsername } = vi.hoisted(() => {
+  const { ref } = require('vue');
+  return { mockUsername: ref('alice') };
+});
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsername,
+  setUsername: vi.fn(),
+}));
 
 const mockPush = vi.fn();
 const mockMutate = vi.fn();
@@ -62,7 +71,7 @@ describe('CreateEvent', () => {
         },
       ],
     };
-    usernameVar.value = 'alice';
+    useUsername().value = 'alice';
   });
 
   function mountCreateEvent() {

--- a/components/event/form/CreateEvent.vue
+++ b/components/event/form/CreateEvent.vue
@@ -15,8 +15,10 @@ import type {
   EventTagsConnectOrCreateFieldInput,
   Event,
 } from '@/__generated__/graphql';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
+
+const usernameVar = useUsername();
 
 const now = DateTime.now();
 const route = useRoute();

--- a/components/favorites/AddImageToFavorites.vue
+++ b/components/favorites/AddImageToFavorites.vue
@@ -6,9 +6,11 @@ import {
   ADD_FAVORITE_IMAGE,
   REMOVE_FAVORITE_IMAGE,
 } from '@/graphQLData/user/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useToastStore } from '@/stores/toastStore';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   imageId: {

--- a/components/favorites/AddToChannelFavorites.vue
+++ b/components/favorites/AddToChannelFavorites.vue
@@ -6,10 +6,12 @@ import {
   ADD_FAVORITE_CHANNEL,
   REMOVE_FAVORITE_CHANNEL,
 } from '@/graphQLData/user/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useToastStore } from '@/stores/toastStore';
 import { useAddToListModalStore } from '@/stores/addToListModalStore';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   allowAddToList: {

--- a/components/favorites/AddToCommentFavorites.vue
+++ b/components/favorites/AddToCommentFavorites.vue
@@ -7,10 +7,12 @@ import {
   ADD_FAVORITE_COMMENT,
   REMOVE_FAVORITE_COMMENT,
 } from '@/graphQLData/user/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useToastStore } from '@/stores/toastStore';
 import { useAddToListModalStore } from '@/stores/addToListModalStore';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   allowAddToList: {

--- a/components/favorites/AddToDiscussionFavorites.vue
+++ b/components/favorites/AddToDiscussionFavorites.vue
@@ -6,10 +6,12 @@ import {
   ADD_FAVORITE_DISCUSSION,
   REMOVE_FAVORITE_DISCUSSION,
 } from '@/graphQLData/user/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useToastStore } from '@/stores/toastStore';
 import { useAddToListModalStore, type AllowedItemType } from '@/stores/addToListModalStore';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   discussionId: {

--- a/components/favorites/AddToImageFavorites.vue
+++ b/components/favorites/AddToImageFavorites.vue
@@ -6,10 +6,12 @@ import {
   ADD_FAVORITE_IMAGE,
   REMOVE_FAVORITE_IMAGE,
 } from '@/graphQLData/user/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useToastStore } from '@/stores/toastStore';
 import { useAddToListModalStore } from '@/stores/addToListModalStore';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   allowAddToList: {

--- a/components/mod/ActivityFeedListItem.spec.ts
+++ b/components/mod/ActivityFeedListItem.spec.ts
@@ -21,10 +21,15 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  modProfileNameVar: { value: 'mod-alice' },
-  usernameVar: { value: 'alice' },
-}));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return {
+    useModProfileName: () => ref('mod-alice'),
+    useUsername: () => ref('alice'),
+    setModProfileName: vi.fn(),
+    setUsername: vi.fn(),
+  };
+});
 
 vi.mock('@/composables/useForumRoleMembership', () => ({
   useForumRoleMembership: () => ({

--- a/components/mod/ActivityFeedListItem.vue
+++ b/components/mod/ActivityFeedListItem.vue
@@ -23,7 +23,7 @@ import TrashIcon from '../icons/TrashIcon.vue';
 import { ActionType } from '@/types/Comment';
 import { useMutation } from '@vue/apollo-composable';
 import { UPDATE_COMMENT } from '@/graphQLData/comment/mutations';
-import { modProfileNameVar, usernameVar } from '@/cache';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
 import RevisionDiffInline from '@/components/mod/RevisionDiffInline.vue';
 import { getForumRoleBadge } from '@/utils/forumRoleBadges';
 import { useForumRoleMembership } from '@/composables/useForumRoleMembership';
@@ -33,6 +33,9 @@ import SuspendModButton from '@/components/mod/SuspendModButton.vue';
 import MenuButton from '@/components/MenuButton.vue';
 import type { MenuItemType } from '@/components/IconButtonDropdown.vue';
 import EllipsisHorizontal from '@/components/icons/EllipsisHorizontal.vue';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 
 const actionTypeToIcon: Record<string, Component> = {

--- a/components/mod/CreateIssueForm.vue
+++ b/components/mod/CreateIssueForm.vue
@@ -15,7 +15,10 @@ import {
   COUNT_OPEN_ISSUES,
   SERVER_SCOPED_ISSUE_COUNT,
 } from '@/graphQLData/mod/queries';
-import { modProfileNameVar, usernameVar } from '@/cache';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 const props = defineProps({
   defaultChannelId: {

--- a/components/mod/DiscussionDetails.vue
+++ b/components/mod/DiscussionDetails.vue
@@ -4,7 +4,7 @@ import { useQuery } from '@vue/apollo-composable';
 import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
 import { DateTime } from 'luxon';
 import { useRoute } from 'nuxt/app';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import { stableRelativeTime } from '@/utils';
 import type { Issue } from '@/__generated__/graphql';
 
@@ -16,6 +16,8 @@ import MarkdownPreview from '../MarkdownPreview.vue';
 import AvatarComponent from '@/components/AvatarComponent.vue';
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import { getOriginalPoster } from '@/utils/originalPoster';
+
+const modProfileNameVar = useModProfileName();
 
 const props = defineProps<{
   activeIssue: Issue;

--- a/components/mod/EditContentModal.spec.ts
+++ b/components/mod/EditContentModal.spec.ts
@@ -1,3 +1,4 @@
+import { ref } from 'vue';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { flushPromises, mount } from '@vue/test-utils';
 import EditContentModal from './EditContentModal.vue';
@@ -48,6 +49,7 @@ vi.mock('@vue/apollo-composable', () => ({
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { forumId: 'test-channel' } }),
+  useState: (_k, init) => ref(init ? init() : undefined),
 }));
 
 vi.mock('@headlessui/vue', () => ({

--- a/components/mod/EditContentModal.vue
+++ b/components/mod/EditContentModal.vue
@@ -19,7 +19,9 @@ import {
   ADD_ISSUE_ACTIVITY_FEED_ITEM_WITH_COMMENT_AS_MOD,
   UPDATE_ISSUE,
 } from '@/graphQLData/issue/mutations';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
+
+const modProfileNameVar = useModProfileName();
 
 type TargetType = 'comment' | 'discussion' | 'download' | 'event';
 

--- a/components/mod/IssueDetail.spec.ts
+++ b/components/mod/IssueDetail.spec.ts
@@ -55,10 +55,17 @@ vi.mock('nuxt/app', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'alice' },
-  modProfileNameVar: { value: 'mod-alice' },
-}));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return {
+    useUsername: () => ref('alice'),
+    useModProfileName: () => ref('mod-alice'),
+    useIsAuthenticated: () => ref(true),
+    setUsername: vi.fn(),
+    setModProfileName: vi.fn(),
+    setIsAuthenticated: vi.fn(),
+  };
+});
 
 vi.mock('@/utils/permissionUtils', () => ({
   getAllPermissions: () => ({

--- a/components/mod/IssueDetail.vue
+++ b/components/mod/IssueDetail.vue
@@ -27,7 +27,7 @@ import IssueCommentForm from '@/components/mod/IssueCommentForm.vue';
 import IssueBodyEditor from '@/components/mod/IssueBodyEditor.vue';
 import IssueRelatedContent from '@/components/mod/IssueRelatedContent.vue';
 import IssueRelatedChannel from '@/components/mod/IssueRelatedChannel.vue';
-import { modProfileNameVar, usernameVar } from '@/cache';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
 import { useRoute, useRouter } from 'nuxt/app';
 import { config } from '@/config';
 import {
@@ -51,6 +51,9 @@ import GenericButton from '@/components/GenericButton.vue';
 import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
 import { provideForumRoleMembership } from '@/composables/useForumRoleMembership';
 import { useResolvedModPermissions } from '@/composables/useResolvedModPermissions';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 type Issue = GeneratedIssue & {
   issueNumber: number;

--- a/components/mod/IssueRelatedChannel.vue
+++ b/components/mod/IssueRelatedChannel.vue
@@ -9,8 +9,11 @@ import LockClosedIcon from '@/components/icons/LockClosedIcon.vue';
 import LockOpenIcon from '@/components/icons/LockOpenIcon.vue';
 import { DateTime } from 'luxon';
 import { config } from '@/config';
-import { usernameVar, modProfileNameVar } from '@/cache';
+import { useUsername, useModProfileName } from '@/composables/useAuthState';
 import { checkPermission } from '@/utils/permissionUtils';
+
+const usernameVar = useUsername();
+const modProfileNameVar = useModProfileName();
 
 const props = defineProps<{
   relatedChannelUniqueName: string;

--- a/components/mod/IssueTitleEditForm.vue
+++ b/components/mod/IssueTitleEditForm.vue
@@ -10,10 +10,12 @@ import { useMutation, useQuery } from '@vue/apollo-composable';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import { GET_ISSUE } from '@/graphQLData/issue/queries';
 import { DISCUSSION_TITLE_CHAR_LIMIT } from '@/utils/constants';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import { useAppTheme } from '@/composables/useTheme';
 import { useRoute } from 'nuxt/app';
 import IssueBadge from '@/components/mod/IssueBadge.vue';
+
+const modProfileNameVar = useModProfileName();
 
 const { theme } = useAppTheme();
 

--- a/components/mod/ModProfileSidebar.vue
+++ b/components/mod/ModProfileSidebar.vue
@@ -5,7 +5,9 @@ import 'md-editor-v3/lib/style.css';
 import { GET_MOD } from '@/graphQLData/mod/queries';
 import { relativeTime } from '@/utils';
 import { useRoute } from 'nuxt/app';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
+
+const modProfileNameVar = useModProfileName();
 
 defineProps({
   isAdmin: {

--- a/components/mod/ModerationWizard.spec.ts
+++ b/components/mod/ModerationWizard.spec.ts
@@ -25,9 +25,10 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  modProfileNameVar: { value: 'mod-alice' },
-}));
+vi.mock('@/composables/useAuthState', () => {
+  const { ref } = require('vue');
+  return { useModProfileName: () => ref('mod-alice'), setModProfileName: vi.fn() };
+});
 
 describe('ModerationWizard', () => {
   const mountWrapper = () =>

--- a/components/mod/ModerationWizard.vue
+++ b/components/mod/ModerationWizard.vue
@@ -9,7 +9,7 @@ import SuspendModButton from './SuspendModButton.vue';
 import AdminIcon from '../icons/AdminIcon.vue';
 import ScalesIcon from '../icons/ScalesIcon.vue';
 import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import PencilIcon from '../icons/PencilIcon.vue';
 import EditContentModal from './EditContentModal.vue';
 import CloseIssueAction from './CloseIssueAction.vue';
@@ -19,6 +19,8 @@ import {
   IS_ORIGINAL_POSTER_SUSPENDED,
 } from '@/graphQLData/mod/queries';
 import { GET_COMMENT_ARCHIVED } from '@/graphQLData/comment/queries';
+
+const modProfileNameVar = useModProfileName();
 
 const props = defineProps({
   issue: {

--- a/components/mod/PendingInvite.vue
+++ b/components/mod/PendingInvite.vue
@@ -9,10 +9,12 @@ import {
   ACCEPT_FORUM_MOD_INVITE,
 } from '@/graphQLData/mod/mutations';
 import { useQuery, useMutation } from '@vue/apollo-composable';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useRoute } from 'nuxt/app';
 import PrimaryButton from '@/components/PrimaryButton.vue';
 import ErrorBanner from '../ErrorBanner.vue';
+
+const usernameVar = useUsername();
 
 const route = useRoute();
 

--- a/components/nav/SiteSidenav.vue
+++ b/components/nav/SiteSidenav.vue
@@ -14,10 +14,14 @@ import BookmarkIcon from '@/components/icons/BookmarkIcon.vue';
 import XIcon from '@/components/icons/XmarkIcon.vue';
 import SearchIcon from '@/components/icons/SearchIcon.vue';
 import { GET_USER } from '@/graphQLData/user/queries';
-import { usernameVar, isAuthenticatedVar, setSideNavIsOpenVar } from '@/cache';
+import { setSideNavIsOpenVar } from '@/cache';
+import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
 import SiteSidenavLogout from './SiteSidenavLogout.vue';
 import { getLocalStorageItem } from '@/utils/localStorageUtils';
 import type { ForumItem } from '@/types/forum';
+
+const usernameVar = useUsername();
+const isAuthenticatedVar = useIsAuthenticated();
 
 type SearchType =
   | 'discussions'

--- a/components/nav/SiteSidenavLogin.vue
+++ b/components/nav/SiteSidenavLogin.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { isAuthenticatedVar } from '@/cache';
+import { useIsAuthenticated } from '@/composables/useAuthState';
 import { useServerLogout } from '@/composables/useServerLogout';
+
+const isAuthenticatedVar = useIsAuthenticated();
 
 defineProps({
   navLinkClasses: {

--- a/components/nav/SiteSidenavLogout.vue
+++ b/components/nav/SiteSidenavLogout.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { isAuthenticatedVar } from '@/cache';
+import { useIsAuthenticated } from '@/composables/useAuthState';
 import { useServerLogout } from '@/composables/useServerLogout';
+
+const isAuthenticatedVar = useIsAuthenticated();
 
 defineProps({
   navLinkClasses: {

--- a/components/nav/TopNav.vue
+++ b/components/nav/TopNav.vue
@@ -10,12 +10,16 @@ import TopNavSearch from '@/components/nav/TopNavSearch.vue';
 // import LogoIcon from "@/components/icons/LogoIcon.vue"; // Unused for now
 import { useRoute } from 'nuxt/app';
 import LoginButton from './LoginButton.vue';
+import { sideNavIsOpenVar } from '@/cache';
 import {
-  modProfileNameVar,
-  usernameVar,
-  sideNavIsOpenVar,
-  notificationCountVar,
-} from '@/cache';
+  useModProfileName,
+  useUsername,
+  useNotificationCount,
+} from '@/composables/useAuthState';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
+const notificationCountVar = useNotificationCount();
 
 defineEmits(['toggleDropdown']);
 

--- a/components/nav/UserProfileDropdownMenu.vue
+++ b/components/nav/UserProfileDropdownMenu.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useRouter } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_USER } from '@/graphQLData/user/queries';
 import { useServerLogout } from '@/composables/useServerLogout';
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   modName: {

--- a/components/notifications/NotificationTabs.spec.ts
+++ b/components/notifications/NotificationTabs.spec.ts
@@ -8,9 +8,9 @@ import {
   GET_GENERAL_NOTIFICATIONS,
 } from '@/graphQLData/notification/queries';
 
-// Mock usernameVar
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'testuser' },
+// Mock useUsername
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ({ value: 'testuser' }),
 }));
 
 // Mock Apollo composables

--- a/components/notifications/NotificationTabs.vue
+++ b/components/notifications/NotificationTabs.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useQuery, useMutation } from '@vue/apollo-composable';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { timeAgo } from '@/utils';
 import type { Notification } from '@/__generated__/graphql';
 import MarkdownRenderer from '../MarkdownRenderer.vue';
@@ -18,6 +18,8 @@ type NotificationTab = 'general' | 'feedback';
 const activeTab = defineModel<NotificationTab>('activeTab', {
   default: 'general',
 });
+
+const usernameVar = useUsername();
 
 const username = computed(() => usernameVar.value);
 

--- a/components/scratchpad/ScratchpadSection.vue
+++ b/components/scratchpad/ScratchpadSection.vue
@@ -7,7 +7,9 @@ import {
 } from '@/graphQLData/scratchpad/queries';
 import ScratchpadEntry from './ScratchpadEntry.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const props = defineProps({
   username: {

--- a/components/user/EditAccountSettingsFields.vue
+++ b/components/user/EditAccountSettingsFields.vue
@@ -8,7 +8,7 @@ import FormRow from '@/components/FormRow.vue';
 import TextEditor from '@/components/TextEditor.vue';
 import AddImage from '@/components/AddImage.vue';
 import { getUploadFileName, uploadAndGetEmbeddedLink } from '@/utils';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import type { EditAccountSettingsFormValues } from '@/types/User';
 import FormComponent from '../FormComponent.vue';
 import { MAX_CHARS_IN_USER_BIO } from '@/utils/constants';
@@ -49,6 +49,8 @@ const emit = defineEmits<{
   updateFormValues: [formData: Partial<EditAccountSettingsFormValues>];
   submit: [];
 }>();
+
+const usernameVar = useUsername();
 
 // Data and Setup
 const titleInputRef = ref<InstanceType<typeof TextInput> | null>(null);

--- a/components/user/NotificationList.vue
+++ b/components/user/NotificationList.vue
@@ -2,13 +2,15 @@
 import { computed } from 'vue';
 import { GET_NOTIFICATIONS } from '@/graphQLData/notification/queries';
 import { useQuery, useMutation } from '@vue/apollo-composable';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { timeAgo } from '@/utils';
 import type { Notification } from '@/__generated__/graphql';
 import MarkdownRenderer from '../MarkdownRenderer.vue';
 import { MARK_NOTIFICATIONS_AS_READ } from '@/graphQLData/user/mutations';
 
 const NOTIFICATION_PAGE_LIMIT = 15;
+
+const usernameVar = useUsername();
 
 // Use computed for username to ensure reactivity
 const username = computed(() => usernameVar.value);

--- a/components/user/UserProfileSidebar.vue
+++ b/components/user/UserProfileSidebar.vue
@@ -9,7 +9,10 @@ import ReportProfilePictureModal from '@/components/mod/ReportProfilePictureModa
 import FlagIcon from '@/components/icons/FlagIcon.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import { useRoute } from 'nuxt/app';
-import { usernameVar, profilePicURLVar } from '@/cache';
+import { useUsername, useProfilePicURL } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
+const profilePicURLVar = useProfilePicURL();
 
 // Define props
 defineProps({

--- a/composables/useAlbumImageUpload.ts
+++ b/composables/useAlbumImageUpload.ts
@@ -4,7 +4,7 @@ import {
   CREATE_SIGNED_STORAGE_URL,
   CREATE_IMAGE,
 } from '@/graphQLData/discussion/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { getUploadFileName, uploadAndGetEmbeddedLink } from '@/utils';
 import { isFileSizeValid } from '@/utils/index';
 
@@ -36,6 +36,8 @@ type UseAlbumImageUploadParams = {
  */
 export function useAlbumImageUpload(params: UseAlbumImageUploadParams) {
   const { maxImages, currentImageCount, onImageUploaded } = params;
+
+  const usernameVar = useUsername();
 
   // GraphQL Mutations
   const { mutate: createSignedStorageUrl, error: createSignedStorageUrlError } =

--- a/composables/useAuthState.ts
+++ b/composables/useAuthState.ts
@@ -1,0 +1,57 @@
+// composables/useAuthState.ts
+//
+// Request-scoped auth state for the server-session migration.
+//
+// These replace the module-level `ref()`s that used to live in cache.ts
+// (isAuthenticatedVar, usernameVar, modProfileNameVar, emailVar,
+// profilePicURLVar, notificationCountVar). Module-level refs are SHARED across
+// every request on a server instance — the classic Nuxt "cross-request state
+// pollution" anti-pattern. Because the auth-session plugin seeds them per
+// request, one user's auth state could bleed into another user's SSR render on
+// the serverless runtime (concurrent requests, reused instances): a privacy
+// leak (one user's authenticated UI served to another) AND a hydration mismatch
+// (the leaked SSR state never matches the visitor's own client payload).
+//
+// `useState` is keyed to the CURRENT request's Nuxt app, so concurrent requests
+// never share auth state. It also serializes into the Nuxt payload on the
+// server and restores automatically on the client — so the auth-session plugin
+// only has to seed on the server; the client picks the values back up with no
+// re-seeding (and no mismatch).
+//
+// Consumers read these exactly like the old refs:
+//   const isAuthenticatedVar = useIsAuthenticated();
+//   ... isAuthenticatedVar.value ...
+import { useState } from 'nuxt/app';
+
+export const useIsAuthenticated = () =>
+  useState<boolean>('auth:isAuthenticated', () => false);
+export const useUsername = () => useState<string>('auth:username', () => '');
+export const useEmail = () => useState<string>('auth:email', () => '');
+export const useProfilePicURL = () =>
+  useState<string>('auth:profilePicURL', () => '');
+export const useModProfileName = () =>
+  useState<string>('auth:modProfileName', () => '');
+export const useNotificationCount = () =>
+  useState<number>('auth:notificationCount', () => 0);
+
+// Imperative setters for the few call sites that mutate auth state directly
+// (login seeding in plugins/auth-session.ts, logout, create-username, test
+// helpers). Reads should prefer the `useX()` composables above.
+export const setIsAuthenticated = (value: boolean) => {
+  useIsAuthenticated().value = value;
+};
+export const setUsername = (value: string) => {
+  useUsername().value = value;
+};
+export const setEmail = (value: string) => {
+  useEmail().value = value;
+};
+export const setProfilePicURL = (value: string) => {
+  useProfilePicURL().value = value;
+};
+export const setModProfileName = (value: string) => {
+  useModProfileName().value = value;
+};
+export const setNotificationCount = (value: number) => {
+  useNotificationCount().value = value;
+};

--- a/composables/useAutoUnsubscribe.spec.ts
+++ b/composables/useAutoUnsubscribe.spec.ts
@@ -16,9 +16,9 @@ vi.mock('nuxt/app', () => ({
   }),
 }));
 
-// Mock the cache for authentication
-vi.mock('@/cache', () => ({
-  isAuthenticatedVar: { value: true },
+// Mock the auth state for authentication
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => ({ value: true }),
 }));
 
 // Mock the toast composable

--- a/composables/useAutoUnsubscribe.ts
+++ b/composables/useAutoUnsubscribe.ts
@@ -1,7 +1,7 @@
 import { ref, watch, type Ref } from 'vue';
 import { useRoute, useRouter } from 'nuxt/app';
 import { useToast } from './useToast';
-import { isAuthenticatedVar } from '@/cache';
+import { useIsAuthenticated } from '@/composables/useAuthState';
 
 type UseAutoUnsubscribeParams = {
   /** The entity ID (discussion channel ID, event channel ID, etc.) */
@@ -24,6 +24,8 @@ export function useAutoUnsubscribe(params: UseAutoUnsubscribeParams) {
   const route = useRoute();
   const router = useRouter();
   const { success, info } = useToast();
+
+  const isAuthenticatedVar = useIsAuthenticated();
 
   const hasHandledUnsubscribe = ref(false);
   const isProcessing = ref(false);

--- a/composables/useBestAnswerMutations.spec.ts
+++ b/composables/useBestAnswerMutations.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
 import { useMutation } from '@vue/apollo-composable';
-import { usernameVar } from '@/cache';
 import { useBestAnswerMutations } from './useBestAnswerMutations';
 import type { Comment } from '@/__generated__/graphql';
 
@@ -9,8 +8,13 @@ vi.mock('@vue/apollo-composable', () => ({
   useMutation: vi.fn(),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'testuser' },
+const { mockUsername } = vi.hoisted(() => ({
+  mockUsername: { value: 'testuser' },
+}));
+const usernameVar = mockUsername;
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsername,
 }));
 
 describe('useBestAnswerMutations', () => {

--- a/composables/useBestAnswerMutations.ts
+++ b/composables/useBestAnswerMutations.ts
@@ -7,7 +7,7 @@ import {
   MARK_AS_ANSWERED_BY_COMMENT,
   UNMARK_COMMENT_AS_ANSWER,
 } from '@/graphQLData/discussion/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 
 type UseBestAnswerMutationsParams = {
   commentId: Ref<string> | ComputedRef<string>;
@@ -72,6 +72,8 @@ export function useBestAnswerMutations(
     onMarked,
     onUnmarked,
   } = params;
+
+  const usernameVar = useUsername();
 
   // Mutation for marking a comment as best answer
   const { mutate: markAsAnsweredByComment } = useMutation(

--- a/composables/useCommentCrudMutations.spec.ts
+++ b/composables/useCommentCrudMutations.spec.ts
@@ -13,8 +13,8 @@ vi.mock('nuxt/app', () => ({
   }),
 }));
 
-vi.mock('@/cache', () => ({
-  modProfileNameVar: { value: 'testmod' },
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ({ value: 'testmod' }),
 }));
 
 describe('useCommentCrudMutations', () => {

--- a/composables/useCommentCrudMutations.ts
+++ b/composables/useCommentCrudMutations.ts
@@ -10,7 +10,7 @@ import {
 } from '@/graphQLData/comment/mutations';
 import { GET_COMMENT_REPLIES } from '@/graphQLData/comment/queries';
 import { getSortFromQuery } from '@/components/comments/getSortFromQuery';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 
 type UseCommentCrudMutationsParams = {
   discussionId: Ref<string | undefined>;
@@ -45,6 +45,7 @@ export function useCommentCrudMutations(params: UseCommentCrudMutationsParams) {
   } = params;
 
   const route = useRoute();
+  const modProfileNameVar = useModProfileName();
 
   // CREATE COMMENT mutation
   const {

--- a/composables/useCommentPermissions.spec.ts
+++ b/composables/useCommentPermissions.spec.ts
@@ -1,16 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
-import { usernameVar, modProfileNameVar } from '@/cache';
 import { useCommentPermissions } from './useCommentPermissions';
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'testuser' },
-  modProfileNameVar: { value: 'testmod' },
+const { mockUsername, mockModProfileName } = vi.hoisted(() => ({
+  mockUsername: { value: 'testuser' },
+  mockModProfileName: { value: 'testmod' },
+}));
+const usernameVar = mockUsername;
+const modProfileNameVar = mockModProfileName;
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsername,
+  useModProfileName: () => mockModProfileName,
 }));
 
 vi.mock('@/config', () => ({

--- a/composables/useCommentPermissions.ts
+++ b/composables/useCommentPermissions.ts
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 import { GET_CHANNEL } from '@/graphQLData/channel/queries';
 import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
 import { USER_IS_MOD_OR_OWNER_IN_CHANNEL } from '@/graphQLData/user/queries';
-import { usernameVar, modProfileNameVar } from '@/cache';
+import { useUsername, useModProfileName } from '@/composables/useAuthState';
 import type { PermissionFlags } from '@/utils/permissionUtils';
 import { config } from '@/config';
 import { useResolvedModPermissions } from '@/composables/useResolvedModPermissions';
@@ -24,6 +24,9 @@ type UseCommentPermissionsReturn = {
 export function useCommentPermissions(
   forumId: Ref<string> | ComputedRef<string>
 ): UseCommentPermissionsReturn {
+  const usernameVar = useUsername();
+  const modProfileNameVar = useModProfileName();
+
   // Fetch channel data for mod roles
   const { result: getChannelResult, loading: channelLoading } = useQuery(
     GET_CHANNEL,

--- a/composables/useImageUpload.ts
+++ b/composables/useImageUpload.ts
@@ -2,7 +2,7 @@ import { ref } from 'vue';
 import { useMutation } from '@vue/apollo-composable';
 import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
 import { uploadAndGetEmbeddedLink, getUploadFileName } from '@/utils';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { isFileSizeValid } from '@/utils/index';
 
 type UploadResult = {
@@ -41,6 +41,8 @@ const getFileTypeFromName = (filename: string): string | null => {
  * Composable for handling image uploads in the text editor
  */
 export function useImageUpload(options: UseImageUploadOptions = {}) {
+  const usernameVar = useUsername();
+
   const { mutate: createSignedStorageUrl, error: createSignedStorageUrlError } =
     useMutation(CREATE_SIGNED_STORAGE_URL);
 

--- a/composables/useServerLogout.ts
+++ b/composables/useServerLogout.ts
@@ -11,7 +11,7 @@
 // We still clear the SPA's localStorage token first, since Apollo reads that
 // token (plugins/apollo-auth.client.ts) until it is wired directly to the
 // server session. This is the one place that knows about both systems.
-import { setIsAuthenticated, setUsername } from '@/cache';
+import { setIsAuthenticated, setUsername } from '@/composables/useAuthState';
 import { clearPersistedAuth } from '@/utils/authUtils';
 
 export const useServerLogout = () => {

--- a/composables/useSuspensionNotice.spec.ts
+++ b/composables/useSuspensionNotice.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
-import { usernameVar } from '@/cache';
 import {
   useChannelSuspensionNotice,
   useServerSuspensionNotice,
@@ -9,6 +8,15 @@ import {
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
+}));
+
+const { mockUsername } = vi.hoisted(() => ({
+  mockUsername: { value: 'alice' },
+}));
+const usernameVar = mockUsername;
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsername,
 }));
 
 describe('useSuspensionNotice', () => {

--- a/composables/useSuspensionNotice.ts
+++ b/composables/useSuspensionNotice.ts
@@ -4,7 +4,7 @@ import {
   GET_USER_ACTIVE_SUSPENSIONS,
   GET_USER_SUSPENSION_IN_CHANNEL,
 } from '@/graphQLData/user/queries';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 
 type ChannelSuspension = {
   suspendedUntil?: string | null;
@@ -19,6 +19,7 @@ type ServerSuspension = ChannelSuspension & {
 export const useChannelSuspensionNotice = (
   channelUniqueName: Ref<string> | string
 ) => {
+  const usernameVar = useUsername();
   const channelId = computed(() =>
     typeof channelUniqueName === 'string'
       ? channelUniqueName
@@ -57,6 +58,7 @@ export const useChannelSuspensionNotice = (
 };
 
 export const useServerSuspensionNotice = () => {
+  const usernameVar = useUsername();
   const nowIso = new Date().toISOString();
 
   const { result } = useQuery(

--- a/composables/useTestAuthHelpers.ts
+++ b/composables/useTestAuthHelpers.ts
@@ -1,9 +1,14 @@
 // composables/useTestAuthHelpers.ts
 import { nextTick, onMounted } from 'vue';
-import { setUsername, setIsAuthenticated, isAuthenticatedVar } from '@/cache';
+import {
+  setUsername,
+  setIsAuthenticated,
+  useIsAuthenticated,
+} from '@/composables/useAuthState';
 import { config } from '@/config';
 
 export function useTestAuthHelpers() {
+  const isAuthenticatedVar = useIsAuthenticated();
   const isDevRuntime = import.meta.env.DEV;
   const isTestEnv =
     config.environment === 'test' ||

--- a/pages/account_settings.spec.ts
+++ b/pages/account_settings.spec.ts
@@ -40,8 +40,8 @@ vi.mock('vue-i18n', () => ({
 
 vi.mock('nuxt/app', () => ({}));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'alice' },
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ({ value: 'alice' }),
 }));
 
 vi.mock('@/config', () => ({

--- a/pages/account_settings.vue
+++ b/pages/account_settings.vue
@@ -11,8 +11,10 @@ import FormRow from '@/components/FormRow.vue';
 import CheckBox from '@/components/CheckBox.vue';
 import type { UserUpdateInput } from '@/__generated__/graphql';
 import type { EditAccountSettingsFormValues } from '@/types/User';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { config } from '@/config';
+
+const usernameVar = useUsername();
 
 const enableLanguagePicker = config.enableLanguagePicker;
 

--- a/pages/admin/accept-admin-invite.spec.ts
+++ b/pages/admin/accept-admin-invite.spec.ts
@@ -34,12 +34,10 @@ vi.mock('@/config', () => ({
   },
 }));
 
-// Mock the cache module
+// Mock the auth state module
 const mockUsernameVar = ref<string | null>(null);
-vi.mock('@/cache', () => ({
-  get usernameVar() {
-    return mockUsernameVar.value;
-  },
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsernameVar,
 }));
 
 describe('accept-admin-invite', () => {

--- a/pages/admin/accept-admin-invite.vue
+++ b/pages/admin/accept-admin-invite.vue
@@ -4,12 +4,14 @@ import { useMutation } from '@vue/apollo-composable';
 import { useRouter } from 'nuxt/app';
 import { config } from '@/config';
 import { ACCEPT_SERVER_ADMIN_INVITE } from '@/graphQLData/admin/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 
 // @ts-ignore - definePageMeta is auto-imported by Nuxt
 definePageMeta({
   middleware: 'auth',
 });
+
+const usernameVar = useUsername();
 
 const router = useRouter();
 const accepted = ref(false);

--- a/pages/admin/accept-mod-invite.spec.ts
+++ b/pages/admin/accept-mod-invite.spec.ts
@@ -34,17 +34,13 @@ vi.mock('@/config', () => ({
   },
 }));
 
-// Mock the cache module with reactive values
+// Mock the auth state module with reactive values
 const mockUsernameVar = ref<string | null>(null);
 const mockModProfileNameVar = ref<string | null>(null);
 
-vi.mock('@/cache', () => ({
-  get usernameVar() {
-    return mockUsernameVar.value;
-  },
-  get modProfileNameVar() {
-    return mockModProfileNameVar.value;
-  },
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsernameVar,
+  useModProfileName: () => mockModProfileNameVar,
 }));
 
 describe('accept-mod-invite', () => {

--- a/pages/admin/accept-mod-invite.vue
+++ b/pages/admin/accept-mod-invite.vue
@@ -4,12 +4,15 @@ import { useMutation } from '@vue/apollo-composable';
 import { useRouter } from 'nuxt/app';
 import { config } from '@/config';
 import { ACCEPT_SERVER_MOD_INVITE } from '@/graphQLData/admin/mutations';
-import { usernameVar, modProfileNameVar } from '@/cache';
+import { useUsername, useModProfileName } from '@/composables/useAuthState';
 
 // @ts-ignore - definePageMeta is auto-imported by Nuxt
 definePageMeta({
   middleware: 'auth',
 });
+
+const usernameVar = useUsername();
+const modProfileNameVar = useModProfileName();
 
 const router = useRouter();
 const accepted = ref(false);

--- a/pages/create-username.vue
+++ b/pages/create-username.vue
@@ -4,14 +4,18 @@ import { useRouter } from 'vue-router';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_EMAIL } from '@/graphQLData/email/queries';
 import type { Email } from '@/__generated__/graphql';
+import { userDataLoadingVar } from '@/cache';
 import {
-  usernameVar,
-  userDataLoadingVar,
-  isAuthenticatedVar,
-  emailVar,
-} from '@/cache';
+  useUsername,
+  useIsAuthenticated,
+  useEmail,
+} from '@/composables/useAuthState';
 import CreateUsernameForm from '@/components/auth/CreateUsernameForm.vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
+
+const usernameVar = useUsername();
+const isAuthenticatedVar = useIsAuthenticated();
+const emailVar = useEmail();
 
 // Auth state + verified email come from the server session (cache vars seeded by
 // plugins/auth-session.ts), not the SPA.

--- a/pages/forums/[forumId]/discussions/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/[discussionId].vue
@@ -3,10 +3,12 @@ import { ref, watchEffect, computed } from 'vue';
 import DiscussionDetailContent from '@/components/discussion/detail/DiscussionDetailContent.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import 'md-editor-v3/lib/style.css';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import { useRoute, useHead } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
+
+const modProfileNameVar = useModProfileName();
 
 const route = useRoute();
 

--- a/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].vue
+++ b/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].vue
@@ -10,8 +10,10 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import PageNotFound from '@/components/PageNotFound.vue';
 import CommentHeader from '@/components/comments/CommentHeader.vue';
 import FeedbackSection from '@/components/comments/FeedbackSection.vue';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import { useRoute } from 'nuxt/app';
+
+const modProfileNameVar = useModProfileName();
 
 const PAGE_LIMIT = 10;
 

--- a/pages/forums/[forumId]/discussions/edit/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/edit/[discussionId].vue
@@ -16,7 +16,9 @@ import type {
   DiscussionUpdateInput,
   Image,
 } from '@/__generated__/graphql';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
+
+const modProfileNameVar = useModProfileName();
 
 const route = useRoute();
 const router = useRouter();

--- a/pages/forums/[forumId]/discussions/feedback/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/feedback/[discussionId].vue
@@ -10,10 +10,12 @@ import FeedbackSection from '@/components/comments/FeedbackSection.vue';
 import { GET_DISCUSSION_FEEDBACK } from '@/graphQLData/discussion/queries';
 import { ADD_FEEDBACK_COMMENT_TO_COMMENT } from '@/graphQLData/comment/mutations';
 import { GET_FEEDBACK_ON_COMMENT } from '@/graphQLData/comment/queries';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import { useRoute } from 'nuxt/app';
 import type { Comment, DownloadableFile } from '@/__generated__/graphql';
 import CrosspostedDiscussionEmbed from '@/components/discussion/detail/CrosspostedDiscussionEmbed.vue';
+
+const modProfileNameVar = useModProfileName();
 
 const PAGE_LIMIT = 10;
 

--- a/pages/forums/[forumId]/downloads/[discussionId].vue
+++ b/pages/forums/[forumId]/downloads/[discussionId].vue
@@ -3,10 +3,12 @@ import { ref, computed } from 'vue';
 import DiscussionDetailContent from '@/components/discussion/detail/DiscussionDetailContent.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import 'md-editor-v3/lib/style.css';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import { useRoute, useHead } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
+
+const modProfileNameVar = useModProfileName();
 
 const route = useRoute();
 

--- a/pages/forums/[forumId]/downloads/[discussionId]/activity.vue
+++ b/pages/forums/[forumId]/downloads/[discussionId]/activity.vue
@@ -3,10 +3,12 @@ import { computed } from 'vue';
 import { useRoute } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import DiscussionTitleVersions from '@/components/discussion/detail/activityFeed/DiscussionTitleVersions.vue';
 import LabelChangeHistory from '@/components/discussion/detail/activityFeed/LabelChangeHistory.vue';
 import type { Discussion } from '@/__generated__/graphql';
+
+const modProfileNameVar = useModProfileName();
 
 const props = defineProps<{
   discussion?: Discussion;

--- a/pages/forums/[forumId]/downloads/[discussionId]/comments.vue
+++ b/pages/forums/[forumId]/downloads/[discussionId]/comments.vue
@@ -8,13 +8,16 @@ import {
   GET_DISCUSSION_CHANNEL_COMMENT_AGGREGATE,
   GET_DISCUSSION_CHANNEL_ROOT_COMMENT_AGGREGATE,
 } from '@/graphQLData/comment/queries';
-import { modProfileNameVar, usernameVar } from '@/cache';
+import { useModProfileName, useUsername } from '@/composables/useAuthState';
 import DiscussionCommentsWrapper from '@/components/discussion/detail/DiscussionCommentsWrapper.vue';
 import DiscussionRootCommentFormWrapper from '@/components/discussion/form/DiscussionRootCommentFormWrapper.vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import InfoBanner from '@/components/InfoBanner.vue';
 import type { Comment, Discussion } from '@/__generated__/graphql';
+
+const modProfileNameVar = useModProfileName();
+const usernameVar = useUsername();
 
 const COMMENT_LIMIT = 50;
 

--- a/pages/forums/[forumId]/downloads/[discussionId]/description.vue
+++ b/pages/forums/[forumId]/downloads/[discussionId]/description.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch } from 'vue';
 import { useRoute } from 'nuxt/app';
 import { useMutation } from '@vue/apollo-composable';
 import { UPDATE_DISCUSSION } from '@/graphQLData/discussion/mutations';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import MarkdownPreview from '@/components/MarkdownPreview.vue';
 import PencilIcon from '@/components/icons/PencilIcon.vue';
 import TextEditor from '@/components/TextEditor.vue';
@@ -15,6 +15,8 @@ import type {
   Discussion,
   DiscussionUpdateInput,
 } from '@/__generated__/graphql';
+
+const usernameVar = useUsername();
 
 const props = defineProps<{
   discussion: Discussion;

--- a/pages/forums/[forumId]/downloads/edit/[discussionId].vue
+++ b/pages/forums/[forumId]/downloads/edit/[discussionId].vue
@@ -22,9 +22,11 @@ import type {
   Image,
   FilterOption,
 } from '@/__generated__/graphql';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
 import { resolveSelectedLabelOptionIds } from '@/utils/downloadLabelUtils';
 import { buildAlbumUpdateInput } from '@/utils/albumUpdateInput';
+
+const modProfileNameVar = useModProfileName();
 
 const route = useRoute();
 const router = useRouter();

--- a/pages/forums/[forumId]/edit.vue
+++ b/pages/forums/[forumId]/edit.vue
@@ -6,13 +6,15 @@ import { UPDATE_CHANNEL } from '@/graphQLData/channel/mutations';
 import type { CreateEditChannelFormValues } from '@/types/Channel';
 import CreateEditChannelFields from '@/components/channel/form/CreateEditChannelFields.vue';
 import Notification from '@/components/NotificationComponent.vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import type {
   ChannelUpdateInput,
   Tag as TagData,
 } from '@/__generated__/graphql';
 import { useRoute } from 'nuxt/app';
 import { useQuery, useMutation } from '@vue/apollo-composable';
+
+const usernameVar = useUsername();
 
 const route = useRoute();
 const channelId = route.params.forumId as string;

--- a/pages/forums/[forumId]/edit/basic.vue
+++ b/pages/forums/[forumId]/edit/basic.vue
@@ -9,7 +9,7 @@ import TextEditor from '@/components/TextEditor.vue';
 import AddImage from '@/components/AddImage.vue';
 import RemoveOwnerModal from '@/components/channel/RemoveOwnerModal.vue';
 import { getUploadFileName, uploadAndGetEmbeddedLink } from '@/utils';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { ref, nextTick, computed } from 'vue';
 import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
 import { REMOVE_FORUM_OWNER } from '@/graphQLData/mod/mutations';
@@ -39,6 +39,8 @@ const props = defineProps({
     required: true,
   },
 });
+
+const usernameVar = useUsername();
 
 type FileChangeInput = {
   // event of HTMLInputElement;

--- a/pages/forums/[forumId]/events/edit/[eventId].vue
+++ b/pages/forums/[forumId]/events/edit/[eventId].vue
@@ -22,7 +22,9 @@ import type {
   Event,
   Tag as TagData,
 } from '@/__generated__/graphql';
-import { modProfileNameVar } from '@/cache';
+import { useModProfileName } from '@/composables/useAuthState';
+
+const modProfileNameVar = useModProfileName();
 
 const route = useRoute();
 const router = useRouter();

--- a/pages/forums/[forumId]/wiki/create-child.vue
+++ b/pages/forums/[forumId]/wiki/create-child.vue
@@ -11,8 +11,10 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import GoBack from '@/components/GoBack.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
+
+const usernameVar = useUsername();
 
 const route = useRoute();
 const router = useRouter();

--- a/pages/forums/[forumId]/wiki/create.vue
+++ b/pages/forums/[forumId]/wiki/create.vue
@@ -10,7 +10,9 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import GoBack from '@/components/GoBack.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const route = useRoute();
 const router = useRouter();

--- a/pages/forums/[forumId]/wiki/edit/[slug].vue
+++ b/pages/forums/[forumId]/wiki/edit/[slug].vue
@@ -14,8 +14,10 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import GoBack from '@/components/GoBack.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
+
+const usernameVar = useUsername();
 
 const route = useRoute();
 const router = useRouter();

--- a/pages/forums/[forumId]/wiki/index.vue
+++ b/pages/forums/[forumId]/wiki/index.vue
@@ -16,7 +16,9 @@ import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
 import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
 import { timeAgo } from '@/utils';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const route = useRoute();
 const router = useRouter();

--- a/pages/forums/create.vue
+++ b/pages/forums/create.vue
@@ -11,9 +11,11 @@ import type {
   ChannelTagsConnectOrCreateFieldInput,
 } from '@/__generated__/graphql';
 import type { CreateEditChannelFormValues } from '@/types/Channel';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useRouter } from 'nuxt/app';
 import { useServerSuspensionNotice } from '@/composables/useSuspensionNotice';
+
+const usernameVar = useUsername();
 
 const router = useRouter();
 

--- a/pages/library.vue
+++ b/pages/library.vue
@@ -9,7 +9,10 @@ import {
   GET_USER_OWNED_DOWNLOADS_COUNT,
 } from '@/graphQLData/user/queries';
 import { GET_ALL_USER_COLLECTIONS } from '@/graphQLData/collection/queries';
-import { usernameVar, isAuthenticatedVar } from '@/cache';
+import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
+const isAuthenticatedVar = useIsAuthenticated();
 
 useHead({
   title: 'Library',

--- a/pages/library/[collectionId].vue
+++ b/pages/library/[collectionId].vue
@@ -20,7 +20,7 @@ import AvatarComponent from '@/components/AvatarComponent.vue';
 import GenericModal from '@/components/GenericModal.vue';
 import WarningModal from '@/components/WarningModal.vue';
 import { relativeTime } from '@/utils';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import type { Discussion, Comment } from '@/__generated__/graphql';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import {
@@ -29,6 +29,8 @@ import {
   buildCollectionDiscussionLink,
   resolveCollectionItemAuthor,
 } from '@/utils/collectionItemUtils';
+
+const usernameVar = useUsername();
 
 // Lazy load the album component since it's not needed for initial render
 const DiscussionAlbum = defineAsyncComponent(

--- a/pages/library/favorite-channels.vue
+++ b/pages/library/favorite-channels.vue
@@ -2,13 +2,15 @@
 import { computed } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { useHead } from 'nuxt/app';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { GET_USER_FAVORITE_CHANNELS } from '@/graphQLData/user/queries';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import AvatarComponent from '@/components/AvatarComponent.vue';
 import ExpandableImage from '@/components/ExpandableImage.vue';
 import Tag from '@/components/TagComponent.vue';
 import AddToChannelFavorites from '@/components/favorites/AddToChannelFavorites.vue';
+
+const usernameVar = useUsername();
 
 useHead({
   title: 'Favorite Forums - Library',

--- a/pages/library/favorite-comments.vue
+++ b/pages/library/favorite-comments.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { gql } from '@apollo/client/core';
 import { useHead } from 'nuxt/app';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import AddToCommentFavorites from '@/components/favorites/AddToCommentFavorites.vue';
@@ -17,6 +17,8 @@ import {
   getCommentAuthorInfo,
 } from '@/utils/commentUtils';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
+
+const usernameVar = useUsername();
 
 useHead({
   title: 'Favorite Comments - Library',

--- a/pages/library/favorite-discussions.vue
+++ b/pages/library/favorite-discussions.vue
@@ -3,7 +3,7 @@ import { computed, defineAsyncComponent } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { gql } from '@apollo/client/core';
 import { useHead } from 'nuxt/app';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import TagComponent from '@/components/TagComponent.vue';
@@ -22,6 +22,8 @@ import type {
   Image,
   Channel,
 } from '@/__generated__/graphql';
+
+const usernameVar = useUsername();
 
 // Partial types matching the query shape (using generated types as base)
 type FavoriteDiscussionChannel = Pick<

--- a/pages/library/favorite-downloads.vue
+++ b/pages/library/favorite-downloads.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { useHead } from 'nuxt/app';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { gql } from '@apollo/client/core';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
@@ -12,6 +12,8 @@ import { relativeTime } from '@/utils';
 import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import { getServerRoleBadge } from '@/utils/serverRoleBadges';
+
+const usernameVar = useUsername();
 
 // Types for favorite downloads
 interface DiscussionChannel {

--- a/pages/library/favorite-images.vue
+++ b/pages/library/favorite-images.vue
@@ -3,9 +3,11 @@ import { computed } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { gql } from '@apollo/client/core';
 import { useHead } from 'nuxt/app';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import ImageListItem from '@/components/image/ImageListItem.vue';
+
+const usernameVar = useUsername();
 
 useHead({
   title: 'Favorite Images - Library',

--- a/pages/library/my-downloads.vue
+++ b/pages/library/my-downloads.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { useHead } from 'nuxt/app';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import TagComponent from '@/components/TagComponent.vue';
@@ -13,6 +13,8 @@ import { relativeTime } from '@/utils';
 import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import { getServerRoleBadge } from '@/utils/serverRoleBadges';
+
+const usernameVar = useUsername();
 
 // Image type for album images
 interface AlbumImage {

--- a/pages/logout.vue
+++ b/pages/logout.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useRouter } from 'nuxt/app';
 import { onMounted, ref } from 'vue';
-import { setIsAuthenticated, setUsername } from '@/cache';
+import { setIsAuthenticated, setUsername } from '@/composables/useAuthState';
 
 const router = useRouter();
 const error = ref(false);

--- a/pages/support.vue
+++ b/pages/support.vue
@@ -8,9 +8,11 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import NotificationComponent from '@/components/NotificationComponent.vue';
 import FormComponent from '@/components/FormComponent.vue';
 import FormRow from '@/components/FormRow.vue';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import { useRoute } from 'nuxt/app';
 import { getSupportReportContent } from '@/utils/supportReportMode';
+
+const usernameVar = useUsername();
 
 type BugReportFormValues = {
   contactEmail: string;

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -13,13 +13,15 @@ import LinkIcon from '@/components/icons/LinkIcon.vue';
 import Notification from '@/components/NotificationComponent.vue';
 import AddImageToFavorites from '@/components/favorites/AddImageToFavorites.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
-import { usernameVar } from '@/cache';
+import { useUsername } from '@/composables/useAuthState';
 import TextEditor from '@/components/TextEditor.vue';
 import SaveButton from '@/components/SaveButton.vue';
 import CancelButton from '@/components/CancelButton.vue';
 import PencilIcon from '@/components/icons/PencilIcon.vue';
 import AlbumThumbnailGrid from '@/components/album/AlbumThumbnailGrid.vue';
 import { useImageZoomPan } from '@/composables/useImageZoomPan';
+
+const usernameVar = useUsername();
 
 // @ts-ignore - definePageMeta is auto-imported by Nuxt
 definePageMeta({

--- a/plugins/auth-session.ts
+++ b/plugins/auth-session.ts
@@ -2,85 +2,43 @@
 //
 // SPIKE (auth0-nuxt server-session migration) — Phase 1, app half.
 //
-// This is the change that makes SSR auth-aware and eliminates the whole class
-// of auth hydration mismatches. With the server-session SDK, the server knows
-// who the user is *before* it renders, so we can:
-//   1. seed the reactive auth vars (usernameVar / isAuthenticatedVar) on the
-//      server so SSR renders authenticated content, and
-//   2. transfer that exact state to the client via the Nuxt payload (useState),
-//      so the client's first hydration render matches the server (no mismatch).
+// Makes SSR auth-aware. The session is read in Nitro
+// (server/middleware/2.auth-session.ts), because useAuth0(event) is a
+// server-only auto-import; that middleware leaves the resolved profile on
+// `event.context.authSession`. Here we seed the request-scoped auth state from
+// it during SSR.
 //
-// The session itself is read in Nitro (server/middleware/2.auth-session.ts),
-// because useAuth0(event) is a server-only auto-import. That middleware leaves
-// the result on `event.context.authSession`; here we pick it up during SSR.
+// The auth state lives in `composables/useAuthState.ts` as `useState` values
+// (NOT module-level refs). `useState` is keyed to the current request's Nuxt
+// app, so it:
+//   1. is isolated per request — one user's auth state can never leak into
+//      another user's SSR render (no cross-request pollution), and
+//   2. serializes into the Nuxt payload on the server and restores on the
+//      client automatically.
 //
-// This is a UNIVERSAL plugin on purpose: the server branch reads the context
-// and writes the payload; the tail runs on BOTH sides and seeds the reactive
-// vars — on the client it reads the value back out of the payload before the
-// first render. A `.server.ts` plugin would not run on the client, so the
-// client would never re-seed and we'd be back to a mismatch.
-//
-// This is the mechanism that replaced the old SPA auth flow: the deleted
-// auth-hint cookie shim, the username-cache.client.ts plugin, and the
-// client-side useAuthManager fetch.
-//
-// The full profile (username, email, modProfileName, notificationCount,
-// profilePicURL) is now resolved server-side in the middleware, so every
-// auth-dependent field is SSR-consistent — there is no async post-mount fetch
-// left to cause a mismatch.
-import { defineNuxtPlugin, useState } from 'nuxt/app';
+// Because of (2) this plugin only seeds on the SERVER — the client picks the
+// exact same values back out of the payload with no re-seeding, so the first
+// hydration render matches the server (no mismatch). For anonymous requests we
+// seed the defaults explicitly so an authenticated value can never linger.
+import { defineNuxtPlugin } from 'nuxt/app';
 import {
+  setIsAuthenticated,
   setUsername,
   setEmail,
-  setIsAuthenticated,
   setModProfileName,
   setNotificationCount,
   setProfilePicURL,
-} from '@/cache';
-
-type SeededAuth = {
-  isAuthenticated: boolean;
-  username: string;
-  email: string;
-  modProfileName: string;
-  notificationCount: number;
-  profilePicURL: string;
-};
+} from '@/composables/useAuthState';
 
 export default defineNuxtPlugin((nuxtApp) => {
-  // useState is SSR-serialized: written on the server, read on the client from
-  // the payload — the transport that keeps both sides in sync.
-  const seeded = useState<SeededAuth>('auth-session', () => ({
-    isAuthenticated: false,
-    username: '',
-    email: '',
-    modProfileName: '',
-    notificationCount: 0,
-    profilePicURL: '',
-  }));
+  // Server-only: the client restores these from the payload via useState.
+  if (!import.meta.server) return;
 
-  if (import.meta.server) {
-    const ctx = nuxtApp.ssrContext?.event?.context?.authSession;
-    if (ctx?.isAuthenticated) {
-      seeded.value = {
-        isAuthenticated: true,
-        username: ctx.username,
-        email: ctx.email,
-        modProfileName: ctx.modProfileName,
-        notificationCount: ctx.notificationCount,
-        profilePicURL: ctx.profilePicURL,
-      };
-    }
-  }
-
-  // Runs on both server (seed reactive vars for the SSR render) and client
-  // (re-seed from the payload before the first render, so hydration matches).
-  if (seeded.value.isAuthenticated) {
-    setIsAuthenticated(true);
-    setUsername(seeded.value.username);
-    setEmail(seeded.value.email);
-    setModProfileName(seeded.value.modProfileName);
-    setNotificationCount(seeded.value.notificationCount);
-    setProfilePicURL(seeded.value.profilePicURL);
-  }
+  const ctx = nuxtApp.ssrContext?.event?.context?.authSession;
+  setIsAuthenticated(!!ctx?.isAuthenticated);
+  setUsername(ctx?.username || '');
+  setEmail(ctx?.email || '');
+  setModProfileName(ctx?.modProfileName || '');
+  setNotificationCount(ctx?.notificationCount || 0);
+  setProfilePicURL(ctx?.profilePicURL || '');
 });

--- a/plugins/test-auth.client.ts
+++ b/plugins/test-auth.client.ts
@@ -4,16 +4,20 @@ import {
   setUsername,
   setModProfileName,
   setIsAuthenticated,
-  isAuthenticatedVar,
-  usernameVar,
-  modProfileNameVar,
-} from '@/cache';
+  useIsAuthenticated,
+  useUsername,
+  useModProfileName,
+} from '@/composables/useAuthState';
 import { config } from '@/config';
 
 export default defineNuxtPlugin(() => {
   if (typeof window === 'undefined') {
     return;
   }
+
+  const isAuthenticatedVar = useIsAuthenticated();
+  const usernameVar = useUsername();
+  const modProfileNameVar = useModProfileName();
 
   // Always check for mock auth data in localStorage - this is safe because
   // mock auth data is only set by test code (Playwright, Cypress)

--- a/tests/playwright/mocked/events/editSeriesEvent.spec.ts
+++ b/tests/playwright/mocked/events/editSeriesEvent.spec.ts
@@ -154,7 +154,7 @@ const getCommonMocks = (username: string) => ({
 
 // NOTE: Edit tests are currently skipped because they require complex auth setup
 // with ownership verification. The mock auth system needs enhancement to properly
-// set usernameVar on page load for RequireAuth ownership checks to work.
+// set the auth username on page load for RequireAuth ownership checks to work.
 // TODO: Fix test-auth.client.ts plugin to properly sync auth state for ownership checks.
 
 test.describe.skip('Edit Series Event', () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,21 @@
-import { vi } from 'vitest';
+import { vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+
+// Minimal request-scoped-ish useState shim for unit tests (happy-dom has no
+// Nuxt runtime). Keyed ref store, cleared between tests so auth state from one
+// test can't leak into the next. Composables in composables/useAuthState.ts call
+// useState from '#imports'; this backs them. Tests that need specific auth state
+// should mock '@/composables/useAuthState' directly.
+const __useStateStore = new Map<string, ReturnType<typeof ref>>();
+beforeEach(() => {
+  __useStateStore.clear();
+});
+const useStateShim = <T>(key: string, init?: () => T) => {
+  if (!__useStateStore.has(key)) {
+    __useStateStore.set(key, ref(init ? init() : undefined));
+  }
+  return __useStateStore.get(key) as ReturnType<typeof ref>;
+};
 
 // Suppress Vue compiler warnings
 const originalConsoleWarn = console.warn;
@@ -64,4 +81,23 @@ vi.mock('#imports', () => ({
     push: vi.fn(),
   }),
   navigateTo: vi.fn(),
+  useState: useStateShim,
+}));
+
+// composables/useAuthState.ts imports useState from 'nuxt/app'. Back it with the
+// same shim so components that exercise the real auth composables (rather than
+// mocking '@/composables/useAuthState') don't crash in happy-dom. Spec files that
+// declare their own vi.mock('nuxt/app', ...) override this for that file.
+vi.mock('nuxt/app', () => ({
+  useState: useStateShim,
+  useNuxtApp: () => ({
+    $apollo: {
+      default: { query: vi.fn().mockResolvedValue({ data: {} }) },
+    },
+  }),
+  useRoute: () => ({ params: {}, query: {} }),
+  useRouter: () => ({ push: vi.fn() }),
+  navigateTo: vi.fn(),
+  defineNuxtPlugin: (fn: unknown) => fn,
+  useRuntimeConfig: () => ({ public: {} }),
 }));

--- a/tests/unit/composables/useAlbumImageUpload.spec.ts
+++ b/tests/unit/composables/useAlbumImageUpload.spec.ts
@@ -26,8 +26,8 @@ vi.mock('@/graphQLData/discussion/mutations', () => ({
   CREATE_IMAGE: Symbol('CREATE_IMAGE'),
 }));
 
-vi.mock('@/cache', () => ({
-  usernameVar: { value: 'testuser' },
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ({ value: 'testuser' }),
 }));
 
 vi.mock('@/utils', () => ({

--- a/tests/utils/mockAuth.ts
+++ b/tests/utils/mockAuth.ts
@@ -1,47 +1,74 @@
 import { ref } from 'vue';
 
 /**
- * Helper for mocking the `@/cache` reactive auth vars in unit tests.
+ * Helper for mocking the `@/composables/useAuthState` request-scoped auth state
+ * in unit tests.
  *
- * `@/cache` exposes module-level `ref`s (usernameVar, isAuthenticatedVar, …).
- * Components read `someVar.value`, so a mock just needs objects with a `value`.
+ * `@/composables/useAuthState` exposes composables that each return a Vue `Ref`
+ * (useUsername, useIsAuthenticated, …) plus imperative setters. Components read
+ * `useUsername().value`, so a mock just needs composables that return objects
+ * with a `value`.
  *
  * Usage (the factory keeps the vi.mock body self-contained, which avoids
  * vitest's hoisting pitfalls):
  *
- *   vi.mock('@/cache', () => createCacheMock({ username: 'alice' }));
+ *   vi.mock('@/composables/useAuthState', () =>
+ *     createAuthStateMock({ username: 'alice' })
+ *   );
  *
  * For an authenticated user, pass `username` (authenticated defaults to true
- * whenever a username is supplied). Returned vars are real refs, so a test
- * can also mutate them mid-run via the object it passed to vi.mock.
+ * whenever a username is supplied). The returned composables close over real
+ * refs, so a test can also mutate them mid-run via the setters.
  */
 export type AuthState = {
   username?: string;
   authenticated?: boolean;
   modProfileName?: string;
+  email?: string;
   profilePicURL?: string;
   notificationCount?: number;
-  isLoadingAuth?: boolean;
 };
 
-export function createCacheMock(state: AuthState = {}) {
+export function createAuthStateMock(state: AuthState = {}) {
   const username = state.username ?? '';
   const authenticated = state.authenticated ?? username !== '';
+
+  const usernameRef = ref(username);
+  const isAuthenticatedRef = ref(authenticated);
+  const modProfileNameRef = ref(state.modProfileName ?? '');
+  const emailRef = ref(state.email ?? '');
+  const profilePicURLRef = ref(state.profilePicURL ?? '');
+  const notificationCountRef = ref(state.notificationCount ?? 0);
+
   return {
-    usernameVar: ref(username),
-    isAuthenticatedVar: ref(authenticated),
-    modProfileNameVar: ref(state.modProfileName ?? ''),
-    profilePicURLVar: ref(state.profilePicURL ?? ''),
-    notificationCountVar: ref(state.notificationCount ?? 0),
-    isLoadingAuthVar: ref(state.isLoadingAuth ?? false),
-    userDataLoadingVar: ref(false),
-    sideNavIsOpenVar: ref(false),
-    setSideNavIsOpenVar: (status: boolean) => status,
-    enteredDevelopmentEnvironmentVar: ref(false),
+    useUsername: () => usernameRef,
+    useIsAuthenticated: () => isAuthenticatedRef,
+    useModProfileName: () => modProfileNameRef,
+    useEmail: () => emailRef,
+    useProfilePicURL: () => profilePicURLRef,
+    useNotificationCount: () => notificationCountRef,
+    setUsername: (value: string) => {
+      usernameRef.value = value;
+    },
+    setIsAuthenticated: (value: boolean) => {
+      isAuthenticatedRef.value = value;
+    },
+    setModProfileName: (value: string) => {
+      modProfileNameRef.value = value;
+    },
+    setEmail: (value: string) => {
+      emailRef.value = value;
+    },
+    setProfilePicURL: (value: string) => {
+      profilePicURLRef.value = value;
+    },
+    setNotificationCount: (value: number) => {
+      notificationCountRef.value = value;
+    },
   };
 }
 
 /** Convenience preset for the most common case: a logged-in user. */
-export function createAuthenticatedCacheMock(username = 'testuser') {
-  return createCacheMock({ username, authenticated: true });
+export function createAuthenticatedAuthStateMock(username = 'testuser') {
+  return createAuthStateMock({ username, authenticated: true });
 }


### PR DESCRIPTION
## Problem

The session-seeded auth state (`isAuthenticatedVar`, `usernameVar`, `modProfileNameVar`, `emailVar`, `profilePicURLVar`, `notificationCountVar`) lived in **module-level `ref()`s** in `cache.ts`. In Nuxt SSR, module-level state is **shared across every request** on a server instance. The auth-session plugin seeds it per request (only when authenticated, never resetting), so on Vercel's serverless runtime (concurrent requests, reused instances) one user's auth state bled into another request's SSR render.

**Two bugs:**
1. 🔴 **Privacy/security** — an anonymous (or different) visitor could be served another user's *authenticated* UI in the SSR HTML.
2. **Hydration mismatch** — the leaked/stale SSR auth state didn't match the visitor's own client payload, so Vue logged `Hydration completed but contains mismatches` and re-rendered the content subtree (the "content loads → black screen → reload" flash on discussion pages). Only reproduced on Vercel because it requires concurrency.

## Fix

Move the auth state into `composables/useAuthState.ts` as request-scoped **`useState`** values (keyed to the current request's Nuxt app). `useState` is isolated per request — no cross-request sharing — and serializes into the payload + restores on the client automatically. So the auth-session plugin now seeds **only on the server**, and the client picks the exact same values back up (no re-seed → no mismatch). `cache.ts` keeps only the Apollo cache config + genuinely-shared UI refs.

~115 consumers read auth via `const usernameVar = useUsername()` etc. (same local names, so call sites are otherwise unchanged). Tests mock `@/composables/useAuthState`; `tests/setup.ts` gains a `useState` shim.

## Verification

Locally, with a **real authenticated session against the prod backend**:
- Before: an anonymous SSR fetch rendered **15 authenticated markers** (leaked from the logged-in session).
- After: anonymous SSR renders **0 authenticated / 15 unauthenticated** markers, while the authenticated render matches its own client payload — no hydration mismatch.

`tsc` clean; all 2371 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)