### PR TITLE
test: unit-test coverage campaign (13 components + utils, +216 tests)

### DIFF
--- a/components/TextEditor.mount.spec.ts
+++ b/components/TextEditor.mount.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import TextEditor from '@/components/TextEditor.vue';
+
+// Vuetify's useDisplay needs the Vuetify plugin context, which we don't install
+// in unit tests. The component only reads `width`, so stub it to a desktop width.
+vi.mock('vuetify', () => ({
+  useDisplay: () => ({ width: ref(1024) }),
+}));
+
+// useImageUpload talks to GraphQL/object storage. It has its own unit tests; here
+// we stub it so we can drive TextEditor's upload *orchestration* deterministically.
+// The placeholder markdown intentionally embeds "<placeholderText> (id:<id>)" so the
+// component's "placeholder still present" lookup succeeds and hits the main branch.
+const { uploadFileMock } = vi.hoisted(() => ({ uploadFileMock: vi.fn() }));
+vi.mock('@/composables/useImageUpload', () => ({
+  useImageUpload: () => ({
+    uploadFile: uploadFileMock,
+    validateFileSize: (file: File) => ({
+      valid: file.size <= 5 * 1024 * 1024,
+      message: 'File too large',
+    }),
+    createUploadPlaceholder: (file: File, id: string) => ({
+      markdown: `![uploading ${file.name} (id:${id})]()`,
+      placeholderText: `uploading ${file.name}`,
+    }),
+    createImageMarkdown: (name: string, link: string) => `![${name}](${link})`,
+    createErrorMarkdown: (name: string, err: string) => `[upload error: ${name} ${err}]`,
+    createPlaceholderRegex: (placeholderText: string, id: string) =>
+      new RegExp(`!\\[${placeholderText} \\(id:${id}\\)\\]\\(\\)`),
+    createSignedStorageUrlError: ref(null),
+  }),
+}));
+
+// Mount the REAL component (not a mock). Child components are stubbed so we
+// exercise TextEditor's own script logic and template branches, while the
+// native <textarea> stays live for interaction.
+const mountEditor = (props: Record<string, unknown> = {}) =>
+  mount(TextEditor, {
+    props,
+    global: {
+      stubs: {
+        AddImage: true,
+        ErrorBanner: true,
+        CharCounter: true,
+        TextEditorToolbar: true,
+        BotSuggestionsPopover: true,
+        ModSuggestionsPopover: true,
+        TextEditorFullScreen: true,
+        EmojiPickerWrapper: true,
+        MarkdownRenderer: true,
+      },
+    },
+  });
+
+describe('TextEditor (real mount)', () => {
+  it('renders the textarea seeded with initialValue', () => {
+    const wrapper = mountEditor({ initialValue: 'hello world' });
+
+    expect(
+      (wrapper.get('[data-testid="texteditor-textarea"]').element as HTMLTextAreaElement)
+        .value
+    ).toBe('hello world');
+  });
+
+  it('applies a custom testId to the textarea', () => {
+    const wrapper = mountEditor({ testId: 'my-editor' });
+
+    expect(wrapper.find('[data-testid="my-editor"]').exists()).toBe(true);
+  });
+
+  it('emits update with the new value when the user types', async () => {
+    const wrapper = mountEditor();
+
+    await wrapper.get('textarea').setValue('typed text');
+
+    expect(wrapper.emitted('update')?.at(-1)).toEqual(['typed text']);
+  });
+
+  describe('accessibleLabel', () => {
+    it('prefers the ariaLabel prop', () => {
+      const wrapper = mountEditor({ ariaLabel: 'Comment body' });
+
+      expect(wrapper.get('textarea').attributes('aria-label')).toBe(
+        'Comment body'
+      );
+    });
+
+    it('falls back to the placeholder when no ariaLabel is given', () => {
+      const wrapper = mountEditor({ placeholder: 'Say something' });
+
+      expect(wrapper.get('textarea').attributes('aria-label')).toBe(
+        'Say something'
+      );
+    });
+  });
+
+  describe('write / preview tabs', () => {
+    it('shows the textarea on the Write tab by default', () => {
+      const wrapper = mountEditor();
+
+      expect(wrapper.find('textarea').exists()).toBe(true);
+    });
+
+    it('switches to the rendered preview when the Preview tab is clicked', async () => {
+      const wrapper = mountEditor({ initialValue: '# Title' });
+
+      const previewTab = wrapper
+        .findAll('button')
+        .find((b) => b.text() === 'Preview');
+      await previewTab?.trigger('click');
+
+      expect(wrapper.find('textarea').exists()).toBe(false);
+    });
+  });
+
+  describe('character counter', () => {
+    it('is hidden by default', () => {
+      const wrapper = mountEditor();
+
+      expect(wrapper.findComponent({ name: 'CharCounter' }).exists()).toBe(
+        false
+      );
+    });
+
+    it('is shown when showCharCounter is true', () => {
+      const wrapper = mountEditor({ showCharCounter: true });
+
+      expect(wrapper.findComponent({ name: 'CharCounter' }).exists()).toBe(
+        true
+      );
+    });
+  });
+
+  describe('image upload affordance', () => {
+    it('renders the AddImage control by default', () => {
+      const wrapper = mountEditor();
+
+      expect(wrapper.findComponent({ name: 'AddImage' }).exists()).toBe(true);
+    });
+
+    it('hides the AddImage control when allowImageUpload is false', () => {
+      const wrapper = mountEditor({ allowImageUpload: false });
+
+      expect(wrapper.findComponent({ name: 'AddImage' }).exists()).toBe(false);
+    });
+  });
+
+  describe('formatting toolbar', () => {
+    it('emits an update after the toolbar requests a format', async () => {
+      const wrapper = mountEditor({ initialValue: 'plain' });
+
+      await wrapper
+        .findComponent({ name: 'TextEditorToolbar' })
+        .vm.$emit('format', 'bold');
+
+      expect(wrapper.emitted('update')).toBeTruthy();
+    });
+  });
+});
+
+describe('TextEditor image upload', () => {
+  const emitFileChange = async (
+    wrapper: ReturnType<typeof mount>,
+    file: File
+  ) => {
+    wrapper.findComponent({ name: 'AddImage' }).vm.$emit('file-change', {
+      event: { target: { files: [file] } },
+      fieldName: '',
+    });
+    await flushPromises();
+  };
+
+  const mountEditor = () =>
+    mount(TextEditor, {
+      global: {
+        stubs: {
+          AddImage: true,
+          ErrorBanner: true,
+          CharCounter: true,
+          TextEditorToolbar: true,
+          BotSuggestionsPopover: true,
+          ModSuggestionsPopover: true,
+          TextEditorFullScreen: true,
+          EmojiPickerWrapper: true,
+          MarkdownRenderer: true,
+        },
+      },
+    });
+
+  beforeEach(() => {
+    uploadFileMock.mockReset();
+    vi.stubGlobal('alert', vi.fn());
+  });
+
+  it('replaces the placeholder with the uploaded image markdown on success', async () => {
+    uploadFileMock.mockResolvedValue({
+      success: true,
+      embeddedLink: 'https://cdn.example.com/pic.png',
+    });
+    const wrapper = mountEditor();
+
+    await emitFileChange(wrapper, new File(['x'], 'pic.png'));
+
+    expect(wrapper.emitted('update')?.at(-1)?.[0]).toContain(
+      'https://cdn.example.com/pic.png'
+    );
+  });
+
+  it('inserts error markdown when the upload reports failure', async () => {
+    uploadFileMock.mockResolvedValue({ success: false, error: 'denied' });
+    const wrapper = mountEditor();
+
+    await emitFileChange(wrapper, new File(['x'], 'pic.png'));
+
+    expect(wrapper.emitted('update')?.at(-1)?.[0]).toContain('upload error');
+  });
+
+  it('inserts error markdown when the upload throws', async () => {
+    uploadFileMock.mockRejectedValue(new Error('boom'));
+    const wrapper = mountEditor();
+
+    await emitFileChange(wrapper, new File(['x'], 'pic.png'));
+
+    expect(wrapper.emitted('update')?.at(-1)?.[0]).toContain('boom');
+  });
+
+  it('alerts and skips upload when the file is too large', async () => {
+    const wrapper = mountEditor();
+    const bigFile = new File(['x'.repeat(6 * 1024 * 1024)], 'big.png');
+
+    await emitFileChange(wrapper, bigFile);
+
+    expect(uploadFileMock).not.toHaveBeenCalled();
+  });
+});

--- a/components/channel/ChannelTabs.spec.ts
+++ b/components/channel/ChannelTabs.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, reactive, nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import type { Channel } from '@/__generated__/graphql';
+
+import ChannelTabs from '@/components/channel/ChannelTabs.vue';
+
+const h = vi.hoisted(() => ({
+  username: null as unknown,
+  modName: null as unknown,
+  isAuth: null as unknown,
+  serverConfig: null as unknown,
+  mdAndUp: null as unknown,
+  route: null as unknown,
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => h.username,
+  useModProfileName: () => h.modName,
+  useIsAuthenticated: () => h.isAuth,
+}));
+vi.mock('vuetify', () => ({ useDisplay: () => ({ mdAndUp: h.mdAndUp }) }));
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.serverConfig }),
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => h.route,
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const makeChannel = (overrides: Partial<Channel> = {}) =>
+  ({
+    downloadsEnabled: false,
+    eventsEnabled: false,
+    wikiEnabled: false,
+    Admins: [],
+    Moderators: [],
+    ...overrides,
+  }) as unknown as Channel;
+
+const mountTabs = (props: Record<string, unknown> = {}) =>
+  mount(ChannelTabs, {
+    props: { channel: makeChannel(), ...props },
+    global: {
+      stubs: {
+        ClientOnly: { template: '<div><slot /></div>' },
+        Popper: { template: '<div><slot /><slot name="content" /></div>' },
+        TabButton: {
+          name: 'TabButton',
+          props: ['label', 'isActive', 'count', 'to', 'showCount', 'vertical'],
+          template: '<div><slot /></div>',
+        },
+      },
+    },
+  });
+
+const labels = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAllComponents({ name: 'TabButton' }).map((c) => c.props('label'));
+
+const tabByLabel = (wrapper: ReturnType<typeof mount>, label: string) =>
+  wrapper
+    .findAllComponents({ name: 'TabButton' })
+    .find((c) => c.props('label') === label);
+
+beforeEach(() => {
+  h.username = ref('');
+  h.modName = ref('');
+  h.isAuth = ref(false);
+  h.serverConfig = ref({
+    serverConfigs: [{ enableDownloads: true, enableEvents: true }],
+  });
+  h.mdAndUp = ref(true);
+  h.route = reactive({
+    params: { forumId: 'cats' },
+    path: '/forums/cats/discussions',
+  });
+});
+
+describe('ChannelTabs base tabs', () => {
+  it('always shows Discussions, Contributors and About', () => {
+    const wrapper = mountTabs();
+
+    expect(labels(wrapper)).toEqual(['Discussions', 'Contributors', 'About']);
+  });
+
+  it('adds Downloads when the channel and server both enable downloads', () => {
+    const wrapper = mountTabs({
+      channel: makeChannel({ downloadsEnabled: true }),
+    });
+
+    expect(labels(wrapper)).toContain('Downloads');
+  });
+
+  it('hides Downloads when the server disables downloads', () => {
+    (h.serverConfig as { value: unknown }).value = {
+      serverConfigs: [{ enableDownloads: false, enableEvents: true }],
+    };
+    const wrapper = mountTabs({
+      channel: makeChannel({ downloadsEnabled: true }),
+    });
+
+    expect(labels(wrapper)).not.toContain('Downloads');
+  });
+
+  it('adds the Calendar tab when events are enabled', () => {
+    const wrapper = mountTabs({ channel: makeChannel({ eventsEnabled: true }) });
+
+    expect(labels(wrapper)).toContain('Calendar');
+  });
+
+  it('adds the Wiki tab when the wiki is enabled', () => {
+    const wrapper = mountTabs({ channel: makeChannel({ wikiEnabled: true }) });
+
+    expect(labels(wrapper)).toContain('Wiki');
+  });
+});
+
+describe('ChannelTabs auth-dependent tabs', () => {
+  it('shows Settings and Issues for an admin', () => {
+    (h.isAuth as { value: boolean }).value = true;
+    (h.username as { value: string }).value = 'alice';
+    const wrapper = mountTabs({
+      channel: makeChannel({ Admins: [{ username: 'alice' }] as never }),
+    });
+
+    expect(labels(wrapper)).toEqual(expect.arrayContaining(['Settings', 'Issues']));
+  });
+
+  it('shows Issues but not Settings for a moderator', () => {
+    (h.isAuth as { value: boolean }).value = true;
+    (h.modName as { value: string }).value = 'modAlice';
+    const wrapper = mountTabs({
+      channel: makeChannel({
+        Moderators: [{ displayName: 'modAlice' }] as never,
+      }),
+    });
+
+    expect(labels(wrapper)).toContain('Issues');
+  });
+
+  it('does not show moderation tabs for a regular authenticated user', () => {
+    (h.isAuth as { value: boolean }).value = true;
+    (h.username as { value: string }).value = 'bob';
+    const wrapper = mountTabs();
+
+    expect(labels(wrapper)).not.toContain('Issues');
+  });
+
+  it('does not show moderation tabs when unauthenticated', () => {
+    const wrapper = mountTabs({
+      channel: makeChannel({ Admins: [{ username: 'alice' }] as never }),
+    });
+
+    expect(labels(wrapper)).not.toContain('Settings');
+  });
+});
+
+describe('ChannelTabs routing and active state', () => {
+  it('builds tab routes scoped to the current forum', () => {
+    const wrapper = mountTabs();
+
+    expect(tabByLabel(wrapper, 'Discussions')?.props('to')).toBe(
+      '/forums/cats/discussions'
+    );
+  });
+
+  it('marks the tab matching the current path as active', () => {
+    (h.route as { path: string }).path = '/forums/cats/about';
+    const wrapper = mountTabs();
+
+    expect(tabByLabel(wrapper, 'About')?.props('isActive')).toBe(true);
+  });
+
+  it('does not mark the wiki tab active on the wiki-settings page', () => {
+    (h.route as { path: string }).path = '/forums/cats/edit/wiki-settings';
+    const wrapper = mountTabs({ channel: makeChannel({ wikiEnabled: true }) });
+
+    expect(tabByLabel(wrapper, 'Wiki')?.props('isActive')).toBe(false);
+  });
+
+  it('rebuilds routes when the forumId route param changes', async () => {
+    const wrapper = mountTabs();
+
+    (h.route as { params: unknown }).params = { forumId: 'dogs' };
+    await nextTick();
+
+    expect(tabByLabel(wrapper, 'Discussions')?.props('to')).toBe(
+      '/forums/dogs/discussions'
+    );
+  });
+});
+
+describe('ChannelTabs mobile layout', () => {
+  it('renders the active tab label in the mobile dropdown', () => {
+    (h.mdAndUp as { value: boolean }).value = false;
+    const wrapper = mountTabs();
+
+    expect(wrapper.text()).toContain('Discussions');
+  });
+});

