### PR TITLE
test: unit-test coverage for more components (mod/channel/...)

### DIFF
--- a/components/admin/ChannelReportsList.spec.ts
+++ b/components/admin/ChannelReportsList.spec.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ChannelReportsList from '@/components/admin/ChannelReportsList.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  loading: null as unknown,
+  error: null as unknown,
+  refetch: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: h.result,
+    loading: h.loading,
+    error: h.error,
+    refetch: h.refetch,
+  }),
+}));
+
+const report = (overrides: Record<string, unknown> = {}) => ({
+  id: 'r1',
+  issueNumber: 1,
+  relatedChannelUniqueName: 'cats',
+  isOpen: true,
+  locked: false,
+  title: 'Spam everywhere',
+  Author: { __typename: 'User', username: 'alice' },
+  createdAt: '2024-01-01T00:00:00Z',
+  ActivityFeedAggregate: { count: 2 },
+  ...overrides,
+});
+
+const dialogStub = (name: string) => ({
+  name,
+  props: ['channelUniqueName', 'open'],
+  emits: ['close', 'locked', 'unlocked'],
+  template: '<div />',
+});
+
+const mountList = () =>
+  mount(ChannelReportsList, {
+    global: {
+      stubs: {
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        LockChannelDialog: dialogStub('LockChannelDialog'),
+        UnlockChannelDialog: dialogStub('UnlockChannelDialog'),
+      },
+    },
+  });
+
+const buttonByText = (w: ReturnType<typeof mount>, text: string) =>
+  w.findAll('button').find((b) => b.text() === text);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref({ issues: [report()] });
+  h.loading = ref(false);
+  h.error = ref(null);
+});
+
+describe('ChannelReportsList states', () => {
+  it('shows a loading message', () => {
+    h.loading = ref(true);
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('shows an error message', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('boom');
+  });
+
+  it('shows an empty message when there are no reports', () => {
+    h.result = ref({ issues: [] });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('No channel reports found');
+  });
+
+  it('shows the report count', () => {
+    h.result = ref({ issues: [report(), report({ id: 'r2', issueNumber: 2 })] });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('2 report(s)');
+  });
+});
+
+describe('ChannelReportsList report card', () => {
+  it('shows the report title and channel', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Spam everywhere');
+  });
+
+  it('shows an Open badge for open reports', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Open');
+  });
+
+  it('shows a Closed badge for closed reports', () => {
+    h.result = ref({ issues: [report({ isOpen: false })] });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Closed');
+  });
+
+  it('shows a Locked badge for locked channels', () => {
+    h.result = ref({ issues: [report({ locked: true })] });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Locked');
+  });
+
+  it('shows a moderation-profile reporter with an @ handle', () => {
+    h.result = ref({
+      issues: [
+        report({ Author: { __typename: 'ModerationProfile', displayName: 'mod1' } }),
+      ],
+    });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('@mod1');
+  });
+});
+
+describe('ChannelReportsList lock/unlock', () => {
+  it('opens the lock dialog from the Lock button', async () => {
+    const wrapper = mountList();
+
+    await buttonByText(wrapper, 'Lock')!.trigger('click');
+
+    expect(wrapper.getComponent({ name: 'LockChannelDialog' }).props('open')).toBe(
+      true
+    );
+  });
+
+  it('opens the unlock dialog for a locked channel', async () => {
+    h.result = ref({ issues: [report({ locked: true })] });
+    const wrapper = mountList();
+
+    await buttonByText(wrapper, 'Unlock')!.trigger('click');
+
+    expect(
+      wrapper.getComponent({ name: 'UnlockChannelDialog' }).props('open')
+    ).toBe(true);
+  });
+
+  it('refetches after a channel is locked', async () => {
+    const wrapper = mountList();
+    await buttonByText(wrapper, 'Lock')!.trigger('click');
+
+    await wrapper.getComponent({ name: 'LockChannelDialog' }).vm.$emit('locked');
+
+    expect(h.refetch).toHaveBeenCalled();
+  });
+
+  it('refetches after a channel is unlocked', async () => {
+    h.result = ref({ issues: [report({ locked: true })] });
+    const wrapper = mountList();
+    await buttonByText(wrapper, 'Unlock')!.trigger('click');
+
+    await wrapper.getComponent({ name: 'UnlockChannelDialog' }).vm.$emit('unlocked');
+
+    expect(h.refetch).toHaveBeenCalled();
+  });
+});

--- a/components/admin/ImageReportsList.spec.ts
+++ b/components/admin/ImageReportsList.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ImageReportsList from '@/components/admin/ImageReportsList.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  loading: null as unknown,
+  error: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.result, loading: h.loading, error: h.error }),
+}));
+
+const report = (overrides: Record<string, unknown> = {}) => ({
+  id: 'r1',
+  issueNumber: 1,
+  isOpen: true,
+  title: 'Bad image',
+  Author: { __typename: 'User', username: 'alice' },
+  createdAt: '2024-01-01T00:00:00Z',
+  ActivityFeedAggregate: { count: 1 },
+  relatedImageId: 'img1',
+  ...overrides,
+});
+
+const mountList = () =>
+  mount(ImageReportsList, {
+    global: { stubs: { NuxtLink: { props: ['to'], template: '<a><slot /></a>' } } },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref({ issues: [report()] });
+  h.loading = ref(false);
+  h.error = ref(null);
+});
+
+describe('ImageReportsList states', () => {
+  it('shows a loading message', () => {
+    h.loading = ref(true);
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('shows an error message', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('boom');
+  });
+
+  it('shows an empty message when there are no reports', () => {
+    h.result = ref({ issues: [] });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('No image reports');
+  });
+
+  it('shows the report count', () => {
+    h.result = ref({ issues: [report(), report({ id: 'r2', issueNumber: 2 })] });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('2 report(s)');
+  });
+
+  it('shows the report title', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Bad image');
+  });
+});
+
+describe('ImageReportsList image type', () => {
+  it.each([
+    [{ relatedProfilePicUserId: 'u1' }, 'Profile Picture'],
+    [{ relatedChannelIconName: 'icon.png' }, 'Channel Icon'],
+    [{ relatedChannelBannerName: 'banner.png' }, 'Channel Banner'],
+    [{ relatedImageId: 'img1' }, 'Album Image'],
+    [{}, 'Image'],
+  ])('labels %o as "%s"', (fields, label) => {
+    h.result = ref({
+      issues: [
+        report({
+          relatedImageId: null,
+          relatedProfilePicUserId: null,
+          relatedChannelIconName: null,
+          relatedChannelBannerName: null,
+          ...fields,
+        }),
+      ],
+    });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain(label);
+  });
+});

