### PR TITLE
test: unit coverage batch 6 (sibling clusters + primitives)

### DIFF
--- a/components/GenericModal.spec.ts
+++ b/components/GenericModal.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import GenericModal from '@/components/GenericModal.vue';
+
+// The global test setup mocks @headlessui/vue with only the Tab components, so
+// re-mock the Dialog primitives this modal uses.
+vi.mock('@headlessui/vue', () => ({
+  TransitionRoot: { name: 'TransitionRoot', template: '<div><slot /></div>' },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>' },
+  Dialog: { name: 'Dialog', emits: ['close'], template: '<div><slot /></div>' },
+  DialogPanel: { name: 'DialogPanel', template: '<div><slot /></div>' },
+  DialogTitle: { name: 'DialogTitle', template: '<div><slot /></div>' },
+}));
+
+const mountModal = (props: Record<string, unknown> = {}, slots = {}) =>
+  mount(GenericModal, {
+    props: { open: true, dataTestid: 'm', ...props },
+    slots,
+    global: {
+      stubs: {
+        ClientOnly: { template: '<div><slot /></div>' },
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
+      },
+    },
+  });
+
+const primary = (w: ReturnType<typeof mount>) => w.find('[data-testid="m-primary-button"]');
+const danger = (w: ReturnType<typeof mount>) => w.find('[data-testid="m-danger-button"]');
+const secondaryBtn = (w: ReturnType<typeof mount>) =>
+  w.findAll('button').find((b) => b.text() === 'Cancel');
+
+describe('GenericModal content', () => {
+  it('renders the title', () => {
+    const wrapper = mountModal({ title: 'Confirm?' });
+
+    expect(wrapper.text()).toContain('Confirm?');
+  });
+
+  it('renders the body', () => {
+    const wrapper = mountModal({ body: 'Body text' });
+
+    expect(wrapper.text()).toContain('Body text');
+  });
+
+  it('renders the content slot', () => {
+    const wrapper = mountModal({}, { content: '<div class="custom">hi</div>' });
+
+    expect(wrapper.find('.custom').exists()).toBe(true);
+  });
+
+  it('shows an error banner when error is set', () => {
+    const wrapper = mountModal({ error: 'boom' });
+
+    expect(wrapper.find('.err').text()).toContain('boom');
+  });
+
+  it('hides the footer when showFooter is false', () => {
+    const wrapper = mountModal({ showFooter: false });
+
+    expect(primary(wrapper).exists()).toBe(false);
+  });
+});
+
+describe('GenericModal primary button', () => {
+  it('shows the primary button text', () => {
+    const wrapper = mountModal({ primaryButtonText: 'Save' });
+
+    expect(primary(wrapper).text()).toBe('Save');
+  });
+
+  it('shows a saving label while loading', () => {
+    const wrapper = mountModal({ loading: true });
+
+    expect(primary(wrapper).text()).toBe('Saving...');
+  });
+
+  it('uses orange styling by default', () => {
+    const wrapper = mountModal();
+
+    expect(primary(wrapper).attributes('class')).toContain('bg-orange-600');
+  });
+
+  it('uses red styling with warningColor', () => {
+    const wrapper = mountModal({ warningColor: true });
+
+    expect(primary(wrapper).attributes('class')).toContain('bg-red-600');
+  });
+
+  it('is disabled and gray when primaryButtonDisabled', () => {
+    const wrapper = mountModal({ primaryButtonDisabled: true });
+
+    expect(primary(wrapper).attributes('disabled')).toBeDefined();
+  });
+
+  it('emits primaryButtonClick', async () => {
+    const wrapper = mountModal();
+
+    await primary(wrapper).trigger('click');
+
+    expect(wrapper.emitted('primaryButtonClick')).toBeTruthy();
+  });
+});
+
+describe('GenericModal danger button', () => {
+  it('is hidden without dangerButtonText', () => {
+    const wrapper = mountModal();
+
+    expect(danger(wrapper).exists()).toBe(false);
+  });
+
+  it('emits dangerButtonClick', async () => {
+    const wrapper = mountModal({ dangerButtonText: 'Redact' });
+
+    await danger(wrapper).trigger('click');
+
+    expect(wrapper.emitted('dangerButtonClick')).toBeTruthy();
+  });
+
+  it('shows a redacting label while loading', () => {
+    const wrapper = mountModal({ dangerButtonText: 'Redact', dangerButtonLoading: true });
+
+    expect(danger(wrapper).text()).toBe('Redacting...');
+  });
+});
+
+describe('GenericModal secondary button', () => {
+  it('emits close on the secondary button', async () => {
+    const wrapper = mountModal();
+
+    await secondaryBtn(wrapper)!.trigger('click');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('hides the secondary button when disabled', () => {
+    const wrapper = mountModal({ showSecondaryButton: false });
+
+    expect(secondaryBtn(wrapper)).toBeUndefined();
+  });
+});

--- a/components/LinkPreview.spec.ts
+++ b/components/LinkPreview.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import LinkPreview from '@/components/LinkPreview.vue';
+
+const ogResponse = {
+  hybridGraph: {
+    title: 'Example Title',
+    description: 'An example description',
+    image: 'https://x/og.png',
+  },
+  htmlInferred: { images: ['https://x/inferred.png'] },
+};
+
+const mountPreview = (url = 'https://example.com') =>
+  mount(LinkPreview, { props: { url } });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve({ json: () => Promise.resolve(ogResponse) }))
+  );
+});
+
+describe('LinkPreview', () => {
+  it('fetches open graph data on mount', async () => {
+    mountPreview('https://example.com');
+    await flushPromises();
+
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  it('renders the fetched title', async () => {
+    const wrapper = mountPreview();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Example Title');
+  });
+
+  it('renders the fetched description', async () => {
+    const wrapper = mountPreview();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('An example description');
+  });
+
+  it('renders the preview image', async () => {
+    const wrapper = mountPreview();
+    await flushPromises();
+
+    expect(wrapper.find('img').attributes('src')).toBe('https://x/og.png');
+  });
+
+  it('links to the target url', () => {
+    const wrapper = mountPreview('https://example.com/page');
+
+    expect(wrapper.find('a').attributes('href')).toBe('https://example.com/page');
+  });
+
+  it('hides the image when it fails to load', async () => {
+    const wrapper = mountPreview();
+    await flushPromises();
+
+    await wrapper.find('img').trigger('error');
+
+    expect(wrapper.find('img').exists()).toBe(false);
+  });
+
+  it('falls back to the url as the title when no title is returned', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              hybridGraph: { url: 'https://x/fallback' },
+              htmlInferred: {},
+            }),
+        })
+      )
+    );
+    const wrapper = mountPreview();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('https://x/fallback');
+  });
+});

--- a/components/ModalComponent.spec.ts
+++ b/components/ModalComponent.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import ModalComponent from '@/components/ModalComponent.vue';
+
+vi.mock('@headlessui/vue', () => ({
+  TransitionRoot: { name: 'TransitionRoot', template: '<div><slot /></div>' },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>' },
+  Dialog: { name: 'Dialog', template: '<div><slot /></div>' },
+  DialogPanel: { name: 'DialogPanel', template: '<div><slot /></div>' },
+  DialogTitle: { name: 'DialogTitle', template: '<div><slot /></div>' },
+}));
+
+const mountModal = (props: Record<string, unknown> = {}, slots = {}) =>
+  mount(ModalComponent, {
+    props: { show: true, title: 'My Modal', ...props },
+    slots,
+    global: {
+      stubs: {
+        ClientOnly: { template: '<div><slot /></div>' },
+        CheckIcon: true,
+      },
+    },
+  });
+
+const buttonByText = (w: ReturnType<typeof mount>, text: string) =>
+  w.findAll('button').find((b) => b.text() === text);
+
+describe('ModalComponent content', () => {
+  it('renders the title', () => {
+    const wrapper = mountModal();
+
+    expect(wrapper.text()).toContain('My Modal');
+  });
+
+  it('renders the content slot', () => {
+    const wrapper = mountModal({}, { content: '<div class="custom">body</div>' });
+
+    expect(wrapper.find('.custom').exists()).toBe(true);
+  });
+
+  it('renders a custom icon slot', () => {
+    const wrapper = mountModal({}, { icon: '<span class="myicon" />' });
+
+    expect(wrapper.find('.myicon').exists()).toBe(true);
+  });
+});
+
+describe('ModalComponent buttons', () => {
+  it('defaults the primary button to Close', () => {
+    const wrapper = mountModal();
+
+    expect(buttonByText(wrapper, 'Close')).toBeTruthy();
+  });
+
+  it('uses a custom primary button label', () => {
+    const wrapper = mountModal({ primaryButtonText: 'Confirm' });
+
+    expect(buttonByText(wrapper, 'Confirm')).toBeTruthy();
+  });
+
+  it('emits close and primaryButtonClick on the primary button', async () => {
+    const wrapper = mountModal();
+
+    await buttonByText(wrapper, 'Close')!.trigger('click');
+
+    expect(wrapper.emitted('primaryButtonClick')).toBeTruthy();
+  });
+
+  it('emits secondaryButtonClick and close on Cancel', async () => {
+    const wrapper = mountModal();
+
+    await buttonByText(wrapper, 'Cancel')!.trigger('click');
+
+    expect(wrapper.emitted('secondaryButtonClick')).toBeTruthy();
+  });
+
+  it('hides the default buttons when useCustomButtons is set', () => {
+    const wrapper = mountModal({ useCustomButtons: true });
+
+    expect(buttonByText(wrapper, 'Close')).toBeUndefined();
+  });
+});