--- a/components/channel/SidebarEventList.spec.ts
+++ b/components/channel/SidebarEventList.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { DateTime } from 'luxon';
+import { mount } from '@vue/test-utils';
+
+import SidebarEventList from '@/components/channel/SidebarEventList.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  loading: null as unknown,
+  error: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.result, loading: h.loading, error: h.error }),
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' } }),
+}));
+
+let idCounter = 0;
+const event = (overrides: Record<string, unknown> = {}) => ({
+  id: `e${idCounter++}`,
+  title: 'Some Event',
+  isAllDay: false,
+  virtualEventUrl: '',
+  ...overrides,
+});
+
+const nowEvent = (overrides = {}) =>
+  event({
+    // happeningNow() compares against new Date().toISOString() (UTC "Z"), so
+    // these must be the same format rather than luxon's offset ISO.
+    startTime: new Date(Date.now() - 3_600_000).toISOString(),
+    endTime: new Date(Date.now() + 3_600_000).toISOString(),
+    ...overrides,
+  });
+
+const tomorrowEvent = (overrides = {}) =>
+  event({
+    startTime: DateTime.now().startOf('day').plus({ days: 1, hours: 12 }).toISO(),
+    endTime: DateTime.now().startOf('day').plus({ days: 1, hours: 13 }).toISO(),
+    ...overrides,
+  });
+
+const futureEvent = (overrides = {}) =>
+  event({
+    startTime: DateTime.now().startOf('day').plus({ days: 3, hours: 12 }).toISO(),
+    endTime: DateTime.now().startOf('day').plus({ days: 3, hours: 13 }).toISO(),
+    ...overrides,
+  });
+
+const mountList = (events: unknown[], eventChannelsAggregate = events.length) =>
+  mount(SidebarEventList, {
+    props: { eventChannelsAggregate },
+    global: {
+      stubs: {
+        NuxtLink: { template: '<a><slot /></a>' },
+        'nuxt-link': { template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  idCounter = 0;
+  h.result = ref({ events: [] });
+  h.loading = ref(false);
+  h.error = ref(null);
+});
+
+describe('SidebarEventList loading and empty states', () => {
+  it('renders nothing while the events query is loading', () => {
+    (h.loading as { value: boolean }).value = true;
+    const wrapper = mountList([nowEvent()]);
+
+    expect(wrapper.text().trim()).toBe('');
+  });
+
+  it('renders nothing when there are no events', () => {
+    const wrapper = mountList([]);
+
+    expect(wrapper.text().trim()).toBe('');
+  });
+});
+
+describe('SidebarEventList time buckets', () => {
+  it('shows the Happening Now section for an in-progress event', () => {
+    (h.result as { value: unknown }).value = { events: [nowEvent()] };
+    const wrapper = mountList([nowEvent()]);
+
+    expect(wrapper.text()).toContain('Happening Now');
+  });
+
+  it('shows the Tomorrow section for an event starting tomorrow', () => {
+    (h.result as { value: unknown }).value = { events: [tomorrowEvent()] };
+    const wrapper = mountList([tomorrowEvent()]);
+
+    expect(wrapper.text()).toContain('Tomorrow');
+  });
+
+  it('groups later events under a date heading', () => {
+    const e = futureEvent();
+    (h.result as { value: unknown }).value = { events: [e] };
+    const wrapper = mountList([e]);
+    const heading = DateTime.fromISO(e.startTime as string).toLocaleString({
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    });
+
+    expect(wrapper.text()).toContain(heading);
+  });
+});
+
+describe('SidebarEventList link text', () => {
+  it('prefixes timed events with the start time', () => {
+    (h.result as { value: unknown }).value = {
+      events: [nowEvent({ title: 'Standup' })],
+    };
+    const wrapper = mountList([nowEvent()]);
+
+    expect(wrapper.text()).toContain('· Standup');
+  });
+
+  it('labels all-day events as "All Day"', () => {
+    (h.result as { value: unknown }).value = {
+      events: [nowEvent({ isAllDay: true, title: 'Festival' })],
+    };
+    const wrapper = mountList([nowEvent()]);
+
+    expect(wrapper.text()).toContain('All Day · Festival');
+  });
+
+  it('shows an online-event link when a virtual URL is present', () => {
+    (h.result as { value: unknown }).value = {
+      events: [nowEvent({ virtualEventUrl: 'https://meet.example.com' })],
+    };
+    const wrapper = mountList([nowEvent()]);
+
+    expect(wrapper.text()).toContain('Go to online event');
+  });
+});
+
+describe('SidebarEventList view-all link', () => {
+  it('shows "View all events" when more events exist than are shown', () => {
+    (h.result as { value: unknown }).value = { events: [nowEvent()] };
+    const wrapper = mountList([nowEvent()], 25);
+
+    expect(wrapper.text()).toContain('View all events');
+  });
+
+  it('hides "View all events" when all events are shown', () => {
+    (h.result as { value: unknown }).value = { events: [nowEvent()] };
+    const wrapper = mountList([nowEvent()], 1);
+
+    expect(wrapper.text()).not.toContain('View all events');
+  });
+});

--- a/components/collection/AddToListPopover.spec.ts
+++ b/components/collection/AddToListPopover.spec.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import AddToListPopover from '@/components/collection/AddToListPopover.vue';
+
+// --- controllable dependency state ------------------------------------------
+const h = vi.hoisted(() => {
+  return {
+    username: { value: 'alice' as string | null | undefined },
+    collectionsResult: { value: undefined as unknown },
+    itemInResult: { value: undefined as unknown },
+    refetchCollections: undefined as unknown,
+    refetchItem: undefined as unknown,
+    showToast: undefined as unknown,
+    createCollection: undefined as unknown,
+    addMutation: undefined as unknown,
+    removeMutation: undefined as unknown,
+    addFav: undefined as unknown,
+    removeFav: undefined as unknown,
+    useQuery: undefined as unknown,
+  };
+});
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: (...args: unknown[]) =>
+    (h.useQuery as (...a: unknown[]) => unknown)(...args),
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => h.username,
+}));
+vi.mock('@/stores/toastStore', () => ({
+  useToastStore: () => ({ showToast: h.showToast }),
+}));
+vi.mock('@/composables/useCollectionQueries', () => ({
+  useCollectionQueries: () => ({
+    collectionType: 'Discussion',
+    getCollectionQuery: () => ({}),
+    getCheckItemQuery: () => ({}),
+  }),
+}));
+vi.mock('@/composables/useCollectionMutations', () => ({
+  useCollectionMutations: () => ({
+    createCollection: h.createCollection,
+    getAddMutation: () => h.addMutation,
+    getRemoveMutation: () => h.removeMutation,
+    getAddFavoriteMutation: () => h.addFav,
+    getRemoveFavoriteMutation: () => h.removeFav,
+  }),
+}));
+vi.mock('@/composables/usePopoverPositioning', () => ({
+  usePopoverPositioning: () => ({ adjustedPosition: ref({ top: 0, left: 0 }) }),
+}));
+
+const mountPopover = (props: Record<string, unknown> = {}) =>
+  mount(AddToListPopover, {
+    props: { itemId: 'item-1', itemType: 'discussion', isVisible: true, ...props },
+    global: { stubs: { Teleport: { template: '<div><slot /></div>' } } },
+  });
+
+const rows = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('.cursor-pointer');
+
+beforeEach(() => {
+  h.username.value = 'alice';
+  h.collectionsResult = ref({
+    users: [
+      {
+        Collections: [{ id: 'c1', name: 'My List', itemCount: 3 }],
+        FavoriteDiscussions: [],
+      },
+    ],
+  }) as never;
+  h.itemInResult = ref({ users: [{ Collections: [] }] }) as never;
+  h.refetchCollections = vi.fn();
+  h.refetchItem = vi.fn();
+  h.showToast = vi.fn();
+  h.createCollection = vi.fn();
+  h.addMutation = vi.fn().mockResolvedValue({});
+  h.removeMutation = vi.fn().mockResolvedValue({});
+  h.addFav = vi.fn().mockResolvedValue({});
+  h.removeFav = vi.fn().mockResolvedValue({});
+  h.useQuery = vi
+    .fn()
+    .mockReturnValueOnce({
+      result: h.collectionsResult,
+      refetch: h.refetchCollections,
+    })
+    .mockReturnValueOnce({ result: h.itemInResult, refetch: h.refetchItem });
+});
+
+describe('AddToListPopover visibility', () => {
+  it('renders nothing when not visible', () => {
+    const wrapper = mountPopover({ isVisible: false });
+
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('renders the dialog when visible', () => {
+    const wrapper = mountPopover();
+
+    expect(wrapper.text()).toContain('Add to List');
+  });
+});
+
+describe('AddToListPopover list rendering', () => {
+  it('always shows the Favorites row', () => {
+    const wrapper = mountPopover();
+
+    expect(wrapper.text()).toContain('Favorites');
+  });
+
+  it('lists the user collections with their item count', () => {
+    const wrapper = mountPopover();
+
+    expect(wrapper.text()).toContain('My List');
+  });
+
+  it('shows the empty state when there are no collections', () => {
+    h.collectionsResult = ref({
+      users: [{ Collections: [], FavoriteDiscussions: [] }],
+    }) as never;
+    h.useQuery = vi
+      .fn()
+      .mockReturnValueOnce({ result: h.collectionsResult, refetch: vi.fn() })
+      .mockReturnValueOnce({ result: h.itemInResult, refetch: vi.fn() });
+    const wrapper = mountPopover();
+
+    expect(wrapper.text()).toContain('No collections yet');
+  });
+
+  it('shows a no-results message when a search matches nothing', async () => {
+    const wrapper = mountPopover();
+
+    await wrapper.get('input[aria-label="Search lists"]').setValue('zzz');
+
+    expect(wrapper.text()).toContain('No collections found');
+  });
+});
+
+describe('AddToListPopover favorites toggle', () => {
+  it('adds a discussion to favorites with a discussionId param', async () => {
+    const wrapper = mountPopover();
+
+    await rows(wrapper)[0].trigger('click');
+    await flushPromises();
+
+    expect(h.addFav).toHaveBeenCalledWith({
+      discussionId: 'item-1',
+      username: 'alice',
+    });
+  });
+
+  it('emits favoriteChange(true) when favoriting', async () => {
+    const wrapper = mountPopover();
+
+    await rows(wrapper)[0].trigger('click');
+    await flushPromises();
+
+    expect(wrapper.emitted('favoriteChange')?.[0]).toEqual([true]);
+  });
+
+  it('removes from favorites when already favorited', async () => {
+    const wrapper = mountPopover({ isAlreadyFavorite: true });
+
+    await rows(wrapper)[0].trigger('click');
+    await flushPromises();
+
+    expect(h.removeFav).toHaveBeenCalled();
+  });
+
+  it('uses a channel param for channel favorites', async () => {
+    const wrapper = mountPopover({ itemType: 'channel' });
+
+    await rows(wrapper)[0].trigger('click');
+    await flushPromises();
+
+    expect(h.addFav).toHaveBeenCalledWith({
+      channel: 'item-1',
+      username: 'alice',
+    });
+  });
+
+  it('uses a discussionId param for download favorites', async () => {
+    const wrapper = mountPopover({ itemType: 'download' });
+
+    await rows(wrapper)[0].trigger('click');
+    await flushPromises();
+
+    expect(h.addFav).toHaveBeenCalledWith({
+      discussionId: 'item-1',
+      username: 'alice',
+    });
+  });
+});
+
+describe('AddToListPopover collection toggle', () => {
+  it('adds the item to a collection it is not in', async () => {
+    const wrapper = mountPopover();
+
+    await rows(wrapper)[1].trigger('click');
+    await flushPromises();
+
+    expect(h.addMutation).toHaveBeenCalledWith({
+      collectionId: 'c1',
+      itemId: 'item-1',
+    });
+  });
+
+  it('removes the item from a collection it is already in', async () => {
+    h.itemInResult = ref({ users: [{ Collections: [{ id: 'c1' }] }] }) as never;
+    h.useQuery = vi
+      .fn()
+      .mockReturnValueOnce({ result: h.collectionsResult, refetch: vi.fn() })
+      .mockReturnValueOnce({ result: h.itemInResult, refetch: vi.fn() });
+    const wrapper = mountPopover();
+
+    await rows(wrapper)[1].trigger('click');
+    await flushPromises();
+
+    expect(h.removeMutation).toHaveBeenCalledWith({
+      collectionId: 'c1',
+      itemId: 'item-1',
+    });
+  });
+});
+
+describe('AddToListPopover create new collection', () => {
+  it('creates a collection and adds the item to it', async () => {
+    (h.createCollection as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        createCollections: { collections: [{ id: 'new1', name: 'New List' }] },
+      },
+    });
+    const wrapper = mountPopover();
+
+    await wrapper.findAll('button').find((b) => b.text().includes('New List'))!.trigger('click');
+    await wrapper.get('input[aria-label="New list name"]').setValue('New List');
+    await wrapper.findAll('button').find((b) => b.text() === 'Create')!.trigger('click');
+    await flushPromises();
+
+    expect(h.addMutation).toHaveBeenCalledWith({
+      collectionId: 'new1',
+      itemId: 'item-1',
+    });
+  });
+});
+
+describe('AddToListPopover dismissal', () => {
+  it('emits close when the Escape key is pressed', async () => {
+    const wrapper = mountPopover();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await flushPromises();
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('emits close when clicking outside the popover', async () => {
+    const wrapper = mountPopover();
+    // the outside-click listener is attached on a setTimeout(0)
+    await new Promise((r) => setTimeout(r, 5));
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushPromises();
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});
+
+describe('AddToListPopover item-type variants', () => {
+  it.each(['comment', 'image'])(
+    'renders the favorites row for the %s item type',
+    (itemType) => {
+      const wrapper = mountPopover({ itemType });
+
+      expect(wrapper.text()).toContain('Favorites');
+    }
+  );
+});
+
+describe('AddToListPopover modal variant', () => {
+  it('renders a modal dialog when variant is modal', () => {
+    const wrapper = mountPopover({ variant: 'modal' });
+
+    expect(wrapper.find('[aria-modal="true"]').exists()).toBe(true);
+  });
+
+  it('emits close when the modal backdrop is clicked', async () => {
+    const wrapper = mountPopover({ variant: 'modal' });
+
+    await wrapper.get('.bg-black\\/50').trigger('click');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/components/discussion/detail/ImageLightbox.spec.ts
+++ b/components/discussion/detail/ImageLightbox.spec.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ImageLightbox from '@/components/discussion/detail/ImageLightbox.vue';
+
+// Only the caption mutation talks to GraphQL; the zoom/navigation/swipe
+// composables are pure state and are exercised for real.
+const h = vi.hoisted(() => ({ updateImage: undefined as unknown }));
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({ mutate: h.updateImage, loading: ref(false) }),
+}));
+
+const childStub = (name: string, props: string[], emits: string[]) => ({
+  name,
+  props,
+  emits,
+  template: '<div />',
+});
+
+const images = [
+  { id: 'img1', url: 'u1', caption: 'cap1', Uploader: { username: 'alice' } },
+  { id: 'img2', url: 'u2', caption: 'cap2' },
+];
+
+const mountLightbox = (props: Record<string, unknown> = {}) =>
+  mount(ImageLightbox, {
+    props: {
+      orderedImages: images,
+      isLoggedInAuthor: true,
+      ...props,
+    },
+    global: {
+      stubs: {
+        LightboxControls: childStub(
+          'LightboxControls',
+          ['lightboxIndex', 'zoomLevel', 'isZoomed', 'currentImageId'],
+          [
+            'close',
+            'zoom-in',
+            'zoom-out',
+            'reset-zoom',
+            'toggle-panel',
+            'toggle-panel-position',
+            'report-image',
+          ]
+        ),
+        LightboxImagePanel: childStub(
+          'LightboxImagePanel',
+          ['currentImage', 'zoomLevel', 'isZoomed', 'isDragging'],
+          ['prev-image', 'next-image', 'mousedown', 'touchstart', 'touchend', 'touchmove']
+        ),
+        LightboxInfoPanel: childStub(
+          'LightboxInfoPanel',
+          ['currentImage', 'isEditing', 'editingCaption'],
+          ['start-editing', 'update-caption', 'save-caption', 'cancel-editing', 'close-panel']
+        ),
+        BrokenRulesModal: childStub(
+          'BrokenRulesModal',
+          ['open', 'imageId'],
+          ['close', 'report-submitted-successfully']
+        ),
+        Notification: childStub('Notification', ['show', 'title'], ['close-notification']),
+      },
+    },
+  });
+
+const controls = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.getComponent({ name: 'LightboxControls' });
+const infoPanel = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.getComponent({ name: 'LightboxInfoPanel' });
+const reportModal = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.getComponent({ name: 'BrokenRulesModal' });
+const imagePanel = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.getComponent({ name: 'LightboxImagePanel' });
+
+beforeEach(() => {
+  h.updateImage = vi.fn().mockResolvedValue({});
+});
+
+describe('ImageLightbox current image', () => {
+  it('shows the image at the initial index', () => {
+    const wrapper = mountLightbox({ initialIndex: 1 });
+
+    expect(controls(wrapper).props('currentImageId')).toBe('img2');
+  });
+
+  it('advances to the next image on ArrowRight', async () => {
+    const wrapper = mountLightbox();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    await wrapper.vm.$nextTick();
+
+    expect(controls(wrapper).props('currentImageId')).toBe('img2');
+  });
+
+  it('wraps to the previous image on ArrowLeft', async () => {
+    const wrapper = mountLightbox();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+    await wrapper.vm.$nextTick();
+
+    expect(controls(wrapper).props('currentImageId')).toBe('img2');
+  });
+
+  it('navigates via the image panel next-image event', async () => {
+    const wrapper = mountLightbox();
+
+    await wrapper.getComponent({ name: 'LightboxImagePanel' }).vm.$emit('next-image');
+
+    expect(controls(wrapper).props('currentImageId')).toBe('img2');
+  });
+});
+
+describe('ImageLightbox zoom', () => {
+  it('marks the view as zoomed after zooming in', async () => {
+    const wrapper = mountLightbox();
+
+    await controls(wrapper).vm.$emit('zoom-in');
+
+    expect(controls(wrapper).props('isZoomed')).toBe(true);
+  });
+
+  it('resets zoom with the 0 key', async () => {
+    const wrapper = mountLightbox();
+    await controls(wrapper).vm.$emit('zoom-in');
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '0' }));
+    await wrapper.vm.$nextTick();
+
+    expect(controls(wrapper).props('isZoomed')).toBe(false);
+  });
+});
+
+describe('ImageLightbox keyboard and layout', () => {
+  it('toggles the info panel with the "i" key', async () => {
+    const wrapper = mountLightbox();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'i' }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'LightboxInfoPanel' }).exists()).toBe(
+      false
+    );
+  });
+
+  it('zooms in with the "+" key', async () => {
+    const wrapper = mountLightbox();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '+' }));
+    await wrapper.vm.$nextTick();
+
+    expect(controls(wrapper).props('isZoomed')).toBe(true);
+  });
+
+  it('keeps a zoomed view after a single zoom-out from a deeper zoom', async () => {
+    const wrapper = mountLightbox();
+    await controls(wrapper).vm.$emit('zoom-in');
+    await controls(wrapper).vm.$emit('zoom-in');
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '-' }));
+    await wrapper.vm.$nextTick();
+
+    expect(controls(wrapper).props('isZoomed')).toBe(true);
+  });
+
+  it('flips the panel layout on toggle-panel-position', async () => {
+    const wrapper = mountLightbox();
+
+    await controls(wrapper).vm.$emit('toggle-panel-position');
+
+    expect(wrapper.get('[role="dialog"]').classes()).toContain('flex-row');
+  });
+
+  it('does not respond to navigation keys while editing a caption', async () => {
+    const wrapper = mountLightbox();
+    await infoPanel(wrapper).vm.$emit('start-editing');
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    await wrapper.vm.$nextTick();
+
+    expect(controls(wrapper).props('currentImageId')).toBe('img1');
+  });
+});
+
+describe('ImageLightbox touch gestures', () => {
+  it('advances to the next image on a left swipe', async () => {
+    const wrapper = mountLightbox();
+
+    await imagePanel(wrapper).vm.$emit('touchstart', {
+      touches: [{ clientX: 300 }],
+    });
+    await imagePanel(wrapper).vm.$emit('touchend', {
+      changedTouches: [{ clientX: 0 }],
+    });
+
+    expect(controls(wrapper).props('currentImageId')).toBe('img2');
+  });
+
+  it('starts dragging when the image is pressed while zoomed', async () => {
+    const wrapper = mountLightbox();
+    await controls(wrapper).vm.$emit('zoom-in');
+
+    await imagePanel(wrapper).vm.$emit('mousedown', {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+      preventDefault: () => {},
+    });
+
+    expect(imagePanel(wrapper).props('isDragging')).toBe(true);
+  });
+});
+
+describe('ImageLightbox close', () => {
+  it('emits close when the controls close button is used', async () => {
+    const wrapper = mountLightbox();
+
+    await controls(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('emits close on the Escape key', async () => {
+    const wrapper = mountLightbox();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});
+
+describe('ImageLightbox info panel', () => {
+  it('hides the info panel when toggled off', async () => {
+    const wrapper = mountLightbox();
+
+    await controls(wrapper).vm.$emit('toggle-panel');
+
+    expect(wrapper.findComponent({ name: 'LightboxInfoPanel' }).exists()).toBe(
+      false
+    );
+  });
+
+  it('enters caption-editing mode on start-editing', async () => {
+    const wrapper = mountLightbox();
+
+    await infoPanel(wrapper).vm.$emit('start-editing');
+
+    expect(infoPanel(wrapper).props('isEditing')).toBe(true);
+  });
+
+  it('saves the caption via the update mutation', async () => {
+    const wrapper = mountLightbox();
+    await infoPanel(wrapper).vm.$emit('start-editing');
+
+    await infoPanel(wrapper).vm.$emit('update-caption', 'new caption');
+    await infoPanel(wrapper).vm.$emit('save-caption');
+
+    expect(h.updateImage).toHaveBeenCalledWith({
+      imageId: 'img1',
+      caption: 'new caption',
+    });
+  });
+
+  it('emits album-updated after a successful caption save', async () => {
+    const wrapper = mountLightbox();
+    await infoPanel(wrapper).vm.$emit('start-editing');
+
+    await infoPanel(wrapper).vm.$emit('save-caption');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('album-updated')).toBeTruthy();
+  });
+
+  it('exits editing mode on cancel', async () => {
+    const wrapper = mountLightbox();
+    await infoPanel(wrapper).vm.$emit('start-editing');
+
+    await infoPanel(wrapper).vm.$emit('cancel-editing');
+
+    expect(infoPanel(wrapper).props('isEditing')).toBe(false);
+  });
+});
+
+describe('ImageLightbox reporting', () => {
+  it('opens the report modal from the controls', async () => {
+    const wrapper = mountLightbox();
+
+    await controls(wrapper).vm.$emit('report-image');
+
+    expect(reportModal(wrapper).props('open')).toBe(true);
+  });
+
+  it('shows the success notification after a report is submitted', async () => {
+    const wrapper = mountLightbox();
+    await controls(wrapper).vm.$emit('report-image');
+
+    await reportModal(wrapper).vm.$emit('report-submitted-successfully');
+
+    expect(
+      wrapper.getComponent({ name: 'Notification' }).props('show')
+    ).toBe(true);
+  });
+
+  it('dismisses the success notification', async () => {
+    const wrapper = mountLightbox();
+    await controls(wrapper).vm.$emit('report-image');
+    await reportModal(wrapper).vm.$emit('report-submitted-successfully');
+
+    await wrapper
+      .getComponent({ name: 'Notification' })
+      .vm.$emit('close-notification');
+
+    expect(
+      wrapper.getComponent({ name: 'Notification' }).props('show')
+    ).toBe(false);
+  });
+});

--- a/components/discussion/detail/activityFeed/EditsDropdown.spec.ts
+++ b/components/discussion/detail/activityFeed/EditsDropdown.spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import EditsDropdown from '@/components/discussion/detail/activityFeed/EditsDropdown.vue';
+import type { Discussion } from '@/__generated__/graphql';
+
+// Build a discussion whose body has been edited `authors.length` times. authors[0]
+// is the most recent editor (BodyLastEditedBy); each past version is authored by
+// the next name in the list.
+const makeDiscussion = (
+  authors: (string | null)[],
+  overrides: Record<string, unknown> = {}
+) =>
+  ({
+    body: 'current body',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-10T00:00:00Z',
+    BodyLastEditedBy: authors[0] ? { username: authors[0] } : null,
+    PastBodyVersions: authors.map((_, i) => ({
+      id: `v${i}`,
+      body: `old body ${i}`,
+      // newest past version first so ordering is deterministic
+      createdAt: `2024-01-0${authors.length - i}T00:00:00Z`,
+      Author: authors[i + 1] ? { username: authors[i + 1] } : null,
+    })),
+    ...overrides,
+  }) as unknown as Discussion;
+
+const mountDropdown = (discussion: Discussion) =>
+  mount(EditsDropdown, {
+    props: { discussion },
+    global: {
+      stubs: {
+        Teleport: { template: '<div><slot /></div>' },
+        RevisionDiffModal: {
+          name: 'RevisionDiffModal',
+          props: ['open', 'oldVersion', 'newVersion', 'isMostRecent'],
+          emits: ['close', 'deleted'],
+          template: '<div class="diff-modal" />',
+        },
+      },
+    },
+  });
+
+const openDropdown = async (wrapper: ReturnType<typeof mount>) => {
+  await wrapper.get('button').trigger('click');
+};
+
+describe('EditsDropdown visibility', () => {
+  it('renders nothing when the discussion has no past versions', () => {
+    const wrapper = mountDropdown(makeDiscussion([]));
+
+    expect(wrapper.find('button').exists()).toBe(false);
+  });
+
+  it('renders the Edits trigger when there is at least one edit', () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice']));
+
+    expect(wrapper.get('button').text()).toBe('Edits');
+  });
+});
+
+describe('EditsDropdown contents', () => {
+  it('summarizes the number of edits', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice', 'bob']));
+
+    await openDropdown(wrapper);
+
+    expect(wrapper.text()).toContain('Edited 2 times');
+  });
+
+  it('attributes the most recent edit to BodyLastEditedBy', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice', 'bob']));
+
+    await openDropdown(wrapper);
+
+    expect(wrapper.findAll('li')[0].text()).toContain('alice');
+  });
+
+  it('attributes an older edit to the next version author', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice', 'bob']));
+
+    await openDropdown(wrapper);
+
+    expect(wrapper.findAll('li')[1].text()).toContain('bob');
+  });
+
+  it('falls back to [Deleted] when the editor is unknown', async () => {
+    const wrapper = mountDropdown(makeDiscussion([null]));
+
+    await openDropdown(wrapper);
+
+    expect(wrapper.get('li').text()).toContain('[Deleted]');
+  });
+});
+
+describe('EditsDropdown toggle', () => {
+  it('closes the dropdown when the trigger is clicked again', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice']));
+
+    await openDropdown(wrapper);
+    await wrapper.get('button').trigger('click');
+
+    expect(wrapper.find('li').exists()).toBe(false);
+  });
+
+  it('closes when a click lands outside the dropdown', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice']));
+    await openDropdown(wrapper);
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await nextTick();
+
+    expect(wrapper.find('li').exists()).toBe(false);
+  });
+});
+
+describe('EditsDropdown revision modal', () => {
+  it('opens the diff modal when an edit is clicked', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice']));
+    await openDropdown(wrapper);
+
+    await wrapper.get('li').trigger('click');
+
+    expect(wrapper.findComponent({ name: 'RevisionDiffModal' }).exists()).toBe(
+      true
+    );
+  });
+
+  it('closes the diff modal on the modal close event', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice']));
+    await openDropdown(wrapper);
+    await wrapper.get('li').trigger('click');
+
+    await wrapper.findComponent({ name: 'RevisionDiffModal' }).vm.$emit('close');
+
+    expect(wrapper.findComponent({ name: 'RevisionDiffModal' }).exists()).toBe(
+      false
+    );
+  });
+
+  it('closes the diff modal when a revision is deleted', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice']));
+    await openDropdown(wrapper);
+    await wrapper.get('li').trigger('click');
+
+    await wrapper
+      .findComponent({ name: 'RevisionDiffModal' })
+      .vm.$emit('deleted', 'v0');
+
+    expect(wrapper.findComponent({ name: 'RevisionDiffModal' }).exists()).toBe(
+      false
+    );
+  });
+});

