### PR TITLE
Discussions & events list UX overhaul + favorites fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Key differentiators:
 - Personal libraries for organizing favorites and collections
 - Granular moderation at both channel and server levels
 
-It's built with Nuxt/Vue on the frontend and a GraphQL/Neo4j backend.
+It's built with Nuxt/Vue on the frontend and a GraphQL/Neo4j backend. The
+backend lives in a separate repository:
+[gennit-project/multiforum-backend](https://github.com/gennit-project/multiforum-backend).
 
 ## Docs
 

--- a/components/channel/ChannelSidebar.vue
+++ b/components/channel/ChannelSidebar.vue
@@ -129,23 +129,13 @@ const handleBecomeAdminSuccess = () => {
           :is-square="false"
         />
       </div>
-      <div class="flex w-full items-center gap-4">
-        <div v-if="channelId" class="flex items-center">
-          <div class="mb-1 mt-3 flex-1">
-            <span
-              class="flex space-y-2 rounded-full border-gray-700 text-xl leading-6 text-black dark:text-gray-200"
-            >
-              {{ channel?.displayName ? channel.displayName : channelId }}
-            </span>
-            <span
-              v-if="channel?.uniqueName && channel?.displayName"
-              class="rounded-full bg-white font-mono text-sm text-gray-500 dark:bg-gray-900 dark:text-gray-300"
-            >
-              {{ `${channel.uniqueName}` }}
-            </span>
-          </div>
-        </div>
-        <div class="flex items-center">
+      <div v-if="channelId" class="mb-1 mt-3 flex w-full flex-col">
+        <div class="flex items-center gap-4">
+          <span
+            class="flex space-y-2 rounded-full border-gray-700 text-xl leading-6 text-black dark:text-gray-200"
+          >
+            {{ channel?.displayName ? channel.displayName : channelId }}
+          </span>
           <AddToChannelFavorites
             :allow-add-to-list="true"
             :channel-unique-name="channelId"
@@ -153,6 +143,12 @@ const handleBecomeAdminSuccess = () => {
             size="medium"
           />
         </div>
+        <span
+          v-if="channel?.uniqueName && channel?.displayName"
+          class="font-mono text-sm text-gray-500 dark:text-gray-300"
+        >
+          {{ `${channel.uniqueName}` }}
+        </span>
       </div>
       <MarkdownPreview
         v-if="channel?.description"

--- a/components/comments/Votes.vue
+++ b/components/comments/Votes.vue
@@ -183,8 +183,8 @@ function viewFeedback() {
       @vote="clickUpvote"
     >
       <i class="fa-solid fa-arrow-up" aria-hidden="true" />
-      <span class="text-xs">{{ upvoteActive ? 'Undo' : 'Upvote' }}</span>
       <span class="text-xs">{{ upvoteCount }}</span>
+      <span class="text-xs">{{ upvoteActive ? 'Undo' : 'Upvote' }}</span>
     </VoteButton>
 
     <!-- Super Upvote button - visible when user has upvoted and not own content -->

--- a/components/discussion/detail/DiscussionTitleEditForm.spec.ts
+++ b/components/discussion/detail/DiscussionTitleEditForm.spec.ts
@@ -66,6 +66,8 @@ const mountForm = () =>
     global: {
       stubs: {
         RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
+        // Apollo/Pinia-backed; not relevant to the title-form behavior here.
+        AddToDiscussionFavorites: true,
         TextInput: {
           name: 'TextInput',
           props: ['value'],

--- a/components/discussion/detail/DiscussionTitleEditForm.vue
+++ b/components/discussion/detail/DiscussionTitleEditForm.vue
@@ -4,6 +4,7 @@ import type { Discussion } from '@/__generated__/graphql';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import PrimaryButton from '@/components/PrimaryButton.vue';
 import GenericButton from '@/components/GenericButton.vue';
+import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
 import TextInput from '@/components/TextInput.vue';
 import { UPDATE_DISCUSSION_WITH_CHANNEL_CONNECTIONS } from '@/graphQLData/discussion/mutations';
 import { useMutation, useQuery } from '@vue/apollo-composable';
@@ -186,61 +187,73 @@ const isDownloadDetailPage = computed(() => {
           </span>
         </p>
       </div>
-      <RequireAuth class="hidden md:block" :full-width="false">
-        <template #has-auth>
-          <GenericButton
-            v-if="!titleEditMode && authorIsLoggedInUser"
-            :text="'Edit'"
-            @click="onClickEdit"
+      <div class="hidden items-center gap-2 md:flex">
+        <div v-if="discussion" class="title-favorite-button flex items-center">
+          <AddToDiscussionFavorites
+            :allow-add-to-list="true"
+            :discussion-id="discussion.id"
+            :discussion-title="discussion.title"
+            :entity-name="isDownloadDetailPage ? 'Download' : 'Discussion'"
+            :entity-type="isDownloadDetailPage ? 'download' : 'discussion'"
+            size="large"
           />
-          <nuxt-link
-            v-if="!titleEditMode && !isDownloadDetailPage"
-            :to="`/forums/${channelId}/discussions/create`"
-            class="ml-2 inline-flex items-center gap-1 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-          >
-            New Discussion
-          </nuxt-link>
-          <nuxt-link
-            v-if="!titleEditMode && isDownloadDetailPage"
-            :to="`/forums/${channelId}/downloads/create`"
-            class="ml-2 inline-flex items-center gap-1 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-          >
-            New Upload
-          </nuxt-link>
-          <PrimaryButton
-            v-if="titleEditMode"
-            :disabled="
-              formValues.title.length === 0 ||
-              formValues.title.length > DISCUSSION_TITLE_CHAR_LIMIT
-            "
-            :label="'Save'"
-            :loading="updateDiscussionLoading"
-            @click="updateDiscussion"
-          />
-          <GenericButton
-            v-if="titleEditMode"
-            :text="'Cancel'"
-            class="ml-2"
-            @click="titleEditMode = false"
-          />
-        </template>
-        <template #does-not-have-auth>
-          <button
-            v-if="!isDownloadDetailPage"
-            type="button"
-            class="ml-2 inline-flex items-center gap-1 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-          >
-            New Discussion
-          </button>
-          <button
-            v-else
-            type="button"
-            class="ml-2 inline-flex items-center gap-1 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-          >
-            New Upload
-          </button>
-        </template>
-      </RequireAuth>
+        </div>
+        <RequireAuth :full-width="false">
+          <template #has-auth>
+            <GenericButton
+              v-if="!titleEditMode && authorIsLoggedInUser"
+              :text="'Edit'"
+              @click="onClickEdit"
+            />
+            <nuxt-link
+              v-if="!titleEditMode && !isDownloadDetailPage"
+              :to="`/forums/${channelId}/discussions/create`"
+              class="ml-2 inline-flex items-center gap-1 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              New Discussion
+            </nuxt-link>
+            <nuxt-link
+              v-if="!titleEditMode && isDownloadDetailPage"
+              :to="`/forums/${channelId}/downloads/create`"
+              class="ml-2 inline-flex items-center gap-1 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              New Upload
+            </nuxt-link>
+            <PrimaryButton
+              v-if="titleEditMode"
+              :disabled="
+                formValues.title.length === 0 ||
+                formValues.title.length > DISCUSSION_TITLE_CHAR_LIMIT
+              "
+              :label="'Save'"
+              :loading="updateDiscussionLoading"
+              @click="updateDiscussion"
+            />
+            <GenericButton
+              v-if="titleEditMode"
+              :text="'Cancel'"
+              class="ml-2"
+              @click="titleEditMode = false"
+            />
+          </template>
+          <template #does-not-have-auth>
+            <button
+              v-if="!isDownloadDetailPage"
+              type="button"
+              class="ml-2 inline-flex items-center gap-1 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              New Discussion
+            </button>
+            <button
+              v-else
+              type="button"
+              class="ml-2 inline-flex items-center gap-1 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              New Upload
+            </button>
+          </template>
+        </RequireAuth>
+      </div>
     </div>
 
     <ErrorBanner
@@ -260,3 +273,12 @@ const isDownloadDetailPage = computed(() => {
     />
   </div>
 </template>
+
+<style scoped>
+/* Match the favorites button height to the adjacent Edit / New Discussion buttons */
+.title-favorite-button :deep(.add-to-favorites-button) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/components/discussion/list/SitewideDiscussionList.vue
+++ b/components/discussion/list/SitewideDiscussionList.vue
@@ -308,7 +308,7 @@ const filterByChannel = (channel: string) => {
             </p>
             <div v-if="discussions && discussions.length > 0" class="p-0">
               <ul
-                class="m-0 flex flex-col divide-y divide-gray-200 bg-white p-0 shadow dark:divide-gray-700 dark:bg-black sm:rounded-lg"
+                class="m-0 flex flex-col p-0 lg:divide-y lg:divide-gray-200 lg:rounded-lg lg:bg-white lg:shadow lg:dark:divide-gray-700 lg:dark:bg-black"
                 data-testid="sitewide-discussion-list"
                 role="list"
               >

--- a/components/discussion/list/SitewideDiscussionList.vue
+++ b/components/discussion/list/SitewideDiscussionList.vue
@@ -367,7 +367,7 @@ const filterByChannel = (channel: string) => {
                 <nuxt-link
                   v-if="selectedDiscussionLink"
                   :to="selectedDiscussionLink"
-                  class="break-words text-lg font-semibold text-gray-900 hover:underline dark:text-gray-100"
+                  class="break-words text-lg font-semibold text-gray-900 underline dark:text-gray-100"
                 >
                   {{ selectedDiscussionTitle }}
                 </nuxt-link>

--- a/components/discussion/list/SitewideDiscussionListItem.spec.ts
+++ b/components/discussion/list/SitewideDiscussionListItem.spec.ts
@@ -22,6 +22,7 @@ const mountItem = (discussion: Discussion) => {
     global: {
       stubs: {
         AddToDiscussionFavorites: true,
+        AvatarComponent: true,
         MarkdownPreview: true,
         UsernameWithTooltip: true,
         TagComponent: true,
@@ -38,6 +39,26 @@ const discussion = (overrides: Record<string, unknown> = {}): Discussion =>
     ...overrides,
   } as Partial<Discussion>);
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const channel = (uniqueName: string, channelIconURL = ''): any => ({
+  channelUniqueName: uniqueName,
+  Channel: { uniqueName, displayName: uniqueName, channelIconURL },
+  CommentsAggregate: { count: 0 },
+});
+
+const album = (
+  images: { id: string; url: string }[],
+  imageOrder: string[] = []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any => ({ id: 'album-1', imageOrder, Images: images });
+
+// The channel-icon wrapper carries the `group/chicon` class; each holds a
+// hover tooltip element carrying `group-hover/chicon`.
+const channelIcons = (wrapper: ReturnType<typeof mountItem>) =>
+  wrapper.findAll('[class~="group/chicon"]');
+const thumbnail = (wrapper: ReturnType<typeof mountItem>) =>
+  wrapper.find('img[class*="object-cover"]');
+
 describe('SitewideDiscussionListItem', () => {
   it('renders the discussion title', () => {
     const wrapper = mountItem(discussion({ title: 'My Discussion' }));
@@ -47,5 +68,108 @@ describe('SitewideDiscussionListItem', () => {
   it('reflects an overridden title', () => {
     const wrapper = mountItem(discussion({ title: 'Another One' }));
     expect(wrapper.text()).toContain('Another One');
+  });
+});
+
+describe('SitewideDiscussionListItem channel icons', () => {
+  it('renders one icon for a single-channel discussion', () => {
+    const wrapper = mountItem(
+      discussion({ DiscussionChannels: [channel('cats')] })
+    );
+    expect(channelIcons(wrapper)).toHaveLength(1);
+  });
+
+  it('caps the icon stack at three for a many-channel discussion', () => {
+    const wrapper = mountItem(
+      discussion({
+        DiscussionChannels: [
+          channel('a'),
+          channel('b'),
+          channel('c'),
+          channel('d'),
+        ],
+      })
+    );
+    expect(channelIcons(wrapper)).toHaveLength(3);
+  });
+
+  it('shows an "and N more" label when posted to more than three channels', () => {
+    const wrapper = mountItem(
+      discussion({
+        DiscussionChannels: [
+          channel('a'),
+          channel('b'),
+          channel('c'),
+          channel('d'),
+        ],
+      })
+    );
+    expect(wrapper.text()).toContain('and 1 more');
+  });
+
+  it('omits the "and N more" label at three or fewer channels', () => {
+    const wrapper = mountItem(
+      discussion({
+        DiscussionChannels: [channel('a'), channel('b'), channel('c')],
+      })
+    );
+    expect(wrapper.text()).not.toContain('more');
+  });
+
+  it('labels each channel icon with its uniqueName via a hover tooltip', () => {
+    const wrapper = mountItem(
+      discussion({ DiscussionChannels: [channel('cats')] })
+    );
+    expect(wrapper.find('[class*="group-hover/chicon"]').text()).toBe('cats');
+  });
+});
+
+describe('SitewideDiscussionListItem thumbnail', () => {
+  it('uses the first album image as the thumbnail', () => {
+    const wrapper = mountItem(
+      discussion({
+        DiscussionChannels: [channel('cats')],
+        Album: album([{ id: 'i1', url: 'https://img/a.jpg' }]),
+      })
+    );
+    expect(thumbnail(wrapper).attributes('src')).toBe('https://img/a.jpg');
+  });
+
+  it('respects imageOrder when choosing the album thumbnail', () => {
+    const wrapper = mountItem(
+      discussion({
+        DiscussionChannels: [channel('cats')],
+        Album: album(
+          [
+            { id: 'i1', url: 'https://img/a.jpg' },
+            { id: 'i2', url: 'https://img/b.jpg' },
+          ],
+          ['i2']
+        ),
+      })
+    );
+    expect(thumbnail(wrapper).attributes('src')).toBe('https://img/b.jpg');
+  });
+
+  it('falls back to the first markdown image in the body when there is no album', () => {
+    const wrapper = mountItem(
+      discussion({
+        DiscussionChannels: [channel('cats')],
+        Album: null,
+        body: 'look ![cat](https://img/body.png) at this',
+      })
+    );
+    expect(thumbnail(wrapper).attributes('src')).toBe('https://img/body.png');
+  });
+
+  it('renders no thumbnail for a text-only discussion', () => {
+    const wrapper = mountItem(
+      discussion({
+        DiscussionChannels: [channel('cats')],
+        Album: null,
+        body: 'just text, no images here',
+      })
+    );
+    expect(thumbnail(wrapper).exists()).toBe(false);
   });
 });

--- a/components/discussion/list/SitewideDiscussionListItem.vue
+++ b/components/discussion/list/SitewideDiscussionListItem.vue
@@ -10,6 +10,7 @@ import type {
 import type { DiscussionWithFavorited } from '@/types/Discussion';
 import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
 import TagComponent from '@/components/TagComponent.vue';
+import AvatarComponent from '@/components/AvatarComponent.vue';
 import HighlightedSearchTerms from '@/components/HighlightedSearchTerms.vue';
 import MarkdownPreview from '@/components/MarkdownPreview.vue';
 import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue';
@@ -125,15 +126,6 @@ const discussionDetailOptions = computed(() => {
   }).sort((a, b) => b.label.localeCompare(a.label));
 });
 
-const primaryForumName = computed(() => {
-  const firstChannel = safeArrayFirst(
-    props.discussion?.DiscussionChannels || []
-  );
-  return (
-    firstChannel?.Channel?.displayName || firstChannel?.channelUniqueName || ''
-  );
-});
-
 const authorIsAdmin = computed(() => {
   return (
     getServerRoleBadge({
@@ -199,6 +191,44 @@ const relative = computed(() =>
   props.discussion ? relativeTime(props.discussion.createdAt) : ''
 );
 
+// Thumbnail for the mobile card layout. Prefers the first album image
+// (respecting imageOrder), then falls back to the first image embedded in the
+// discussion body markdown so image posts without an album still show one.
+const thumbnailUrl = computed(() => {
+  const album = props.discussion?.Album;
+  const images = album?.Images || [];
+  if (images.length) {
+    const order = album?.imageOrder || [];
+    if (order.length) {
+      const firstOrdered = images.find((img) => img?.id === order[0]);
+      if (firstOrdered?.url) return firstOrdered.url;
+    }
+    if (images[0]?.url) return images[0].url;
+  }
+
+  const body = props.discussion?.body || '';
+  const markdownImage = body.match(/!\[[^\]]*\]\(([^)\s]+)\)/);
+  if (markdownImage?.[1]) return markdownImage[1];
+  const htmlImage = body.match(/<img[^>]+src=["']([^"']+)["']/i);
+  if (htmlImage?.[1]) return htmlImage[1];
+
+  return '';
+});
+
+// Channel icons for the mobile card. A discussion can be posted to multiple
+// forums; we show up to three overlapping channel icons and an "and N more"
+// label for the remainder.
+const channelIcons = computed(() =>
+  (props.discussion?.DiscussionChannels || []).map((dc: DiscussionChannel) => ({
+    uniqueName: dc.channelUniqueName,
+    iconURL: dc.Channel?.channelIconURL || '',
+  }))
+);
+const displayChannelIcons = computed(() => channelIcons.value.slice(0, 3));
+const extraChannelCount = computed(() =>
+  Math.max(0, channelIcons.value.length - 3)
+);
+
 // Sensitive content logic
 const sensitiveContentRevealed = ref(false);
 const hasSensitiveContent = computed(
@@ -223,24 +253,62 @@ const revealSensitiveContent = () => {
 </script>
 
 <template>
-  <li
-    class="list-none px-4 py-4"
-    :class="{
-      'bg-gray-100 dark:bg-gray-800': isSelected,
-    }"
-  >
-    <div class="flex w-full justify-between">
-      <div class="w-full">
-        <div class="flex items-center">
+  <li class="list-none">
+    <div
+      class="m-2 flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-900 lg:m-0 lg:block lg:gap-0 lg:rounded-none lg:border-0 lg:bg-transparent lg:p-4 lg:dark:bg-transparent"
+      :class="{
+        'ring-2 ring-orange-400 dark:ring-orange-500 lg:bg-gray-100 lg:ring-0 dark:lg:bg-gray-800':
+          isSelected,
+      }"
+    >
+      <!-- Discussion row -->
+      <div class="flex items-start gap-3">
+        <div class="flex flex-shrink-0 flex-col items-center gap-1">
+          <div v-if="displayChannelIcons.length" class="flex -space-x-2">
+            <div
+              v-for="channel in displayChannelIcons"
+              :key="channel.uniqueName"
+              class="group/chicon relative"
+            >
+              <AvatarComponent
+                class="h-8 w-8 shrink-0 rounded-full ring-2 ring-white dark:ring-gray-900"
+                :text="channel.uniqueName"
+                :src="channel.iconURL"
+                :is-small="true"
+                :is-square="false"
+                :is-decorative="true"
+              />
+              <span
+                class="pointer-events-none absolute -top-8 left-1/2 z-20 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 shadow-lg transition-opacity duration-200 group-hover/chicon:opacity-100 dark:bg-gray-700"
+              >
+                {{ channel.uniqueName }}
+              </span>
+            </div>
+          </div>
+          <span
+            v-if="extraChannelCount > 0"
+            class="text-center text-[10px] leading-tight text-gray-500 dark:text-gray-400"
+          >
+            and {{ extraChannelCount }} more
+          </span>
+          <AddToDiscussionFavorites
+            v-if="discussion"
+            :allow-add-to-list="true"
+            :discussion-id="discussion.id"
+            :discussion-title="discussion.title"
+            :initial-is-favorited="(discussion as Discussion & DiscussionWithFavorited).isFavorited"
+            size="small"
+          />
+        </div>
+        <div class="min-w-0 flex-1">
           <nuxt-link
             v-if="discussion"
             :to="getDetailLink()"
-            class="w-full text-left lg:hidden"
+            class="block lg:hidden"
           >
             <div class="flex items-start gap-2">
               <span
-                :class="isSelected ? 'text-black dark:text-white' : ''"
-                class="cursor-pointer text-sm text-gray-900 hover:text-gray-500 dark:text-gray-100 dark:hover:text-gray-300"
+                class="text-base font-semibold leading-snug text-gray-900 dark:text-gray-100"
               >
                 <HighlightedSearchTerms
                   :text="title"
@@ -249,7 +317,7 @@ const revealSensitiveContent = () => {
               </span>
               <span
                 v-if="hasSensitiveContent"
-                class="rounded-full border border-amber-700 px-2 text-xs text-amber-700 dark:border-orange-400 dark:text-orange-400"
+                class="mt-1 flex-shrink-0 rounded-full border border-amber-700 px-2 text-xs text-amber-700 dark:border-orange-400 dark:text-orange-400"
               >
                 Sensitive
               </span>
@@ -257,13 +325,12 @@ const revealSensitiveContent = () => {
           </nuxt-link>
           <nuxt-link
             v-if="discussion"
-            class="hidden w-full text-left lg:block"
             :to="getDesktopSelectionLink()"
+            class="hidden lg:block"
           >
             <div class="flex items-start gap-2">
               <span
-                :class="isSelected ? 'text-black dark:text-white' : ''"
-                class="cursor-pointer text-sm text-gray-900 hover:text-gray-500 dark:text-gray-100 dark:hover:text-gray-300"
+                class="text-base font-semibold leading-snug text-gray-900 dark:text-gray-100"
               >
                 <HighlightedSearchTerms
                   :text="title"
@@ -272,107 +339,113 @@ const revealSensitiveContent = () => {
               </span>
               <span
                 v-if="hasSensitiveContent"
-                class="rounded-full border border-amber-700 px-2 text-xs text-amber-700 dark:border-orange-400 dark:text-orange-400"
+                class="mt-1 flex-shrink-0 rounded-full border border-amber-700 px-2 text-xs text-amber-700 dark:border-orange-400 dark:text-orange-400"
               >
                 Sensitive
               </span>
             </div>
           </nuxt-link>
-        </div>
-        <div
-          class="-mt-1 text-xs text-gray-600 no-underline dark:text-gray-200"
-        >
-          <div>
-            <span class="inline">Posted {{ relative }} in </span>
+          <div
+            class="mt-1.5 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-gray-500 dark:text-gray-400"
+          >
             <nuxt-link
               v-if="discussion"
               :to="{
                 name: 'forums-forumId-discussions',
-                params: {
-                  forumId,
-                },
+                params: { forumId },
               }"
-              class="inline text-gray-800 hover:underline dark:text-gray-100"
+              class="rounded bg-gray-100 px-1.5 py-0.5 font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200"
             >
-              {{ primaryForumName }}
+              {{ forumId }}
             </nuxt-link>
             <span
               v-if="submittedToMultipleChannels"
-              class="inline text-gray-500 dark:text-gray-400"
+              class="text-gray-400 dark:text-gray-500"
             >
-              and {{ channelCount - 1 }} more
+              +{{ channelCount - 1 }}
             </span>
-            <span class="inline"> by</span>
-            <div class="inline-flex">
-              <UsernameWithTooltip
-                v-if="authorUsername"
-                :is-admin="authorIsAdmin"
-                :username="authorUsername"
-                :src="discussion?.Author?.profilePicURL || ''"
-                :display-name="discussion?.Author?.displayName || ''"
-                :comment-karma="discussion?.Author?.commentKarma ?? 0"
-                :discussion-karma="discussion?.Author?.discussionKarma ?? 0"
-                :account-created="discussion?.Author?.createdAt"
-              />
-            </div>
-
-            <!-- Comment count -->
-            <span class="mx-1 inline">•</span>
+            <span aria-hidden="true">•</span>
+            <span>{{ relative }}</span>
+            <span aria-hidden="true">•</span>
+            <UsernameWithTooltip
+              v-if="authorUsername"
+              :is-admin="authorIsAdmin"
+              :username="authorUsername"
+              :src="discussion?.Author?.profilePicURL || ''"
+              :display-name="discussion?.Author?.displayName || ''"
+              :comment-karma="discussion?.Author?.commentKarma ?? 0"
+              :discussion-karma="discussion?.Author?.discussionKarma ?? 0"
+              :account-created="discussion?.Author?.createdAt"
+            />
+            <span aria-hidden="true">•</span>
             <template v-if="discussion && !submittedToMultipleChannels">
-              <nuxt-link :to="getDetailLink()" class="inline">
+              <nuxt-link
+                :to="getDetailLink()"
+                class="flex items-center gap-1 hover:underline"
+              >
+                <i class="fa-regular fa-comment" aria-hidden="true" />
                 {{ commentCount }}
-                {{ commentCount === 1 ? 'comment' : 'comments' }}
               </nuxt-link>
             </template>
-
             <template v-else-if="discussion">
-              <span class="inline-flex">
-                <MenuButton :items="discussionDetailOptions">
-                  <span class="inline cursor-pointer">
-                    <i
-                      class="fa-regular fa-comment mr-1 h-4 w-4"
-                      aria-hidden="true"
-                    />
-                    {{ commentCount }}
-                    {{ commentCount === 1 ? 'comment' : 'comments' }} in
-                    {{ channelCount }}
-                    {{ channelCount === 1 ? 'forum' : 'forums' }}
-                    <ChevronDownIcon
-                      class="ml-1 inline h-4 w-4"
-                      aria-hidden="true"
-                    />
-                  </span>
-                </MenuButton>
-              </span>
+              <MenuButton :items="discussionDetailOptions">
+                <span class="flex cursor-pointer items-center gap-1">
+                  <i class="fa-regular fa-comment" aria-hidden="true" />
+                  {{ commentCount }} in {{ channelCount }}
+                  <ChevronDownIcon class="h-3 w-3" aria-hidden="true" />
+                </span>
+              </MenuButton>
             </template>
-
-            <div class="inline-flex">
-              <AddToDiscussionFavorites
-                v-if="discussion"
-                :allow-add-to-list="true"
-                :discussion-id="discussion.id"
-                :discussion-title="discussion.title"
-                :initial-is-favorited="(discussion as Discussion & DiscussionWithFavorited).isFavorited"
-                size="small"
-              />
-            </div>
+            <template v-if="discussion && (discussion.body || discussion.Album)">
+              <span aria-hidden="true">•</span>
+              <button
+                type="button"
+                class="flex items-center gap-1 hover:underline"
+                :aria-expanded="isExpanded"
+                @click="isExpanded = !isExpanded"
+              >
+                <i
+                  :class="isExpanded ? 'fa-solid fa-xmark' : 'fa-solid fa-expand'"
+                  class="text-[10px]"
+                  aria-hidden="true"
+                />
+                {{ isExpanded ? 'Collapse' : 'Expand' }}
+              </button>
+            </template>
           </div>
         </div>
-        <button
-          v-if="discussion && (discussion.body || discussion.Album)"
-          type="button"
-          class="text-xs text-gray-600 hover:underline dark:text-gray-300"
-          :aria-expanded="isExpanded"
-          @click="isExpanded = !isExpanded"
+        <nuxt-link
+          v-if="thumbnailUrl && discussion"
+          :to="getDetailLink()"
+          class="flex-shrink-0 lg:hidden"
         >
-          <i
-            v-if="!isExpanded"
-            class="fa-solid fa-expand mr-1 text-xs"
-            aria-hidden="true"
-          />
-          <i v-else class="fa-solid fa-x mr-1 text-xs" aria-hidden="true" />
-          {{ isExpanded ? 'Collapse' : 'Expand' }}
-        </button>
+          <img
+            :src="thumbnailUrl"
+            :alt="title"
+            class="h-16 w-16 rounded-lg object-cover sm:h-20 sm:w-20"
+          >
+        </nuxt-link>
+        <nuxt-link
+          v-if="thumbnailUrl && discussion"
+          :to="getDesktopSelectionLink()"
+          class="hidden flex-shrink-0 lg:block"
+        >
+          <img
+            :src="thumbnailUrl"
+            :alt="title"
+            class="h-16 w-16 rounded-lg object-cover sm:h-20 sm:w-20"
+          >
+        </nuxt-link>
+        <nuxt-link
+          v-if="discussion"
+          :to="getDetailLink()"
+          class="flex items-center self-center text-gray-300 dark:text-gray-600 lg:hidden"
+          aria-label="Open discussion"
+        >
+          <i class="fa-solid fa-chevron-right" aria-hidden="true" />
+        </nuxt-link>
+      </div>
+
         <div
           v-if="
             discussion && (discussion.body || discussion.Album) && isExpanded
@@ -451,7 +524,6 @@ const revealSensitiveContent = () => {
             @click="$emit('filterByTag', tag)"
           />
         </div>
-      </div>
     </div>
   </li>
 </template>

--- a/components/discussion/vote/DiscussionVotes.vue
+++ b/components/discussion/vote/DiscussionVotes.vue
@@ -280,7 +280,7 @@ async function handleUndoSuperUpvote() {
     :suspended-indefinitely="suspensionIndefinitely ?? false"
     :message="'You are suspended in this forum and cannot react.'"
   />
-  <div class="flex items-center justify-between">
+  <div class="flex items-center gap-2">
     <div class="flex items-center gap-2">
       <VoteButtons
         :downvote-active="loggedInUserDownvoted"

--- a/components/discussion/vote/VoteButtons.vue
+++ b/components/discussion/vote/VoteButtons.vue
@@ -174,8 +174,8 @@ const clickUndoSuperUpvote = () => {
           @vote="clickUp"
         >
           <span class="flex items-center gap-1">
-            <span class="text-sm">{{ upvoteCount }}</span>
             <i :class="upvoteIcon" aria-hidden="true" />
+            <span class="text-sm">{{ upvoteCount }}</span>
             <span class="text-xs">{{ upvoteActive ? 'Undo' : 'Upvote' }}</span>
           </span>
         </VoteButton>
@@ -238,8 +238,8 @@ const clickUndoSuperUpvote = () => {
         >
           <span class="flex items-center gap-1">
             <i :class="upvoteIcon" aria-hidden="true" />
-            <span class="text-sm">Upvote</span>
             <span class="text-sm">{{ upvoteCount }}</span>
+            <span class="text-sm">Upvote</span>
           </span>
         </VoteButton>
 

--- a/components/event/detail/EventDetail.vue
+++ b/components/event/detail/EventDetail.vue
@@ -88,6 +88,13 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  // When the title is shown in a preview (e.g. the search right pane), render
+  // it as an underlined link to the event detail page so it's clear that
+  // clicking it navigates away.
+  linkTitle: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(['fetchedOriginalPosterUsername']);
@@ -459,6 +466,20 @@ watchEffect(() => {
                       }"
                       class="text-orange-500 dark:text-orange-400"
                       rel="noopener noreferrer"
+                    >
+                      {{ event.title }}
+                    </nuxt-link>
+                  </template>
+                  <template v-else-if="linkTitle && channelId && event">
+                    <nuxt-link
+                      :to="{
+                        name: 'forums-forumId-events-eventId',
+                        params: {
+                          forumId: channelId,
+                          eventId: event.id,
+                        },
+                      }"
+                      class="underline"
                     >
                       {{ event.title }}
                     </nuxt-link>

--- a/components/event/list/EventListView.vue
+++ b/components/event/list/EventListView.vue
@@ -351,6 +351,7 @@ watch(isSearchListRoute, (isSearchRoute) => {
           :channel-unique-name="selectedSearchEventChannelId"
           :show-comments="false"
           :show-title="true"
+          :link-title="true"
         />
       </div>
       <div

--- a/components/favorites/AddToFavoritesButton.spec.ts
+++ b/components/favorites/AddToFavoritesButton.spec.ts
@@ -1,7 +1,24 @@
 import { describe, it, expect } from 'vitest';
+import { defineComponent, h } from 'vue';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
+
+// Override the default RequireAuth stub (which renders the has-auth slot) to
+// render the unauthenticated branch instead.
+const RequireAuthUnauth = defineComponent({
+  name: 'RequireAuth',
+  setup(_props, { slots }) {
+    return () => h('div', slots['does-not-have-auth']?.());
+  },
+});
+
+// A popover stub that exposes `isVisible` so the spec can assert it opens.
+const PopoverStub = defineComponent({
+  name: 'AddToListPopover',
+  props: { isVisible: { type: Boolean, default: false } },
+  template: '<div />',
+});
 
 // RequireAuth is stubbed by mountWithDefaults (renders the has-auth slot);
 // AddToListPopover is Apollo-backed, so stub it here.
@@ -9,6 +26,12 @@ const mountButton = (props: Record<string, unknown> = {}) =>
   mountWithDefaults(AddToFavoritesButton, {
     props: { isFavorited: false, ...props },
     global: { stubs: { AddToListPopover: true } },
+  });
+
+const mountUnauthButton = (props: Record<string, unknown> = {}) =>
+  mountWithDefaults(AddToFavoritesButton, {
+    props: { isFavorited: false, ...props },
+    global: { stubs: { RequireAuth: RequireAuthUnauth, AddToListPopover: true } },
   });
 
 const clickFavorite = (wrapper: ReturnType<typeof mountButton>) =>
@@ -49,5 +72,28 @@ describe('AddToFavoritesButton', () => {
     const wrapper = mountButton({ isFavorited: false, isLoading: true });
     await clickFavorite(wrapper);
     expect(wrapper.emitted('toggle')).toBeUndefined();
+  });
+
+  it('opens the collection popover when clicked while favorited', async () => {
+    const wrapper = mountWithDefaults(AddToFavoritesButton, {
+      props: { isFavorited: true, allowAddToList: true },
+      global: { stubs: { AddToListPopover: PopoverStub } },
+    });
+    await clickFavorite(wrapper);
+    expect(wrapper.getComponent(PopoverStub).props('isVisible')).toBe(true);
+  });
+});
+
+describe('AddToFavoritesButton (unauthenticated)', () => {
+  it('still renders a favorites button labelled to add', () => {
+    const wrapper = mountUnauthButton({ displayName: 'Trivia' });
+    expect(
+      wrapper.find('[aria-label="Add Trivia to favorites"]').exists()
+    ).toBe(true);
+  });
+
+  it('renders the unauthenticated button as clickable (cursor-pointer)', () => {
+    const wrapper = mountUnauthButton();
+    expect(wrapper.get('[aria-label]').classes()).toContain('cursor-pointer');
   });
 });

--- a/components/favorites/AddToFavoritesButton.vue
+++ b/components/favorites/AddToFavoritesButton.vue
@@ -260,7 +260,7 @@ watch(
           type="button"
           :aria-label="buttonLabel"
           :disabled="isLoading"
-          class="add-to-favorites-button rounded-full p-1 transition-all duration-200"
+          class="add-to-favorites-button rounded-full transition-all duration-200"
           :class="{
             'text-white hover:text-orange-300': !isFavorited && overlayStyle,
             'text-gray-400 hover:bg-gray-100 hover:text-orange-500 dark:hover:bg-gray-800 dark:hover:text-orange-400':
@@ -338,15 +338,17 @@ watch(
       </div>
     </template>
     <template #does-not-have-auth>
-      <div class="relative inline-block">
+      <div class="align-center relative flex justify-end">
         <button
           ref="buttonRef"
           type="button"
           :aria-label="`Add ${displayName || entityType} to favorites`"
           class="add-to-favorites-button cursor-pointer rounded-full p-1 transition-all duration-200"
-          :class="overlayStyle
-            ? 'text-white hover:text-orange-300'
-            : 'text-gray-400 hover:bg-gray-100 hover:text-orange-500 dark:hover:bg-gray-800 dark:hover:text-orange-400'"
+          :class="
+            overlayStyle
+              ? 'text-white hover:text-orange-300'
+              : 'text-gray-400 hover:bg-gray-100 hover:text-orange-500 dark:hover:bg-gray-800 dark:hover:text-orange-400'
+          "
           @click="handleClick"
           @mouseenter="handleMouseEnter"
           @mouseleave="handleMouseLeave"

--- a/components/nav/TopNav.vue
+++ b/components/nav/TopNav.vue
@@ -86,7 +86,7 @@ const isOnMapPage = computed(() => {
           @click="$emit('toggleDropdown')"
         />
 
-        <div class="ml-2 flex min-w-0 items-center space-x-1 text-sm">
+        <div class="ml-2 flex min-w-0 items-baseline space-x-1 text-sm">
           <nuxt-link to="/" class="flex items-center gap-1">
             <h1
               class="logo-font text-lg font-bold text-gray-900 dark:text-white"

--- a/graphQLData/discussion/queries.js
+++ b/graphQLData/discussion/queries.js
@@ -185,7 +185,9 @@ export const GET_SITE_WIDE_DISCUSSION_LIST = gql`
           SuperUpvotedByUsers {
             username
           }
-          CommentsAggregate {
+          CommentsAggregate(
+            where: { OR: [{ isFeedbackComment: null }, { isFeedbackComment: false }] }
+          ) {
             count
           }
           Channel {

--- a/graphQLData/discussion/queries.js
+++ b/graphQLData/discussion/queries.js
@@ -193,6 +193,7 @@ export const GET_SITE_WIDE_DISCUSSION_LIST = gql`
           Channel {
             uniqueName
             displayName
+            channelIconURL
           }
         }
         Album {

--- a/pages/events/list/search.vue
+++ b/pages/events/list/search.vue
@@ -9,7 +9,7 @@ useHead({
 
 <template>
   <NuxtLayout>
-    <div class="px-3 md:px-12">
+    <div class="px-2">
       <EventListView />
     </div>
   </NuxtLayout>

--- a/plugins/auth-username-fallback.client.spec.ts
+++ b/plugins/auth-username-fallback.client.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+
+import plugin from '@/plugins/auth-username-fallback.client';
+
+// Hoisted handles so the module mocks can read/assert the same state the test
+// configures per-case.
+const h = vi.hoisted(() => ({
+  isAuthenticated: { value: true } as { value: boolean },
+  email: { value: '' } as { value: string },
+  username: { value: '' } as { value: string },
+  setUsername: vi.fn(),
+  setModProfileName: vi.fn(),
+  setProfilePicURL: vi.fn(),
+  setNotificationCount: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('nuxt/app', () => ({
+  defineNuxtPlugin: (fn: unknown) => fn,
+}));
+vi.mock('@/config', () => ({
+  config: { graphqlUrl: 'http://test.local/graphql' },
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => h.isAuthenticated,
+  useEmail: () => h.email,
+  useUsername: () => h.username,
+  setUsername: h.setUsername,
+  setModProfileName: h.setModProfileName,
+  setProfilePicURL: h.setProfilePicURL,
+  setNotificationCount: h.setNotificationCount,
+}));
+
+const run = async () => {
+  (plugin as () => void)();
+  await flushPromises();
+};
+
+const resolvedUser = (user: Record<string, unknown> | null) => ({
+  ok: true,
+  json: async () => ({ data: { emails: [{ User: user }] } }),
+});
+
+const fullUser = {
+  username: 'cluse',
+  profilePicURL: 'https://pics/cluse.png',
+  ModerationProfile: { displayName: 'mod-cluse' },
+  NotificationsAggregate: { count: 4 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.isAuthenticated.value = true;
+  h.email.value = 'cat@example.com';
+  h.username.value = '';
+  h.fetch.mockResolvedValue(resolvedUser(fullUser));
+  global.fetch = h.fetch as unknown as typeof fetch;
+});
+
+describe('auth-username-fallback plugin: resolves when authenticated but username is empty', () => {
+  it('seeds the username from the backend lookup', async () => {
+    await run();
+    expect(h.setUsername).toHaveBeenCalledWith('cluse');
+  });
+
+  it('seeds the moderation profile name', async () => {
+    await run();
+    expect(h.setModProfileName).toHaveBeenCalledWith('mod-cluse');
+  });
+
+  it('seeds the profile picture URL', async () => {
+    await run();
+    expect(h.setProfilePicURL).toHaveBeenCalledWith('https://pics/cluse.png');
+  });
+
+  it('seeds the unread notification count', async () => {
+    await run();
+    expect(h.setNotificationCount).toHaveBeenCalledWith(4);
+  });
+
+  it('looks the user up by their email address', async () => {
+    await run();
+    const body = JSON.parse(h.fetch.mock.calls[0][1].body as string);
+    expect(body.variables.emailAddress).toBe('cat@example.com');
+  });
+});
+
+describe('auth-username-fallback plugin: skips resolution when not needed', () => {
+  it.each([
+    ['username is already resolved', () => (h.username.value = 'cluse')],
+    ['the session is not authenticated', () => (h.isAuthenticated.value = false)],
+    ['there is no email to look up by', () => (h.email.value = '')],
+  ])('does not call the backend when %s', async (_label, setup) => {
+    setup();
+    await run();
+    expect(h.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('auth-username-fallback plugin: degrades gracefully', () => {
+  it('does not seed a username when the backend has no matching user', async () => {
+    h.fetch.mockResolvedValue(resolvedUser(null));
+    await run();
+    expect(h.setUsername).not.toHaveBeenCalled();
+  });
+
+  it('does not seed a username when the lookup request fails', async () => {
+    h.fetch.mockRejectedValue(new Error('network'));
+    await run();
+    expect(h.setUsername).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/auth-username-fallback.client.ts
+++ b/plugins/auth-username-fallback.client.ts
@@ -1,0 +1,122 @@
+// plugins/auth-username-fallback.client.ts
+//
+// Client-side fallback for the app username.
+//
+// The app identity username (e.g. "cluse") is resolved server-side during SSR
+// in server/middleware/2.auth-session.ts (Auth0 email -> backend GET_EMAIL ->
+// username) and travels to the client through the Nuxt payload. There is no
+// client-side resolver anymore — the SPA `useAuthManager` was removed when the
+// server-session migration landed.
+//
+// That makes username resolution single-point-of-failure: if the SSR lookup
+// doesn't produce a username for a render (e.g. the server-side getAccessToken
+// or profile $fetch fails at render time), the client is left authenticated but
+// with an EMPTY username for the whole session. Everything keyed off username
+// then silently breaks — most visibly "Add to favorites" does nothing, because
+// the toggle handlers bail on `if (!usernameVar.value) return` and the favorite
+// mutations require the username.
+//
+// This plugin restores a minimal client fallback: when the session is
+// authenticated (we have a verified email) but username is still empty, resolve
+// it from the backend by email and seed the auth state. It mirrors GET_EMAIL
+// (graphQLData/email/queries.js) and the SSR middleware. It is fire-and-forget
+// so it never delays app startup; the reactive `username` update lets the
+// favorite-status query and ownership-gated UI come to life once it lands.
+import { defineNuxtPlugin } from 'nuxt/app';
+import { config } from '@/config';
+import {
+  useIsAuthenticated,
+  useUsername,
+  useEmail,
+  setUsername,
+  setModProfileName,
+  setProfilePicURL,
+  setNotificationCount,
+} from '@/composables/useAuthState';
+
+const GET_EMAIL_QUERY = /* GraphQL */ `
+  query getEmail($emailAddress: String!) {
+    emails(where: { address: $emailAddress }) {
+      User {
+        username
+        profilePicURL
+        ModerationProfile {
+          displayName
+        }
+        NotificationsAggregate(where: { read: false }) {
+          count
+        }
+      }
+    }
+  }
+`;
+
+type EmailLookupResponse = {
+  data?: {
+    emails?: Array<{
+      User?: {
+        username?: string | null;
+        profilePicURL?: string | null;
+        ModerationProfile?: { displayName?: string | null } | null;
+        NotificationsAggregate?: { count?: number | null } | null;
+      } | null;
+    } | null> | null;
+  };
+};
+
+const resolveUsername = async (emailAddress: string) => {
+  const endpoint = config?.graphqlUrl;
+  if (!endpoint) return;
+
+  try {
+    const token = localStorage.getItem('token');
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({
+        query: GET_EMAIL_QUERY,
+        variables: { emailAddress },
+      }),
+    });
+    if (!res.ok) return;
+
+    const json = (await res.json()) as EmailLookupResponse;
+    const user = json?.data?.emails?.[0]?.User;
+    if (!user?.username) return;
+
+    // Only seed if SSR still hasn't filled it in (avoid clobbering a value that
+    // arrived between scheduling and resolving).
+    if (!useUsername().value) {
+      setUsername(user.username);
+    }
+    if (user.ModerationProfile?.displayName) {
+      setModProfileName(user.ModerationProfile.displayName);
+    }
+    if (user.profilePicURL) {
+      setProfilePicURL(user.profilePicURL);
+    }
+    if (typeof user.NotificationsAggregate?.count === 'number') {
+      setNotificationCount(user.NotificationsAggregate.count);
+    }
+  } catch {
+    // Ignore — username stays empty and will be retried on the next load.
+  }
+};
+
+export default defineNuxtPlugin(() => {
+  if (typeof window === 'undefined') return;
+
+  const isAuthenticated = useIsAuthenticated();
+  const email = useEmail();
+  const username = useUsername();
+
+  // Nothing to do when anonymous, when we have no email to look up by, or when
+  // SSR already resolved the username.
+  if (!isAuthenticated.value || !email.value || username.value) return;
+
+  // Fire-and-forget: never block app startup on this network round-trip.
+  void resolveUsername(email.value);
+});

--- a/tests/playwright/mocked/links/verifyLinks.spec.ts
+++ b/tests/playwright/mocked/links/verifyLinks.spec.ts
@@ -353,9 +353,15 @@ test.describe('Link verification - pages resolve correctly', () => {
       // Navigate to discussion permalink
       await page.goto(`/forums/${TEST_CHANNEL}/discussions/${discussionId}`);
 
-      // Verify the page loads with correct content
+      // Verify the page loads with correct content. The detail page shows two
+      // "Add to favorites" buttons (header + title-edit form), so scope to the
+      // first to avoid a strict-mode match on both.
       await expect(
-        page.getByRole('button', { name: 'Add "Test Discussion Title" to favorites' })
+        page
+          .getByRole('button', {
+            name: 'Add "Test Discussion Title" to favorites',
+          })
+          .first()
       ).toBeVisible();
       await expect(page.getByText('Test discussion body content')).toBeVisible();
 


### PR DESCRIPTION
## Summary

A batch of frontend UX improvements to the sitewide discussion list, the events search page, favorites, and the top nav — plus the favorites "does nothing when logged in" bug fix and supporting tests.

## Discussions list redesign (`/discussions`)
- Sitewide list items redesigned: **card layout on mobile**, **flat with dividers on desktop**.
- Overlapping **channel icons** (up to 3 + "and N more") with `uniqueName` hover tooltips, replacing the author avatar.
- Bold title, forum chip + meta row, right-side **thumbnail** (album image, falling back to the first body image), inline **Expand**, and a mobile chevron.
- Right-pane discussion title underlined to signal navigation.
- Sitewide comment counts now exclude feedback comments and no longer get clobbered to 0 by the detail query (filtered `CommentsAggregate`). Fetches `channelIconURL`.

## Favorites
- **Fix: "Add to favorites" silently did nothing when logged in.** Root cause: `username` could be empty even when authenticated (SSR-only resolution with no client fallback). Added a client-side `auth-username-fallback` plugin that resolves the username from the backend by email when it's missing.
- Larger Add-to-Favorites button in the discussion title-edit form (sized to match the adjacent buttons), and the unauthenticated favorites wrapper now matches the authenticated one so it aligns the same in both states.

## Events search (`/events/list/search`)
- Tightened page margins (`px-3 md:px-12` → `px-2`) to match `/discussions`.
- Right-pane event title is now an underlined link to the event detail page (new `EventDetail` `linkTitle` prop; the actual detail page is unaffected).

## Vote buttons & nav polish
- Vote buttons show the English label last (icon → count → label) consistently; upvote/react/feedback buttons evenly spaced.
- Channel sidebar: favorites button aligned with the top name line; removed the dark-mode shaded pill behind the unique name.
- Top nav: baseline-aligned the "Topical • <label>" wordmark/label.

## Tests
- New: `auth-username-fallback` plugin spec (guards the empty-username fix).
- Extended: `SitewideDiscussionListItem` (channel-icon + thumbnail logic) and `AddToFavoritesButton` (unauthenticated slot + popover-open).
- Fixed `DiscussionTitleEditForm` spec to stub the newly-added Apollo/Pinia-backed favorites button.

## Related
- Backend comment-count fix (excludes feedback comments from the sitewide count): gennit-project/multiforum-backend#33

## Notes
- The desktop (`lg+`) flat-with-dividers layout and the right-pane event-title underline were implemented to mirror the discussions pattern but couldn't be visually verified locally (test viewport capped below the `lg` breakpoint); worth a glance on a ≥1024px screen.
- Pre-commit `verify` (tsc + full unit suite) passes on the branch tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)