### PR TITLE
docs: link to the backend repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Key differentiators:
 - Personal libraries for organizing favorites and collections
 - Granular moderation at both channel and server levels
 
-It's built with Nuxt/Vue on the frontend and a GraphQL/Neo4j backend.
+It's built with Nuxt/Vue on the frontend and a GraphQL/Neo4j backend. The
+backend lives in a separate repository:
+[gennit-project/multiforum-backend](https://github.com/gennit-project/multiforum-backend).
 
 ## Docs
 


### PR DESCRIPTION
## What changed

Adds a link from the frontend README's **About** section to the backend repository, [`gennit-project/multiforum-backend`](https://github.com/gennit-project/multiforum-backend).

## Why

The backend README links to this frontend repo, but the link wasn't reciprocal. This makes it easy to navigate from the frontend repo to the backend.

This is a companion to the backend-side cleanup in [multiforum-backend#32](https://github.com/gennit-project/multiforum-backend/pull/32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)