--- a/components/discussion/form/DiscussionRootCommentFormWrapper.spec.ts
+++ b/components/discussion/form/DiscussionRootCommentFormWrapper.spec.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, h as createElement } from 'vue';
+import { mount } from '@vue/test-utils';
+import type { DiscussionChannel } from '@/__generated__/graphql';
+
+import DiscussionRootCommentFormWrapper from '@/components/discussion/form/DiscussionRootCommentFormWrapper.vue';
+
+const hh = vi.hoisted(() => ({
+  username: null as unknown,
+  getUserResult: null as unknown,
+  createComment: null as unknown,
+  mutationOptions: null as undefined | (() => Record<string, unknown>),
+  onDone: null as undefined | ((r?: unknown) => void),
+  suspension: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: hh.getUserResult }),
+  useMutation: (_doc: unknown, optionsFactory: () => Record<string, unknown>) => {
+    hh.mutationOptions = optionsFactory;
+    return {
+      mutate: hh.createComment,
+      error: ref(null),
+      onDone: (cb: (r?: unknown) => void) => {
+        hh.onDone = cb;
+      },
+    };
+  },
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+vi.mock('@/composables/useAuthState', () => ({ useUsername: () => hh.username }));
+vi.mock('@/composables/useSuspensionNotice', () => ({
+  useChannelSuspensionNotice: () => hh.suspension,
+}));
+
+const discussionChannel = () =>
+  ({
+    id: 'dc1',
+    channelUniqueName: 'cats',
+    discussionId: 'd1',
+    Channel: { imageUploadsEnabled: true },
+  }) as unknown as DiscussionChannel;
+
+// Captured slot props from the most recent render, so tests can read exposed
+// state and invoke the exposed methods.
+let slotProps: Record<string, unknown> = {};
+
+const mountWrapper = (props: Record<string, unknown> = {}) =>
+  mount(DiscussionRootCommentFormWrapper, {
+    props: { previousOffset: 0, discussionChannel: discussionChannel(), ...props },
+    slots: {
+      default: (p: Record<string, unknown>) => {
+        slotProps = p;
+        return createElement('div', [
+          createElement('button', {
+            class: 'create',
+            onClick: p.handleCreateComment as () => void,
+          }),
+          createElement('button', {
+            class: 'update',
+            onClick: () => (p.handleUpdateComment as (s: string) => void)('typed'),
+          }),
+          createElement('button', {
+            class: 'open',
+            onClick: p.openCommentEditor as () => void,
+          }),
+        ]);
+      },
+    },
+  });
+
+beforeEach(() => {
+  slotProps = {};
+  hh.username = ref('alice');
+  hh.getUserResult = ref({ users: [{ notifyOnReplyToCommentByDefault: false }] });
+  hh.createComment = vi.fn();
+  hh.mutationOptions = undefined;
+  hh.onDone = undefined;
+  hh.suspension = {
+    issueNumber: ref(null),
+    suspendedUntil: ref(null),
+    suspendedIndefinitely: ref(false),
+    channelId: ref(null),
+  };
+});
+
+describe('DiscussionRootCommentFormWrapper exposed state', () => {
+  it('exposes the create form values to the slot', () => {
+    mountWrapper();
+
+    expect(slotProps.createFormValues).toMatchObject({ isRootComment: true });
+  });
+
+  it('opens the comment editor via the exposed method', async () => {
+    const wrapper = mountWrapper();
+
+    await wrapper.get('.open').trigger('click');
+
+    expect(slotProps.commentEditorOpen).toBe(true);
+  });
+
+  it('updates the draft text via the exposed handler', async () => {
+    const wrapper = mountWrapper();
+
+    await wrapper.get('.update').trigger('click');
+
+    expect(hh.mutationOptions?.().variables).toMatchObject({
+      createCommentInput: [expect.objectContaining({ text: 'typed' })],
+    });
+  });
+});
+
+describe('DiscussionRootCommentFormWrapper createCommentInput', () => {
+  it('omits the subscription when the user opts out by default', () => {
+    mountWrapper();
+
+    const input = (hh.mutationOptions?.().variables as {
+      createCommentInput: { SubscribedToNotifications?: unknown }[];
+    }).createCommentInput[0];
+    expect(input.SubscribedToNotifications).toBeUndefined();
+  });
+
+  it('subscribes the author when their default preference is on', () => {
+    (hh.getUserResult as { value: unknown }).value = {
+      users: [{ notifyOnReplyToCommentByDefault: true }],
+    };
+    mountWrapper();
+
+    const input = (hh.mutationOptions?.().variables as {
+      createCommentInput: { SubscribedToNotifications?: unknown }[];
+    }).createCommentInput[0];
+    expect(input.SubscribedToNotifications).toBeDefined();
+  });
+});
+
+describe('DiscussionRootCommentFormWrapper handleCreateComment', () => {
+  it('runs the mutation when channel and user are present', async () => {
+    const wrapper = mountWrapper();
+
+    await wrapper.get('.create').trigger('click');
+
+    expect(hh.createComment).toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no discussion channel', async () => {
+    const wrapper = mountWrapper({ discussionChannel: null });
+
+    await wrapper.get('.create').trigger('click');
+
+    expect(hh.createComment).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no logged-in user', async () => {
+    (hh.username as { value: string | null }).value = null;
+    const wrapper = mountWrapper();
+
+    await wrapper.get('.create').trigger('click');
+
+    expect(hh.createComment).not.toHaveBeenCalled();
+  });
+});
+
+describe('DiscussionRootCommentFormWrapper suspension notice', () => {
+  it('surfaces the suspension issue after a submit attempt', async () => {
+    (hh.suspension as { issueNumber: { value: number } }).issueNumber.value = 42;
+    const wrapper = mountWrapper();
+
+    await wrapper.get('.create').trigger('click');
+
+    expect(slotProps.suspensionIssueNumber).toBe(42);
+  });
+});
+
+describe('DiscussionRootCommentFormWrapper onDone', () => {
+  it('shows the saved notice and closes the editor on success', async () => {
+    const wrapper = mountWrapper();
+    await wrapper.get('.open').trigger('click');
+
+    hh.onDone?.({ errors: [] });
+    await wrapper.vm.$nextTick();
+
+    expect(slotProps.showSavedNotice).toBe(true);
+  });
+
+  it('does not reset state when the mutation returned errors', async () => {
+    const wrapper = mountWrapper();
+    await wrapper.get('.open').trigger('click');
+
+    hh.onDone?.({ errors: [{ message: 'nope' }] });
+    await wrapper.vm.$nextTick();
+
+    expect(slotProps.commentEditorOpen).toBe(true);
+  });
+});
+
+describe('DiscussionRootCommentFormWrapper cache update', () => {
+  const newComment = { id: 'c1', text: 'hi', CommentAuthor: {} };
+  const result = { data: { createComments: { comments: [newComment] } } };
+
+  const makeCache = (queryResult: unknown) => ({
+    writeFragment: vi.fn(() => ({ __ref: 'Comment:c1' })),
+    readQuery: vi.fn(() => queryResult),
+    writeQuery: vi.fn(),
+    modify: vi.fn(),
+    identify: vi.fn(() => 'id'),
+  });
+
+  it('prepends the new comment via writeQuery when the section is cached', () => {
+    mountWrapper();
+    const cache = makeCache({ getCommentSection: { Comments: [] } });
+
+    (hh.mutationOptions?.().update as (c: unknown, r: unknown) => void)(
+      cache,
+      result
+    );
+
+    expect(cache.writeQuery).toHaveBeenCalled();
+  });
+
+  it('falls back to cache.modify when the section is not cached', () => {
+    mountWrapper();
+    const cache = makeCache(null);
+
+    (hh.mutationOptions?.().update as (c: unknown, r: unknown) => void)(
+      cache,
+      result
+    );
+
+    expect(cache.modify).toHaveBeenCalled();
+  });
+});

--- a/components/discussion/form/DownloadEditForm.spec.ts
+++ b/components/discussion/form/DownloadEditForm.spec.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+import type { Discussion } from '@/__generated__/graphql';
+
+import DownloadEditForm from '@/components/discussion/form/DownloadEditForm.vue';
+
+const h = vi.hoisted(() => ({
+  username: { value: 'alice' as string | null },
+  createSignedStorageUrl: undefined as unknown,
+  createDownloadableFile: undefined as unknown,
+  updateMutate: undefined as unknown,
+  uploadLink: undefined as unknown,
+  onDoneCb: { fn: undefined as undefined | (() => void) },
+  callIndex: { n: 0 },
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => {
+    h.callIndex.n++;
+    if (h.callIndex.n === 1)
+      return { mutate: h.createSignedStorageUrl, error: ref(null) };
+    if (h.callIndex.n === 2)
+      return { mutate: h.createDownloadableFile, error: ref(null) };
+    return {
+      mutate: h.updateMutate,
+      error: ref(null),
+      onDone: (cb: () => void) => {
+        h.onDoneCb.fn = cb;
+      },
+    };
+  },
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => h.username,
+}));
+vi.mock('@/utils', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    uploadAndGetEmbeddedLink: (...a: unknown[]) =>
+      (h.uploadLink as (...x: unknown[]) => unknown)(...a),
+  };
+});
+
+const fileRecord = () => ({
+  id: 'f1',
+  fileName: 'model.stl',
+  url: 'http://files/model.stl',
+  kind: 'STL',
+  size: 1048576,
+  priceModel: 'FREE',
+  priceCents: 0,
+  priceCurrency: 'USD',
+  license: { id: 'mit' },
+});
+
+const makeDiscussion = (overrides: Record<string, unknown> = {}) =>
+  ({ id: 'd1', DownloadableFiles: [], ...overrides }) as unknown as Discussion;
+
+const stubs = {
+  FormRow: { template: '<div><slot name="content" /></div>' },
+  ErrorBanner: {
+    name: 'ErrorBanner',
+    props: ['text'],
+    template: '<div class="error-banner">{{ text }}</div>',
+  },
+  Notification: {
+    name: 'Notification',
+    props: ['show', 'title'],
+    emits: ['close-notification'],
+    template: '<div />',
+  },
+  DownloadLabelPicker: {
+    name: 'DownloadLabelPicker',
+    props: ['filterGroups', 'selectedLabels'],
+    emits: ['update:selected-labels'],
+    template: '<div />',
+  },
+};
+
+const mountForm = (props: Record<string, unknown> = {}) =>
+  mount(DownloadEditForm, {
+    props: { discussion: makeDiscussion(), ...props },
+    global: { stubs },
+  });
+
+const setFiles = async (
+  wrapper: ReturnType<typeof mount>,
+  selector: string,
+  files: File[]
+) => {
+  const el = wrapper.get(selector).element as HTMLInputElement;
+  Object.defineProperty(el, 'files', { value: files, configurable: true });
+  await wrapper.get(selector).trigger('change');
+  await flushPromises();
+};
+
+beforeEach(() => {
+  h.username.value = 'alice';
+  h.callIndex.n = 0;
+  h.onDoneCb.fn = undefined;
+  h.createSignedStorageUrl = vi.fn().mockResolvedValue({
+    data: { createSignedStorageURL: { url: 'https://signed' } },
+  });
+  h.createDownloadableFile = vi.fn().mockResolvedValue({
+    data: {
+      createDownloadableFiles: {
+        downloadableFiles: [
+          {
+            id: 'new1',
+            fileName: 'new.stl',
+            url: 'http://files/new.stl',
+            kind: 'STL',
+            size: 2048,
+            priceModel: 'FREE',
+            priceCents: 0,
+            priceCurrency: 'USD',
+          },
+        ],
+      },
+    },
+  });
+  h.updateMutate = vi.fn().mockResolvedValue({});
+  h.uploadLink = vi.fn().mockResolvedValue('http://files/new.stl');
+});
+
+describe('DownloadEditForm rendering', () => {
+  it('shows the choose-file control when there are no files', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('Choose File');
+  });
+
+  it('shows a downloads-disabled state when the channel disables downloads', () => {
+    const wrapper = mountForm({ channelData: { downloadsEnabled: false } });
+
+    expect(wrapper.text()).toContain('Downloads Disabled');
+  });
+
+  it('lists files that already exist on the discussion', async () => {
+    const wrapper = mountForm({
+      discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('model.stl');
+  });
+
+  it('renders the label picker when the channel has filter groups', () => {
+    const wrapper = mountForm({
+      channelData: { FilterGroups: [{ id: 'g1' }] },
+    });
+
+    expect(wrapper.findComponent({ name: 'DownloadLabelPicker' }).exists()).toBe(
+      true
+    );
+  });
+});
+
+describe('DownloadEditForm file editing', () => {
+  it('removes a file and emits the updated form values', async () => {
+    const wrapper = mountForm({
+      discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),
+    });
+    await flushPromises();
+
+    await wrapper.get('button[title="Delete this file"]').trigger('click');
+
+    expect(
+      (wrapper.emitted('updateFormValues')?.at(-1)?.[0] as {
+        downloadableFiles: unknown[];
+      }).downloadableFiles
+    ).toHaveLength(0);
+  });
+
+  it('updates a file license and emits the change', async () => {
+    const wrapper = mountForm({
+      discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),
+    });
+    await flushPromises();
+
+    await wrapper.get('select').setValue('apache-2');
+
+    expect(
+      (
+        wrapper.emitted('updateFormValues')?.at(-1)?.[0] as {
+          downloadableFiles: { license: string }[];
+        }
+      ).downloadableFiles[0].license
+    ).toBe('apache-2');
+  });
+
+  it('updates a support field and emits the change', async () => {
+    const wrapper = mountForm({
+      discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),
+    });
+    await flushPromises();
+
+    await wrapper.get('textarea').setValue('Thanks for downloading');
+
+    expect(
+      (
+        wrapper.emitted('updateFormValues')?.at(-1)?.[0] as {
+          downloadableFiles: { attributionOverride: string }[];
+        }
+      ).downloadableFiles[0].attributionOverride
+    ).toBe('Thanks for downloading');
+  });
+});
+
+describe('DownloadEditForm upload', () => {
+  it('uploads a file and adds it to the form values', async () => {
+    const wrapper = mountForm();
+
+    await setFiles(wrapper, '#downloadable-file-input', [
+      new File(['x'], 'new.stl'),
+    ]);
+
+    expect(h.createDownloadableFile).toHaveBeenCalled();
+  });
+
+  it('emits the new file to the parent after upload', async () => {
+    const wrapper = mountForm();
+
+    await setFiles(wrapper, '#downloadable-file-input', [
+      new File(['x'], 'new.stl'),
+    ]);
+
+    expect(
+      (
+        wrapper.emitted('updateFormValues')?.at(-1)?.[0] as {
+          downloadableFiles: { id: string }[];
+        }
+      ).downloadableFiles.some((f) => f.id === 'new1')
+    ).toBe(true);
+  });
+
+  it('surfaces an error when the file is too large', async () => {
+    const wrapper = mountForm();
+    const bigFile = new File(['x'], 'big.stl');
+    Object.defineProperty(bigFile, 'size', { value: 5_000 * 1024 * 1024 });
+
+    await setFiles(wrapper, '#downloadable-file-input', [bigFile]);
+
+    expect(wrapper.find('.error-banner').exists()).toBe(true);
+  });
+});
+
+describe('DownloadEditForm save side effects', () => {
+  it('shows the saved notification in temp-id (create) mode', async () => {
+    const wrapper = mountForm({
+      discussion: makeDiscussion({
+        id: 'temp-id',
+        DownloadableFiles: [fileRecord()],
+      }),
+    });
+    await flushPromises();
+
+    await wrapper.get('button[title="Delete this file"]').trigger('click');
+
+    expect(
+      wrapper.getComponent({ name: 'Notification' }).props('show')
+    ).toBe(true);
+  });
+
+  it('closes the editor when the update mutation completes', () => {
+    const wrapper = mountForm();
+
+    h.onDoneCb.fn?.();
+
+    expect(wrapper.emitted('closeEditor')).toBeTruthy();
+  });
+
+  it('updates download labels from the label picker', async () => {
+    const wrapper = mountForm({
+      channelData: { FilterGroups: [{ id: 'g1' }] },
+    });
+
+    await wrapper
+      .getComponent({ name: 'DownloadLabelPicker' })
+      .vm.$emit('update:selected-labels', { g1: ['a'] });
+
+    expect(
+      (
+        wrapper.emitted('updateFormValues')?.at(-1)?.[0] as {
+          downloadLabels: Record<string, string[]>;
+        }
+      ).downloadLabels
+    ).toEqual({ g1: ['a'] });
+  });
+});

