### PR TITLE
test: unit-test coverage campaign, part 2 (mod/auth/form components)

### DIFF
--- a/components/auth/CreateUsernameForm.spec.ts
+++ b/components/auth/CreateUsernameForm.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import CreateUsernameForm from '@/components/auth/CreateUsernameForm.vue';
+
+const h = vi.hoisted(() => ({
+  setUsername: vi.fn(),
+  setModProfileName: vi.fn(),
+  setIsAuthenticated: vi.fn(),
+  setIsLoadingAuth: vi.fn(),
+  createMutate: vi.fn(),
+  onDone: undefined as undefined | ((r: unknown) => void),
+  userResult: { value: { users: [] as unknown[] } },
+  getError: { value: null as unknown },
+  getLoading: { value: false },
+  createError: { value: null as unknown },
+  createLoading: { value: false },
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: h.userResult,
+    error: h.getError,
+    loading: h.getLoading,
+  }),
+  useMutation: () => ({
+    mutate: h.createMutate,
+    error: h.createError,
+    loading: h.createLoading,
+    onDone: (cb: (r: unknown) => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  setUsername: h.setUsername,
+  setModProfileName: h.setModProfileName,
+  setIsAuthenticated: h.setIsAuthenticated,
+}));
+vi.mock('@/cache', () => ({ setIsLoadingAuth: h.setIsLoadingAuth }));
+
+const stubs = {
+  PrimaryButton: {
+    name: 'PrimaryButton',
+    props: ['label', 'disabled', 'loading'],
+    emits: ['click'],
+    template: '<button @click="$emit(\'click\')">{{ label }}</button>',
+  },
+  DatePicker: {
+    name: 'DatePicker',
+    props: ['value', 'testId'],
+    emits: ['update'],
+    template: '<div />',
+  },
+  CharCounter: { props: ['current', 'max'], template: '<div />' },
+  ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err" />' },
+  CheckCircleIcon: true,
+  ExclamationIcon: true,
+};
+
+const mountForm = (email = 'alice@example.com') =>
+  mount(CreateUsernameForm, { props: { email }, global: { stubs } });
+
+const saveButton = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.getComponent({ name: 'PrimaryButton' });
+
+const setBirthday = (wrapper: ReturnType<typeof mount>, date: string) =>
+  wrapper.getComponent({ name: 'DatePicker' }).vm.$emit('update', date);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.onDone = undefined;
+  h.userResult = { value: { users: [] } };
+  h.getError = { value: null };
+  h.getLoading = { value: false };
+  h.createError = { value: null };
+  h.createLoading = { value: false };
+});
+
+describe('CreateUsernameForm initial state', () => {
+  it('seeds the username from the local part of the email', () => {
+    const wrapper = mountForm('bob@example.com');
+
+    expect((wrapper.get('input').element as HTMLInputElement).value).toBe('bob');
+  });
+
+  it('shows the username as available for a fresh valid name', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('This username is available');
+  });
+});
+
+describe('CreateUsernameForm username validation', () => {
+  it('flags a taken username and disables saving', () => {
+    h.userResult = { value: { users: [{ username: 'alice' }] } };
+    const wrapper = mountForm();
+
+    expect(saveButton(wrapper).props('disabled')).toBe(true);
+  });
+
+  it('does not show the available message when the name is taken', () => {
+    h.userResult = { value: { users: [{ username: 'alice' }] } };
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).not.toContain('This username is available');
+  });
+
+  it('disables saving for an invalid username', async () => {
+    const wrapper = mountForm();
+
+    await wrapper.get('input').setValue('has spaces!!');
+
+    expect(saveButton(wrapper).props('disabled')).toBe(true);
+  });
+});
+
+describe('CreateUsernameForm birthday and canSave', () => {
+  it('keeps saving disabled until a birthday is entered', () => {
+    const wrapper = mountForm();
+
+    expect(saveButton(wrapper).props('disabled')).toBe(true);
+  });
+
+  it('enables saving for a valid username and an adult birthday', async () => {
+    const wrapper = mountForm();
+
+    await setBirthday(wrapper, '2000-01-01');
+
+    expect(saveButton(wrapper).props('disabled')).toBe(false);
+  });
+
+  it('disables saving when the user is under the minimum age', async () => {
+    const wrapper = mountForm();
+
+    await setBirthday(wrapper, '2020-01-01');
+
+    expect(saveButton(wrapper).props('disabled')).toBe(true);
+  });
+});
+
+describe('CreateUsernameForm submission', () => {
+  it('runs the create mutation when Save is clicked', async () => {
+    const wrapper = mountForm();
+    await setBirthday(wrapper, '2000-01-01');
+
+    await saveButton(wrapper).trigger('click');
+
+    expect(h.createMutate).toHaveBeenCalled();
+  });
+
+  it('shows an error banner when creation fails', () => {
+    h.createError = { value: { message: 'boom' } };
+    const wrapper = mountForm();
+
+    expect(wrapper.find('.err').exists()).toBe(true);
+  });
+});
+
+describe('CreateUsernameForm account creation completion', () => {
+  const result = {
+    data: {
+      createEmailAndUser: {
+        username: 'alice',
+        ModerationProfile: { displayName: 'modAlice' },
+      },
+    },
+  };
+
+  it('stores the username and authenticates on success', () => {
+    mountForm();
+
+    h.onDone?.(result);
+
+    expect(h.setUsername).toHaveBeenCalledWith('alice');
+  });
+
+  it('sets the moderation profile name on success', () => {
+    mountForm();
+
+    h.onDone?.(result);
+
+    expect(h.setModProfileName).toHaveBeenCalledWith('modAlice');
+  });
+
+  it('emits emailAndUserCreated on success', () => {
+    const wrapper = mountForm();
+
+    h.onDone?.(result);
+
+    expect(wrapper.emitted('emailAndUserCreated')).toBeTruthy();
+  });
+
+  it('marks the user as authenticated', () => {
+    mountForm();
+
+    h.onDone?.(result);
+
+    expect(h.setIsAuthenticated).toHaveBeenCalledWith(true);
+  });
+});