--- a/components/channel/DownloadList.spec.ts
+++ b/components/channel/DownloadList.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+
+import DownloadList from '@/components/channel/DownloadList.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  error: null as unknown,
+  loading: null as unknown,
+  refetch: vi.fn(),
+  fetchMore: vi.fn(),
+  route: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: h.result,
+    error: h.error,
+    loading: h.loading,
+    refetch: h.refetch,
+    fetchMore: h.fetchMore,
+  }),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+vi.mock('@/composables/useAuthState', () => ({ useUsername: () => ref('') }));
+
+const channel = (id: string) => ({
+  id: `dc-${id}`,
+  discussionId: id,
+  Discussion: { id, title: `Download ${id}`, Album: { Images: [] } },
+});
+
+const resultWith = (channels: unknown[], aggregate = channels.length) => ({
+  getDiscussionsInChannel: {
+    discussionChannels: channels,
+    aggregateDiscussionChannelsCount: aggregate,
+  },
+});
+
+const mountList = () =>
+  mount(DownloadList, {
+    global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn })],
+      stubs: {
+        ChannelDownloadListItem: {
+          name: 'ChannelDownloadListItem',
+          props: ['discussion', 'discussionChannel'],
+          emits: ['filter-by-tag', 'filter-by-channel', 'open-album'],
+          template: '<li />',
+        },
+        LoadMore: {
+          name: 'LoadMore',
+          props: ['loading', 'reachedEndOfResults'],
+          emits: ['load-more'],
+          template: '<div />',
+        },
+        DiscussionAlbum: {
+          name: 'DiscussionAlbum',
+          props: ['album', 'discussionId'],
+          emits: ['close-lightbox'],
+          template: '<div />',
+        },
+        DownloadSkeletonCard: { name: 'DownloadSkeletonCard', template: '<div class="skeleton" />' },
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err" />' },
+        RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
+        ClientOnly: { template: '<div><slot /></div>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref(resultWith([channel('d1')]));
+  h.error = ref(null);
+  h.loading = ref(false);
+  h.route = { params: { forumId: 'cats' }, query: {} };
+});
+
+describe('DownloadList states', () => {
+  it('shows skeleton cards while loading with no results', () => {
+    h.result = ref(null);
+    h.loading = ref(true);
+    const wrapper = mountList();
+
+    expect(wrapper.find('.skeleton').exists()).toBe(true);
+  });
+
+  it('shows an error banner on query error', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountList();
+
+    expect(wrapper.find('.err').exists()).toBe(true);
+  });
+
+  it('shows an empty message when there are no downloads', () => {
+    h.result = ref(resultWith([]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('There are no downloads yet');
+  });
+
+  it('renders an item per download', () => {
+    h.result = ref(resultWith([channel('d1'), channel('d2')]));
+    const wrapper = mountList();
+
+    expect(
+      wrapper.findAllComponents({ name: 'ChannelDownloadListItem' })
+    ).toHaveLength(2);
+  });
+});
+
+describe('DownloadList pagination', () => {
+  it('fetches more on request', async () => {
+    const wrapper = mountList();
+
+    await wrapper.getComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+
+    expect(h.fetchMore).toHaveBeenCalled();
+  });
+
+  it('reports the end of results when all rows are loaded', () => {
+    h.result = ref(resultWith([channel('d1')], 1));
+    const wrapper = mountList();
+
+    expect(
+      wrapper.getComponent({ name: 'LoadMore' }).props('reachedEndOfResults')
+    ).toBe(true);
+  });
+});
+
+describe('DownloadList filter events', () => {
+  it('re-emits filterByTag', async () => {
+    const wrapper = mountList();
+
+    await wrapper
+      .getComponent({ name: 'ChannelDownloadListItem' })
+      .vm.$emit('filter-by-tag', 'stl');
+
+    expect(wrapper.emitted('filterByTag')?.[0]).toEqual(['stl']);
+  });
+
+  it('re-emits filterByChannel', async () => {
+    const wrapper = mountList();
+
+    await wrapper
+      .getComponent({ name: 'ChannelDownloadListItem' })
+      .vm.$emit('filter-by-channel', 'cats');
+
+    expect(wrapper.emitted('filterByChannel')?.[0]).toEqual(['cats']);
+  });
+});
+
+describe('DownloadList album lightbox', () => {
+  it('opens the album lightbox on open-album', async () => {
+    const wrapper = mountList();
+
+    await wrapper.getComponent({ name: 'ChannelDownloadListItem' }).vm.$emit('open-album', {
+      discussion: { id: 'd1' },
+      album: { Images: [{ id: 'i1' }] },
+    });
+
+    expect(wrapper.findComponent({ name: 'DiscussionAlbum' }).exists()).toBe(true);
+  });
+
+  it('closes the album lightbox', async () => {
+    const wrapper = mountList();
+    await wrapper.getComponent({ name: 'ChannelDownloadListItem' }).vm.$emit('open-album', {
+      discussion: { id: 'd1' },
+      album: { Images: [{ id: 'i1' }] },
+    });
+
+    await wrapper.getComponent({ name: 'DiscussionAlbum' }).vm.$emit('close-lightbox');
+
+    expect(wrapper.findComponent({ name: 'DiscussionAlbum' }).exists()).toBe(false);
+  });
+});

--- a/components/comments/CommentEditsDropdown.spec.ts
+++ b/components/comments/CommentEditsDropdown.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import CommentEditsDropdown from '@/components/comments/CommentEditsDropdown.vue';
+import type { Comment } from '@/__generated__/graphql';
+
+// authors[0] is the current author (most-recent edit); each past version is
+// authored by the matching entry in `pastAuthors`.
+const makeComment = (
+  currentAuthor: string | null,
+  pastAuthors: string[]
+) =>
+  ({
+    text: 'current body',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-10T00:00:00Z',
+    CommentAuthor: currentAuthor ? { username: currentAuthor } : null,
+    PastVersions: pastAuthors.map((name, i) => ({
+      id: `v${i}`,
+      body: `old ${i}`,
+      createdAt: `2024-01-0${pastAuthors.length - i}T00:00:00Z`,
+      Author: { username: name },
+    })),
+  }) as unknown as Comment;
+
+const mountDropdown = (comment: Comment) =>
+  mount(CommentEditsDropdown, {
+    props: { comment },
+    global: {
+      stubs: {
+        Teleport: { template: '<div><slot /></div>' },
+        CommentRevisionDiffModal: {
+          name: 'CommentRevisionDiffModal',
+          props: ['open', 'oldVersion', 'newVersion', 'isMostRecent'],
+          emits: ['close', 'deleted'],
+          template: '<div class="diff-modal" />',
+        },
+      },
+    },
+  });
+
+const open = async (w: ReturnType<typeof mount>) => {
+  await w.get('button').trigger('click');
+};
+
+describe('CommentEditsDropdown visibility', () => {
+  it('renders nothing when the comment has no past versions', () => {
+    const wrapper = mountDropdown(makeComment('alice', []));
+
+    expect(wrapper.find('button').exists()).toBe(false);
+  });
+
+  it('renders the Edits trigger when there is at least one edit', () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+
+    expect(wrapper.get('button').text()).toBe('Edits');
+  });
+});
+
+describe('CommentEditsDropdown contents', () => {
+  it('summarizes the edit count', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob', 'carol']));
+
+    await open(wrapper);
+
+    expect(wrapper.text()).toContain('Edited 2 times');
+  });
+
+  it('attributes the most recent edit to the current author', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+
+    await open(wrapper);
+
+    expect(wrapper.get('li').text()).toContain('alice');
+  });
+
+  it('attributes an older edit to the past version author', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob', 'carol']));
+
+    await open(wrapper);
+
+    expect(wrapper.findAll('li')[1].text()).toContain('carol');
+  });
+
+  it('falls back to [Deleted] when the author is unknown', async () => {
+    const wrapper = mountDropdown(makeComment(null, ['bob']));
+
+    await open(wrapper);
+
+    expect(wrapper.get('li').text()).toContain('[Deleted]');
+  });
+});
+
+describe('CommentEditsDropdown toggle', () => {
+  it('closes when the trigger is clicked again', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+
+    await open(wrapper);
+    await wrapper.get('button').trigger('click');
+
+    expect(wrapper.find('li').exists()).toBe(false);
+  });
+
+  it('closes when a click lands outside', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+    await open(wrapper);
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await nextTick();
+
+    expect(wrapper.find('li').exists()).toBe(false);
+  });
+});
+
+describe('CommentEditsDropdown diff modal', () => {
+  it('opens the diff modal when an edit is clicked', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+    await open(wrapper);
+
+    await wrapper.get('li').trigger('click');
+
+    expect(
+      wrapper.findComponent({ name: 'CommentRevisionDiffModal' }).exists()
+    ).toBe(true);
+  });
+
+  it('closes the diff modal on the close event', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+    await open(wrapper);
+    await wrapper.get('li').trigger('click');
+
+    await wrapper
+      .findComponent({ name: 'CommentRevisionDiffModal' })
+      .vm.$emit('close');
+
+    expect(
+      wrapper.findComponent({ name: 'CommentRevisionDiffModal' }).exists()
+    ).toBe(false);
+  });
+
+  it('closes the diff modal when a revision is deleted', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+    await open(wrapper);
+    await wrapper.get('li').trigger('click');
+
+    await wrapper
+      .findComponent({ name: 'CommentRevisionDiffModal' })
+      .vm.$emit('deleted', 'v0');
+
+    expect(
+      wrapper.findComponent({ name: 'CommentRevisionDiffModal' }).exists()
+    ).toBe(false);
+  });
+});