--- a/components/RulesEditor.spec.ts
+++ b/components/RulesEditor.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import RulesEditor from '@/components/RulesEditor.vue';
+
+const rules = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ summary: `Rule ${i}`, detail: `Detail ${i}` }));
+
+const textInputStub = {
+  name: 'TextInput',
+  props: ['value', 'testId', 'placeholder'],
+  emits: ['update'],
+  template: '<input :data-testid="testId" />',
+};
+
+const mountEditor = (ruleList = rules(2)) =>
+  mount(RulesEditor, {
+    props: { formValues: { rules: ruleList } },
+    global: {
+      stubs: {
+        TextInput: textInputStub,
+        TextEditor: { name: 'TextEditor', props: ['initialValue', 'testId'], emits: ['update'], template: '<div />' },
+        XmarkIcon: true,
+      },
+    },
+  });
+
+const buttonByText = (w: ReturnType<typeof mount>, text: string) =>
+  w.findAll('button').find((b) => b.text().includes(text));
+
+describe('RulesEditor rendering', () => {
+  it('renders a block per rule', () => {
+    const wrapper = mountEditor(rules(3));
+
+    expect(wrapper.text()).toContain('Rule 3');
+  });
+
+  it('renders nothing extra for an empty rule list', () => {
+    const wrapper = mountEditor([]);
+
+    expect(wrapper.findAllComponents(textInputStub)).toHaveLength(0);
+  });
+});
+
+describe('RulesEditor editing', () => {
+  it('emits an updated summary', async () => {
+    const wrapper = mountEditor();
+
+    await wrapper.getComponent(textInputStub).vm.$emit('update', 'New summary');
+
+    const emitted = wrapper.emitted('updateFormValues');
+    expect(emitted?.at(-1)?.[0]).toEqual({
+      rules: [
+        { summary: 'New summary', detail: 'Detail 0' },
+        { summary: 'Rule 1', detail: 'Detail 1' },
+      ],
+    });
+  });
+
+  it('emits an updated detail from the editor', async () => {
+    const wrapper = mountEditor();
+
+    await wrapper.getComponent({ name: 'TextEditor' }).vm.$emit('update', 'New detail');
+
+    expect(wrapper.emitted('updateFormValues')?.at(-1)?.[0]).toEqual({
+      rules: [
+        { summary: 'Rule 0', detail: 'New detail' },
+        { summary: 'Rule 1', detail: 'Detail 1' },
+      ],
+    });
+  });
+
+  it('appends a new blank rule', async () => {
+    const wrapper = mountEditor(rules(1));
+
+    await buttonByText(wrapper, 'Add New Rule')!.trigger('click');
+
+    expect(wrapper.emitted('updateFormValues')?.[0]?.[0]).toEqual({
+      rules: [{ summary: 'Rule 0', detail: 'Detail 0' }, { summary: '', detail: '' }],
+    });
+  });
+
+  it('deletes a rule', async () => {
+    const wrapper = mountEditor(rules(2));
+
+    await buttonByText(wrapper, 'Delete Rule')!.trigger('click');
+
+    expect(wrapper.emitted('updateFormValues')?.[0]?.[0]).toEqual({
+      rules: [{ summary: 'Rule 1', detail: 'Detail 1' }],
+    });
+  });
+});

--- a/components/SearchableFileTypeList.spec.ts
+++ b/components/SearchableFileTypeList.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import SearchableFileTypeList from '@/components/SearchableFileTypeList.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  error: null as unknown,
+  loading: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.result, error: h.error, loading: h.loading }),
+}));
+
+const config = (fileTypes: string[] | null) => ({
+  serverConfigs: [{ allowedFileTypes: fileTypes }],
+});
+
+const mountList = (props: Record<string, unknown> = {}) =>
+  mount(SearchableFileTypeList, {
+    props,
+    global: {
+      stubs: {
+        SearchBar: { name: 'SearchBar', props: ['initialValue'], emits: ['update-search-input'], template: '<input class="search" />' },
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
+      },
+    },
+  });
+
+const checkbox = (w: ReturnType<typeof mount>, type: string) =>
+  w.find(`input[aria-label="Select file type ${type}"]`);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref(config(['png', 'glb', 'stl']));
+  h.error = ref(null);
+  h.loading = ref(false);
+});
+
+describe('SearchableFileTypeList states', () => {
+  it('shows a loading message', () => {
+    h.loading = ref(true);
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('shows an error banner', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountList();
+
+    expect(wrapper.find('.err').text()).toContain('boom');
+  });
+
+  it('shows the no-config message when none are configured', () => {
+    h.result = ref(config([]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('No file types are configured');
+  });
+});
+
+describe('SearchableFileTypeList list', () => {
+  it('renders a checkbox per allowed file type', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.findAll('input[type="checkbox"]')).toHaveLength(3);
+  });
+
+  it('checks a file type that is already selected', () => {
+    const wrapper = mountList({ selectedFileTypes: ['png'] });
+
+    expect((checkbox(wrapper, 'png').element as HTMLInputElement).checked).toBe(
+      true
+    );
+  });
+
+  it('emits toggleSelection when a type is checked', async () => {
+    const wrapper = mountList();
+
+    await checkbox(wrapper, 'glb').trigger('change');
+
+    expect(wrapper.emitted('toggleSelection')?.[0]).toEqual(['glb']);
+  });
+});
+
+describe('SearchableFileTypeList search', () => {
+  it('filters the list by the search input', async () => {
+    const wrapper = mountList();
+
+    await wrapper.getComponent({ name: 'SearchBar' }).vm.$emit('update-search-input', 'st');
+
+    expect(wrapper.findAll('input[type="checkbox"]')).toHaveLength(1);
+  });
+
+  it('shows a no-match message when the search matches nothing', async () => {
+    const wrapper = mountList();
+
+    await wrapper.getComponent({ name: 'SearchBar' }).vm.$emit('update-search-input', 'zzz');
+
+    expect(wrapper.text()).toContain('No file types match your search');
+  });
+});

--- a/components/TextInput.spec.ts
+++ b/components/TextInput.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import TextInput from '@/components/TextInput.vue';
+
+const mountInput = (props: Record<string, unknown> = {}) =>
+  mount(TextInput, {
+    props,
+    global: { stubs: { ExclamationTriangleIcon: true } },
+  });
+
+describe('TextInput mode', () => {
+  it('renders a single-line input by default', () => {
+    const wrapper = mountInput();
+
+    expect(wrapper.find('input').exists()).toBe(true);
+  });
+
+  it('renders a textarea for multiple rows', () => {
+    const wrapper = mountInput({ rows: 3 });
+
+    expect(wrapper.find('textarea').exists()).toBe(true);
+  });
+});
+
+describe('TextInput value', () => {
+  it('shows the initial value', () => {
+    const wrapper = mountInput({ value: 'hello' });
+
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('hello');
+  });
+
+  it('emits update on input', async () => {
+    const wrapper = mountInput();
+
+    await wrapper.find('input').setValue('typed');
+
+    expect(wrapper.emitted('update')?.[0]).toEqual(['typed']);
+  });
+
+  it('syncs the input when the value prop changes', async () => {
+    const wrapper = mountInput({ value: 'a' });
+
+    await wrapper.setProps({ value: 'b' });
+
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('b');
+  });
+});
+
+describe('TextInput labelling', () => {
+  it('renders a label when provided', () => {
+    const wrapper = mountInput({ label: 'Your name' });
+
+    expect(wrapper.find('label').text()).toBe('Your name');
+  });
+
+  it('uses the aria-label from the placeholder when there is no label', () => {
+    const wrapper = mountInput({ placeholder: 'Search' });
+
+    expect(wrapper.find('input').attributes('aria-label')).toBe('Search');
+  });
+
+  it('derives the input id from the testId', () => {
+    const wrapper = mountInput({ testId: 'name-input' });
+
+    expect(wrapper.find('input').attributes('id')).toBe('input-name-input');
+  });
+
+  it('uses an explicit id when provided', () => {
+    const wrapper = mountInput({ id: 'custom-id' });
+
+    expect(wrapper.find('input').attributes('id')).toBe('custom-id');
+  });
+});
+
+describe('TextInput validation', () => {
+  it('shows an error message', () => {
+    const wrapper = mountInput({ errorMessage: 'Required' });
+
+    expect(wrapper.find('[role="alert"]').text()).toBe('Required');
+  });
+
+  it('marks the input invalid', () => {
+    const wrapper = mountInput({ invalid: true });
+
+    expect(wrapper.find('input').attributes('aria-invalid')).toBe('true');
+  });
+
+  it('disables the input', () => {
+    const wrapper = mountInput({ disabled: true });
+
+    expect(wrapper.find('input').attributes('disabled')).toBeDefined();
+  });
+});
+
+describe('TextInput focus', () => {
+  it('focuses the input via the exposed focus method', () => {
+    const wrapper = mountInput();
+    const input = wrapper.find('input').element as HTMLInputElement;
+    const spy = vi.spyOn(input, 'focus');
+
+    (wrapper.vm as unknown as { focus: () => void }).focus();
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/components/VoteButton.spec.ts
+++ b/components/VoteButton.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import VoteButton from '@/components/VoteButton.vue';
+
+const authButtonStub = {
+  name: 'AuthButton',
+  props: ['testId', 'buttonClasses', 'props', 'loading', 'showCount', 'count'],
+  emits: ['click'],
+  template: '<button :data-classes="buttonClasses" @click="$emit(\'click\')"><slot /></button>',
+};
+
+const mountButton = (props: Record<string, unknown> = {}, slot = 'X') =>
+  mount(VoteButton, {
+    props,
+    slots: { default: slot },
+    global: {
+      stubs: {
+        AuthButton: authButtonStub,
+        ClientOnly: { template: '<div><slot /></div>' },
+        'v-tooltip': { template: '<div><slot name="activator" :props="{}" /><slot /></div>' },
+        TooltipContent: true,
+      },
+    },
+  });
+
+const authButton = (w: ReturnType<typeof mount>) => w.getComponent(authButtonStub);
+const classes = (w: ReturnType<typeof mount>) => authButton(w).props('buttonClasses') as string;
+
+describe('VoteButton classes', () => {
+  it('uses orange styling when active', () => {
+    const wrapper = mountButton({ active: true });
+
+    expect(classes(wrapper)).toContain('bg-orange-400');
+  });
+
+  it('uses gray styling when inactive', () => {
+    const wrapper = mountButton({ active: false });
+
+    expect(classes(wrapper)).toContain('bg-gray-100');
+  });
+
+  it('uses green styling for an active best answer', () => {
+    const wrapper = mountButton({ isMarkedAsAnswer: true, active: true });
+
+    expect(classes(wrapper)).toContain('bg-green-500');
+  });
+
+  it('uses light-green styling for an inactive best answer', () => {
+    const wrapper = mountButton({ isMarkedAsAnswer: true, active: false });
+
+    expect(classes(wrapper)).toContain('bg-green-100');
+  });
+
+  it('adds permalink styling when permalinked', () => {
+    const wrapper = mountButton({ isPermalinked: true });
+
+    expect(classes(wrapper)).toContain('border-orange-500');
+  });
+
+  it('includes the external class', () => {
+    const wrapper = mountButton({ class: 'my-extra-class' });
+
+    expect(classes(wrapper)).toContain('my-extra-class');
+  });
+});
+
+describe('VoteButton rendering', () => {
+  it('renders the slot content', () => {
+    const wrapper = mountButton({}, 'Upvote');
+
+    expect(wrapper.text()).toContain('Upvote');
+  });
+
+  it('forwards the count to the button', () => {
+    const wrapper = mountButton({ count: 9, showCount: true });
+
+    expect(authButton(wrapper).props('count')).toBe(9);
+  });
+
+  it('emits vote on click without a tooltip', async () => {
+    const wrapper = mountButton();
+
+    await authButton(wrapper).trigger('click');
+
+    expect(wrapper.emitted('vote')).toBeTruthy();
+  });
+
+  it('renders inside a tooltip when tooltipText is set', () => {
+    const wrapper = mountButton({ tooltipText: 'Upvote this' });
+
+    expect(authButton(wrapper).exists()).toBe(true);
+  });
+
+  it('emits vote from the tooltip activator button', async () => {
+    const wrapper = mountButton({ tooltipText: 'Upvote this' });
+
+    await authButton(wrapper).trigger('click');
+
+    expect(wrapper.emitted('vote')).toBeTruthy();
+  });
+});

--- a/components/channel/ChannelListItem.spec.ts
+++ b/components/channel/ChannelListItem.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import ChannelListItem from '@/components/channel/ChannelListItem.vue';
+import type { Channel } from '@/__generated__/graphql';
+
+const channel = (overrides: Record<string, unknown> = {}) =>
+  ({
+    uniqueName: 'cats',
+    displayName: 'Cats Forum',
+    description: 'All about cats',
+    Tags: [{ text: 'pets' }, { text: 'cute' }],
+    DiscussionChannelsAggregate: { count: 12 },
+    EventChannelsAggregate: { count: 0 },
+    ...overrides,
+  }) as unknown as Channel;
+
+const highlightStub = { name: 'HighlightedSearchTerms', props: ['text', 'searchInput'], template: '<span>{{ text }}</span>' };
+const tagStub = { name: 'Tag', props: ['tag', 'active'], emits: ['click'], template: '<button class="tag" @click="$emit(\'click\')">{{ tag }}</button>' };
+
+const mountItem = (props: Record<string, unknown> = {}) =>
+  mount(ChannelListItem, {
+    props: { channel: channel(), ...props },
+    global: {
+      stubs: {
+        HighlightedSearchTerms: highlightStub,
+        Tag: tagStub,
+        TagComponent: tagStub,
+        AvatarComponent: true,
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+        DiscussionIcon: true,
+        DownloadIcon: true,
+        CalendarIcon: true,
+      },
+    },
+  });
+
+describe('ChannelListItem content', () => {
+  it('shows the display name', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('Cats Forum');
+  });
+
+  it('shows the unique name', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('cats');
+  });
+
+  it('shows the description', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('All about cats');
+  });
+});
+
+describe('ChannelListItem tags', () => {
+  it('renders a tag per channel tag', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.findAll('.tag')).toHaveLength(2);
+  });
+
+  it('caps the tags at five with a +more indicator', () => {
+    const wrapper = mountItem({
+      channel: channel({ Tags: Array.from({ length: 8 }, (_, i) => ({ text: `t${i}` })) }),
+    });
+
+    expect(wrapper.text()).toContain('+3 more');
+  });
+
+  it('marks a selected tag active', () => {
+    const wrapper = mountItem({ selectedTags: ['pets'] });
+
+    expect(wrapper.getComponent(tagStub).props('active')).toBe(true);
+  });
+
+  it('emits filterByTag when a tag is clicked', async () => {
+    const wrapper = mountItem();
+
+    await wrapper.find('.tag').trigger('click');
+
+    expect(wrapper.emitted('filterByTag')?.[0]).toEqual(['pets']);
+  });
+});
+
+describe('ChannelListItem stats', () => {
+  it('shows the discussion count', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('12');
+  });
+
+  it('shows the download count when there are downloads', () => {
+    const wrapper = mountItem({ downloadCount: 4 });
+
+    expect(wrapper.text()).toContain('4');
+  });
+
+  it('hides downloads when the count is zero', () => {
+    const wrapper = mountItem({ downloadCount: 0 });
+
+    expect(wrapper.text()).not.toContain('Downloads');
+  });
+
+  it('shows events when there are event channels', () => {
+    const wrapper = mountItem({
+      channel: channel({ EventChannelsAggregate: { count: 3 } }),
+    });
+
+    expect(wrapper.text()).toContain('Events');
+  });
+});