--- a/components/comments/CommentOnFeedbackPage.spec.ts
+++ b/components/comments/CommentOnFeedbackPage.spec.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import type { Comment } from '@/__generated__/graphql';
+
+import CommentOnFeedbackPage from '@/components/comments/CommentOnFeedbackPage.vue';
+
+const h = vi.hoisted(() => ({
+  modName: null as unknown,
+  username: null as unknown,
+  editMutate: vi.fn(),
+  deleteMutate: vi.fn(),
+  editDone: undefined as undefined | (() => void),
+  deleteDone: undefined as undefined | (() => void),
+  callIndex: { n: 0 },
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => {
+    h.callIndex.n++;
+    if (h.callIndex.n === 1)
+      return {
+        mutate: h.editMutate,
+        loading: ref(false),
+        error: ref(null),
+        onDone: (cb: () => void) => {
+          h.editDone = cb;
+        },
+      };
+    return {
+      mutate: h.deleteMutate,
+      loading: ref(false),
+      error: ref(null),
+      onDone: (cb: () => void) => {
+        h.deleteDone = cb;
+      },
+    };
+  },
+}));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' }, name: 'feedback' }),
+  useRouter: () => ({ resolve: () => ({ href: '/link' }) }),
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => h.modName,
+  useUsername: () => h.username,
+}));
+
+const makeComment = (overrides: Partial<Comment> = {}) =>
+  ({
+    id: 'c1',
+    text: 'hello',
+    createdAt: '2024-01-01T00:00:00Z',
+    archived: false,
+    CommentAuthor: { displayName: 'bob' },
+    ...overrides,
+  }) as unknown as Comment;
+
+const stub = (name: string, props: string[] = [], emits: string[] = []) => ({
+  name,
+  props,
+  emits,
+  template: '<div><slot /></div>',
+});
+
+const mountComment = (comment: Comment) =>
+  mount(CommentOnFeedbackPage, {
+    props: { comment },
+    global: {
+      stubs: {
+        MenuButton: stub(
+          'MenuButton',
+          ['items'],
+          ['copy-link', 'handle-edit', 'click-report', 'handle-delete', 'click-archive', 'click-unarchive', 'click-archive-and-suspend']
+        ),
+        TextEditor: stub('TextEditor', ['initialValue'], ['update']),
+        SaveButton: stub('SaveButton', ['disabled', 'loading'], ['click']),
+        CancelButton: stub('CancelButton', [], ['click']),
+        WarningModal: stub('WarningModal', ['open'], ['close', 'primary-button-click']),
+        BrokenRulesModal: stub('BrokenRulesModal', ['open'], ['close']),
+        UnarchiveModal: stub('UnarchiveModal', ['open'], ['close']),
+        Notification: stub('Notification', ['show'], ['close-notification']),
+        VoteButtons: true,
+        MarkdownPreview: true,
+        ArchivedCommentText: true,
+        ErrorBanner: true,
+        AvatarComponent: true,
+        EllipsisHorizontal: true,
+      },
+    },
+  });
+
+const menu = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.getComponent({ name: 'MenuButton' });
+const menuLabels = (wrapper: ReturnType<typeof mount>) =>
+  (menu(wrapper).props('items') as { label: string }[]).map((i) => i.label);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.modName = ref('alice');
+  h.username = ref('alice');
+  h.editDone = undefined;
+  h.deleteDone = undefined;
+  h.callIndex.n = 0;
+});
+
+describe('CommentOnFeedbackPage menu items', () => {
+  it('offers Edit and Delete to the comment author', () => {
+    const wrapper = mountComment(
+      makeComment({ CommentAuthor: { displayName: 'alice' } as never })
+    );
+
+    expect(menuLabels(wrapper)).toEqual(['Edit', 'Delete', 'Copy Link']);
+  });
+
+  it('offers Report and archive actions to a moderator on active content', () => {
+    const wrapper = mountComment(makeComment());
+
+    expect(menuLabels(wrapper)).toEqual([
+      'Report',
+      'Archive',
+      'Archive and Suspend',
+      'Copy Link',
+    ]);
+  });
+
+  it('offers Unarchive to a moderator on archived content', () => {
+    const wrapper = mountComment(makeComment({ archived: true }));
+
+    expect(menuLabels(wrapper)).toContain('Unarchive');
+  });
+
+  it('offers only Report to a logged-in non-moderator', () => {
+    (h.modName as { value: string }).value = '';
+    const wrapper = mountComment(makeComment());
+
+    expect(menuLabels(wrapper)).toEqual(['Report', 'Copy Link']);
+  });
+
+  it('offers only Copy Link to a logged-out viewer', () => {
+    (h.username as { value: string }).value = '';
+    (h.modName as { value: string }).value = '';
+    const wrapper = mountComment(makeComment());
+
+    expect(menuLabels(wrapper)).toEqual(['Copy Link']);
+  });
+});
+
+describe('CommentOnFeedbackPage edit flow', () => {
+  it('enters edit mode and shows the editor', async () => {
+    const wrapper = mountComment(
+      makeComment({ CommentAuthor: { displayName: 'alice' } as never })
+    );
+
+    await menu(wrapper).vm.$emit('handle-edit');
+
+    expect(wrapper.findComponent({ name: 'TextEditor' }).exists()).toBe(true);
+  });
+
+  it('saves the edited comment once the text changes', async () => {
+    const wrapper = mountComment(
+      makeComment({ CommentAuthor: { displayName: 'alice' } as never })
+    );
+    await menu(wrapper).vm.$emit('handle-edit');
+
+    await wrapper.getComponent({ name: 'TextEditor' }).vm.$emit('update', 'edited');
+    // SaveButton uses @click.prevent, so the payload needs preventDefault().
+    await wrapper
+      .getComponent({ name: 'SaveButton' })
+      .vm.$emit('click', { preventDefault: () => {} });
+
+    expect(h.editMutate).toHaveBeenCalled();
+  });
+
+  it('leaves edit mode when the update completes', async () => {
+    const wrapper = mountComment(
+      makeComment({ CommentAuthor: { displayName: 'alice' } as never })
+    );
+    await menu(wrapper).vm.$emit('handle-edit');
+
+    h.editDone?.();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'TextEditor' }).exists()).toBe(false);
+  });
+});
+
+describe('CommentOnFeedbackPage delete flow', () => {
+  it('opens the delete confirmation modal', async () => {
+    const wrapper = mountComment(
+      makeComment({ CommentAuthor: { displayName: 'alice' } as never })
+    );
+
+    await menu(wrapper).vm.$emit('handle-delete');
+
+    expect(wrapper.getComponent({ name: 'WarningModal' }).props('open')).toBe(
+      true
+    );
+  });
+
+  it('deletes the comment on confirmation', async () => {
+    const wrapper = mountComment(
+      makeComment({ CommentAuthor: { displayName: 'alice' } as never })
+    );
+
+    await wrapper
+      .getComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+
+    expect(h.deleteMutate).toHaveBeenCalledWith({ id: 'c1' });
+  });
+});
+
+describe('CommentOnFeedbackPage moderation modals', () => {
+  it('opens the report modal', async () => {
+    const wrapper = mountComment(makeComment());
+
+    await menu(wrapper).vm.$emit('click-report');
+
+    expect(
+      wrapper.findAllComponents({ name: 'BrokenRulesModal' }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('opens the unarchive modal', async () => {
+    const wrapper = mountComment(makeComment({ archived: true }));
+
+    await menu(wrapper).vm.$emit('click-unarchive');
+
+    expect(wrapper.findComponent({ name: 'UnarchiveModal' }).exists()).toBe(
+      true
+    );
+  });
+});
+
+describe('CommentOnFeedbackPage copy link', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
+  it('copies the permalink and notifies the parent', async () => {
+    const wrapper = mountComment(makeComment());
+
+    await menu(wrapper).vm.$emit('copy-link');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('showCopiedLinkNotification')?.[0]).toEqual([true]);
+  });
+});

--- a/components/discussion/list/ChannelDiscussionList.spec.ts
+++ b/components/discussion/list/ChannelDiscussionList.spec.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import type { TestingPinia } from '@pinia/testing';
+
+import ChannelDiscussionList from '@/components/discussion/list/ChannelDiscussionList.vue';
+import { useUIStore } from '@/stores/uiStore';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  error: null as unknown,
+  loading: null as unknown,
+  refetch: vi.fn(),
+  fetchMore: vi.fn(),
+  route: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: h.result,
+    error: h.error,
+    loading: h.loading,
+    refetch: h.refetch,
+    fetchMore: h.fetchMore,
+  }),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+vi.mock('@/composables/useAuthState', () => ({ useUsername: () => ref('') }));
+vi.mock('@/composables/useTheme', () => ({
+  useAppTheme: () => ({ theme: ref('light') }),
+}));
+
+const discussionChannel = (id: string, title: string) => ({
+  id: `dc-${id}`,
+  discussionId: id,
+  Discussion: { id, title },
+});
+
+const resultWith = (channels: unknown[], aggregate = channels.length) => ({
+  getDiscussionsInChannel: {
+    discussionChannels: channels,
+    aggregateDiscussionChannelsCount: aggregate,
+  },
+});
+
+const itemStub = {
+  name: 'ChannelDiscussionListItem',
+  props: ['discussion', 'discussionChannel', 'selectedDiscussionId'],
+  emits: ['filter-by-tag', 'filter-by-channel', 'open-mod-profile'],
+  template: '<li />',
+};
+const loadMoreStub = {
+  name: 'LoadMore',
+  props: ['loading', 'reachedEndOfResults'],
+  emits: ['load-more'],
+  template: '<div />',
+};
+
+let pinia: TestingPinia;
+
+const mountList = () => {
+  pinia = createTestingPinia({ createSpy: vi.fn });
+  return mount(ChannelDiscussionList, {
+    global: {
+      plugins: [pinia],
+      stubs: {
+        ChannelDiscussionListItem: itemStub,
+        LoadMore: loadMoreStub,
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err" />' },
+        RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
+        'v-skeleton-loader': { template: '<div class="skeleton" />' },
+      },
+    },
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref(resultWith([discussionChannel('d1', 'First')]));
+  h.error = ref(null);
+  h.loading = ref(false);
+  h.route = { params: { forumId: 'cats' }, query: {} };
+});
+
+describe('ChannelDiscussionList states', () => {
+  it('shows skeleton loaders while loading with no result', () => {
+    h.result = ref(null);
+    h.loading = ref(true);
+    const wrapper = mountList();
+
+    expect(wrapper.find('.skeleton').exists()).toBe(true);
+  });
+
+  it('shows an error banner on query error', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountList();
+
+    expect(wrapper.find('.err').exists()).toBe(true);
+  });
+
+  it('shows an empty message when there are no discussions', () => {
+    h.result = ref(resultWith([]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('There are no discussions to show');
+  });
+
+  it('renders a list item per discussion channel', () => {
+    h.result = ref(
+      resultWith([
+        discussionChannel('d1', 'First'),
+        discussionChannel('d2', 'Second'),
+      ])
+    );
+    const wrapper = mountList();
+
+    expect(
+      wrapper.findAllComponents({ name: 'ChannelDiscussionListItem' })
+    ).toHaveLength(2);
+  });
+});
+
+describe('ChannelDiscussionList pagination', () => {
+  it('fetches more when LoadMore requests it', async () => {
+    const wrapper = mountList();
+
+    await wrapper.getComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+
+    expect(h.fetchMore).toHaveBeenCalled();
+  });
+
+  it('reports the end of results when all rows are loaded', () => {
+    h.result = ref(resultWith([discussionChannel('d1', 'First')], 1));
+    const wrapper = mountList();
+
+    expect(
+      wrapper.getComponent({ name: 'LoadMore' }).props('reachedEndOfResults')
+    ).toBe(true);
+  });
+
+  it('is not at the end when more results remain', () => {
+    h.result = ref(resultWith([discussionChannel('d1', 'First')], 10));
+    const wrapper = mountList();
+
+    expect(
+      wrapper.getComponent({ name: 'LoadMore' }).props('reachedEndOfResults')
+    ).toBe(false);
+  });
+});
+
+describe('ChannelDiscussionList filter events', () => {
+  it('re-emits filterByTag from a list item', async () => {
+    const wrapper = mountList();
+
+    await wrapper
+      .getComponent({ name: 'ChannelDiscussionListItem' })
+      .vm.$emit('filter-by-tag', 'vue');
+
+    expect(wrapper.emitted('filterByTag')?.[0]).toEqual(['vue']);
+  });
+
+  it('re-emits filterByChannel from a list item', async () => {
+    const wrapper = mountList();
+
+    await wrapper
+      .getComponent({ name: 'ChannelDiscussionListItem' })
+      .vm.$emit('filter-by-channel', 'cats');
+
+    expect(wrapper.emitted('filterByChannel')?.[0]).toEqual(['cats']);
+  });
+});
+
+describe('ChannelDiscussionList selected discussion sync', () => {
+  it('records the selected discussion in the UI store', () => {
+    h.route = {
+      params: { forumId: 'cats' },
+      query: { selectedDiscussionId: 'd1' },
+    };
+    h.result = ref(resultWith([discussionChannel('d1', 'First')]));
+    mountList();
+    const store = useUIStore(pinia);
+
+    expect(store.setSelectedChannelDiscussionSelection).toHaveBeenCalledWith({
+      discussionId: 'd1',
+      title: 'First',
+    });
+  });
+
+  it('clears the selection when no discussion is selected', () => {
+    mountList();
+    const store = useUIStore(pinia);
+
+    expect(store.clearSelectedChannelDiscussion).toHaveBeenCalled();
+  });
+});

--- a/components/mod/UnarchiveModal.spec.ts
+++ b/components/mod/UnarchiveModal.spec.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import UnarchiveModal from '@/components/mod/UnarchiveModal.vue';
+
+type Slot = {
+  mutate?: ReturnType<typeof vi.fn>;
+  done?: () => void;
+  update?: (cache: unknown) => void;
+};
+
+const h = vi.hoisted(() => ({
+  client: { refetchQueries: undefined as unknown },
+  disc: {} as Slot,
+  evt: {} as Slot,
+  comment: {} as Slot,
+  callIndex: { n: 0 },
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useApolloClient: () => ({ client: h.client }),
+  useMutation: (_doc: unknown, options?: { update?: (c: unknown) => void }) => {
+    h.callIndex.n++;
+    const slot = h.callIndex.n === 1 ? h.disc : h.callIndex.n === 2 ? h.evt : h.comment;
+    slot.update = options?.update;
+    return {
+      mutate: slot.mutate,
+      loading: ref(false),
+      error: ref(null),
+      onDone: (cb: () => void) => {
+        slot.done = cb;
+      },
+    };
+  },
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => ({ params: { forumId: 'cats' } }) }));
+
+const stubs = {
+  GenericModal: {
+    name: 'GenericModal',
+    props: ['title', 'body', 'open', 'loading', 'primaryButtonDisabled', 'error'],
+    emits: ['primary-button-click', 'close'],
+    template: '<div><slot name="content" /></div>',
+  },
+  TextEditor: {
+    name: 'TextEditor',
+    props: ['initialValue', 'placeholder'],
+    emits: ['update'],
+    template: '<div />',
+  },
+  ArchiveBoxXMark: true,
+};
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(UnarchiveModal, { props: { open: true, ...props }, global: { stubs } });
+
+const modal = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.getComponent({ name: 'GenericModal' });
+
+beforeEach(() => {
+  h.callIndex.n = 0;
+  h.disc = { mutate: vi.fn() };
+  h.evt = { mutate: vi.fn() };
+  h.comment = { mutate: vi.fn() };
+  h.client = { refetchQueries: vi.fn() };
+});
+
+describe('UnarchiveModal labels', () => {
+  it('titles the modal for a comment', () => {
+    const wrapper = mountModal({ commentId: 'c1' });
+
+    expect(modal(wrapper).props('title')).toBe('Unarchive Comment');
+  });
+
+  it('titles the modal for a discussion', () => {
+    const wrapper = mountModal({ discussionId: 'd1' });
+
+    expect(modal(wrapper).props('title')).toBe('Unarchive Discussion');
+  });
+
+  it('titles the modal for an event', () => {
+    const wrapper = mountModal({ eventId: 'e1' });
+
+    expect(modal(wrapper).props('title')).toBe('Unarchive Event');
+  });
+
+  it('describes the content type in the body', () => {
+    const wrapper = mountModal({ eventId: 'e1' });
+
+    expect(modal(wrapper).props('body')).toContain('event');
+  });
+});
+
+describe('UnarchiveModal submit', () => {
+  it('does nothing when no content id is provided', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.comment.mutate).not.toHaveBeenCalled();
+  });
+
+  it('unarchives a comment with its explanation', async () => {
+    const wrapper = mountModal({ commentId: 'c1' });
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.comment.mutate).toHaveBeenCalledWith({
+      commentId: 'c1',
+      explanation: 'No violation',
+    });
+  });
+
+  it('unarchives a discussion with the channel name', async () => {
+    const wrapper = mountModal({ discussionId: 'd1' });
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.disc.mutate).toHaveBeenCalledWith({
+      discussionId: 'd1',
+      explanation: 'No violation',
+      channelUniqueName: 'cats',
+    });
+  });
+
+  it('unarchives an event with the channel name', async () => {
+    const wrapper = mountModal({ eventId: 'e1' });
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.evt.mutate).toHaveBeenCalledWith({
+      eventId: 'e1',
+      explanation: 'No violation',
+      channelUniqueName: 'cats',
+    });
+  });
+});
+
+describe('UnarchiveModal explanation', () => {
+  it('disables the primary button when the explanation is cleared', async () => {
+    const wrapper = mountModal({ discussionId: 'd1' });
+
+    await wrapper.getComponent({ name: 'TextEditor' }).vm.$emit('update', '');
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(true);
+  });
+});
+
+describe('UnarchiveModal completion', () => {
+  it('refetches the issue and reports success when a discussion is unarchived', () => {
+    const wrapper = mountModal({ discussionId: 'd1' });
+
+    h.disc.done?.();
+
+    expect(wrapper.emitted('unarchivedSuccessfully')).toBeTruthy();
+  });
+
+  it('refetches queries on completion', () => {
+    mountModal({ commentId: 'c1' });
+
+    h.comment.done?.();
+
+    expect(h.client.refetchQueries).toHaveBeenCalled();
+  });
+
+  it('emits close when the modal is dismissed', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});
+
+describe('UnarchiveModal cache updates', () => {
+  const makeCache = () => ({ modify: vi.fn(), identify: vi.fn(() => 'id') });
+
+  it('flips archived to false for the discussion channel', () => {
+    mountModal({ discussionId: 'd1', discussionChannelId: 'dc1' });
+    const cache = makeCache();
+
+    h.disc.update?.(cache);
+
+    expect(cache.modify).toHaveBeenCalled();
+  });
+
+  it('skips the cache update when no discussion channel id is present', () => {
+    mountModal({ discussionId: 'd1' });
+    const cache = makeCache();
+
+    h.disc.update?.(cache);
+
+    expect(cache.modify).not.toHaveBeenCalled();
+  });
+
+  it('flips archived to false for the comment', () => {
+    mountModal({ commentId: 'c1' });
+    const cache = makeCache();
+
+    h.comment.update?.(cache);
+
+    expect(cache.modify).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Part 2 of the unit-test coverage campaign, **stacked on #120** (base is `chore/coverage-tier3`, so this PR's diff shows only the new specs). Same approach: real-mount each component, mock the data layer, keep the component's own logic real.

Merge #120 first; this one will retarget to `main` automatically once its base merges.

## Covered so far

| Component | Before → After (lines) |
|---|---|
| `components/mod/UnarchiveModal.vue` | ~0% → **84%** |
| `components/auth/CreateUsernameForm.vue` | ~0% → **94%** |

(more components being added to this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)