--- a/components/comments/CommentHeader.spec.ts
+++ b/components/comments/CommentHeader.spec.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CommentHeader from '@/components/comments/CommentHeader.vue';
+import type { Comment } from '@/__generated__/graphql';
+
+const makeComment = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'c1',
+    createdAt: '2020-01-01T00:00:00Z',
+    CommentAuthor: { username: 'alice', displayName: '', profilePicURL: '' },
+    ...overrides,
+  }) as unknown as Comment;
+
+const mountHeader = (props: Record<string, unknown> = {}) =>
+  mount(CommentHeader, {
+    props: { commentData: makeComment(), ...props },
+    global: {
+      stubs: {
+        AvatarComponent: true,
+        CommentEditsDropdown: { name: 'CommentEditsDropdown', props: ['comment'], template: '<div />' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+describe('CommentHeader author', () => {
+  it('shows the author username', () => {
+    const wrapper = mountHeader();
+
+    expect(wrapper.text()).toContain('alice');
+  });
+
+  it('shows the display name with the username in parentheses', () => {
+    const wrapper = mountHeader({
+      commentData: makeComment({
+        CommentAuthor: { username: 'alice', displayName: 'Alice A' },
+      }),
+    });
+
+    expect(wrapper.text()).toContain('Alice A');
+  });
+
+  it('shows [Deleted] when there is no author', () => {
+    const wrapper = mountHeader({ commentData: makeComment({ CommentAuthor: null }) });
+
+    expect(wrapper.text()).toContain('[Deleted]');
+  });
+
+  it('marks bot authors with a bot badge', () => {
+    const wrapper = mountHeader({ botUsernames: ['alice'] });
+
+    expect(wrapper.text()).toContain('Bot');
+  });
+});
+
+describe('CommentHeader timestamps', () => {
+  it('shows a posted-time string', () => {
+    const wrapper = mountHeader();
+
+    expect(wrapper.text()).toContain('posted');
+  });
+
+  it('includes the channel when showChannel is set', () => {
+    const wrapper = mountHeader({
+      showChannel: true,
+      commentData: makeComment({ DiscussionChannel: { channelUniqueName: 'cats' } }),
+    });
+
+    expect(wrapper.text()).toContain('in c/cats');
+  });
+
+  it('shows an edited time from textLastEdited', () => {
+    const wrapper = mountHeader({
+      commentData: makeComment({ textLastEdited: '2020-06-01T00:00:00Z' }),
+    });
+
+    expect(wrapper.text()).toContain('Edited');
+  });
+
+  it('falls back to updatedAt with past versions for the edited time', () => {
+    const wrapper = mountHeader({
+      commentData: makeComment({
+        updatedAt: '2020-06-01T00:00:00Z',
+        PastVersions: [{ id: 'v1' }],
+      }),
+    });
+
+    expect(wrapper.text()).toContain('Edited');
+  });
+
+  it('shows the edits dropdown when there is revision history', () => {
+    const wrapper = mountHeader({
+      commentData: makeComment({
+        textLastEdited: '2020-06-01T00:00:00Z',
+        PastVersions: [{ id: 'v1' }],
+      }),
+    });
+
+    expect(wrapper.findComponent({ name: 'CommentEditsDropdown' }).exists()).toBe(
+      true
+    );
+  });
+});
+
+describe('CommentHeader badges', () => {
+  it('shows a Forum Admin badge', () => {
+    const wrapper = mountHeader({ forumRoleBadge: 'forumAdmin' });
+
+    expect(wrapper.text()).toContain('Forum Admin');
+  });
+
+  it('shows a Forum Mod badge', () => {
+    const wrapper = mountHeader({ forumRoleBadge: 'forumMod' });
+
+    expect(wrapper.text()).toContain('Forum Mod');
+  });
+
+  it('shows an OP badge for the original poster', () => {
+    const wrapper = mountHeader({ originalPoster: 'alice' });
+
+    expect(wrapper.text()).toContain('OP');
+  });
+
+  it('shows a Permalinked badge when highlighted', () => {
+    const wrapper = mountHeader({ isHighlighted: true });
+
+    expect(wrapper.text()).toContain('Permalinked');
+  });
+
+  it('shows a custom label', () => {
+    const wrapper = mountHeader({ label: 'Pinned' });
+
+    expect(wrapper.text()).toContain('Pinned');
+  });
+
+  it('shows a Best Answer badge', () => {
+    const wrapper = mountHeader({ isAnswer: true });
+
+    expect(wrapper.text()).toContain('Best Answer');
+  });
+});
+
+describe('CommentHeader context link', () => {
+  const withContext = (extra: Record<string, unknown>) =>
+    makeComment({
+      DiscussionChannel: { channelUniqueName: 'cats', discussionId: 'd1' },
+      Channel: { uniqueName: 'cats' },
+      ...extra,
+    });
+
+  it('links to the comment by default', () => {
+    const wrapper = mountHeader({
+      parentCommentId: 'p1',
+      commentData: withContext({}),
+    });
+
+    expect(wrapper.text()).toContain('View Context');
+  });
+
+  it('links to the parent comment when present', () => {
+    const wrapper = mountHeader({
+      parentCommentId: 'p1',
+      commentData: withContext({ ParentComment: { id: 'parent1' } }),
+    });
+
+    const link = wrapper
+      .findAll('a')
+      .find((a) => a.text() === 'View Context');
+    expect(link?.exists()).toBe(true);
+  });
+
+  it('links to the discussion it gives feedback on', () => {
+    const wrapper = mountHeader({
+      parentCommentId: 'p1',
+      commentData: withContext({ GivesFeedbackOnDiscussion: { id: 'd9' } }),
+    });
+
+    expect(wrapper.text()).toContain('View Context');
+  });
+});

--- a/components/comments/FeedbackSection.spec.ts
+++ b/components/comments/FeedbackSection.spec.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import type { Comment } from '@/__generated__/graphql';
+
+import FeedbackSection from '@/components/comments/FeedbackSection.vue';
+
+vi.mock('nuxt/app', () => ({ useRoute: () => ({ params: { forumId: 'cats' } }) }));
+
+const stub = (name: string, props: string[] = [], emits: string[] = []) => ({
+  name,
+  props,
+  emits,
+  template: '<div />',
+});
+
+const comment = (id: string) => ({ id }) as unknown as Comment;
+
+const defaultProps = () => ({
+  addFeedbackCommentToCommentError: '',
+  addFeedbackCommentToCommentLoading: false,
+  feedbackCommentsAggregate: 2,
+  feedbackComments: [comment('c1'), comment('c2')],
+  loading: false,
+  loadMore: vi.fn(),
+  reachedEndOfResults: false,
+  showFeedbackFormModal: false,
+  showFeedbackSubmittedSuccessfully: false,
+});
+
+const mountSection = (props: Record<string, unknown> = {}) =>
+  mount(FeedbackSection, {
+    props: { ...defaultProps(), ...props },
+    global: {
+      stubs: {
+        NuxtPage: stub('NuxtPage'),
+        InfoBanner: true,
+        LoadMore: stub('LoadMore', ['reachedEndOfResults'], ['load-more']),
+        CommentOnFeedbackPage: stub(
+          'CommentOnFeedbackPage',
+          ['comment'],
+          ['click-feedback', 'click-undo-feedback', 'click-edit-feedback', 'click-report', 'click-archive', 'click-unarchive', 'click-archive-and-suspend']
+        ),
+        Notification: stub('Notification', ['show']),
+        GenericFeedbackFormModal: stub(
+          'GenericFeedbackFormModal',
+          ['open', 'loading', 'error'],
+          ['close', 'update-feedback', 'primary-button-click']
+        ),
+        ConfirmUndoCommentFeedbackModal: stub('ConfirmUndoCommentFeedbackModal', ['open'], ['close']),
+        EditCommentFeedbackModal: stub('EditCommentFeedbackModal', ['open'], ['close']),
+        BrokenRulesModal: stub('BrokenRulesModal', ['open', 'commentId'], ['close']),
+        UnarchiveModal: stub('UnarchiveModal', ['open'], ['close']),
+      },
+    },
+  });
+
+const firstComment = (w: ReturnType<typeof mount>) =>
+  w.findAllComponents({ name: 'CommentOnFeedbackPage' })[0];
+const feedbackModal = (w: ReturnType<typeof mount>) =>
+  w.getComponent({ name: 'GenericFeedbackFormModal' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('FeedbackSection rendering', () => {
+  it('shows the feedback count', () => {
+    const wrapper = mountSection({ feedbackCommentsAggregate: 7 });
+
+    expect(wrapper.text()).toContain('Feedback Comments (7)');
+  });
+
+  it('shows an empty state when there is no feedback', () => {
+    const wrapper = mountSection({ feedbackCommentsAggregate: 0, feedbackComments: [] });
+
+    expect(wrapper.text()).toContain('No feedback yet');
+  });
+
+  it('renders a comment per feedback item', () => {
+    const wrapper = mountSection();
+
+    expect(
+      wrapper.findAllComponents({ name: 'CommentOnFeedbackPage' })
+    ).toHaveLength(2);
+  });
+
+  it('shows a loading indicator while loading', () => {
+    const wrapper = mountSection({ loading: true });
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('loads more results when requested', async () => {
+    const loadMore = vi.fn();
+    const wrapper = mountSection({ loadMore });
+
+    await wrapper.getComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+
+    expect(loadMore).toHaveBeenCalled();
+  });
+});
+
+describe('FeedbackSection feedback actions', () => {
+  it('opens the feedback form on give-feedback', async () => {
+    const wrapper = mountSection();
+
+    await firstComment(wrapper).vm.$emit('click-feedback', {
+      commentData: comment('c1'),
+      parentCommentId: 'p1',
+    });
+
+    expect(wrapper.emitted('openFeedbackFormModal')).toBeTruthy();
+  });
+
+  it('opens the undo modal on undo-feedback', async () => {
+    const wrapper = mountSection({ commentToRemoveFeedbackFrom: comment('c1') });
+
+    await firstComment(wrapper).vm.$emit('click-undo-feedback', {
+      commentData: comment('c1'),
+      parentCommentId: 'p1',
+    });
+
+    expect(
+      wrapper.findComponent({ name: 'ConfirmUndoCommentFeedbackModal' }).exists()
+    ).toBe(true);
+  });
+
+  it('opens the edit modal on edit-feedback', async () => {
+    const wrapper = mountSection();
+
+    await firstComment(wrapper).vm.$emit('click-edit-feedback', {
+      commentData: comment('c1'),
+    });
+
+    expect(
+      wrapper.findComponent({ name: 'EditCommentFeedbackModal' }).exists()
+    ).toBe(true);
+  });
+});
+
+describe('FeedbackSection submit', () => {
+  it('emits feedback when a comment and mod name are present', async () => {
+    const wrapper = mountSection({
+      commentToGiveFeedbackOn: comment('c1'),
+      loggedInUserModName: 'mod1',
+    });
+
+    await feedbackModal(wrapper).vm.$emit('primary-button-click');
+
+    expect(wrapper.emitted('addFeedbackCommentToComment')?.[0]?.[0]).toMatchObject({
+      commentId: 'c1',
+      modProfileName: 'mod1',
+      channelId: 'cats',
+    });
+  });
+
+  it('does not emit feedback without a target comment', async () => {
+    const wrapper = mountSection({ loggedInUserModName: 'mod1' });
+
+    await feedbackModal(wrapper).vm.$emit('primary-button-click');
+
+    expect(wrapper.emitted('addFeedbackCommentToComment')).toBeUndefined();
+  });
+
+  it('does not emit feedback without a mod name', async () => {
+    const wrapper = mountSection({ commentToGiveFeedbackOn: comment('c1') });
+
+    await feedbackModal(wrapper).vm.$emit('primary-button-click');
+
+    expect(wrapper.emitted('addFeedbackCommentToComment')).toBeUndefined();
+  });
+
+  it('closes the feedback form on close', async () => {
+    const wrapper = mountSection();
+
+    await feedbackModal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('closeFeedbackFormModal')).toBeTruthy();
+  });
+});
+
+describe('FeedbackSection moderation', () => {
+  it('opens the report modal on click-report', async () => {
+    const wrapper = mountSection();
+
+    await firstComment(wrapper).vm.$emit('click-report');
+
+    expect(wrapper.findComponent({ name: 'BrokenRulesModal' }).exists()).toBe(true);
+  });
+
+  it('opens the unarchive modal on click-unarchive', async () => {
+    const wrapper = mountSection();
+
+    await firstComment(wrapper).vm.$emit('click-unarchive');
+
+    expect(wrapper.findComponent({ name: 'UnarchiveModal' }).exists()).toBe(true);
+  });
+});

--- a/components/discussion/detail/AlbumEditForm.spec.ts
+++ b/components/discussion/detail/AlbumEditForm.spec.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+import type { Discussion } from '@/__generated__/graphql';
+
+import AlbumEditForm from '@/components/discussion/detail/AlbumEditForm.vue';
+
+const h = vi.hoisted(() => ({
+  updateDiscussion: vi.fn(),
+  mutationOptions: undefined as undefined | (() => Record<string, unknown>),
+  onDone: undefined as undefined | (() => void),
+  error: { value: null as unknown },
+  route: { params: {} as Record<string, unknown> },
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: (_doc: unknown, optionsFactory: () => Record<string, unknown>) => {
+    h.mutationOptions = optionsFactory;
+    return {
+      mutate: h.updateDiscussion,
+      error: h.error,
+      loading: ref(false),
+      onDone: (cb: () => void) => {
+        h.onDone = cb;
+      },
+    };
+  },
+}));
+vi.mock('vue-router', () => ({ useRoute: () => h.route }));
+
+const stub = (name: string, props: string[] = [], emits: string[] = []) => ({
+  name,
+  props,
+  emits,
+  template: '<div><slot /></div>',
+});
+
+const mountForm = (props: Record<string, unknown> = {}) =>
+  mount(AlbumEditForm, {
+    props,
+    global: {
+      stubs: {
+        AlbumEditor: stub('AlbumEditor', ['formValues'], ['update-form-values']),
+        PrimaryButton: stub('PrimaryButton', ['label', 'loading'], ['click']),
+        GenericButton: stub('GenericButton', ['text'], ['click']),
+        Notification: stub('Notification', ['show'], ['close-notification']),
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err" />' },
+      },
+    },
+  });
+
+const editor = (w: ReturnType<typeof mount>) =>
+  w.getComponent({ name: 'AlbumEditor' });
+const updateInput = () =>
+  (h.mutationOptions?.().variables as { updateDiscussionInput: Record<string, unknown> })
+    .updateDiscussionInput;
+
+const editDiscussion = () =>
+  ({
+    id: 'd1',
+    Album: {
+      id: 'alb1',
+      imageOrder: ['img1'],
+      Images: [{ id: 'img1', url: 'u1', caption: 'c1', alt: 'a1', copyright: '' }],
+    },
+  }) as unknown as Discussion;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.mutationOptions = undefined;
+  h.onDone = undefined;
+  h.error = { value: null };
+  h.route = { params: {} };
+});
+
+describe('AlbumEditForm mode', () => {
+  it('shows the Save Album button in create mode', () => {
+    const wrapper = mountForm({ discussion: undefined });
+
+    expect(wrapper.findComponent({ name: 'PrimaryButton' }).exists()).toBe(true);
+  });
+
+  it('has no Save button in edit mode', () => {
+    const wrapper = mountForm({ discussion: editDiscussion() });
+
+    expect(wrapper.findComponent({ name: 'PrimaryButton' }).exists()).toBe(false);
+  });
+
+  it('shows the auto-save / Close UI in edit mode', () => {
+    const wrapper = mountForm({ discussion: editDiscussion() });
+
+    expect(wrapper.text()).toContain('saved automatically');
+  });
+});
+
+describe('AlbumEditForm album updates', () => {
+  it('emits form values on album change in create mode', async () => {
+    const wrapper = mountForm({ discussion: undefined });
+
+    await editor(wrapper).vm.$emit('update-form-values', {
+      album: { images: [{ id: 'x' }], imageOrder: ['x'] },
+    });
+
+    expect(wrapper.emitted('updateFormValues')).toBeTruthy();
+  });
+
+  it('does not auto-emit on album change in edit mode', async () => {
+    const wrapper = mountForm({ discussion: editDiscussion() });
+
+    await editor(wrapper).vm.$emit('update-form-values', {
+      album: { images: [], imageOrder: [] },
+    });
+
+    expect(wrapper.emitted('updateFormValues')).toBeUndefined();
+  });
+});
+
+describe('AlbumEditForm save', () => {
+  it('emits form values and shows a notification in temp-id mode', async () => {
+    const wrapper = mountForm({ discussion: { id: 'temp-id' } });
+
+    await wrapper.getComponent({ name: 'PrimaryButton' }).vm.$emit('click');
+
+    expect(wrapper.getComponent({ name: 'Notification' }).props('show')).toBe(true);
+  });
+
+  it('runs the update mutation when saving a new (non-temp) album', async () => {
+    const wrapper = mountForm({ discussion: undefined });
+
+    await wrapper.getComponent({ name: 'PrimaryButton' }).vm.$emit('click');
+
+    expect(h.updateDiscussion).toHaveBeenCalled();
+  });
+
+  it('closes the editor when the mutation completes', () => {
+    const wrapper = mountForm({ discussion: editDiscussion() });
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('closeEditor')).toBeTruthy();
+  });
+
+  it('shows an error banner when the mutation errors', () => {
+    h.error = { value: { message: 'boom' } };
+    const wrapper = mountForm({ discussion: editDiscussion() });
+
+    expect(wrapper.find('.err').exists()).toBe(true);
+  });
+});
+
+describe('AlbumEditForm update input', () => {
+  it('builds an Album.create input in create mode', () => {
+    mountForm({ discussion: undefined });
+
+    expect(updateInput().Album).toHaveProperty('create');
+  });
+
+  it('builds an Album.update input for an existing album', async () => {
+    mountForm({ discussion: editDiscussion() });
+    await flushPromises();
+
+    expect(updateInput().Album).toHaveProperty('update');
+  });
+
+  it('disconnects images removed from an existing album', async () => {
+    const wrapper = mountForm({ discussion: editDiscussion() });
+    await flushPromises();
+
+    await editor(wrapper).vm.$emit('update-form-values', {
+      album: { images: [], imageOrder: [] },
+    });
+
+    const ops = (updateInput().Album as { update: { node: { Images: unknown[] } } })
+      .update.node.Images;
+    expect(ops.some((op) => Object.prototype.hasOwnProperty.call(op, 'disconnect'))).toBe(
+      true
+    );
+  });
+});

--- a/components/discussion/detail/DiscussionTitleEditForm.spec.ts
+++ b/components/discussion/detail/DiscussionTitleEditForm.spec.ts
@@ -66,7 +66,15 @@ const mountForm = () =>
     global: {
       stubs: {
         RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
-        TextInput: { name: 'TextInput', props: ['value'], emits: ['update'], template: '<input />' },
+        TextInput: {
+          name: 'TextInput',
+          props: ['value'],
+          emits: ['update'],
+          // onClickEdit focuses the ref in nextTick; expose focus so it
+          // doesn't throw an unhandled rejection.
+          methods: { focus() {} },
+          template: '<input />',
+        },
         PrimaryButton: {
           name: 'PrimaryButton',
           props: ['disabled', 'loading', 'label'],

--- a/components/discussion/detail/DiscussionTitleEditForm.spec.ts
+++ b/components/discussion/detail/DiscussionTitleEditForm.spec.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import DiscussionTitleEditForm from '@/components/discussion/detail/DiscussionTitleEditForm.vue';
+
+const h = vi.hoisted(() => ({
+  answeredResult: null as unknown,
+  answeredLoading: null as unknown,
+  answeredError: null as unknown,
+  discussionResult: null as unknown,
+  discussionLoading: null as unknown,
+  discussionError: null as unknown,
+  onResult: undefined as undefined | ((r: unknown) => void),
+  updateDiscussion: vi.fn(),
+  updateError: { value: null as unknown },
+  onDone: undefined as undefined | (() => void),
+  username: null as unknown,
+  route: null as unknown,
+  callIndex: { n: 0 },
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => {
+    h.callIndex.n++;
+    if (h.callIndex.n === 1)
+      return {
+        result: h.answeredResult,
+        error: h.answeredError,
+        loading: h.answeredLoading,
+      };
+    return {
+      result: h.discussionResult,
+      error: h.discussionError,
+      loading: h.discussionLoading,
+      onResult: (cb: (r: unknown) => void) => {
+        h.onResult = cb;
+      },
+    };
+  },
+  useMutation: () => ({
+    mutate: h.updateDiscussion,
+    error: h.updateError,
+    loading: ref(false),
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+vi.mock('@/composables/useTheme', () => ({ useAppTheme: () => ({ theme: ref('light') }) }));
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ref(''),
+  useUsername: () => h.username,
+}));
+
+const discussion = () => ({
+  id: 'd1',
+  title: 'My Discussion',
+  Author: { username: 'alice' },
+  createdAt: '2024-03-30T00:00:00Z',
+});
+
+const mountForm = () =>
+  mount(DiscussionTitleEditForm, {
+    global: {
+      stubs: {
+        RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
+        TextInput: { name: 'TextInput', props: ['value'], emits: ['update'], template: '<input />' },
+        PrimaryButton: {
+          name: 'PrimaryButton',
+          props: ['disabled', 'loading', 'label'],
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')">{{ label }}</button>',
+        },
+        GenericButton: {
+          name: 'GenericButton',
+          props: ['text'],
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')">{{ text }}</button>',
+        },
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err" />' },
+        InfoBanner: { name: 'InfoBanner', props: ['text'], template: '<div class="info" />' },
+        CharCounter: { props: ['current', 'max'], template: '<div />' },
+        CheckCircleIcon: true,
+        'v-skeleton-loader': { template: '<div class="skeleton" />' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+const button = (w: ReturnType<typeof mount>, text: string) =>
+  w.findAll('button').find((b) => b.text() === text);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.callIndex.n = 0;
+  h.answeredResult = ref({ discussionChannels: [{ answered: false }] });
+  h.answeredLoading = ref(false);
+  h.answeredError = ref(null);
+  h.discussionResult = ref({ discussions: [discussion()] });
+  h.discussionLoading = ref(false);
+  h.discussionError = ref(null);
+  h.onResult = undefined;
+  h.updateError = { value: null };
+  h.onDone = undefined;
+  h.username = ref('alice');
+  h.route = {
+    params: { forumId: 'cats', discussionId: 'd1' },
+    name: 'forums-forumId-discussions-discussionId',
+  };
+});
+
+describe('DiscussionTitleEditForm display', () => {
+  it('shows skeletons while loading', () => {
+    h.discussionLoading = ref(true);
+    h.discussionResult = ref(null);
+    const wrapper = mountForm();
+
+    expect(wrapper.find('.skeleton').exists()).toBe(true);
+  });
+
+  it('shows the discussion title', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.get('h1').text()).toBe('My Discussion');
+  });
+
+  it('shows a not-found message when the discussion is missing', () => {
+    h.discussionResult = ref({ discussions: [] });
+    const wrapper = mountForm();
+
+    expect(wrapper.find('.info').exists()).toBe(true);
+  });
+
+  it('shows an error banner on query error', () => {
+    h.discussionError = ref({ message: 'boom' });
+    const wrapper = mountForm();
+
+    expect(wrapper.find('.err').exists()).toBe(true);
+  });
+
+  it('shows the answered badge when the discussion is answered', () => {
+    h.answeredResult = ref({ discussionChannels: [{ answered: true }] });
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('Answered');
+  });
+});
+
+describe('DiscussionTitleEditForm author actions', () => {
+  it('shows the Edit button to the author', () => {
+    const wrapper = mountForm();
+
+    expect(button(wrapper, 'Edit')).toBeTruthy();
+  });
+
+  it('hides the Edit button from non-authors', () => {
+    h.username = ref('bob');
+    const wrapper = mountForm();
+
+    expect(button(wrapper, 'Edit')).toBeUndefined();
+  });
+
+  it('shows the New Discussion link on a discussion page', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('New Discussion');
+  });
+
+  it('shows the New Upload link on a download page', () => {
+    h.route = {
+      params: { forumId: 'cats', discussionId: 'd1' },
+      name: 'forums-forumId-downloads-discussionId',
+    };
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('New Upload');
+  });
+});
+
+describe('DiscussionTitleEditForm edit flow', () => {
+  it('enters edit mode on Edit click', async () => {
+    const wrapper = mountForm();
+
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    expect(wrapper.findComponent({ name: 'TextInput' }).exists()).toBe(true);
+  });
+
+  it('saves the new title', async () => {
+    const wrapper = mountForm();
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    await button(wrapper, 'Save')!.trigger('click');
+
+    expect(h.updateDiscussion).toHaveBeenCalled();
+  });
+
+  it('leaves edit mode when the update completes', async () => {
+    const wrapper = mountForm();
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    h.onDone?.();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'TextInput' }).exists()).toBe(false);
+  });
+
+  it('exits edit mode on Cancel', async () => {
+    const wrapper = mountForm();
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    await button(wrapper, 'Cancel')!.trigger('click');
+
+    expect(wrapper.findComponent({ name: 'TextInput' }).exists()).toBe(false);
+  });
+
+  it('syncs the form title from the query result', async () => {
+    const wrapper = mountForm();
+
+    h.onResult?.({ data: { discussions: [{ title: 'Loaded Title' }] } });
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    expect(wrapper.getComponent({ name: 'TextInput' }).props('value')).toBe(
+      'Loaded Title'
+    );
+  });
+});

--- a/components/mod/CreateIssueForm.spec.ts
+++ b/components/mod/CreateIssueForm.spec.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import CreateIssueForm from '@/components/mod/CreateIssueForm.vue';
+
+const h = vi.hoisted(() => ({
+  modName: null as unknown,
+  username: null as unknown,
+  createIssue: vi.fn(),
+  mutationOptions: undefined as undefined | (() => Record<string, unknown>),
+  onDone: undefined as undefined | ((r: unknown) => void),
+  error: { value: null as unknown },
+  push: vi.fn(),
+  back: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: (_doc: unknown, optionsFactory: () => Record<string, unknown>) => {
+    h.mutationOptions = optionsFactory;
+    return {
+      mutate: h.createIssue,
+      loading: ref(false),
+      error: h.error,
+      onDone: (cb: (r: unknown) => void) => {
+        h.onDone = cb;
+      },
+    };
+  },
+}));
+vi.mock('nuxt/app', () => ({
+  useRouter: () => ({ push: h.push, back: h.back }),
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => h.modName,
+  useUsername: () => h.username,
+}));
+
+const stub = (name: string, props: string[] = [], emits: string[] = []) => ({
+  name,
+  props,
+  emits,
+  template: '<div><slot /></div>',
+});
+
+const mountForm = (props: Record<string, unknown> = {}, hasAuth = true) =>
+  mount(CreateIssueForm, {
+    props,
+    global: {
+      stubs: {
+        RequireAuth: {
+          template: `<div><slot name="${hasAuth ? 'has-auth' : 'does-not-have-auth'}" /></div>`,
+        },
+        TextInput: stub('TextInput', ['value'], ['update']),
+        TextEditor: stub('TextEditor', ['initialValue'], ['update']),
+        PrimaryButton: stub('PrimaryButton', ['disabled', 'loading', 'label'], ['click']),
+        GenericButton: stub('GenericButton', ['text'], ['click']),
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err" />' },
+      },
+    },
+  });
+
+const titleInput = (w: ReturnType<typeof mount>) =>
+  w.getComponent({ name: 'TextInput' });
+const bodyInput = (w: ReturnType<typeof mount>) =>
+  w.getComponent({ name: 'TextEditor' });
+const submitBtn = (w: ReturnType<typeof mount>) =>
+  w.getComponent({ name: 'PrimaryButton' });
+
+const fill = async (w: ReturnType<typeof mount>, title = 'T', body = 'B') => {
+  await titleInput(w).vm.$emit('update', title);
+  await bodyInput(w).vm.$emit('update', body);
+};
+
+const input = () =>
+  (h.mutationOptions?.().variables as { input: Record<string, unknown> }).input;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.modName = ref('');
+  h.username = ref('alice');
+  h.mutationOptions = undefined;
+  h.onDone = undefined;
+  h.error = { value: null };
+});
+
+describe('CreateIssueForm auth gate', () => {
+  it('shows a sign-in message when unauthenticated', () => {
+    const wrapper = mountForm({}, false);
+
+    expect(wrapper.text()).toContain("don't have permission");
+  });
+
+  it('shows the form when authenticated', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('New Issue');
+  });
+});
+
+describe('CreateIssueForm canSubmit', () => {
+  it('disables submit until title and body are filled', () => {
+    const wrapper = mountForm();
+
+    expect(submitBtn(wrapper).props('disabled')).toBe(true);
+  });
+
+  it('enables submit once title and body are present', async () => {
+    const wrapper = mountForm();
+
+    await fill(wrapper);
+
+    expect(submitBtn(wrapper).props('disabled')).toBe(false);
+  });
+
+  it('stays disabled with no author', async () => {
+    h.username = ref('');
+    const wrapper = mountForm();
+
+    await fill(wrapper);
+
+    expect(submitBtn(wrapper).props('disabled')).toBe(true);
+  });
+});
+
+describe('CreateIssueForm issue input', () => {
+  it('connects the author as a user when only a username exists', async () => {
+    const wrapper = mountForm();
+    await fill(wrapper);
+
+    expect(input().Author).toMatchObject({
+      User: { connect: { where: { node: { username: 'alice' } } } },
+    });
+  });
+
+  it('prefers the moderation profile as the author when present', async () => {
+    h.modName = ref('modAlice');
+    const wrapper = mountForm();
+    await fill(wrapper);
+
+    expect(input().Author).toMatchObject({
+      ModerationProfile: { connect: { where: { node: { displayName: 'modAlice' } } } },
+    });
+  });
+
+  it('attaches a channel connection when a channel is selected', async () => {
+    const wrapper = mountForm({ defaultChannelId: 'cats' });
+    await fill(wrapper);
+
+    expect(input().channelUniqueName).toBe('cats');
+  });
+
+  it('omits the channel when none is selected', async () => {
+    const wrapper = mountForm();
+    await fill(wrapper);
+
+    expect(input().Channel).toBeUndefined();
+  });
+});
+
+describe('CreateIssueForm submit', () => {
+  it('runs the mutation when submitting a valid form', async () => {
+    const wrapper = mountForm();
+    await fill(wrapper);
+
+    await submitBtn(wrapper).vm.$emit('click');
+
+    expect(h.createIssue).toHaveBeenCalled();
+  });
+
+  it('does not run the mutation when the form is invalid', async () => {
+    const wrapper = mountForm();
+
+    await submitBtn(wrapper).vm.$emit('click');
+
+    expect(h.createIssue).not.toHaveBeenCalled();
+  });
+
+  it('navigates back on cancel', async () => {
+    const wrapper = mountForm();
+
+    await wrapper.getComponent({ name: 'GenericButton' }).vm.$emit('click');
+
+    expect(h.back).toHaveBeenCalled();
+  });
+
+  it('shows an error banner when the mutation errors', () => {
+    h.error = { value: { message: 'boom' } };
+    const wrapper = mountForm();
+
+    expect(wrapper.find('.err').exists()).toBe(true);
+  });
+});
+
+describe('CreateIssueForm navigation on success', () => {
+  it('routes to the forum issue page when the issue has a channel', () => {
+    mountForm({ defaultChannelId: 'cats' });
+
+    h.onDone?.({
+      data: { createIssue: { issueNumber: 5, Channel: { uniqueName: 'cats' } } },
+    });
+
+    expect(h.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'forums-forumId-issues-issueNumber',
+        params: { forumId: 'cats', issueNumber: 5 },
+      })
+    );
+  });
+
+  it('routes to the admin issue page when there is no channel', () => {
+    mountForm();
+
+    h.onDone?.({ data: { createIssue: { issueNumber: 9 } } });
+
+    expect(h.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'admin-issues-issueNumber',
+        params: { issueNumber: 9 },
+      })
+    );
+  });
+});
+
+describe('CreateIssueForm cache update', () => {
+  const makeCache = () => ({
+    readQuery: vi.fn(() => ({
+      channels: [{ Issues: [] }],
+      issuesAggregate: { count: 2 },
+    })),
+    writeQuery: vi.fn(),
+  });
+
+  it('prepends the new issue and bumps counts for a channel issue', () => {
+    mountForm({ defaultChannelId: 'cats' });
+    const cache = makeCache();
+
+    (h.mutationOptions?.().update as (c: unknown, r: unknown) => void)(cache, {
+      data: { createIssue: { issueNumber: 1 } },
+    });
+
+    expect(cache.writeQuery).toHaveBeenCalled();
+  });
+
+  it('still bumps the server count for an issue with no channel', () => {
+    mountForm();
+    const cache = makeCache();
+
+    (h.mutationOptions?.().update as (c: unknown, r: unknown) => void)(cache, {
+      data: { createIssue: { issueNumber: 1 } },
+    });
+
+    expect(cache.writeQuery).toHaveBeenCalled();
+  });
+});