--- a/components/discussion/list/SearchDiscussions.spec.ts
+++ b/components/discussion/list/SearchDiscussions.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { reactive, ref, nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import SearchDiscussions from '@/components/discussion/list/SearchDiscussions.vue';
+
+// Drive the router/route ourselves. The global tests/setup.ts mock of nuxt/app
+// has no router.replace (which this component calls), so override it per-file
+// with a reactive route we can mutate to exercise the query-mutation branches
+// and the watchers.
+const nuxt = vi.hoisted(() => ({
+  route: { params: {}, query: {} },
+  replace: vi.fn(),
+  push: vi.fn(),
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => nuxt.route,
+  useRouter: () => ({ replace: nuxt.replace, push: nuxt.push }),
+  useState: <T>(_k: string, init?: () => T) => ref(init ? init() : undefined),
+  useNuxtApp: () => ({ $apollo: { default: { query: vi.fn() } } }),
+  navigateTo: vi.fn(),
+  useRuntimeConfig: () => ({ public: {} }),
+}));
+
+const childStub = (name: string, props: string[] = []) => ({
+  name,
+  props,
+  template: '<div><slot /></div>',
+});
+
+const mountSearch = (props: Record<string, unknown> = {}) =>
+  mount(SearchDiscussions, {
+    props,
+    global: {
+      stubs: {
+        SitewideDiscussionList: childStub('SitewideDiscussionList'),
+        ChannelDiscussionList: childStub('ChannelDiscussionList', [
+          'channelId',
+          'searchInput',
+          'selectedTags',
+          'selectedChannels',
+        ]),
+        DiscussionFilterBar: childStub('DiscussionFilterBar', ['isForumScoped']),
+      },
+    },
+  });
+
+const lastReplaceQuery = () => nuxt.replace.mock.calls.at(-1)?.[0]?.query;
+
+beforeEach(() => {
+  nuxt.route = reactive({ params: {}, query: {} });
+  nuxt.replace.mockReset();
+  nuxt.push.mockReset();
+});
+
+describe('SearchDiscussions rendering', () => {
+  it('renders the sitewide list when not forum-scoped', () => {
+    const wrapper = mountSearch({ isForumScoped: false });
+
+    expect(
+      wrapper.findComponent({ name: 'SitewideDiscussionList' }).exists()
+    ).toBe(true);
+  });
+
+  it('renders the channel list when forum-scoped', () => {
+    const wrapper = mountSearch({ isForumScoped: true });
+
+    expect(
+      wrapper.findComponent({ name: 'ChannelDiscussionList' }).exists()
+    ).toBe(true);
+  });
+
+  it('seeds channelId from the forumId route param', () => {
+    nuxt.route = reactive({ params: { forumId: 'cats' }, query: {} });
+    const wrapper = mountSearch({ isForumScoped: true });
+
+    expect(
+      wrapper.findComponent({ name: 'ChannelDiscussionList' }).props('channelId')
+    ).toBe('cats');
+  });
+});
+
+describe('SearchDiscussions tag filtering', () => {
+  const clickTag = async (wrapper: ReturnType<typeof mount>, tag: string) => {
+    await wrapper
+      .findComponent({ name: 'SitewideDiscussionList' })
+      .vm.$emit('filter-by-tag', tag);
+  };
+
+  it('adds a tag to the query when not already filtering by it', async () => {
+    const wrapper = mountSearch();
+
+    await clickTag(wrapper, 'vue');
+
+    expect(lastReplaceQuery().tags).toEqual(['vue']);
+  });
+
+  it('clears the tag when it is the only active tag', async () => {
+    nuxt.route = reactive({ params: {}, query: { tags: 'vue' } });
+    const wrapper = mountSearch();
+
+    await clickTag(wrapper, 'vue');
+
+    expect(lastReplaceQuery().tags).toBeUndefined();
+  });
+
+  it('removes only the clicked tag when several are active', async () => {
+    nuxt.route = reactive({ params: {}, query: { tags: ['vue', 'nuxt'] } });
+    const wrapper = mountSearch();
+
+    await clickTag(wrapper, 'vue');
+
+    expect(lastReplaceQuery().tags).toEqual(['nuxt']);
+  });
+});
+
+describe('SearchDiscussions channel filtering', () => {
+  const clickChannel = async (
+    wrapper: ReturnType<typeof mount>,
+    channel: string
+  ) => {
+    await wrapper
+      .findComponent({ name: 'SitewideDiscussionList' })
+      .vm.$emit('filter-by-channel', channel);
+  };
+
+  it('adds a channel to the query when not already filtering by it', async () => {
+    const wrapper = mountSearch();
+
+    await clickChannel(wrapper, 'cats');
+
+    expect(lastReplaceQuery().channels).toEqual(['cats']);
+  });
+
+  it('clears the channel when it is the only active channel', async () => {
+    nuxt.route = reactive({ params: {}, query: { channels: 'cats' } });
+    const wrapper = mountSearch();
+
+    await clickChannel(wrapper, 'cats');
+
+    expect(lastReplaceQuery().channels).toBeUndefined();
+  });
+
+  it('removes only the clicked channel when several are active', async () => {
+    nuxt.route = reactive({ params: {}, query: { channels: ['cats', 'dogs'] } });
+    const wrapper = mountSearch();
+
+    await clickChannel(wrapper, 'cats');
+
+    expect(lastReplaceQuery().channels).toEqual(['dogs']);
+  });
+});
+
+describe('SearchDiscussions route watchers', () => {
+  it('updates channelId when the forumId route param changes', async () => {
+    const wrapper = mountSearch({ isForumScoped: true });
+
+    nuxt.route.params.forumId = 'dogs';
+    await nextTick();
+
+    expect(
+      wrapper.findComponent({ name: 'ChannelDiscussionList' }).props('channelId')
+    ).toBe('dogs');
+  });
+
+  it('recomputes filter values when the query changes', async () => {
+    const wrapper = mountSearch({ isForumScoped: true });
+
+    nuxt.route.query = { tags: ['vue'] };
+    await nextTick();
+
+    expect(
+      wrapper
+        .findComponent({ name: 'ChannelDiscussionList' })
+        .props('selectedTags')
+    ).toEqual(['vue']);
+  });
+});

--- a/components/download/form/CreateDownload.spec.ts
+++ b/components/download/form/CreateDownload.spec.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, reactive } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import CreateDownload from '@/components/download/form/CreateDownload.vue';
+
+const h = vi.hoisted(() => ({
+  username: null as unknown,
+  channelResult: null as unknown,
+  channelLoading: null as unknown,
+  createDownload: null as unknown,
+  updateLabels: null as unknown,
+  updateDiscussion: null as unknown,
+  updateSupport: null as unknown,
+  onDone: undefined as undefined | ((r: unknown) => void),
+  push: null as unknown,
+  route: null as unknown,
+  callIndex: { n: 0 },
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.channelResult, loading: h.channelLoading }),
+  useMutation: () => {
+    h.callIndex.n++;
+    if (h.callIndex.n === 1)
+      return {
+        mutate: h.createDownload,
+        loading: ref(false),
+        error: ref(null),
+        onDone: (cb: (r: unknown) => void) => {
+          h.onDone = cb;
+        },
+      };
+    if (h.callIndex.n === 2)
+      return { mutate: h.updateLabels, loading: ref(false), error: ref(null) };
+    if (h.callIndex.n === 3)
+      return { mutate: h.updateDiscussion, loading: ref(false), error: ref(null) };
+    return { mutate: h.updateSupport, loading: ref(false), error: ref(null) };
+  },
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => h.route,
+  useRouter: () => ({ push: h.push }),
+}));
+vi.mock('@/composables/useAuthState', () => ({ useUsername: () => h.username }));
+
+const fieldsStub = {
+  name: 'CreateEditDiscussionFields',
+  props: ['formValues', 'channelData', 'createDiscussionLoading', 'downloadMode'],
+  emits: ['submit', 'update-form-values'],
+  template: '<div />',
+};
+
+const mountCreate = () =>
+  mount(CreateDownload, {
+    global: {
+      stubs: {
+        CreateEditDiscussionFields: fieldsStub,
+        ErrorBanner: {
+          name: 'ErrorBanner',
+          props: ['text'],
+          template: '<div class="error-banner">{{ text }}</div>',
+        },
+      },
+    },
+  });
+
+const fields = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.getComponent({ name: 'CreateEditDiscussionFields' });
+
+const submit = async (
+  wrapper: ReturnType<typeof mount>,
+  values: Record<string, unknown> = {}
+) => {
+  if (Object.keys(values).length) {
+    await fields(wrapper).vm.$emit('update-form-values', values);
+  }
+  await fields(wrapper).vm.$emit('submit');
+  await flushPromises();
+};
+
+beforeEach(() => {
+  h.username = ref('alice');
+  h.channelResult = ref({
+    channels: [{ downloadsEnabled: true, FilterGroups: [] }],
+  });
+  h.channelLoading = ref(false);
+  h.createDownload = vi.fn().mockResolvedValue({});
+  h.updateLabels = vi.fn().mockResolvedValue({});
+  h.updateDiscussion = vi.fn().mockResolvedValue({});
+  h.updateSupport = vi.fn().mockResolvedValue({});
+  h.push = vi.fn();
+  h.onDone = undefined;
+  h.callIndex.n = 0;
+  h.route = reactive({ params: { forumId: 'cats' } });
+});
+
+describe('CreateDownload rendering', () => {
+  it('shows a loading message while the channel query is in flight', () => {
+    (h.channelLoading as { value: boolean }).value = true;
+    const wrapper = mountCreate();
+
+    expect(wrapper.text()).toContain('Loading channel data');
+  });
+
+  it('passes channel data to the form fields', () => {
+    const wrapper = mountCreate();
+
+    expect(fields(wrapper).props('channelData')).toMatchObject({
+      downloadsEnabled: true,
+    });
+  });
+
+  it('seeds the selected channel from the forumId route param', () => {
+    const wrapper = mountCreate();
+
+    expect(
+      (fields(wrapper).props('formValues') as { selectedChannels: string[] })
+        .selectedChannels
+    ).toEqual(['cats']);
+  });
+});
+
+describe('CreateDownload submit', () => {
+  it('blocks submission when downloads are disabled', async () => {
+    (h.channelResult as { value: unknown }).value = {
+      channels: [{ downloadsEnabled: false }],
+    };
+    const wrapper = mountCreate();
+
+    await submit(wrapper, { title: 'T' });
+
+    expect(h.createDownload).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error banner when downloads are disabled', async () => {
+    (h.channelResult as { value: unknown }).value = {
+      channels: [{ downloadsEnabled: false }],
+    };
+    const wrapper = mountCreate();
+
+    await submit(wrapper, { title: 'T' });
+
+    expect(wrapper.find('.error-banner').exists()).toBe(true);
+  });
+
+  it('creates the download with the entered title', async () => {
+    const wrapper = mountCreate();
+
+    await submit(wrapper, { title: 'My Model' });
+
+    expect(
+      (h.createDownload as ReturnType<typeof vi.fn>).mock.calls[0][0].input[0]
+        .discussionCreateInput.title
+    ).toBe('My Model');
+  });
+
+  it('connects downloadable files that have ids', async () => {
+    const wrapper = mountCreate();
+
+    await submit(wrapper, {
+      title: 'T',
+      downloadableFiles: [{ id: 'f1' }, { id: '' }],
+    });
+
+    expect(
+      (h.createDownload as ReturnType<typeof vi.fn>).mock.calls[0][0].input[0]
+        .discussionCreateInput.DownloadableFiles.connect
+    ).toHaveLength(1);
+  });
+});
+
+describe('CreateDownload onDone follow-ups', () => {
+  const respond = (id = 'newD') => ({
+    data: { createDiscussionWithChannelConnections: { id } },
+  });
+
+  it('navigates to the new download page on success', async () => {
+    const wrapper = mountCreate();
+    await submit(wrapper, { title: 'T' });
+
+    await h.onDone?.(respond());
+    await flushPromises();
+
+    expect(h.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ discussionId: 'newD' }),
+      })
+    );
+  });
+
+  it('does not navigate when the response has no discussion id', async () => {
+    const wrapper = mountCreate();
+    await submit(wrapper, { title: 'T' });
+
+    await h.onDone?.({ data: {} });
+    await flushPromises();
+
+    expect(h.push).not.toHaveBeenCalled();
+  });
+
+  it('creates the album when images were attached', async () => {
+    const wrapper = mountCreate();
+    await submit(wrapper, {
+      title: 'T',
+      album: { images: [{ id: 'img1' }], imageOrder: ['img1'] },
+    });
+
+    await h.onDone?.(respond());
+    await flushPromises();
+
+    expect(h.updateDiscussion).toHaveBeenCalled();
+  });
+
+  it('saves download labels mapped to filter-option ids', async () => {
+    (h.channelResult as { value: unknown }).value = {
+      channels: [
+        {
+          downloadsEnabled: true,
+          FilterGroups: [
+            { key: 'color', options: [{ value: 'red', id: 'opt-red' }] },
+          ],
+        },
+      ],
+    };
+    const wrapper = mountCreate();
+    await submit(wrapper, { title: 'T', downloadLabels: { color: ['red'] } });
+
+    await h.onDone?.(respond());
+    await flushPromises();
+
+    expect(h.updateLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ labelOptionIds: ['opt-red'] })
+    );
+  });
+
+  it('saves support settings for files with ids', async () => {
+    const wrapper = mountCreate();
+    await submit(wrapper, {
+      title: 'T',
+      downloadableFiles: [{ id: 'f1', supportPatreonUrl: 'p' }],
+    });
+
+    await h.onDone?.(respond());
+    await flushPromises();
+
+    expect(h.updateSupport).toHaveBeenCalled();
+  });
+});
+
+describe('CreateDownload form updates', () => {
+  it('merges emitted form values into the current form state', async () => {
+    const wrapper = mountCreate();
+
+    await fields(wrapper).vm.$emit('update-form-values', { title: 'Edited' });
+
+    expect(
+      (fields(wrapper).props('formValues') as { title: string }).title
+    ).toBe('Edited');
+  });
+});