--- a/components/channel/RemoveOwnerModal.spec.ts
+++ b/components/channel/RemoveOwnerModal.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import RemoveOwnerModal from '@/components/channel/RemoveOwnerModal.vue';
+
+const genericModalStub = {
+  name: 'GenericModal',
+  props: ['open', 'title', 'body', 'error', 'loading', 'primaryButtonDisabled'],
+  emits: ['primary-button-click', 'close'],
+  template: '<div><slot name="content" /></div>',
+};
+
+const textInputStub = {
+  name: 'TextInput',
+  props: ['value', 'testId'],
+  emits: ['update'],
+  template: '<input />',
+};
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(RemoveOwnerModal, {
+    props: { open: true, forumName: 'cats', ...props },
+    global: { stubs: { GenericModal: genericModalStub, TextInput: textInputStub } },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent(genericModalStub);
+const input = (w: ReturnType<typeof mount>) => w.getComponent(textInputStub);
+
+describe('RemoveOwnerModal content', () => {
+  it('shows the title', () => {
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('title')).toBe('Remove Yourself as Owner');
+  });
+
+  it('prompts to type the forum name', () => {
+    const wrapper = mountModal();
+
+    expect(wrapper.text()).toContain('Please type');
+  });
+
+  it('passes the error through to the modal', () => {
+    const wrapper = mountModal({ error: 'boom' });
+
+    expect(modal(wrapper).props('error')).toBe('boom');
+  });
+});
+
+describe('RemoveOwnerModal confirmation gate', () => {
+  it('disables the primary button until the name matches', () => {
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(true);
+  });
+
+  it('enables the primary button when the name matches', async () => {
+    const wrapper = mountModal();
+
+    await input(wrapper).vm.$emit('update', 'cats');
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(false);
+  });
+
+  it('shows a mismatch message for the wrong name', async () => {
+    const wrapper = mountModal();
+
+    await input(wrapper).vm.$emit('update', 'dogs');
+
+    expect(wrapper.text()).toContain("Forum name doesn't match");
+  });
+});
+
+describe('RemoveOwnerModal actions', () => {
+  it('emits confirm when the name matches and confirm is clicked', async () => {
+    const wrapper = mountModal();
+    await input(wrapper).vm.$emit('update', 'cats');
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(wrapper.emitted('confirm')).toBeTruthy();
+  });
+
+  it('does not emit confirm when the name does not match', async () => {
+    const wrapper = mountModal();
+    await input(wrapper).vm.$emit('update', 'dogs');
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(wrapper.emitted('confirm')).toBeUndefined();
+  });
+
+  it('emits close from the modal', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/components/channel/TabButton.spec.ts
+++ b/components/channel/TabButton.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import TabButton from '@/components/channel/TabButton.vue';
+
+const h = vi.hoisted(() => ({ route: null as unknown }));
+
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+
+const mountTab = (props: Record<string, unknown> = {}, slot = '') =>
+  mount(TabButton, {
+    props: { to: '/forums/cats', label: 'Discussions', ...props },
+    slots: { default: slot },
+    global: {
+      stubs: {
+        NuxtLink: { props: ['to'], template: '<a :class="$attrs.class"><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a :class="$attrs.class"><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.route = { path: '/forums/dogs' };
+});
+
+describe('TabButton content', () => {
+  it('renders the label', () => {
+    const wrapper = mountTab();
+
+    expect(wrapper.text()).toContain('Discussions');
+  });
+
+  it('renders the slot (icon)', () => {
+    const wrapper = mountTab({}, '<span class="icon">i</span>');
+
+    expect(wrapper.find('.icon').exists()).toBe(true);
+  });
+
+  it('shows the count when enabled', () => {
+    const wrapper = mountTab({ showCount: true, count: 7 });
+
+    expect(wrapper.text()).toContain('7');
+  });
+
+  it('hides the count when showCount is false', () => {
+    const wrapper = mountTab({ showCount: false, count: 7 });
+
+    expect(wrapper.text()).not.toContain('7');
+  });
+});
+
+describe('TabButton active state', () => {
+  it('is active when the isActive prop is true', () => {
+    const wrapper = mountTab({ isActive: true });
+
+    expect(wrapper.find('a').classes()).toContain('border-orange-500');
+  });
+
+  it('is active when the route path matches', () => {
+    h.route = { path: '/forums/cats' };
+    const wrapper = mountTab();
+
+    expect(wrapper.find('a').classes()).toContain('border-orange-500');
+  });
+
+  it('is inactive when the path does not match', () => {
+    const wrapper = mountTab();
+
+    expect(wrapper.find('a').classes()).toContain('text-gray-500');
+  });
+
+  it('uses background highlight for an active vertical tab', () => {
+    const wrapper = mountTab({ isActive: true, vertical: true });
+
+    expect(wrapper.find('a').classes()).toContain('bg-gray-100');
+  });
+});
+
+describe('TabButton hover', () => {
+  it('highlights on hover for a horizontal tab', async () => {
+    const wrapper = mountTab();
+
+    await wrapper.find('a').trigger('mouseenter');
+
+    expect(wrapper.html()).toContain('bg-gray-100');
+  });
+});

--- a/components/channel/form/SuspendedModList.spec.ts
+++ b/components/channel/form/SuspendedModList.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import SuspendedModList from '@/components/channel/form/SuspendedModList.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  loading: null as unknown,
+  error: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.result, loading: h.loading, error: h.error }),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => ({ params: { forumId: 'cats' } }) }));
+
+const suspension = (overrides: Record<string, unknown> = {}) => ({
+  username: 'alice',
+  SuspendedMod: { displayName: 'mod1' },
+  suspendedIndefinitely: false,
+  suspendedUntil: '2024-06-01T00:00:00Z',
+  createdAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const withSuspensions = (list: unknown[], count?: number) => ({
+  channels: [{ SuspendedMods: list, SuspendedModsAggregate: { count: count ?? list.length } }],
+});
+
+const mountList = () =>
+  mount(SuspendedModList, {
+    global: {
+      stubs: {
+        AvatarComponent: true,
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref(withSuspensions([suspension()]));
+  h.loading = ref(false);
+  h.error = ref(null);
+});
+
+describe('SuspendedModList states', () => {
+  it('shows a loading message', () => {
+    h.loading = ref(true);
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('shows an error message', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Error');
+  });
+
+  it('shows an empty message when there are no suspensions', () => {
+    h.result = ref(withSuspensions([]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('no active mod suspensions');
+  });
+});
+
+describe('SuspendedModList content', () => {
+  it('shows the active suspension count', () => {
+    h.result = ref(withSuspensions([suspension()], 1));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Active Suspensions (1)');
+  });
+
+  it('shows the suspended mod name and username', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('mod1 (alice)');
+  });
+
+  it('shows a suspended-until date for a temporary suspension', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Suspended until');
+  });
+
+  it('shows an indefinite-suspension message', () => {
+    h.result = ref(withSuspensions([suspension({ suspendedIndefinitely: true })]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Suspended indefinitely');
+  });
+
+  it('links to the related issue when present', () => {
+    h.result = ref(withSuspensions([suspension({ RelatedIssue: { issueNumber: 9 } })]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Related Issue');
+  });
+});

--- a/components/comments/ChildComments.spec.ts
+++ b/components/comments/ChildComments.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ChildComments from '@/components/comments/ChildComments.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  error: null as unknown,
+  loading: null as unknown,
+  fetchMore: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: h.result,
+    error: h.error,
+    loading: h.loading,
+    fetchMore: h.fetchMore,
+  }),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => ({ query: {} }) }));
+
+const replies = (ids: string[], total?: number) => ({
+  getCommentReplies: {
+    ChildComments: ids.map((id) => ({ id })),
+    aggregateChildCommentCount: total ?? ids.length,
+  },
+});
+
+const mountChild = () =>
+  mount(ChildComments, {
+    props: { modName: 'mod1', parentCommentId: 'c1' },
+    slots: {
+      default: `<template #default="{ comments }"><div class="count">{{ comments.length }}</div></template>`,
+    },
+    global: {
+      stubs: {
+        LoadMore: { name: 'LoadMore', props: ['reachedEndOfResults'], emits: ['load-more'], template: '<div class="load" />' },
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref(replies(['r1'], 3));
+  h.error = ref(null);
+  h.loading = ref(false);
+});
+
+describe('ChildComments states', () => {
+  it('shows an error banner on query error', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountChild();
+
+    expect(wrapper.find('.err').text()).toContain('boom');
+  });
+
+  it('shows a loading message', () => {
+    h.loading = ref(true);
+    const wrapper = mountChild();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('exposes the comments to the default slot', () => {
+    const wrapper = mountChild();
+
+    expect(wrapper.find('.count').text()).toBe('1');
+  });
+});
+
+describe('ChildComments load more', () => {
+  it('shows Load More when there are more replies', () => {
+    const wrapper = mountChild();
+
+    expect(wrapper.findComponent({ name: 'LoadMore' }).exists()).toBe(true);
+  });
+
+  it('hides Load More when all replies are loaded', () => {
+    h.result = ref(replies(['r1', 'r2', 'r3'], 3));
+    const wrapper = mountChild();
+
+    expect(wrapper.findComponent({ name: 'LoadMore' }).exists()).toBe(false);
+  });
+
+  it('fetches more on load-more', async () => {
+    const wrapper = mountChild();
+
+    await wrapper.getComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+
+    expect(h.fetchMore).toHaveBeenCalled();
+  });
+
+  it('merges fetched pages via updateQuery', async () => {
+    const wrapper = mountChild();
+    await wrapper.getComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+
+    const { updateQuery } = h.fetchMore.mock.calls[0][0];
+    const merged = updateQuery(replies(['r1']), { fetchMoreResult: replies(['r2']) });
+
+    expect(merged.getCommentReplies.ChildComments).toHaveLength(2);
+  });
+
+  it('keeps the previous result when there is no fetchMoreResult', async () => {
+    const wrapper = mountChild();
+    await wrapper.getComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+
+    const { updateQuery } = h.fetchMore.mock.calls[0][0];
+    const prev = replies(['r1']);
+
+    expect(updateQuery(prev, { fetchMoreResult: null })).toBe(prev);
+  });
+});

--- a/components/comments/Votes.spec.ts
+++ b/components/comments/Votes.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import Votes from '@/components/comments/Votes.vue';
+
+const voteButtonStub = {
+  name: 'VoteButton',
+  props: ['active', 'count', 'testId', 'loading', 'tooltipText', 'showCount', 'isPermalinked', 'isMarkedAsAnswer'],
+  emits: ['vote'],
+  template: '<button :data-testid="testId" @click="$emit(\'vote\')"><slot /></button>',
+};
+
+const menuButtonStub = {
+  name: 'MenuButton',
+  props: ['items', 'ariaLabel'],
+  emits: ['view-feedback', 'give-feedback', 'edit-feedback', 'undo-feedback'],
+  template: '<div class="menu"><slot /></div>',
+};
+
+const mountVotes = (props: Record<string, unknown> = {}) =>
+  mount(Votes, {
+    props,
+    global: { stubs: { VoteButton: voteButtonStub, MenuButton: menuButtonStub, FlagIcon: true } },
+  });
+
+const button = (w: ReturnType<typeof mount>, testId: string) =>
+  w.find(`[data-testid="${testId}"]`);
+const menu = (w: ReturnType<typeof mount>) => w.getComponent(menuButtonStub);
+
+describe('Votes upvote', () => {
+  it('shows the upvote button with its count', () => {
+    const wrapper = mountVotes({ upvoteCount: 5 });
+
+    expect(button(wrapper, 'upvote-comment-button').text()).toContain('5');
+  });
+
+  it('hides the upvote button when showUpvote is false', () => {
+    const wrapper = mountVotes({ showUpvote: false });
+
+    expect(button(wrapper, 'upvote-comment-button').exists()).toBe(false);
+  });
+
+  it('emits upvote when inactive', async () => {
+    const wrapper = mountVotes({ upvoteActive: false });
+
+    await button(wrapper, 'upvote-comment-button').trigger('click');
+
+    expect(wrapper.emitted('upvote')).toBeTruthy();
+  });
+
+  it('emits undoUpvote when already upvoted', async () => {
+    const wrapper = mountVotes({ upvoteActive: true });
+
+    await button(wrapper, 'upvote-comment-button').trigger('click');
+
+    expect(wrapper.emitted('undoUpvote')).toBeTruthy();
+  });
+});
+
+describe('Votes super upvote', () => {
+  it('shows the super upvote button when upvoted and not own content', () => {
+    const wrapper = mountVotes({ upvoteActive: true, isOwnContent: false });
+
+    expect(button(wrapper, 'super-upvote-comment-button').exists()).toBe(true);
+  });
+
+  it('hides the super upvote button on own content', () => {
+    const wrapper = mountVotes({ upvoteActive: true, isOwnContent: true });
+
+    expect(button(wrapper, 'super-upvote-comment-button').exists()).toBe(false);
+  });
+
+  it('emits superUpvote when inactive', async () => {
+    const wrapper = mountVotes({ upvoteActive: true, superUpvoteActive: false });
+
+    await button(wrapper, 'super-upvote-comment-button').trigger('click');
+
+    expect(wrapper.emitted('superUpvote')).toBeTruthy();
+  });
+
+  it('emits undoSuperUpvote when active', async () => {
+    const wrapper = mountVotes({ upvoteActive: true, superUpvoteActive: true });
+
+    await button(wrapper, 'super-upvote-comment-button').trigger('click');
+
+    expect(wrapper.emitted('undoSuperUpvote')).toBeTruthy();
+  });
+});
+
+describe('Votes feedback menu', () => {
+  it('offers Give Feedback when no feedback exists', () => {
+    const wrapper = mountVotes({ downvoteActive: false });
+
+    const labels = menu(wrapper).props('items').map((i: { label: string }) => i.label);
+    expect(labels).toContain('Give Feedback');
+  });
+
+  it('offers Undo and Edit Feedback when feedback exists', () => {
+    const wrapper = mountVotes({ downvoteActive: true });
+
+    const labels = menu(wrapper).props('items').map((i: { label: string }) => i.label);
+    expect(labels).toEqual(expect.arrayContaining(['Undo Feedback', 'Edit Feedback']));
+  });
+
+  it('uses active styling for the downvote when feedback is given', () => {
+    const wrapper = mountVotes({ downvoteActive: true });
+
+    expect(wrapper.html()).toContain('bg-orange-400');
+  });
+
+  it('uses green styling for a best-answer downvote', () => {
+    const wrapper = mountVotes({ downvoteActive: true, isMarkedAsAnswer: true });
+
+    expect(wrapper.html()).toContain('bg-green-500');
+  });
+
+  it('re-emits giveFeedback from the menu', async () => {
+    const wrapper = mountVotes();
+
+    await menu(wrapper).vm.$emit('give-feedback');
+
+    expect(wrapper.emitted('giveFeedback')).toBeTruthy();
+  });
+
+  it('hides the menu when showDownvote is false', () => {
+    const wrapper = mountVotes({ showDownvote: false });
+
+    expect(wrapper.findComponent(menuButtonStub).exists()).toBe(false);
+  });
+});

--- a/components/common/IconTooltip.spec.ts
+++ b/components/common/IconTooltip.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import IconTooltip from '@/components/common/IconTooltip.vue';
+
+const mountTooltip = (props: Record<string, unknown> = {}, slot = '<i class="icon" />') =>
+  mount(IconTooltip, {
+    props: { text: 'Helpful hint', ...props },
+    slots: { default: slot },
+    global: {
+      stubs: {
+        ClientOnly: { template: '<div><slot /></div>' },
+        teleport: true,
+        transition: true,
+      },
+    },
+  });
+
+const trigger = (w: ReturnType<typeof mount>) =>
+  w.find('div[class="relative inline-block"] > div');
+
+describe('IconTooltip', () => {
+  it('renders the trigger slot', () => {
+    const wrapper = mountTooltip();
+
+    expect(wrapper.find('.icon').exists()).toBe(true);
+  });
+
+  it('is hidden by default', () => {
+    const wrapper = mountTooltip();
+
+    expect(wrapper.text()).not.toContain('Helpful hint');
+  });
+
+  it('shows the tooltip on mouse enter', async () => {
+    const wrapper = mountTooltip();
+
+    await trigger(wrapper).trigger('mouseenter');
+
+    expect(wrapper.text()).toContain('Helpful hint');
+  });
+
+  it('hides the tooltip on mouse leave', async () => {
+    const wrapper = mountTooltip();
+    await trigger(wrapper).trigger('mouseenter');
+
+    await trigger(wrapper).trigger('mouseleave');
+
+    expect(wrapper.text()).not.toContain('Helpful hint');
+  });
+
+  it('shows the tooltip on focus', async () => {
+    const wrapper = mountTooltip();
+
+    await trigger(wrapper).trigger('focus');
+
+    expect(wrapper.text()).toContain('Helpful hint');
+  });
+});

--- a/components/discussion/detail/ConfirmUndoDiscussionFeedbackModal.spec.ts
+++ b/components/discussion/detail/ConfirmUndoDiscussionFeedbackModal.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ConfirmUndoDiscussionFeedbackModal from '@/components/discussion/detail/ConfirmUndoDiscussionFeedbackModal.vue';
+
+const h = vi.hoisted(() => ({
+  getError: null as unknown,
+  onResult: undefined as undefined | ((r: unknown) => void),
+  deleteFeedback: vi.fn(),
+  deleteError: null as unknown,
+  onDone: undefined as undefined | (() => void),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    error: h.getError,
+    onResult: (cb: (r: unknown) => void) => {
+      h.onResult = cb;
+    },
+  }),
+  useMutation: () => ({
+    mutate: h.deleteFeedback,
+    loading: ref(false),
+    error: h.deleteError,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const genericModalStub = {
+  name: 'GenericModal',
+  props: ['open', 'title', 'body', 'loading'],
+  emits: ['primary-button-click', 'secondary-button-click'],
+  template: '<div><slot name="content" /></div>',
+};
+
+const mountModal = () =>
+  mount(ConfirmUndoDiscussionFeedbackModal, {
+    props: { discussionId: 'd1', modName: 'mod1', open: true },
+    global: {
+      stubs: {
+        GenericModal: genericModalStub,
+        CommentHeader: { name: 'CommentHeader', props: ['commentData'], template: '<div class="header" />' },
+        MarkdownPreview: { name: 'MarkdownPreview', props: ['text'], template: '<div class="md">{{ text }}</div>' },
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
+      },
+    },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent({ name: 'GenericModal' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getError = ref(null);
+  h.onResult = undefined;
+  h.deleteError = ref(null);
+  h.onDone = undefined;
+});
+
+describe('ConfirmUndoDiscussionFeedbackModal', () => {
+  it('shows the confirm title', () => {
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('title')).toBe('Delete your feedback?');
+  });
+
+  it('renders the feedback comment once the query resolves', async () => {
+    const wrapper = mountModal();
+
+    h.onResult?.({ data: { comments: [{ id: 'fb1', text: 'mean note' }] } });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.md').text()).toBe('mean note');
+  });
+
+  it('ignores a query result with no feedback', async () => {
+    const wrapper = mountModal();
+
+    h.onResult?.({ data: { comments: [] } });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.md').exists()).toBe(false);
+  });
+
+  it('deletes the loaded feedback on confirm', async () => {
+    const wrapper = mountModal();
+    h.onResult?.({ data: { comments: [{ id: 'fb1', text: 'mean note' }] } });
+    await wrapper.vm.$nextTick();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.deleteFeedback).toHaveBeenCalledWith({ id: 'fb1' });
+  });
+
+  it('emits close when the deletion completes', () => {
+    const wrapper = mountModal();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('emits close from the secondary button', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('secondary-button-click');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('shows a delete error banner', () => {
+    h.deleteError = ref({ message: 'delete boom' });
+    const wrapper = mountModal();
+
+    expect(wrapper.find('.err').text()).toContain('delete boom');
+  });
+});

--- a/components/discussion/detail/LightboxImagePanel.spec.ts
+++ b/components/discussion/detail/LightboxImagePanel.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import LightboxImagePanel from '@/components/discussion/detail/LightboxImagePanel.vue';
+
+const baseProps = {
+  zoomLevel: 1,
+  translateX: 0,
+  translateY: 0,
+  isZoomed: false,
+  isDragging: false,
+};
+
+const mountPanel = (props: Record<string, unknown> = {}) =>
+  mount(LightboxImagePanel, {
+    props: {
+      currentImage: { id: 'i1', url: 'https://x/pic.png', alt: 'a pic' },
+      ...baseProps,
+      ...props,
+    },
+    global: {
+      stubs: {
+        ModelViewer: { name: 'ModelViewer', props: ['modelUrl'], template: '<div class="model" />' },
+        StlViewer: { name: 'StlViewer', props: ['src'], template: '<div class="stl" />' },
+        ClientOnly: { template: '<div><slot /></div>' },
+        LeftArrowIcon: true,
+        RightArrowIcon: true,
+      },
+    },
+  });
+
+const navButton = (w: ReturnType<typeof mount>, label: string) =>
+  w.find(`button[aria-label="${label}"]`);
+
+describe('LightboxImagePanel viewer selection', () => {
+  it('renders an img for a regular image', () => {
+    const wrapper = mountPanel();
+
+    expect(wrapper.find('img').attributes('src')).toBe('https://x/pic.png');
+  });
+
+  it('renders a ModelViewer for a glb file', () => {
+    const wrapper = mountPanel({ currentImage: { id: 'i1', url: 'https://x/model.glb' } });
+
+    expect(wrapper.find('.model').exists()).toBe(true);
+  });
+
+  it('renders an StlViewer for an stl file', () => {
+    const wrapper = mountPanel({ currentImage: { id: 'i1', url: 'https://x/model.stl' } });
+
+    expect(wrapper.find('.stl').exists()).toBe(true);
+  });
+});
+
+describe('LightboxImagePanel navigation', () => {
+  it('shows navigation buttons when enabled', () => {
+    const wrapper = mountPanel({ showNavigation: true });
+
+    expect(navButton(wrapper, 'Previous image').exists()).toBe(true);
+  });
+
+  it('hides navigation buttons by default', () => {
+    const wrapper = mountPanel();
+
+    expect(navButton(wrapper, 'Previous image').exists()).toBe(false);
+  });
+
+  it('emits prev-image', async () => {
+    const wrapper = mountPanel({ showNavigation: true });
+
+    await navButton(wrapper, 'Previous image').trigger('click');
+
+    expect(wrapper.emitted('prev-image')).toBeTruthy();
+  });
+
+  it('emits next-image', async () => {
+    const wrapper = mountPanel({ showNavigation: true });
+
+    await navButton(wrapper, 'Next image').trigger('click');
+
+    expect(wrapper.emitted('next-image')).toBeTruthy();
+  });
+});
+
+describe('LightboxImagePanel interactions', () => {
+  it('emits mousedown from the image', async () => {
+    const wrapper = mountPanel();
+
+    await wrapper.find('img').trigger('mousedown');
+
+    expect(wrapper.emitted('mousedown')).toBeTruthy();
+  });
+
+  it.each(['touchstart', 'touchend', 'touchmove'])(
+    'emits %s from the image',
+    async (evt) => {
+      const wrapper = mountPanel();
+
+      await wrapper.find('img').trigger(evt);
+
+      expect(wrapper.emitted(evt)).toBeTruthy();
+    }
+  );
+
+  it('emits mousedown from the model viewer', async () => {
+    const wrapper = mountPanel({ currentImage: { id: 'i1', url: 'https://x/m.glb' } });
+
+    await wrapper.find('.model').trigger('mousedown');
+
+    expect(wrapper.emitted('mousedown')).toBeTruthy();
+  });
+
+  it('emits mousedown from the stl wrapper', async () => {
+    const wrapper = mountPanel({ currentImage: { id: 'i1', url: 'https://x/m.stl' } });
+
+    await wrapper.find('.stl').trigger('mousedown');
+
+    expect(wrapper.emitted('mousedown')).toBeTruthy();
+  });
+
+  it('handles a click on the region while editing a caption', async () => {
+    const wrapper = mountPanel({ editingCaption: true });
+
+    await wrapper.find('[role="region"]').trigger('click');
+
+    expect(wrapper.find('[role="region"]').exists()).toBe(true);
+  });
+
+  it('stops propagation when clicking a button while editing a caption', async () => {
+    const wrapper = mountPanel({ editingCaption: true, showNavigation: true });
+
+    await navButton(wrapper, 'Previous image').trigger('click');
+
+    expect(wrapper.emitted('prev-image')).toBeTruthy();
+  });
+});

--- a/components/event/AddToCalendarButton.spec.ts
+++ b/components/event/AddToCalendarButton.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import AddToCalendarButton from '@/components/event/AddToCalendarButton.vue';
+import type { Event as EventData } from '@/__generated__/graphql';
+
+const event = (overrides: Record<string, unknown> = {}) =>
+  ({
+    startTime: '2024-03-30T18:00:00.000Z',
+    endTime: '2024-03-30T20:00:00.000Z',
+    title: 'Cat Meetup',
+    description: 'Bring your cat',
+    address: '123 Main St',
+    ...overrides,
+  }) as unknown as EventData;
+
+const menuButtonStub = {
+  name: 'MenuButton',
+  props: ['items', 'buttonClass'],
+  emits: ['google', 'ical', 'outlook'],
+  template: '<div class="menu"><slot /></div>',
+};
+
+const mountButton = (props: Record<string, unknown> = {}) =>
+  mount(AddToCalendarButton, {
+    props: { event: event(), ...props },
+    global: { stubs: { MenuButton: menuButtonStub, ChevronDownIcon: true } },
+  });
+
+const menu = (w: ReturnType<typeof mount>) => w.getComponent(menuButtonStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('open', vi.fn());
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:x');
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+});
+
+describe('AddToCalendarButton', () => {
+  it('renders the label', () => {
+    const wrapper = mountButton();
+
+    expect(wrapper.text()).toContain('Add to Calendar');
+  });
+
+  it('offers three calendar options', () => {
+    const wrapper = mountButton();
+
+    expect(menu(wrapper).props('items')).toHaveLength(3);
+  });
+
+  it('opens a Google Calendar link', async () => {
+    const wrapper = mountButton();
+
+    await menu(wrapper).vm.$emit('google');
+
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining('google.com/calendar/render'),
+      '_blank'
+    );
+  });
+
+  it('encodes the event title in the Google link', async () => {
+    const wrapper = mountButton();
+
+    await menu(wrapper).vm.$emit('google');
+
+    expect((window.open as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain(
+      'Cat%20Meetup'
+    );
+  });
+
+  it('downloads an iCal file', async () => {
+    const wrapper = mountButton();
+
+    await menu(wrapper).vm.$emit('ical');
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+  });
+
+  it('downloads an iCal file for Outlook too', async () => {
+    const wrapper = mountButton();
+
+    await menu(wrapper).vm.$emit('outlook');
+
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+  });
+});

--- a/components/event/list/filters/TimeShortcuts.spec.ts
+++ b/components/event/list/filters/TimeShortcuts.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import TimeShortcuts from '@/components/event/list/filters/TimeShortcuts.vue';
+import {
+  timeFilterShortcuts,
+  timeShortcutValues,
+} from '@/components/event/list/filters/eventSearchOptions';
+
+const h = vi.hoisted(() => ({ route: null as unknown, replace: vi.fn(), filterValues: {} as Record<string, unknown> }));
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => h.route,
+  useRouter: () => ({ replace: h.replace }),
+}));
+vi.mock('@/components/event/list/filters/getEventFilterValuesFromParams', () => ({
+  getFilterValuesFromParams: () => h.filterValues,
+}));
+
+const firstShortcut = timeFilterShortcuts[0];
+
+const tagStub = {
+  name: 'Tag',
+  props: ['tag', 'active', 'dataTestid', 'hideIcon', 'large'],
+  emits: ['click'],
+  template: '<button :data-active="active" @click="$emit(\'click\')">{{ tag }}</button>',
+};
+
+const mountShortcuts = () =>
+  mount(TimeShortcuts, { global: { stubs: { Tag: tagStub, TagComponent: tagStub } } });
+
+const tags = (w: ReturnType<typeof mount>) => w.findAllComponents(tagStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.route = { params: { forumId: 'cats' }, query: {} };
+  h.filterValues = {};
+});
+
+describe('TimeShortcuts rendering', () => {
+  it('renders a tag per shortcut', () => {
+    const wrapper = mountShortcuts();
+
+    expect(tags(wrapper)).toHaveLength(timeFilterShortcuts.length);
+  });
+
+  it('marks the active shortcut from the filter values', () => {
+    h.filterValues = { timeShortcut: firstShortcut.value };
+    const wrapper = mountShortcuts();
+
+    expect(tags(wrapper)[0].props('active')).toBe(true);
+  });
+});
+
+describe('TimeShortcuts interactions', () => {
+  it('applies a time filter when an inactive shortcut is clicked', async () => {
+    const wrapper = mountShortcuts();
+
+    await tags(wrapper)[0].vm.$emit('click');
+
+    expect(h.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ timeShortcut: firstShortcut.value }),
+      })
+    );
+  });
+
+  it('clears the filter when the active shortcut is clicked again', async () => {
+    h.route = { params: { forumId: 'cats' }, query: { timeShortcut: firstShortcut.value } };
+    const wrapper = mountShortcuts();
+
+    await tags(wrapper)[0].vm.$emit('click');
+
+    expect(h.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ timeShortcut: timeShortcutValues.NONE }),
+      })
+    );
+  });
+});

--- a/components/event/list/filters/WeekdaySelector.spec.ts
+++ b/components/event/list/filters/WeekdaySelector.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import WeekdaySelector from '@/components/event/list/filters/WeekdaySelector.vue';
+import { weekdays } from '@/components/event/list/filters/eventSearchOptions';
+
+const firstDay = weekdays[0];
+
+const mountSelector = (selectedWeekdays: Record<string, boolean> = {}) =>
+  mount(WeekdaySelector, {
+    props: { selectedWeekdays },
+    global: {
+      stubs: {
+        ResetButton: { name: 'ResetButton', emits: ['reset'], template: '<button class="reset" @click="$emit(\'reset\')" />' },
+      },
+    },
+  });
+
+const checkbox = (w: ReturnType<typeof mount>, num: string | number) =>
+  w.find(`[data-testid="weekday-${num}-checkbox"]`);
+
+describe('WeekdaySelector rendering', () => {
+  it('renders a checkbox per weekday', () => {
+    const wrapper = mountSelector();
+
+    expect(wrapper.findAll('input[type="checkbox"]')).toHaveLength(weekdays.length);
+  });
+
+  it('checks a weekday that is already selected', () => {
+    const wrapper = mountSelector({ [firstDay.number]: true });
+
+    expect(
+      (checkbox(wrapper, firstDay.number).element as HTMLInputElement).checked
+    ).toBe(true);
+  });
+});
+
+describe('WeekdaySelector selection', () => {
+  it('emits the selected weekday when toggled on', async () => {
+    const wrapper = mountSelector();
+
+    await checkbox(wrapper, firstDay.number).trigger('input');
+
+    expect(wrapper.emitted('updateWeekdays')?.[0]?.[0]).toContain(
+      String(firstDay.number)
+    );
+  });
+
+  it('removes a weekday when toggled off', async () => {
+    const wrapper = mountSelector({ [firstDay.number]: true });
+
+    await checkbox(wrapper, firstDay.number).trigger('input');
+
+    expect(wrapper.emitted('updateWeekdays')?.[0]?.[0]).toBe('[]');
+  });
+
+  it('emits reset when the reset button fires', async () => {
+    const wrapper = mountSelector({ [firstDay.number]: true });
+
+    await wrapper.getComponent({ name: 'ResetButton' }).vm.$emit('reset');
+
+    expect(wrapper.emitted('reset')).toBeTruthy();
+  });
+});

--- a/components/mod/UnsuspendModModal.spec.ts
+++ b/components/mod/UnsuspendModModal.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import UnsuspendModModal from '@/components/mod/UnsuspendModModal.vue';
+
+const h = vi.hoisted(() => ({
+  unsuspend: vi.fn(() => Promise.resolve()),
+  error: null as unknown,
+  onDone: undefined as undefined | (() => void),
+  refetch: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useApolloClient: () => ({ client: { refetchQueries: h.refetch } }),
+  useMutation: () => ({
+    mutate: h.unsuspend,
+    loading: ref(false),
+    error: h.error,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const genericModalStub = {
+  name: 'GenericModal',
+  props: ['open', 'title', 'body', 'error', 'loading', 'primaryButtonDisabled'],
+  emits: ['primary-button-click', 'close'],
+  template: '<div><slot name="content" /></div>',
+};
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(UnsuspendModModal, {
+    props: { open: true, issueId: 'issue-1', ...props },
+    global: {
+      stubs: {
+        GenericModal: genericModalStub,
+        TextEditor: { name: 'TextEditor', emits: ['update'], template: '<div />' },
+        UserPlus: true,
+      },
+    },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent({ name: 'GenericModal' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.unsuspend = vi.fn(() => Promise.resolve());
+  h.error = ref(null);
+  h.onDone = undefined;
+});
+
+describe('UnsuspendModModal title', () => {
+  it('uses the default title', () => {
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('title')).toBe('Unsuspend Mod');
+  });
+
+  it('uses a custom title when provided', () => {
+    const wrapper = mountModal({ title: 'Unsuspend This Mod' });
+
+    expect(modal(wrapper).props('title')).toBe('Unsuspend This Mod');
+  });
+
+  it('passes the mutation error to the modal', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('error')).toBe('boom');
+  });
+});
+
+describe('UnsuspendModModal submit', () => {
+  it('unsuspends with the issue id and explanation', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.unsuspend).toHaveBeenCalledWith(
+      expect.objectContaining({ issueId: 'issue-1' })
+    );
+  });
+
+  it('does not submit without an issue id', async () => {
+    const wrapper = mountModal({ issueId: '' });
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.unsuspend).not.toHaveBeenCalled();
+  });
+});
+
+describe('UnsuspendModModal lifecycle', () => {
+  it('emits success when the mutation completes', () => {
+    const wrapper = mountModal();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('unsuspendedSuccessfully')).toBeTruthy();
+  });
+
+  it('refetches the issue query on success', () => {
+    mountModal();
+
+    h.onDone?.();
+
+    expect(h.refetch).toHaveBeenCalled();
+  });
+
+  it('emits close from the modal', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/components/mod/UnsuspendUserModal.spec.ts
+++ b/components/mod/UnsuspendUserModal.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import UnsuspendUserModal from '@/components/mod/UnsuspendUserModal.vue';
+
+const h = vi.hoisted(() => ({
+  unsuspend: vi.fn(() => Promise.resolve()),
+  error: null as unknown,
+  onDone: undefined as undefined | (() => void),
+  refetch: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useApolloClient: () => ({ client: { refetchQueries: h.refetch } }),
+  useMutation: () => ({
+    mutate: h.unsuspend,
+    loading: ref(false),
+    error: h.error,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const genericModalStub = {
+  name: 'GenericModal',
+  props: ['open', 'title', 'body', 'error', 'loading', 'primaryButtonDisabled'],
+  emits: ['primary-button-click', 'close'],
+  template: '<div><slot name="content" /></div>',
+};
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(UnsuspendUserModal, {
+    props: { open: true, issueId: 'issue-1', ...props },
+    global: {
+      stubs: {
+        GenericModal: genericModalStub,
+        TextEditor: { name: 'TextEditor', emits: ['update'], template: '<div />' },
+        UserPlus: true,
+      },
+    },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent({ name: 'GenericModal' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.unsuspend = vi.fn(() => Promise.resolve());
+  h.error = ref(null);
+  h.onDone = undefined;
+});
+
+describe('UnsuspendUserModal', () => {
+  it('shows the unsuspend author title', () => {
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('title')).toBe('Unsuspend Author');
+  });
+
+  it('passes the mutation error to the modal', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('error')).toBe('boom');
+  });
+
+  it('unsuspends with the issue id', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.unsuspend).toHaveBeenCalledWith(
+      expect.objectContaining({ issueId: 'issue-1' })
+    );
+  });
+
+  it('does not submit without an issue id', async () => {
+    const wrapper = mountModal({ issueId: '' });
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.unsuspend).not.toHaveBeenCalled();
+  });
+
+  it('emits success when the mutation completes', () => {
+    const wrapper = mountModal();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('unsuspendedSuccessfully')).toBeTruthy();
+  });
+
+  it('refetches the issue query on success', () => {
+    mountModal();
+
+    h.onDone?.();
+
+    expect(h.refetch).toHaveBeenCalled();
+  });
+
+  it('emits close from the modal', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/components/nav/TopNav.spec.ts
+++ b/components/nav/TopNav.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import TopNav from '@/components/nav/TopNav.vue';
+
+const h = vi.hoisted(() => ({
+  route: null as unknown,
+  username: null as unknown,
+  notificationCount: null as unknown,
+}));
+
+vi.mock('vuetify', () => ({ useDisplay: () => ({ smAndDown: ref(false) }) }));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+vi.mock('@/cache', () => ({ sideNavIsOpenVar: false }));
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ref(''),
+  useUsername: () => h.username,
+  useNotificationCount: () => h.notificationCount,
+}));
+
+const mountNav = () =>
+  mount(TopNav, {
+    global: {
+      stubs: {
+        HamburgerMenuButton: { name: 'HamburgerMenuButton', emits: ['click'], template: '<button class="hamburger" @click="$emit(\'click\')" />' },
+        UserProfileDropdownMenu: { name: 'UserProfileDropdownMenu', template: '<div class="profile" />' },
+        ThemeSwitcher: true,
+        CreateAnythingButton: true,
+        AddToChannelFavorites: { name: 'AddToChannelFavorites', template: '<div class="fav" />' },
+        TopNavSearch: true,
+        LoginButton: true,
+        ClientOnly: { template: '<div><slot /></div>' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.route = { params: {}, name: 'home' };
+  h.username = ref('');
+  h.notificationCount = ref(0);
+});
+
+describe('TopNav branding', () => {
+  it('shows the logo', () => {
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).toContain('Topical');
+  });
+
+  it('shows the channel name and favorites when on a forum route', () => {
+    h.route = { params: { forumId: 'cats' }, name: 'forums-forumId' };
+    const wrapper = mountNav();
+
+    expect(wrapper.find('.fav').exists()).toBe(true);
+  });
+});
+
+describe('TopNav route label', () => {
+  it.each([
+    ['discussions', 'discussions'],
+    ['downloads', 'downloads'],
+    ['events-list-search', 'online events'],
+    ['forums', 'forums'],
+    ['map-search-something', 'in-person events'],
+  ])('labels the %s route', (name, label) => {
+    h.route = { params: {}, name };
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).toContain(label);
+  });
+
+  it('falls back to getLabel for a search preview route', () => {
+    h.route = { params: {}, name: 'SitewideSearchDiscussionPreview' };
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).toContain('• discussions');
+  });
+
+  it('labels admin routes', () => {
+    h.route = { params: {}, name: 'admin-dashboard' };
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).toContain('• admin dashboard');
+  });
+});
+
+describe('TopNav actions', () => {
+  it('emits toggleDropdown from the hamburger button', async () => {
+    const wrapper = mountNav();
+
+    await wrapper.find('.hamburger').trigger('click');
+
+    expect(wrapper.emitted('toggleDropdown')).toBeTruthy();
+  });
+
+  it('shows a notification count badge', () => {
+    h.notificationCount = ref(5);
+    const wrapper = mountNav();
+
+    expect(wrapper.find('[data-testid="notification-bell"]').text()).toContain('5');
+  });
+
+  it('shows the profile menu when logged in', () => {
+    h.username = ref('alice');
+    const wrapper = mountNav();
+
+    expect(wrapper.find('.profile').exists()).toBe(true);
+  });
+
+  it('hides the profile menu when logged out', () => {
+    const wrapper = mountNav();
+
+    expect(wrapper.find('.profile').exists()).toBe(false);
+  });
+
+  it('applies fixed positioning on map pages', () => {
+    h.route = { params: {}, name: 'map-search' };
+    const wrapper = mountNav();
+
+    expect(wrapper.find('nav').classes()).toContain('fixed');
+  });
+});

--- a/components/nav/VerticalIconNav.spec.ts
+++ b/components/nav/VerticalIconNav.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import VerticalIconNav from '@/components/nav/VerticalIconNav.vue';
+
+const h = vi.hoisted(() => ({ route: null as unknown }));
+
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+vi.mock('vuetify', () => ({ useDisplay: () => ({ height: ref(900) }) }));
+vi.mock('@/utils/localStorageUtils', () => ({
+  getLocalStorageItem: () => [],
+  setLocalStorageItem: vi.fn(),
+}));
+
+const mountNav = () =>
+  mount(VerticalIconNav, {
+    global: {
+      stubs: {
+        IconTooltip: { name: 'IconTooltip', props: ['text'], template: '<div><slot /></div>' },
+        NuxtLink: { props: ['to', 'ariaLabel'], template: '<a :class="$attrs.class" :aria-label="ariaLabel"><slot /></a>' },
+        'nuxt-link': { props: ['to', 'ariaLabel'], template: '<a :class="$attrs.class" :aria-label="ariaLabel"><slot /></a>' },
+        ClientOnly: { template: '<div><slot /></div>' },
+        AvatarComponent: true,
+        CreateAnythingButton: true,
+        RecentForumsDrawer: { name: 'RecentForumsDrawer', props: ['forums', 'isOpen'], template: '<div class="drawer" />' },
+        DiscussionIcon: true,
+        DownloadIcon: true,
+        CalendarIcon: true,
+        BookIcon: true,
+        ChannelIcon: true,
+        BookmarkIcon: true,
+        AdminIcon: true,
+        LoginIcon: true,
+        MoreIcon: true,
+      },
+    },
+  });
+
+const navLink = (w: ReturnType<typeof mount>, label: string) =>
+  w.find(`a[aria-label="${label}"]`);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.route = { params: {}, name: 'home' };
+});
+
+describe('VerticalIconNav items', () => {
+  it.each(['Discuss', 'Downloads', 'Calendars', 'Wikis', 'Forums', 'Library'])(
+    'renders the %s nav item',
+    (name) => {
+      const wrapper = mountNav();
+
+      expect(navLink(wrapper, name).exists()).toBe(true);
+    }
+  );
+
+  it('renders the admin dashboard item', () => {
+    const wrapper = mountNav();
+
+    expect(navLink(wrapper, 'Admin dashboard').exists()).toBe(true);
+  });
+});
+
+describe('VerticalIconNav active state', () => {
+  it('highlights the active nav item', () => {
+    h.route = { params: {}, name: 'forums' };
+    const wrapper = mountNav();
+
+    expect(navLink(wrapper, 'Forums').classes().join(' ')).toContain('ring-1');
+  });
+
+  it('does not highlight an inactive nav item', () => {
+    h.route = { params: {}, name: 'forums' };
+    const wrapper = mountNav();
+
+    expect(navLink(wrapper, 'Discuss').classes().join(' ')).not.toContain('ring-1');
+  });
+
+  it('highlights the admin item on admin routes', () => {
+    h.route = { params: {}, name: 'admin-issues' };
+    const wrapper = mountNav();
+
+    expect(navLink(wrapper, 'Admin dashboard').classes().join(' ')).toContain('ring-1');
+  });
+});
+
+describe('VerticalIconNav drawer', () => {
+  it('renders the recent forums drawer closed', () => {
+    const wrapper = mountNav();
+
+    expect(wrapper.getComponent({ name: 'RecentForumsDrawer' }).props('isOpen')).toBe(
+      false
+    );
+  });
+});

--- a/components/text-editor/TextEditorFullScreen.spec.ts
+++ b/components/text-editor/TextEditorFullScreen.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import TextEditorFullScreen from '@/components/text-editor/TextEditorFullScreen.vue';
+
+const mountEditor = (props: Record<string, unknown> = {}) =>
+  mount(TextEditorFullScreen, {
+    props: {
+      text: 'hello',
+      placeholder: 'Type here',
+      testId: 'editor',
+      accessibleLabel: 'Editor',
+      allowImageUpload: true,
+      fieldName: 'body',
+      showEmojiPicker: false,
+      emojiPickerPosition: { top: '0', left: '0' },
+      ...props,
+    },
+    global: {
+      stubs: {
+        TextEditorToolbar: { name: 'TextEditorToolbar', emits: ['format', 'toggle-emoji'], template: '<div class="toolbar" />' },
+        AddImage: { name: 'AddImage', props: ['fieldName', 'label'], emits: ['file-change'], template: '<div class="add-image" />' },
+        EmojiPickerWrapper: { name: 'EmojiPickerWrapper', props: ['position'], emits: ['emoji-click', 'close'], template: '<div class="emoji" />' },
+        MarkdownRenderer: { name: 'MarkdownRenderer', props: ['text'], template: '<div class="preview">{{ text }}</div>' },
+      },
+    },
+  });
+
+const textarea = (w: ReturnType<typeof mount>) => w.find('textarea');
+
+describe('TextEditorFullScreen layout', () => {
+  it('renders the full-screen header', () => {
+    const wrapper = mountEditor();
+
+    expect(wrapper.text()).toContain('Full Screen Editor');
+  });
+
+  it('shows the text in the editor', () => {
+    const wrapper = mountEditor();
+
+    expect((textarea(wrapper).element as HTMLTextAreaElement).value).toBe('hello');
+  });
+
+  it('renders the preview with the text', () => {
+    const wrapper = mountEditor();
+
+    expect(wrapper.find('.preview').text()).toBe('hello');
+  });
+
+  it('links to the markdown guide', () => {
+    const wrapper = mountEditor();
+
+    expect(wrapper.find('a[href*="markdownguide"]').exists()).toBe(true);
+  });
+});
+
+describe('TextEditorFullScreen emits', () => {
+  it('emits exit from the close button', async () => {
+    const wrapper = mountEditor();
+
+    await wrapper.find('button[aria-label="Exit full screen"]').trigger('click');
+
+    expect(wrapper.emitted('exit')).toBeTruthy();
+  });
+
+  it.each(['input', 'click', 'keyup', 'drop'])(
+    'emits %s from the textarea',
+    async (evt) => {
+      const wrapper = mountEditor();
+
+      await textarea(wrapper).trigger(evt);
+
+      expect(wrapper.emitted(evt)).toBeTruthy();
+    }
+  );
+
+  it('re-emits format from the toolbar', async () => {
+    const wrapper = mountEditor();
+
+    await wrapper.getComponent({ name: 'TextEditorToolbar' }).vm.$emit('format', 'bold');
+
+    expect(wrapper.emitted('format')?.[0]).toEqual(['bold']);
+  });
+
+  it('re-emits toggle-emoji from the toolbar', async () => {
+    const wrapper = mountEditor();
+
+    await wrapper.getComponent({ name: 'TextEditorToolbar' }).vm.$emit('toggle-emoji', {});
+
+    expect(wrapper.emitted('toggle-emoji')).toBeTruthy();
+  });
+});
+
+describe('TextEditorFullScreen image upload', () => {
+  it('shows the image uploader when enabled', () => {
+    const wrapper = mountEditor();
+
+    expect(wrapper.find('.add-image').exists()).toBe(true);
+  });
+
+  it('hides the image uploader when disabled', () => {
+    const wrapper = mountEditor({ allowImageUpload: false });
+
+    expect(wrapper.find('.add-image').exists()).toBe(false);
+  });
+
+  it('re-emits file-change from the uploader', async () => {
+    const wrapper = mountEditor();
+
+    await wrapper.getComponent({ name: 'AddImage' }).vm.$emit('file-change', { fieldName: 'body' });
+
+    expect(wrapper.emitted('file-change')).toBeTruthy();
+  });
+});
+
+describe('TextEditorFullScreen emoji picker', () => {
+  it('hides the emoji picker by default', () => {
+    const wrapper = mountEditor();
+
+    expect(wrapper.find('.emoji').exists()).toBe(false);
+  });
+
+  it('shows the emoji picker when enabled', async () => {
+    const wrapper = mountEditor({ showEmojiPicker: true });
+    await flushPromises();
+
+    expect(wrapper.find('.emoji').exists()).toBe(true);
+  });
+
+  it('re-emits emoji-click', async () => {
+    const wrapper = mountEditor({ showEmojiPicker: true });
+    await flushPromises();
+
+    await wrapper.getComponent({ name: 'EmojiPickerWrapper' }).vm.$emit('emoji-click', { emoji: 'x' });
+
+    expect(wrapper.emitted('emoji-click')).toBeTruthy();
+  });
+});

--- a/components/user/UserProfileTabs.spec.ts
+++ b/components/user/UserProfileTabs.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import UserProfileTabs from '@/components/user/UserProfileTabs.vue';
+import type { User } from '@/__generated__/graphql';
+
+const h = vi.hoisted(() => ({ route: null as unknown }));
+
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+
+const tabButtonStub = {
+  name: 'TabButton',
+  props: ['to', 'label', 'isActive', 'count', 'showCount'],
+  template: '<a>{{ label }}</a>',
+};
+
+const user = (overrides: Record<string, unknown> = {}) =>
+  ({ CommentsAggregate: { count: 4 }, ...overrides }) as unknown as User;
+
+const mountTabs = (props: Record<string, unknown> = {}) =>
+  mount(UserProfileTabs, {
+    props: { user: user(), ...props },
+    global: { stubs: { TabButton: tabButtonStub } },
+  });
+
+const tabs = (w: ReturnType<typeof mount>) => w.findAllComponents(tabButtonStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.route = { params: { username: 'alice' }, path: '/u/alice/comments', query: {} };
+});
+
+describe('UserProfileTabs', () => {
+  it('renders all profile tabs', () => {
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)).toHaveLength(10);
+  });
+
+  it('labels the first tab Comments', () => {
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('label')).toBe('Comments');
+  });
+
+  it('passes the comment count to the comments tab', () => {
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('count')).toBe(4);
+  });
+
+  it('marks the tab matching the route as active', () => {
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('isActive')).toBe(true);
+  });
+
+  it('treats a nested route as active', () => {
+    h.route = { params: { username: 'alice' }, path: '/u/alice/comments/123', query: {} };
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('isActive')).toBe(true);
+  });
+
+  it('hides counts unless showCounts is set', () => {
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('showCount')).toBe(false);
+  });
+
+  it('shows the count when showCounts is enabled and a count exists', () => {
+    const wrapper = mountTabs({ showCounts: true });
+
+    expect(tabs(wrapper)[0].props('showCount')).toBe(true);
+  });
+
+  it('carries the channels query into the tab links', () => {
+    h.route = { params: { username: 'alice' }, path: '/u/alice/comments', query: { channels: 'cats' } };
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('to')).toEqual({
+      path: '/u/alice/comments',
+      query: { channels: ['cats'] },
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
+    // The default 5s per-test timeout is too tight under full-suite parallel
+    // load: the first test in each file pays a one-time Vue SFC compile +
+    // happy-dom warmup cost, and when many worker processes saturate the CPU
+    // that first mount can be starved past 5s and flake as a timeout (the
+    // tests themselves run in <500ms in isolation). Give generous headroom so
+    // contention can't trip a false timeout; a genuine hang is still caught.
+    testTimeout: 20000,
+    hookTimeout: 20000,
     include: ['**/*.{spec,test}.ts', '**/*.{spec,test}.tsx'],
     exclude: [
       'node_modules/**',


### PR DESCRIPTION
Continues the unit-test coverage campaign (follows #126/#127). Each commit adds a real-mount Vitest spec for a previously-untested component, validated to exit-0 with no unhandled errors and tsc clean.

## Components covered so far (sibling clusters)
| Component | After |
|-----------|-------|
| event/list/filters/WeekdaySelector | 100% |
| event/list/filters/TimeShortcuts | 100% |
| mod/UnsuspendModModal | 88% |
| mod/UnsuspendUserModal | 88% |
| discussion/detail/ConfirmUndoDiscussionFeedbackModal | 85% |

These are siblings of components already covered in prior batches (TimeSelector, OnlineInPersonShortcuts, SuspendModModal, ConfirmUndoCommentFeedbackModal), cloned and adapted.

More foundational primitives (GenericModal, TextInput, VoteButton, ModalComponent, IconTooltip, TabButton, …) to follow on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)