--- a/components/mod/IssueTitleEditForm.spec.ts
+++ b/components/mod/IssueTitleEditForm.spec.ts
@@ -52,7 +52,15 @@ const mountForm = () =>
     global: {
       stubs: {
         RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
-        TextInput: { name: 'TextInput', props: ['value'], emits: ['update'], template: '<input />' },
+        TextInput: {
+          name: 'TextInput',
+          props: ['value'],
+          emits: ['update'],
+          // onClickEdit focuses the ref in nextTick; expose focus so it
+          // doesn't throw an unhandled rejection.
+          methods: { focus() {} },
+          template: '<input />',
+        },
         PrimaryButton: {
           name: 'PrimaryButton',
           props: ['disabled', 'loading', 'label'],

--- a/components/mod/IssueTitleEditForm.spec.ts
+++ b/components/mod/IssueTitleEditForm.spec.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import IssueTitleEditForm from '@/components/mod/IssueTitleEditForm.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  loading: null as unknown,
+  error: null as unknown,
+  onResult: undefined as undefined | ((r: unknown) => void),
+  updateIssue: vi.fn(),
+  updateError: { value: null as unknown },
+  onDone: undefined as undefined | (() => void),
+  modName: null as unknown,
+  route: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: h.result,
+    error: h.error,
+    loading: h.loading,
+    onResult: (cb: (r: unknown) => void) => {
+      h.onResult = cb;
+    },
+  }),
+  useMutation: () => ({
+    mutate: h.updateIssue,
+    error: h.updateError,
+    loading: ref(false),
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+vi.mock('@/composables/useTheme', () => ({ useAppTheme: () => ({ theme: ref('light') }) }));
+vi.mock('@/composables/useAuthState', () => ({ useModProfileName: () => h.modName }));
+
+const issue = (overrides: Record<string, unknown> = {}) => ({
+  id: 'i1',
+  title: 'My Issue',
+  isOpen: true,
+  createdAt: '2024-03-30T00:00:00Z',
+  Author: { displayName: 'mod1' },
+  ...overrides,
+});
+
+const mountForm = () =>
+  mount(IssueTitleEditForm, {
+    global: {
+      stubs: {
+        RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
+        TextInput: { name: 'TextInput', props: ['value'], emits: ['update'], template: '<input />' },
+        PrimaryButton: {
+          name: 'PrimaryButton',
+          props: ['disabled', 'loading', 'label'],
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')">{{ label }}</button>',
+        },
+        GenericButton: {
+          name: 'GenericButton',
+          props: ['text'],
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')">{{ text }}</button>',
+        },
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err" />' },
+        IssueBadge: { name: 'IssueBadge', props: ['issue'], template: '<div class="badge" />' },
+        CharCounter: { props: ['current', 'max'], template: '<div />' },
+        'v-skeleton-loader': { template: '<div class="skeleton" />' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+const button = (w: ReturnType<typeof mount>, text: string) =>
+  w.findAll('button').find((b) => b.text() === text);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref({ issues: [issue()] });
+  h.loading = ref(false);
+  h.error = ref(null);
+  h.onResult = undefined;
+  h.updateError = { value: null };
+  h.onDone = undefined;
+  h.modName = ref('mod1');
+  h.route = { params: { forumId: 'cats', issueNumber: '5' } };
+});
+
+describe('IssueTitleEditForm display', () => {
+  it('shows skeletons while loading', () => {
+    h.loading = ref(true);
+    h.result = ref(null);
+    const wrapper = mountForm();
+
+    expect(wrapper.find('.skeleton').exists()).toBe(true);
+  });
+
+  it('shows the issue title', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.get('h2').text()).toBe('My Issue');
+  });
+
+  it('shows a not-found message when the issue is missing', () => {
+    h.result = ref({ issues: [] });
+    const wrapper = mountForm();
+
+    expect(wrapper.get('h2').text()).toContain("Couldn't find the issue");
+  });
+
+  it('shows an error banner on query error', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountForm();
+
+    expect(wrapper.find('.err').exists()).toBe(true);
+  });
+
+  it('shows the issue badge', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.find('.badge').exists()).toBe(true);
+  });
+
+  it('notes when the issue collects reports for content', () => {
+    h.result = ref({ issues: [issue({ relatedDiscussionId: 'd1' })] });
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('All reports for this content');
+  });
+
+  it('shows the reporter and date', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('First reported on');
+  });
+});
+
+describe('IssueTitleEditForm author actions', () => {
+  it('shows the Edit button to the author', () => {
+    const wrapper = mountForm();
+
+    expect(button(wrapper, 'Edit')).toBeTruthy();
+  });
+
+  it('hides the Edit button from non-authors', () => {
+    h.modName = ref('someoneElse');
+    const wrapper = mountForm();
+
+    expect(button(wrapper, 'Edit')).toBeUndefined();
+  });
+
+  it('always shows the New Issue link', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('New Issue');
+  });
+});
+
+describe('IssueTitleEditForm edit flow', () => {
+  it('enters edit mode on Edit click', async () => {
+    const wrapper = mountForm();
+
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    expect(wrapper.findComponent({ name: 'TextInput' }).exists()).toBe(true);
+  });
+
+  it('saves the new title', async () => {
+    const wrapper = mountForm();
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    await button(wrapper, 'Save')!.trigger('click');
+
+    expect(h.updateIssue).toHaveBeenCalled();
+  });
+
+  it('leaves edit mode when the update completes', async () => {
+    const wrapper = mountForm();
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    h.onDone?.();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'TextInput' }).exists()).toBe(false);
+  });
+
+  it('exits edit mode on Cancel', async () => {
+    const wrapper = mountForm();
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    await button(wrapper, 'Cancel')!.trigger('click');
+
+    expect(wrapper.findComponent({ name: 'TextInput' }).exists()).toBe(false);
+  });
+
+  it('syncs the form title from the query result', async () => {
+    const wrapper = mountForm();
+
+    h.onResult?.({ data: { issues: [{ title: 'Loaded Issue' }] } });
+    await button(wrapper, 'Edit')!.trigger('click');
+
+    expect(wrapper.getComponent({ name: 'TextInput' }).props('value')).toBe(
+      'Loaded Issue'
+    );
+  });
+});

