### PR TITLE
fix(sentry): initialize SDK by moving runtime config into Sentry.init()

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -211,18 +211,13 @@ export default defineNuxtConfig({
     ],
   ],
   sentry: {
-    dsn: process.env.VITE_SENTRY_DSN,
+    // Build-time module options ONLY (source maps upload). Runtime options such
+    // as `dsn`, `environment`, `integrations`, and sample rates belong in
+    // `Sentry.init()` inside sentry.client.config.ts / sentry.server.config.ts —
+    // they are ignored if placed here.
+    org: 'none-y1x',
+    project: 'javascript-nuxt',
     authToken: process.env.VITE_SENTRY_AUTH_TOKEN,
-    environment: process.env.VITE_ENVIRONMENT || 'development',
-    integrations: ['replayIntegration'],
-    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
-    replaysSessionSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
-    replaysOnErrorSampleRate: 1.0,
-    sourceMapsUploadOptions: {
-      org: 'none-y1x',
-      project: 'javascript-nuxt',
-      authToken: process.env.VITE_SENTRY_AUTH_TOKEN,
-    },
   },
   nitro: {
     preset: 'vercel',

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,6 +1,19 @@
 import * as Sentry from '@sentry/nuxt';
 
+const environment = import.meta.env.VITE_ENVIRONMENT || 'development';
+const isProduction = environment === 'production';
+
 Sentry.init({
-  // This will be set by the Nuxt module based on the VITE_SENTRY_DSN environment variable
-  // Additional client-side configuration can be added here if needed
+  // Runtime options must live here (and in sentry.server.config.ts), not in the
+  // `sentry` block of nuxt.config.ts — that block is only read for build-time
+  // module options (source maps upload), so runtime options placed there are
+  // silently ignored.
+  dsn: import.meta.env.VITE_SENTRY_DSN,
+  environment,
+  integrations: [Sentry.replayIntegration()],
+  // Performance tracing — sample everything outside production to keep noise low.
+  tracesSampleRate: isProduction ? 0.1 : 1.0,
+  // Session Replay sampling.
+  replaysSessionSampleRate: isProduction ? 0.1 : 1.0,
+  replaysOnErrorSampleRate: 1.0,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,6 +1,14 @@
 import * as Sentry from '@sentry/nuxt';
 
+const environment = process.env.VITE_ENVIRONMENT || 'development';
+const isProduction = environment === 'production';
+
 Sentry.init({
-  // This will be set by the Nuxt module based on the VITE_SENTRY_DSN environment variable
-  // Additional server-side configuration can be added here if needed
+  // Runtime options must live here (and in sentry.client.config.ts), not in the
+  // `sentry` block of nuxt.config.ts — that block is only read for build-time
+  // module options (source maps upload), so runtime options placed there are
+  // silently ignored. Session Replay is client-only, so it is not configured here.
+  dsn: process.env.VITE_SENTRY_DSN,
+  environment,
+  tracesSampleRate: isProduction ? 0.1 : 1.0,
 });


### PR DESCRIPTION
## Problem

The Sentry SDK was **never initializing at runtime**. All runtime options (`dsn`, `environment`, `integrations`, sample rates) were placed in the `sentry` block of `nuxt.config.ts` — but that block only accepts **build-time** module options (source maps upload) and silently ignores everything else.

Meanwhile the actual `Sentry.init()` calls in `sentry.client.config.ts` and `sentry.server.config.ts` were empty, so the SDK had no DSN and never started. On top of that, `integrations: ['replayIntegration']` was a bare **string** rather than an integration instance, which would not work even if it were read.

## Fix

- **`sentry.client.config.ts`** — moved `dsn`, `environment`, `tracesSampleRate`, and Session Replay sampling into `Sentry.init()`, using the real `Sentry.replayIntegration()` instance.
- **`sentry.server.config.ts`** — moved `dsn`, `environment`, and `tracesSampleRate` into `Sentry.init()` (Session Replay is client-only, so it is omitted here).
- **`nuxt.config.ts`** — reduced the `sentry` block to valid build-time options (`org`, `project`, `authToken`) and dropped the deprecated `sourceMapsUploadOptions` nesting.

Env vars are unchanged: `VITE_SENTRY_DSN`, `VITE_SENTRY_AUTH_TOKEN`, and `VITE_ENVIRONMENT` are still the source of truth (client via `import.meta.env`, server via `process.env`, matching existing patterns in `config.ts` and `server/robots.txt.ts`).

## Verification

- `npm run tsc` passes clean.
- Pre-commit hook (tsc + lint + unit tests) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)