--- a/components/event/form/OccurrencesList.spec.ts
+++ b/components/event/form/OccurrencesList.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import OccurrencesList from '@/components/event/form/OccurrencesList.vue';
+import type { DateOccurrence } from '@/types/Event';
+
+const occ = (startTime: string, endTime: string) =>
+  ({ startTime, endTime }) as DateOccurrence;
+
+const pickerStub = (name: string) => ({
+  name,
+  props: ['testId', 'value', 'ariaLabel'],
+  emits: ['update'],
+  template: '<div />',
+});
+
+const mountList = (
+  occurrences: DateOccurrence[],
+  props: Record<string, unknown> = {}
+) =>
+  mount(OccurrencesList, {
+    props: { occurrences, ...props },
+    global: {
+      stubs: {
+        DatePicker: pickerStub('DatePicker'),
+        TimePicker: pickerStub('TimePicker'),
+      },
+    },
+  });
+
+const oneOccurrence = () => [
+  occ('2024-06-01T10:00:00Z', '2024-06-01T12:00:00Z'),
+];
+
+describe('OccurrencesList rendering', () => {
+  it('renders one date row per occurrence', () => {
+    const wrapper = mountList([
+      occ('2024-06-01T10:00:00Z', '2024-06-01T12:00:00Z'),
+      occ('2024-06-02T10:00:00Z', '2024-06-02T12:00:00Z'),
+    ]);
+
+    expect(wrapper.findAllComponents({ name: 'DatePicker' })).toHaveLength(2);
+  });
+
+  it('hides the time pickers when isAllDay is true', () => {
+    const wrapper = mountList(oneOccurrence(), { isAllDay: true });
+
+    expect(wrapper.findAllComponents({ name: 'TimePicker' })).toHaveLength(0);
+  });
+
+  it('shows start and end time pickers when not all-day', () => {
+    const wrapper = mountList(oneOccurrence());
+
+    expect(wrapper.findAllComponents({ name: 'TimePicker' })).toHaveLength(2);
+  });
+
+  it('passes a formatted yyyy-MM-dd value to the date picker', () => {
+    const wrapper = mountList(oneOccurrence());
+
+    expect(
+      wrapper.getComponent({ name: 'DatePicker' }).props('value')
+    ).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('passes an empty date value when the start time is invalid', () => {
+    const wrapper = mountList([occ('not-a-date', 'also-bad')]);
+
+    expect(wrapper.getComponent({ name: 'DatePicker' }).props('value')).toBe('');
+  });
+});
+
+describe('OccurrencesList labels', () => {
+  it('renders a readable date label for a valid occurrence', () => {
+    const wrapper = mountList(oneOccurrence());
+
+    expect(wrapper.text()).toMatch(/\w{3}, \w{3} \d/);
+  });
+
+  it('falls back to a numbered label when the date is invalid', () => {
+    const wrapper = mountList([occ('garbage', 'garbage')]);
+
+    expect(wrapper.text()).toContain('Date 1');
+  });
+});
+
+describe('OccurrencesList editing', () => {
+  it('syncs both dates to the chosen day on a start-date change', async () => {
+    const wrapper = mountList(oneOccurrence());
+
+    await wrapper
+      .getComponent({ name: 'DatePicker' })
+      .vm.$emit('update', '2024-07-15');
+
+    const payload = wrapper.emitted('update')?.[0];
+    expect(payload?.[1]).toMatchObject({
+      startTime: expect.stringContaining('2024-07-15'),
+      endTime: expect.stringContaining('2024-07-15'),
+    });
+  });
+
+  it('updates the start time on a start-time change', async () => {
+    const wrapper = mountList(oneOccurrence());
+
+    await wrapper
+      .findAllComponents({ name: 'TimePicker' })[0]
+      .vm.$emit('update', '14:30');
+
+    expect((wrapper.emitted('update')?.[0]?.[1] as DateOccurrence).startTime).toContain(
+      'T14:30'
+    );
+  });
+
+  it('updates the end time on an end-time change', async () => {
+    const wrapper = mountList(oneOccurrence());
+
+    await wrapper
+      .findAllComponents({ name: 'TimePicker' })[1]
+      .vm.$emit('update', '16:45');
+
+    expect((wrapper.emitted('update')?.[0]?.[1] as DateOccurrence).endTime).toContain(
+      'T16:45'
+    );
+  });
+
+  it('ignores a start-date change when the new date is invalid', async () => {
+    const wrapper = mountList(oneOccurrence());
+
+    await wrapper
+      .getComponent({ name: 'DatePicker' })
+      .vm.$emit('update', 'not-a-date');
+
+    expect(wrapper.emitted('update')).toBeUndefined();
+  });
+});
+
+describe('OccurrencesList add / remove', () => {
+  it('emits add with default start and end times', async () => {
+    const wrapper = mountList(oneOccurrence());
+
+    await wrapper.get('[data-testid="add-occurrence-button"]').trigger('click');
+
+    expect(wrapper.emitted('add')?.[0]?.[0]).toHaveProperty('startTime');
+  });
+
+  it('emits remove with the occurrence index', async () => {
+    const wrapper = mountList([
+      occ('2024-06-01T10:00:00Z', '2024-06-01T12:00:00Z'),
+      occ('2024-06-02T10:00:00Z', '2024-06-02T12:00:00Z'),
+    ]);
+
+    await wrapper.get('[data-testid="remove-occurrence-1"]').trigger('click');
+
+    expect(wrapper.emitted('remove')?.[0]).toEqual([1]);
+  });
+
+  it('hides the remove button when only one occurrence remains', () => {
+    const wrapper = mountList(oneOccurrence());
+
+    expect(wrapper.find('[data-testid="remove-occurrence-0"]').exists()).toBe(
+      false
+    );
+  });
+});

--- a/components/nav/CreateAnythingButton.spec.ts
+++ b/components/nav/CreateAnythingButton.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import CreateAnythingButton from '@/components/nav/CreateAnythingButton.vue';
+
+// Per-file nuxt/app mock: controllable route + a router.push spy for the menu
+// item actions. The global mock works too but we need to vary route here.
+const nuxt = vi.hoisted(() => ({
+  route: { params: {}, query: {}, name: 'home' },
+  push: vi.fn(),
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => nuxt.route,
+  useRouter: () => ({ push: nuxt.push }),
+  useState: <T>(_k: string, init?: () => T) => ref(init ? init() : undefined),
+  useNuxtApp: () => ({ $apollo: { default: { query: vi.fn() } } }),
+}));
+
+// Stub RequireAuth to render whichever slot we want, so we can exercise both the
+// authenticated menu and the unauthenticated placeholder without real auth.
+const requireAuthStub = (slot: 'has-auth' | 'does-not-have-auth') => ({
+  name: 'RequireAuth',
+  template: `<div><slot name="${slot}" /></div>`,
+});
+
+// Vuetify + client-only stubs. VMenu renders its default slot (the list) so the
+// menu items mount; VListItem becomes a button that forwards click + data-testid.
+const vuetifyStubs = {
+  ClientOnly: { template: '<div><slot /></div>' },
+  VMenu: { template: '<div><slot /></div>' },
+  VList: { template: '<div><slot /></div>' },
+  VListItem: {
+    inheritAttrs: false,
+    template: '<button v-bind="$attrs"><slot /></button>',
+  },
+  VTooltip: { name: 'VTooltip', template: '<div><slot /></div>' },
+  ChevronDownIcon: true,
+};
+
+const mountButton = (
+  slot: 'has-auth' | 'does-not-have-auth',
+  props: Record<string, unknown> = {}
+) =>
+  mount(CreateAnythingButton, {
+    props,
+    global: {
+      stubs: { RequireAuth: requireAuthStub(slot), ...vuetifyStubs },
+    },
+  });
+
+beforeEach(() => {
+  nuxt.route = { params: {}, query: {}, name: 'home' };
+  nuxt.push.mockReset();
+});
+
+describe('CreateAnythingButton classes', () => {
+  it('uses the round icon-only style when iconOnly is set', () => {
+    const wrapper = mountButton('does-not-have-auth', { iconOnly: true });
+
+    expect(wrapper.get('button').classes()).toContain('rounded-full');
+  });
+
+  it('shows "Create" wording when usePrimaryButton is set', () => {
+    const wrapper = mountButton('does-not-have-auth', { usePrimaryButton: true });
+
+    expect(wrapper.get('button').text()).toContain('Create');
+  });
+
+  it('applies the light background style by default', () => {
+    const wrapper = mountButton('does-not-have-auth');
+
+    expect(wrapper.get('button').classes()).toContain('bg-white');
+  });
+
+  it('applies the dark background style when backgroundColor is dark', () => {
+    const wrapper = mountButton('does-not-have-auth', {
+      backgroundColor: 'dark',
+    });
+
+    expect(wrapper.get('button').classes()).toContain('bg-gray-800');
+  });
+});
+
+describe('CreateAnythingButton menu actions (sitewide)', () => {
+  it('navigates to the global discussion create page', async () => {
+    const wrapper = mountButton('has-auth');
+
+    await wrapper.get('[data-testid="create-discussion-menu-item"]').trigger('click');
+
+    expect(nuxt.push).toHaveBeenCalledWith('/discussions/create');
+  });
+
+  it('navigates to the global event create page', async () => {
+    const wrapper = mountButton('has-auth');
+
+    await wrapper.get('[data-testid="create-event-menu-item"]').trigger('click');
+
+    expect(nuxt.push).toHaveBeenCalledWith('/events/create');
+  });
+
+  it('navigates to the forum create page', async () => {
+    const wrapper = mountButton('has-auth');
+
+    await wrapper.get('[data-testid="create-channel-menu-item"]').trigger('click');
+
+    expect(nuxt.push).toHaveBeenCalledWith('/forums/create');
+  });
+});
+
+describe('CreateAnythingButton menu actions (forum-scoped)', () => {
+  beforeEach(() => {
+    nuxt.route = { params: { forumId: 'cats' }, query: {}, name: 'forum' };
+  });
+
+  it('scopes the discussion create route to the current forum', async () => {
+    const wrapper = mountButton('has-auth');
+
+    await wrapper.get('[data-testid="create-discussion-menu-item"]').trigger('click');
+
+    expect(nuxt.push).toHaveBeenCalledWith('/forums/cats/discussions/create');
+  });
+
+  it('scopes the event create route to the current forum', async () => {
+    const wrapper = mountButton('has-auth');
+
+    await wrapper.get('[data-testid="create-event-menu-item"]').trigger('click');
+
+    expect(nuxt.push).toHaveBeenCalledWith('/forums/cats/events/create');
+  });
+});
+
+describe('CreateAnythingButton footer tooltip', () => {
+  it('shows the tooltip when the route is not a map view', () => {
+    nuxt.route = { params: {}, query: {}, name: 'forums-home' };
+    const wrapper = mountButton('does-not-have-auth');
+
+    expect(wrapper.findComponent({ name: 'VTooltip' }).exists()).toBe(true);
+  });
+
+  it('hides the tooltip on map routes', () => {
+    nuxt.route = { params: {}, query: {}, name: 'forums-map' };
+    const wrapper = mountButton('does-not-have-auth');
+
+    expect(wrapper.findComponent({ name: 'VTooltip' }).exists()).toBe(false);
+  });
+});

--- a/components/nav/SiteSidenav.spec.ts
+++ b/components/nav/SiteSidenav.spec.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import SiteSidenav from '@/components/nav/SiteSidenav.vue';
+
+const h = vi.hoisted(() => ({
+  push: null as unknown,
+  setSideNavIsOpenVar: null as unknown,
+  username: null as unknown,
+  isAuth: null as unknown,
+  getUserResult: null as unknown,
+}));
+
+vi.mock('nuxt/app', () => ({ useRouter: () => ({ push: h.push }) }));
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.getUserResult }),
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => h.username,
+  useIsAuthenticated: () => h.isAuth,
+}));
+vi.mock('@/cache', () => ({
+  setSideNavIsOpenVar: (...a: unknown[]) =>
+    (h.setSideNavIsOpenVar as (...x: unknown[]) => unknown)(...a),
+}));
+vi.mock('@/utils/localStorageUtils', () => ({ getLocalStorageItem: () => [] }));
+
+const mountNav = (props: Record<string, unknown> = {}) =>
+  mount(SiteSidenav, {
+    props: { showDropdown: true, ...props },
+    global: {
+      directives: { 'click-outside': {} },
+      stubs: {
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+        RequireAuth: {
+          template: '<div><slot name="does-not-have-auth" /></div>',
+        },
+        SiteSidenavLogout: { template: '<div />' },
+        AvatarComponent: { template: '<div />' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  h.push = vi.fn().mockResolvedValue(undefined);
+  h.setSideNavIsOpenVar = vi.fn();
+  h.username = ref('alice');
+  h.isAuth = ref(true);
+  h.getUserResult = ref({ users: [{ profilePicURL: 'pic.png' }] });
+});
+
+describe('SiteSidenav visibility', () => {
+  it('renders nothing when the dropdown is closed', () => {
+    const wrapper = mountNav({ showDropdown: false });
+
+    expect(wrapper.text().trim()).toBe('');
+  });
+
+  it('renders the panel when the dropdown is open', () => {
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).toContain('Search');
+  });
+});
+
+describe('SiteSidenav navigation', () => {
+  it('navigates and closes the nav when a primary link is clicked', async () => {
+    const wrapper = mountNav();
+
+    await wrapper.get('[data-testid="nav-link-Discussions"]').trigger('click');
+
+    expect(h.push).toHaveBeenCalledWith({ name: 'discussions' });
+  });
+
+  it('closes the side nav after navigating', async () => {
+    const wrapper = mountNav();
+
+    await wrapper.get('[data-testid="nav-link-Discussions"]').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(h.setSideNavIsOpenVar).toHaveBeenCalledWith(false);
+  });
+
+  it('emits close when the close button is pressed', async () => {
+    const wrapper = mountNav();
+
+    await wrapper.get('button').trigger('click');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});
+
+describe('SiteSidenav search', () => {
+  const searchButton = (wrapper: ReturnType<typeof mount>) =>
+    wrapper.findAll('button').find((b) => b.text() === 'Search');
+
+  it('searches discussions by default', async () => {
+    const wrapper = mountNav();
+    await wrapper.get('input[type="text"]').setValue('hello');
+
+    await searchButton(wrapper)!.trigger('click');
+
+    expect(h.push).toHaveBeenCalledWith({
+      path: '/discussions',
+      query: { searchInput: 'hello', type: 'discussions', searchOpen: 'true' },
+    });
+  });
+
+  it('runs the search on Enter', async () => {
+    const wrapper = mountNav();
+    const input = wrapper.get('input[type="text"]');
+    await input.setValue('q');
+
+    await input.trigger('keydown.enter');
+
+    expect(h.push).toHaveBeenCalled();
+  });
+
+  it('omits searchInput from the query when the box is empty', async () => {
+    const wrapper = mountNav();
+
+    await searchButton(wrapper)!.trigger('click');
+
+    expect(h.push).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.objectContaining({ searchInput: undefined }) })
+    );
+  });
+
+  it('switches the search type and routes accordingly', async () => {
+    const wrapper = mountNav();
+    // open the type dropdown (the button showing the current label)
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Discussions')!
+      .trigger('click');
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Comments')!
+      .trigger('click');
+
+    await searchButton(wrapper)!.trigger('click');
+
+    expect(h.push).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/comments/search' })
+    );
+  });
+});
+
+describe('SiteSidenav auth links', () => {
+  it('shows profile and account links when authenticated', () => {
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).toContain('My Profile');
+  });
+
+  it('hides profile links when unauthenticated', () => {
+    (h.isAuth as { value: boolean }).value = false;
+    (h.username as { value: string }).value = '';
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).not.toContain('My Profile');
+  });
+
+  it('shows the Log In button when unauthenticated', () => {
+    (h.isAuth as { value: boolean }).value = false;
+    (h.username as { value: string }).value = '';
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).toContain('Log In');
+  });
+
+  it('always shows the Admin Dashboard link', () => {
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).toContain('Admin Dashboard');
+  });
+});