--- a/components/mod/ReportChannelImageModal.spec.ts
+++ b/components/mod/ReportChannelImageModal.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ReportChannelImageModal from '@/components/mod/ReportChannelImageModal.vue';
+
+const h = vi.hoisted(() => ({
+  rulesResult: null as unknown,
+  rulesLoading: null as unknown,
+  rulesError: null as unknown,
+  report: vi.fn(),
+  reportError: { value: null as unknown },
+  onDone: undefined as undefined | (() => void),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: h.rulesResult,
+    loading: h.rulesLoading,
+    error: h.rulesError,
+  }),
+  useMutation: () => ({
+    mutate: h.report,
+    loading: ref(false),
+    error: h.reportError,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const rules = (list: { summary: string; detail: string }[]) =>
+  ref({ serverConfigs: [{ rules: JSON.stringify(list) }] });
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(ReportChannelImageModal, {
+    props: { channelUniqueName: 'cats', imageType: 'ICON', open: true, ...props },
+    global: {
+      stubs: {
+        GenericModal: {
+          name: 'GenericModal',
+          props: ['title', 'open', 'primaryButtonDisabled', 'error'],
+          emits: ['primary-button-click', 'close'],
+          template: '<div><slot name="content" /></div>',
+        },
+        TextEditor: { name: 'TextEditor', props: ['initialValue'], emits: ['update'], template: '<div />' },
+        BrokenRuleListItem: {
+          name: 'BrokenRuleListItem',
+          props: ['rule', 'selected'],
+          emits: ['toggle-selection'],
+          template: '<div />',
+        },
+        FlagIcon: true,
+      },
+    },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent({ name: 'GenericModal' });
+const selectRule = (w: ReturnType<typeof mount>) =>
+  w.getComponent({ name: 'BrokenRuleListItem' }).vm.$emit('toggle-selection');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.rulesResult = rules([{ summary: 'No spam', detail: 'd1' }]);
+  h.rulesLoading = ref(false);
+  h.rulesError = ref(null);
+  h.reportError = { value: null };
+  h.onDone = undefined;
+});
+
+describe('ReportChannelImageModal', () => {
+  it('renders a list item per server rule', () => {
+    h.rulesResult = rules([
+      { summary: 'No spam', detail: 'd1' },
+      { summary: 'Be nice', detail: 'd2' },
+    ]);
+    const wrapper = mountModal();
+
+    expect(wrapper.findAllComponents({ name: 'BrokenRuleListItem' })).toHaveLength(2);
+  });
+
+  it('shows a loading state while rules load', () => {
+    h.rulesLoading = ref(true);
+    const wrapper = mountModal();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('disables submit until a rule is selected', () => {
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(true);
+  });
+
+  it('submits the report with the channel name and image type', async () => {
+    const wrapper = mountModal();
+    await selectRule(wrapper);
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.report).toHaveBeenCalledWith({
+      channelUniqueName: 'cats',
+      imageType: 'ICON',
+      reportText: '',
+      selectedServerRules: ['No spam'],
+    });
+  });
+
+  it('does not submit when no rule is selected', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.report).not.toHaveBeenCalled();
+  });
+
+  it('emits success when the report completes', () => {
+    const wrapper = mountModal();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('reportSubmittedSuccessfully')).toBeTruthy();
+  });
+
+  it('emits close when dismissed', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/components/mod/ReportChannelModal.spec.ts
+++ b/components/mod/ReportChannelModal.spec.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ReportChannelModal from '@/components/mod/ReportChannelModal.vue';
+
+const h = vi.hoisted(() => ({
+  rulesResult: null as unknown,
+  rulesLoading: null as unknown,
+  rulesError: null as unknown,
+  report: vi.fn(),
+  reportError: { value: null as unknown },
+  onDone: undefined as undefined | (() => void),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: h.rulesResult,
+    loading: h.rulesLoading,
+    error: h.rulesError,
+  }),
+  useMutation: () => ({
+    mutate: h.report,
+    loading: ref(false),
+    error: h.reportError,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const rules = (list: { summary: string; detail: string }[]) =>
+  ref({ serverConfigs: [{ rules: JSON.stringify(list) }] });
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(ReportChannelModal, {
+    props: { channelUniqueName: 'cats', open: true, ...props },
+    global: {
+      stubs: {
+        GenericModal: {
+          name: 'GenericModal',
+          props: ['title', 'open', 'primaryButtonDisabled', 'error'],
+          emits: ['primary-button-click', 'close'],
+          template: '<div><slot name="content" /></div>',
+        },
+        TextEditor: { name: 'TextEditor', props: ['initialValue'], emits: ['update'], template: '<div />' },
+        BrokenRuleListItem: {
+          name: 'BrokenRuleListItem',
+          props: ['rule', 'selected'],
+          emits: ['toggle-selection'],
+          template: '<div />',
+        },
+        FlagIcon: true,
+      },
+    },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent({ name: 'GenericModal' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.rulesResult = rules([{ summary: 'No spam', detail: 'd1' }]);
+  h.rulesLoading = ref(false);
+  h.rulesError = ref(null);
+  h.reportError = { value: null };
+  h.onDone = undefined;
+});
+
+describe('ReportChannelModal rules', () => {
+  it('shows a loading state while rules load', () => {
+    h.rulesLoading = ref(true);
+    const wrapper = mountModal();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('shows an error when rules fail to load', () => {
+    h.rulesError = ref({ message: 'rules boom' });
+    const wrapper = mountModal();
+
+    expect(wrapper.text()).toContain('rules boom');
+  });
+
+  it('renders a list item per server rule', () => {
+    h.rulesResult = rules([
+      { summary: 'No spam', detail: 'd1' },
+      { summary: 'Be nice', detail: 'd2' },
+    ]);
+    const wrapper = mountModal();
+
+    expect(wrapper.findAllComponents({ name: 'BrokenRuleListItem' })).toHaveLength(2);
+  });
+
+  it('shows a message when no rules are configured', () => {
+    h.rulesResult = rules([]);
+    const wrapper = mountModal();
+
+    expect(wrapper.text()).toContain('No server rules configured');
+  });
+});
+
+describe('ReportChannelModal title', () => {
+  it('prefers the display name', () => {
+    const wrapper = mountModal({ channelDisplayName: 'Cats Forum' });
+
+    expect(modal(wrapper).props('title')).toContain('Cats Forum');
+  });
+});
+
+describe('ReportChannelModal submit', () => {
+  it('disables submit until a rule is selected', () => {
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(true);
+  });
+
+  it('enables submit after selecting a rule', async () => {
+    const wrapper = mountModal();
+
+    await wrapper.getComponent({ name: 'BrokenRuleListItem' }).vm.$emit('toggle-selection');
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(false);
+  });
+
+  it('submits the report with the selected rules', async () => {
+    const wrapper = mountModal();
+    await wrapper.getComponent({ name: 'BrokenRuleListItem' }).vm.$emit('toggle-selection');
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.report).toHaveBeenCalledWith({
+      channelUniqueName: 'cats',
+      reportText: '',
+      selectedServerRules: ['No spam'],
+    });
+  });
+
+  it('does not submit when no rule is selected', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.report).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReportChannelModal lifecycle', () => {
+  it('emits success when the report completes', () => {
+    const wrapper = mountModal();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('reportSubmittedSuccessfully')).toBeTruthy();
+  });
+
+  it('emits close when dismissed', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/components/mod/ReportProfilePictureModal.spec.ts
+++ b/components/mod/ReportProfilePictureModal.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ReportProfilePictureModal from '@/components/mod/ReportProfilePictureModal.vue';
+
+const h = vi.hoisted(() => ({
+  rulesResult: null as unknown,
+  rulesLoading: null as unknown,
+  rulesError: null as unknown,
+  report: vi.fn(),
+  reportError: { value: null as unknown },
+  onDone: undefined as undefined | (() => void),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: h.rulesResult,
+    loading: h.rulesLoading,
+    error: h.rulesError,
+  }),
+  useMutation: () => ({
+    mutate: h.report,
+    loading: ref(false),
+    error: h.reportError,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const rules = (list: { summary: string; detail: string }[]) =>
+  ref({ serverConfigs: [{ rules: JSON.stringify(list) }] });
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(ReportProfilePictureModal, {
+    props: { username: 'alice', open: true, ...props },
+    global: {
+      stubs: {
+        GenericModal: {
+          name: 'GenericModal',
+          props: ['title', 'open', 'primaryButtonDisabled', 'error'],
+          emits: ['primary-button-click', 'close'],
+          template: '<div><slot name="content" /></div>',
+        },
+        TextEditor: { name: 'TextEditor', props: ['initialValue'], emits: ['update'], template: '<div />' },
+        BrokenRuleListItem: {
+          name: 'BrokenRuleListItem',
+          props: ['rule', 'selected'],
+          emits: ['toggle-selection'],
+          template: '<div />',
+        },
+        FlagIcon: true,
+      },
+    },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent({ name: 'GenericModal' });
+const selectRule = (w: ReturnType<typeof mount>) =>
+  w.getComponent({ name: 'BrokenRuleListItem' }).vm.$emit('toggle-selection');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.rulesResult = rules([{ summary: 'No spam', detail: 'd1' }]);
+  h.rulesLoading = ref(false);
+  h.rulesError = ref(null);
+  h.reportError = { value: null };
+  h.onDone = undefined;
+});
+
+describe('ReportProfilePictureModal', () => {
+  it('renders a list item per server rule', () => {
+    h.rulesResult = rules([
+      { summary: 'No spam', detail: 'd1' },
+      { summary: 'Be nice', detail: 'd2' },
+    ]);
+    const wrapper = mountModal();
+
+    expect(wrapper.findAllComponents({ name: 'BrokenRuleListItem' })).toHaveLength(2);
+  });
+
+  it('shows an error when rules fail to load', () => {
+    h.rulesError = ref({ message: 'rules boom' });
+    const wrapper = mountModal();
+
+    expect(wrapper.text()).toContain('rules boom');
+  });
+
+  it('disables submit until a rule is selected', () => {
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(true);
+  });
+
+  it('submits the report with the username', async () => {
+    const wrapper = mountModal();
+    await selectRule(wrapper);
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.report).toHaveBeenCalledWith({
+      username: 'alice',
+      reportText: '',
+      selectedServerRules: ['No spam'],
+    });
+  });
+
+  it('does not submit when no rule is selected', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.report).not.toHaveBeenCalled();
+  });
+
+  it('emits success when the report completes', () => {
+    const wrapper = mountModal();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('reportSubmittedSuccessfully')).toBeTruthy();
+  });
+
+  it('emits close when dismissed', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/components/user/EditAccountSettingsFields.spec.ts
+++ b/components/user/EditAccountSettingsFields.spec.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import EditAccountSettingsFields from '@/components/user/EditAccountSettingsFields.vue';
+
+const h = vi.hoisted(() => ({
+  username: null as unknown,
+  createSignedStorageUrl: vi.fn(),
+  uploadLink: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({ mutate: h.createSignedStorageUrl }),
+}));
+vi.mock('@/composables/useAuthState', () => ({ useUsername: () => h.username }));
+vi.mock('@/utils', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    uploadAndGetEmbeddedLink: (...a: unknown[]) =>
+      (h.uploadLink as (...x: unknown[]) => unknown)(...a),
+  };
+});
+
+const stub = (name: string, props: string[] = [], emits: string[] = []) => ({
+  name,
+  props,
+  emits,
+  template: '<div><slot /></div>',
+});
+
+const mountFields = (props: Record<string, unknown> = {}) =>
+  mount(EditAccountSettingsFields, {
+    props: {
+      formValues: { displayName: 'Alice', bio: 'hi', profilePicURL: '' },
+      ...props,
+    },
+    global: {
+      mocks: { $t: (k: string) => k },
+      stubs: {
+        FormComponent: stub('FormComponent', ['needsChanges', 'loading'], ['input', 'submit']),
+        FormRow: { template: '<div><slot name="content" /></div>' },
+        TextInput: stub('TextInput', ['value', 'disabled'], ['update']),
+        TextEditor: stub('TextEditor', ['initialValue'], ['update']),
+        AddImage: stub('AddImage', ['fieldName'], ['file-change']),
+        CharCounter: stub('CharCounter', ['current', 'max']),
+        AvatarComponent: true,
+      },
+    },
+  });
+
+const displayNameInput = (w: ReturnType<typeof mount>) =>
+  w.findAllComponents({ name: 'TextInput' })[1];
+
+const changeProfilePic = async (w: ReturnType<typeof mount>, file: File) => {
+  await w.getComponent({ name: 'AddImage' }).vm.$emit('file-change', {
+    event: { target: { files: [file] } },
+    fieldName: 'coverImageURL',
+  });
+  await flushPromises();
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.username = ref('alice');
+  vi.stubGlobal('alert', vi.fn());
+  h.createSignedStorageUrl.mockResolvedValue({
+    data: { createSignedStorageURL: { url: 'https://signed' } },
+  });
+  h.uploadLink.mockResolvedValue('https://cdn.example.com/pic.png');
+});
+
+describe('EditAccountSettingsFields states', () => {
+  it('shows a loading message while the user is loading with no form', () => {
+    const wrapper = mountFields({ formValues: null, userLoading: true });
+
+    expect(wrapper.text()).toContain('common.loading');
+  });
+
+  it('shows query errors', () => {
+    const wrapper = mountFields({
+      formValues: null,
+      getUserError: { graphQLErrors: [{ message: 'nope' }] },
+    });
+
+    expect(wrapper.text()).toContain('nope');
+  });
+
+  it('renders the form when form values are present', () => {
+    const wrapper = mountFields();
+
+    expect(wrapper.findComponent({ name: 'FormComponent' }).exists()).toBe(true);
+  });
+});
+
+describe('EditAccountSettingsFields editing', () => {
+  it('emits a display-name change', async () => {
+    const wrapper = mountFields();
+
+    await displayNameInput(wrapper).vm.$emit('update', 'New Name');
+
+    expect(wrapper.emitted('updateFormValues')?.at(-1)?.[0]).toEqual({
+      displayName: 'New Name',
+    });
+  });
+
+  it('emits a bio change', async () => {
+    const wrapper = mountFields();
+
+    await wrapper.getComponent({ name: 'TextEditor' }).vm.$emit('update', 'new bio');
+
+    expect(wrapper.emitted('updateFormValues')?.at(-1)?.[0]).toEqual({
+      bio: 'new bio',
+    });
+  });
+
+  it('emits submit from the form', async () => {
+    const wrapper = mountFields();
+
+    await wrapper.getComponent({ name: 'FormComponent' }).vm.$emit('submit');
+
+    expect(wrapper.emitted('submit')).toBeTruthy();
+  });
+
+  it('flags needsChanges when the bio is too long', () => {
+    const wrapper = mountFields({
+      formValues: { displayName: 'A', bio: 'x'.repeat(5000), profilePicURL: '' },
+    });
+
+    expect(
+      wrapper.getComponent({ name: 'FormComponent' }).props('needsChanges')
+    ).toBe(true);
+  });
+});
+
+describe('EditAccountSettingsFields profile picture upload', () => {
+  it('uploads and emits the new picture URL then submits', async () => {
+    const wrapper = mountFields();
+
+    await changeProfilePic(wrapper, new File(['x'], 'pic.png'));
+
+    expect(wrapper.emitted('updateFormValues')?.at(-1)?.[0]).toEqual({
+      profilePicURL: 'https://cdn.example.com/pic.png',
+    });
+  });
+
+  it('emits submit after a successful upload', async () => {
+    const wrapper = mountFields();
+
+    await changeProfilePic(wrapper, new File(['x'], 'pic.png'));
+
+    expect(wrapper.emitted('submit')).toBeTruthy();
+  });
+
+  it('alerts and skips upload for an oversized profile picture', async () => {
+    const wrapper = mountFields();
+    const big = new File(['x'], 'big.png');
+    Object.defineProperty(big, 'size', { value: 5 * 1024 * 1024 });
+
+    await changeProfilePic(wrapper, big);
+
+    expect(h.createSignedStorageUrl).not.toHaveBeenCalled();
+  });
+});

--- a/components/user/EditAccountSettingsFields.spec.ts
+++ b/components/user/EditAccountSettingsFields.spec.ts
@@ -41,7 +41,14 @@ const mountFields = (props: Record<string, unknown> = {}) =>
       stubs: {
         FormComponent: stub('FormComponent', ['needsChanges', 'loading'], ['input', 'submit']),
         FormRow: { template: '<div><slot name="content" /></div>' },
-        TextInput: stub('TextInput', ['value', 'disabled'], ['update']),
+        TextInput: {
+          name: 'TextInput',
+          props: ['value', 'disabled'],
+          emits: ['update'],
+          // The component focuses $el.children[0].childNodes[0] in a nextTick on
+          // create; give the stub that nested structure so it doesn't throw.
+          template: '<div><span><input /></span></div>',
+        },
         TextEditor: stub('TextEditor', ['initialValue'], ['update']),
         AddImage: stub('AddImage', ['fieldName'], ['file-change']),
         CharCounter: stub('CharCounter', ['current', 'max']),

--- a/components/wiki/OnThisPage.spec.ts
+++ b/components/wiki/OnThisPage.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import OnThisPage from '@/components/wiki/OnThisPage.vue';
+
+const h = vi.hoisted(() => ({
+  headings: null as unknown,
+  scrollToHeading: vi.fn(),
+}));
+
+vi.mock('@/composables/useMarkdownHeadings', () => ({
+  useMarkdownHeadings: () => ({
+    headings: h.headings,
+    scrollToHeading: h.scrollToHeading,
+  }),
+}));
+
+const mountToc = (props: Record<string, unknown> = {}) =>
+  mount(OnThisPage, {
+    props: { markdownContent: '# hi', ...props },
+    global: { stubs: { ChevronDownIcon: true } },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.headings = ref([
+    { id: '1', anchor: 'intro', text: 'Intro', level: 1 },
+    { id: '2', anchor: 'sub', text: 'Sub', level: 2 },
+    { id: '3', anchor: 'deep', text: 'Too Deep', level: 5 },
+  ]);
+});
+
+describe('OnThisPage rendering', () => {
+  it('renders nothing when there are no headings', () => {
+    h.headings = ref([]);
+    const wrapper = mountToc();
+
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('renders the On This Page heading on desktop', () => {
+    const wrapper = mountToc();
+
+    expect(wrapper.text()).toContain('On This Page');
+  });
+
+  it('lists headings up to level 4 only', () => {
+    const wrapper = mountToc();
+
+    // 2 of 3 headings (level 5 excluded); no mobile toggle button on desktop
+    expect(wrapper.findAll('button')).toHaveLength(2);
+  });
+
+  it('shows the heading text', () => {
+    const wrapper = mountToc();
+
+    expect(wrapper.text()).toContain('Intro');
+  });
+});
+
+describe('OnThisPage navigation', () => {
+  it('scrolls to the heading on click', async () => {
+    const wrapper = mountToc();
+
+    await wrapper.findAll('button')[0].trigger('click');
+
+    expect(h.scrollToHeading).toHaveBeenCalledWith('intro');
+  });
+
+  it('marks the clicked heading active', async () => {
+    const wrapper = mountToc();
+
+    await wrapper.findAll('button')[0].trigger('click');
+
+    expect(wrapper.findAll('button')[0].classes()).toContain('bg-orange-100');
+  });
+
+  it('updates the URL hash on click', async () => {
+    const wrapper = mountToc();
+
+    await wrapper.findAll('button')[0].trigger('click');
+
+    expect(window.location.hash).toBe('#intro');
+  });
+});
+
+describe('OnThisPage scroll spy', () => {
+  it('activates the last heading scrolled past', async () => {
+    const intro = document.createElement('div');
+    intro.id = 'intro';
+    Object.defineProperty(intro, 'offsetTop', { value: 0, configurable: true });
+    const sub = document.createElement('div');
+    sub.id = 'sub';
+    Object.defineProperty(sub, 'offsetTop', { value: 500, configurable: true });
+    document.body.append(intro, sub);
+    Object.defineProperty(window, 'scrollY', { value: 1000, configurable: true });
+
+    const wrapper = mountToc();
+    window.dispatchEvent(new Event('scroll'));
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.findAll('button').find((b) => b.text() === 'Sub')?.classes()
+    ).toContain('bg-orange-100');
+    document.body.innerHTML = '';
+  });
+});
+
+describe('OnThisPage mobile', () => {
+  it('hides the heading list until the dropdown is opened', () => {
+    const wrapper = mountToc({ isMobile: true });
+
+    expect(wrapper.find('nav').exists()).toBe(false);
+  });
+
+  it('opens the dropdown on toggle', async () => {
+    const wrapper = mountToc({ isMobile: true });
+
+    await wrapper.get('button').trigger('click');
+
+    expect(wrapper.find('nav').exists()).toBe(true);
+  });
+
+  it('closes the dropdown after selecting a heading', async () => {
+    const wrapper = mountToc({ isMobile: true });
+    await wrapper.get('button').trigger('click');
+
+    await wrapper.findAll('nav button')[0].trigger('click');
+
+    expect(wrapper.find('nav').exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Continues the unit-test coverage campaign on a fresh branch off `main`. Spec files only — real-mount each component, mock the data layer, keep the component's own logic real.

This PR accumulates several components; running list below.

## Covered

| Component | Before → After (lines) |
|---|---|
| `components/mod/CreateIssueForm.vue` | ~0% → **97%** |
| `components/channel/DownloadList.vue` | ~0% → **85%** |

(more being added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)