--- a/components/plugins/PluginPipelineEditor.spec.ts
+++ b/components/plugins/PluginPipelineEditor.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PluginPipelineEditor from '@/components/plugins/PluginPipelineEditor.vue';
+import type { PipelineConfig } from '@/utils/pipelineSchema';
+
+const plugins = [{ id: 'p1', name: 'Plugin One' }];
+
+const validConfig: PipelineConfig = {
+  pipelines: [
+    { event: 'downloadableFile.created', steps: [{ plugin: 'p1' }] },
+  ],
+};
+
+const editorStub = {
+  name: 'PipelineYamlEditor',
+  props: ['modelValue', 'errors'],
+  emits: ['parse', 'update:modelValue'],
+  template: '<div />',
+};
+
+const mountEditor = (props: Record<string, unknown> = {}) =>
+  mount(PluginPipelineEditor, {
+    props: { availablePlugins: plugins, ...props },
+    global: { stubs: { PipelineYamlEditor: editorStub } },
+  });
+
+const emitParse = (
+  wrapper: ReturnType<typeof mount>,
+  config: PipelineConfig | null,
+  error: string | null = null
+) => wrapper.getComponent({ name: 'PipelineYamlEditor' }).vm.$emit('parse', config, error);
+
+const saveButton = (wrapper: ReturnType<typeof mount>) => wrapper.get('button');
+
+describe('PluginPipelineEditor reference panels', () => {
+  it('lists the available plugins', () => {
+    const wrapper = mountEditor();
+
+    expect(wrapper.text()).toContain('Plugin One');
+  });
+
+  it('shows an empty-state message when no plugins are installed', () => {
+    const wrapper = mountEditor({ availablePlugins: [] });
+
+    expect(wrapper.text()).toContain('No plugins installed');
+  });
+
+  it('lists server events for the server scope', () => {
+    const wrapper = mountEditor({ scope: 'server' });
+
+    expect(wrapper.text()).toContain('downloadableFile.created');
+  });
+
+  it('lists channel events for the channel scope', () => {
+    const wrapper = mountEditor({ scope: 'channel' });
+
+    expect(wrapper.text()).toContain('discussionChannel.created');
+  });
+});
+
+describe('PluginPipelineEditor parsing and validation', () => {
+  it('marks unsaved changes after a successful parse', async () => {
+    const wrapper = mountEditor();
+
+    await emitParse(wrapper, validConfig);
+
+    expect(wrapper.text()).toContain('Unsaved changes');
+  });
+
+  it('enables saving when the parsed config is valid', async () => {
+    const wrapper = mountEditor();
+
+    await emitParse(wrapper, validConfig);
+
+    expect(saveButton(wrapper).attributes('disabled')).toBeUndefined();
+  });
+
+  it('disables saving when a step references an unknown plugin', async () => {
+    const wrapper = mountEditor();
+
+    await emitParse(wrapper, {
+      pipelines: [
+        { event: 'downloadableFile.created', steps: [{ plugin: 'ghost' }] },
+      ],
+    });
+
+    expect(saveButton(wrapper).attributes('disabled')).toBeDefined();
+  });
+
+  it('disables saving when the YAML fails to parse', async () => {
+    const wrapper = mountEditor();
+
+    await emitParse(wrapper, null, 'bad yaml');
+
+    expect(saveButton(wrapper).attributes('disabled')).toBeDefined();
+  });
+});
+
+describe('PluginPipelineEditor save', () => {
+  it('emits save with the parsed config', async () => {
+    const wrapper = mountEditor();
+    await emitParse(wrapper, validConfig);
+
+    await saveButton(wrapper).trigger('click');
+
+    expect(wrapper.emitted('save')?.[0]?.[0]).toEqual(validConfig);
+  });
+
+  it('clears the unsaved indicator after saving', async () => {
+    const wrapper = mountEditor();
+    await emitParse(wrapper, validConfig);
+
+    await saveButton(wrapper).trigger('click');
+
+    expect(wrapper.text()).not.toContain('Unsaved changes');
+  });
+});
+
+describe('PluginPipelineEditor initialConfig', () => {
+  it('loads an initial config without marking it unsaved', () => {
+    const wrapper = mountEditor({ initialConfig: validConfig });
+
+    expect(wrapper.text()).not.toContain('Unsaved changes');
+  });
+
+  it('enables saving immediately for a valid initial config', () => {
+    const wrapper = mountEditor({ initialConfig: validConfig });
+
+    expect(saveButton(wrapper).attributes('disabled')).toBeUndefined();
+  });
+
+  it('disables saving while a save is in progress', () => {
+    const wrapper = mountEditor({ initialConfig: validConfig, saving: true });
+
+    expect(saveButton(wrapper).attributes('disabled')).toBeDefined();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "coverage:e2e:build": "E2E_COVERAGE=true NITRO_PRESET=node-server VITE_E2E_MOCK_MODE=true VITE_GRAPHQL_URL=http://127.0.0.1:4100/graphql VITE_SERVER_NAME='Playwright Test Server' VITE_SENTRY_AUTH_TOKEN='' nuxt build",
     "coverage:e2e:collect": "E2E_COVERAGE=true playwright test --config playwright.build.config.ts",
     "coverage:e2e:report": "node --max-old-space-size=6144 tests/playwright/coverage/report.mjs",
+    "coverage:audit": "node scripts/coverage-audit.mjs",
     "knip": "knip",
     "tsc": "vue-tsc --noEmit",
     "verify": "npm run tsc && npm run test:unit:run",

--- a/scripts/coverage-audit.mjs
+++ b/scripts/coverage-audit.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Coverage audit + test-writing worklist.
+ *
+ * Refresh coverage first, then run this:
+ *   npm run coverage
+ *   node scripts/coverage-audit.mjs
+ *
+ * It reads coverage/lcov.info plus the component/spec layout on disk and prints:
+ *   1. Buckets       — where uncovered component lines actually live
+ *      (recoverable-behind-a-spec vs net-new work).
+ *   2. Recoverable   — components that HAVE a spec but still sit <25% covered
+ *      (usually a spec that never mounts the real component).
+ *   3. Worklist      — the highest-value net-new targets: components with no
+ *      related spec, ranked by uncovered lines, annotated with a rough
+ *      difficulty signal, and with heavy third-party-lib wrappers split out
+ *      (extract their logic into utils instead of mounting them).
+ *
+ * Flags: --all shows the full worklist instead of the top 25.
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { join, basename } from 'path';
+
+const ROOT = process.cwd();
+const LOW = 25; // line-% threshold below which a file is "barely covered"
+const TOP = process.argv.includes('--all') ? Infinity : 25;
+
+if (!existsSync('coverage/lcov.info')) {
+  console.error('coverage/lcov.info not found. Run `npm run coverage` first.');
+  process.exit(1);
+}
+
+// --- gather component .vue files and spec basenames -------------------------
+const walk = (dir, test, out = []) => {
+  for (const e of readdirSync(dir)) {
+    if (e === 'node_modules' || e.startsWith('.')) continue;
+    const p = join(dir, e);
+    statSync(p).isDirectory() ? walk(p, test, out) : test(e) && out.push(p);
+  }
+  return out;
+};
+const components = walk(join(ROOT, 'components'), (e) => e.endsWith('.vue')).map(
+  (p) => p.replace(ROOT + '/', '')
+);
+const specBasenames = new Set(
+  walk(ROOT, (e) => /\.(spec|test)\.ts$/.test(e)).map((p) => basename(p))
+);
+const hasRelatedSpec = (comp) => {
+  const n = basename(comp, '.vue');
+  for (const b of specBasenames) {
+    if (b === `${n}.spec.ts` || b === `${n}.test.ts` || b.startsWith(`${n}.`)) return true;
+  }
+  return false;
+};
+
+// --- per-file coverage from lcov --------------------------------------------
+const cov = {};
+for (const rec of readFileSync('coverage/lcov.info', 'utf8').split('end_of_record')) {
+  const m = rec.match(/SF:(.*)/);
+  if (!m) continue;
+  const lf = +(rec.match(/LF:(\d+)/) || [])[1] || 0;
+  const lh = +(rec.match(/LH:(\d+)/) || [])[1] || 0;
+  if (lf) cov[m[1].trim()] = { pct: Math.round((lh / lf) * 100), unc: lf - lh };
+}
+
+// --- testability signals from component source ------------------------------
+const HEAVY = [
+  ["three", 'three.js / WebGL'],
+  ['@google/model-viewer', '3D model-viewer'],
+  ['js-api-loader', 'Google Maps'],
+  ['@googlemaps', 'Google Maps'],
+  ['google.maps', 'Google Maps'],
+  ['lightgallery', 'lightgallery'],
+  ['chart.js', 'Chart.js canvas'],
+  ['vue-chartjs', 'Chart.js canvas'],
+  ['vuemoji-picker', 'emoji picker'],
+  ['monaco', 'Monaco editor'],
+  ['codemirror', 'CodeMirror'],
+  ['md-editor-v3', 'md-editor-v3'],
+];
+const signals = (comp) => {
+  const src = readFileSync(join(ROOT, comp), 'utf8');
+  const heavy = HEAVY.find(([pat]) => src.includes(pat));
+  let difficulty = 'pure-ish';
+  if (/useQuery|useMutation|@vue\/apollo-composable/.test(src)) difficulty = 'needs-apollo-mock';
+  else if (/useDisplay|from 'vuetify'/.test(src)) difficulty = 'needs-vuetify-stub';
+  return { heavy: heavy ? heavy[1] : null, difficulty };
+};
+
+// --- buckets ----------------------------------------------------------------
+const buckets = { specLow: [0, 0], specOk: [0, 0], noSpecLow: [0, 0], noSpecOk: [0, 0] };
+for (const c of components) {
+  const cc = cov[c] || { pct: 0, unc: 0 };
+  const key = (hasRelatedSpec(c) ? 'spec' : 'noSpec') + (cc.pct < LOW ? 'Low' : 'Ok');
+  buckets[key][0]++;
+  buckets[key][1] += cc.unc;
+}
+const fmt = (n) => String(n).padStart(5);
+console.log('=== Where uncovered component lines live ===');
+console.log('bucket                               | files | uncovered');
+console.log(`has spec  & <${LOW}% cov (RECOVERABLE)  | ${fmt(buckets.specLow[0])} | ${buckets.specLow[1]}`);
+console.log(`has spec  & >=${LOW}% cov              | ${fmt(buckets.specOk[0])} | ${buckets.specOk[1]}`);
+console.log(`NO spec   & <${LOW}% cov (NET-NEW)     | ${fmt(buckets.noSpecLow[0])} | ${buckets.noSpecLow[1]}`);
+console.log(`NO spec   & >=${LOW}% cov              | ${fmt(buckets.noSpecOk[0])} | ${buckets.noSpecOk[1]}`);
+
+// --- recoverable: have a spec but still barely covered ----------------------
+const recoverable = components
+  .filter((c) => hasRelatedSpec(c) && (cov[c]?.pct ?? 0) < LOW)
+  .sort((a, b) => (cov[b]?.unc ?? 0) - (cov[a]?.unc ?? 0));
+console.log(`\n=== Recoverable (spec exists but <${LOW}% — fix the spec) ===`);
+if (!recoverable.length) console.log('(none)');
+for (const c of recoverable) console.log(`${String(cov[c].pct).padStart(3)}% | ${String(cov[c].unc).padStart(4)} unc | ${c}`);
+
+// --- worklist: net-new targets ----------------------------------------------
+const candidates = components
+  .filter((c) => !hasRelatedSpec(c) && (cov[c]?.pct ?? 0) < LOW && (cov[c]?.unc ?? 0) > 0)
+  .map((c) => ({ comp: c, ...cov[c], ...signals(c) }))
+  .sort((a, b) => b.unc - a.unc);
+
+const mountable = candidates.filter((c) => !c.heavy);
+const heavyOnes = candidates.filter((c) => c.heavy);
+
+console.log(`\n=== WORKLIST: net-new mountable components (top ${TOP === Infinity ? 'all' : TOP} by uncovered) ===`);
+console.log('uncov | difficulty         | component');
+for (const c of mountable.slice(0, TOP)) {
+  console.log(`${String(c.unc).padStart(5)} | ${c.difficulty.padEnd(18)} | ${c.comp}`);
+}
+
+console.log(`\n=== Heavy 3rd-party wrappers (extract logic into utils; do NOT mount) ===`);
+for (const c of heavyOnes.slice(0, 15)) {
+  console.log(`${String(c.unc).padStart(5)} | ${c.heavy.padEnd(18)} | ${c.comp}`);
+}

--- a/tests/unit/utils/index.spec.ts
+++ b/tests/unit/utils/index.spec.ts
@@ -14,8 +14,21 @@ import {
   formatDuration,
   formatAbbreviatedDuration,
   uploadAndGetEmbeddedLink,
+  durationHoursAndMinutes,
+  getDurationObj,
+  compareDate,
+  getReadableTimeFromISO,
+  convertTimeToReadableFormat,
+  relativeTimeHoursAndMinutes,
+  updateTagsInCache,
+  getTimePieces,
+  getDatePieces,
+  relativeTime,
 } from '@/utils/index';
+import { DateTime } from 'luxon';
 import type { Duration } from 'luxon';
+import type { ApolloCache } from '@apollo/client/core';
+import type { Event, Tag as TagData } from '@/__generated__/graphql';
 
 describe('isFileSizeValid', () => {
   it('returns valid for file under 5MB', () => {
@@ -679,5 +692,172 @@ describe('uploadAndGetEmbeddedLink', () => {
 
     expect(result).toContain('my%20file.jpg');
     expect(result).not.toContain('my file.jpg');
+  });
+});
+
+describe('durationHoursAndMinutes', () => {
+  // start/end use UTC instants, so the resulting duration is timezone-independent.
+  it.each([
+    ['2024-01-01T10:00:00Z', '2024-01-01T10:30:00Z', 'for 30 minutes'],
+    ['2024-01-01T10:00:00Z', '2024-01-01T11:00:00Z', 'for 1 hour'],
+    ['2024-01-01T10:00:00Z', '2024-01-01T12:00:00Z', 'for 2 hours'],
+    ['2024-01-01T10:00:00Z', '2024-01-01T11:30:00Z', 'for 1 hour and 30 minutes'],
+    ['2024-01-01T10:00:00Z', '2024-01-01T12:15:00Z', 'for 2 hours and 15 minutes'],
+  ])('formats %s -> %s as "%s"', (start, end, expected) => {
+    expect(durationHoursAndMinutes(start, end)).toBe(expected);
+  });
+
+  it('reports zero-length intervals as "for 0 minutes"', () => {
+    expect(
+      durationHoursAndMinutes('2024-01-01T10:00:00Z', '2024-01-01T10:00:00Z')
+    ).toBe('for 0 minutes');
+  });
+});
+
+describe('getDurationObj', () => {
+  it('returns the interval as an { hours, minutes } object', () => {
+    expect(
+      getDurationObj('2024-01-01T10:00:00Z', '2024-01-01T12:30:00Z')
+    ).toEqual({ hours: 2, minutes: 30 });
+  });
+});
+
+describe('compareDate', () => {
+  const eventAt = (startTime: string) =>
+    ({ startTime }) as unknown as Event;
+
+  it.each([
+    ['2024-01-01T10:00:00Z', '2024-01-02T10:00:00Z', -1],
+    ['2024-01-02T10:00:00Z', '2024-01-01T10:00:00Z', 1],
+    ['2024-01-01T10:00:00Z', '2024-01-01T10:00:00Z', 0],
+  ])('compares %s vs %s -> %i', (a, b, expected) => {
+    expect(compareDate(eventAt(a), eventAt(b))).toBe(expected);
+  });
+});
+
+describe('getReadableTimeFromISO', () => {
+  it('renders an ISO timestamp as a simple clock time', () => {
+    expect(getReadableTimeFromISO('2024-01-01T13:30:00Z')).toMatch(
+      /\d{1,2}:\d{2}/
+    );
+  });
+});
+
+describe('convertTimeToReadableFormat', () => {
+  it('renders an ISO timestamp as a simple clock time', () => {
+    expect(convertTimeToReadableFormat('2024-01-01T09:05:00Z')).toMatch(
+      /\d{1,2}:\d{2}/
+    );
+  });
+});
+
+describe('relativeTimeHoursAndMinutes', () => {
+  it('returns a past date as a relative "ago" string', () => {
+    expect(relativeTimeHoursAndMinutes('2000-01-01T00:00:00Z')).toContain(
+      'ago'
+    );
+  });
+});
+
+describe('updateTagsInCache', () => {
+  type FieldRef = { __ref: string; text: string };
+
+  // Builds a minimal Apollo cache stub that captures the value returned by the
+  // `tags` field policy so we can assert the merge/de-dup behavior directly.
+  const buildCache = (existingRefs: FieldRef[]) => {
+    const writeFragment = vi.fn(
+      ({ data }: { data: TagData }) =>
+        ({ __ref: `Tags:${data.text}`, text: data.text }) as FieldRef
+    );
+    let merged: FieldRef[] | undefined;
+    const cache = {
+      writeFragment,
+      modify: ({
+        fields,
+      }: {
+        fields: {
+          tags: (
+            existing: FieldRef[] | undefined,
+            helpers: { readField: (f: string, ref: FieldRef) => unknown }
+          ) => FieldRef[];
+        };
+      }) => {
+        merged = fields.tags(existingRefs, {
+          readField: (field, ref) => ref[field as keyof FieldRef],
+        });
+      },
+    } as unknown as ApolloCache<unknown>;
+    return { cache, writeFragment, getMerged: () => merged };
+  };
+
+  it('appends a new tag ahead of the existing refs', () => {
+    const existing: FieldRef[] = [{ __ref: 'Tags:old', text: 'old' }];
+    const { cache, getMerged } = buildCache(existing);
+
+    updateTagsInCache(cache, [{ text: 'new' }] as TagData[]);
+
+    expect(getMerged()).toEqual([
+      { __ref: 'Tags:new', text: 'new' },
+      { __ref: 'Tags:old', text: 'old' },
+    ]);
+  });
+
+  it('does not duplicate a tag that already exists in the cache', () => {
+    const existing: FieldRef[] = [{ __ref: 'Tags:dup', text: 'dup' }];
+    const { cache, getMerged } = buildCache(existing);
+
+    updateTagsInCache(cache, [{ text: 'dup' }] as TagData[]);
+
+    expect(getMerged()).toEqual([{ __ref: 'Tags:dup', text: 'dup' }]);
+  });
+
+  it('writes a fragment for every updated tag', () => {
+    const { cache, writeFragment } = buildCache([]);
+
+    updateTagsInCache(cache, [{ text: 'a' }, { text: 'b' }] as TagData[]);
+
+    expect(writeFragment).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getTimePieces', () => {
+  it('breaks a DateTime into stringified calendar/clock pieces', () => {
+    const dt = DateTime.fromObject(
+      { year: 2024, month: 3, day: 5, hour: 14 },
+      { zone: 'utc' }
+    );
+
+    expect(getTimePieces(dt)).toEqual({
+      startTimeYear: '2024',
+      startTimeMonth: '3',
+      startTimeDayOfMonth: '5',
+      startTimeDayOfWeek: '2', // Tuesday
+      startTimeHourOfDay: 14,
+    });
+  });
+});
+
+describe('getDatePieces', () => {
+  const dt = DateTime.fromObject(
+    { year: 2024, month: 3, day: 5, hour: 14 },
+    { zone: 'utc' }
+  );
+
+  it('uses "all day" for the time of day when isAllDay is true', () => {
+    expect(getDatePieces(dt, true).timeOfDay).toBe('all day');
+  });
+
+  it('renders a clock time for the time of day when not all day', () => {
+    expect(getDatePieces(dt, false).timeOfDay).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it('exposes the long weekday name', () => {
+    expect(getDatePieces(dt).weekday).toBe('Tuesday');
+  });
+});
+
+describe('relativeTime', () => {
+  it('returns a past date as a relative "ago" string', () => {
+    expect(relativeTime('2000-01-01T00:00:00Z')).toContain('ago');
   });
 });


### PR DESCRIPTION
## Summary

Raises unit-test coverage by **real-mounting previously-untested components** and driving their logic, rather than re-implementing it in tests. Each commit is one component (or the shared util file), self-contained.

Net effect: the unit suite grew **2371 → 2587 (+216 tests)**; `npm run tsc` is clean and the full suite is green.

## What's covered

| Area | Before → After (lines) |
|---|---|
| `utils/index.ts` | 78% → **100%** |
| `components/TextEditor.vue` | ~0% → **60%** |
| `components/discussion/list/SearchDiscussions.vue` | ~4% → **88%** |
| `components/nav/CreateAnythingButton.vue` | ~0% → **80%** |
| `components/discussion/detail/activityFeed/EditsDropdown.vue` | ~0% → **95%** |
| `components/event/form/OccurrencesList.vue` | ~0% → **100%** |
| `components/plugins/PluginPipelineEditor.vue` | ~0% → **91%** |
| `components/collection/AddToListPopover.vue` | ~0% → **85%** |
| `components/discussion/detail/ImageLightbox.vue` | ~0% → **78%** |
| `components/discussion/form/DownloadEditForm.vue` | ~0% → **86%** |
| `components/channel/ChannelTabs.vue` | ~0% → **95%** |
| `components/discussion/form/DiscussionRootCommentFormWrapper.vue` | ~0% → **80%** |
| `components/download/form/CreateDownload.vue` | ~0% → **88%** |
| `components/channel/SidebarEventList.vue` | ~0% → **92%** |
| `components/nav/SiteSidenav.vue` | ~0% → **82%** |

## Also added

- **`scripts/coverage-audit.mjs`** (`npm run coverage:audit`) — reads `coverage/lcov.info` + the component/spec layout and prints where uncovered lines live, components with a spec but still low coverage, and a prioritized worklist (heavy 3rd-party-lib wrappers split out as "extract logic instead of mounting"). This is the tool that drove the campaign's ordering.

## Approach & notes

- **Mock the data layer, keep the logic real.** Specs mock `@vue/apollo-composable`, auth composables, router/route, and stores; the component's own computeds/handlers/branches run for real. Pure state composables (zoom/nav/swipe in ImageLightbox) are kept real too.
- **Captured the `useMutation` options factory** to exercise inline Apollo cache `update` logic with a mock cache (DiscussionRootCommentFormWrapper).
- A pre-existing anti-pattern was found and fixed for `TextEditor`: its three existing specs never mounted the real component (they mounted a local mock), so it had ~0% real coverage.
- **Out of scope in jsdom** (left partial by design): `import.meta.client`-gated blocks (e.g. SiteSidenav recent-forums) and inline Apollo cache field-policy callbacks that a mock cache never invokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)