### PR TITLE
test: unit coverage batch 7 (sibling clusters + pure-ish tail)

### DIFF
--- a/components/DrawerFlyout.spec.ts
+++ b/components/DrawerFlyout.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import DrawerFlyout from '@/components/DrawerFlyout.vue';
+
+vi.mock('vuetify', () => ({ useDisplay: () => ({ smAndDown: ref(false) }) }));
+vi.mock('@headlessui/vue', () => ({
+  TransitionRoot: { name: 'TransitionRoot', template: '<div><slot /></div>' },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>' },
+  Dialog: { name: 'Dialog', emits: ['close'], template: '<div><slot /></div>' },
+  DialogOverlay: { name: 'DialogOverlay', template: '<div />' },
+  DialogPanel: { name: 'DialogPanel', template: '<div><slot /></div>' },
+}));
+
+const mountDrawer = (props: Record<string, unknown> = {}, slot = '') =>
+  mount(DrawerFlyout, {
+    props: { isOpen: true, ...props },
+    slots: { default: slot },
+    global: { stubs: { ClientOnly: { template: '<div><slot /></div>' }, XmarkIcon: true } },
+  });
+
+describe('DrawerFlyout', () => {
+  it('renders the title', () => {
+    const wrapper = mountDrawer({ title: 'Recent forums' });
+
+    expect(wrapper.text()).toContain('Recent forums');
+  });
+
+  it('renders the default slot', () => {
+    const wrapper = mountDrawer({}, '<div class="body">content</div>');
+
+    expect(wrapper.find('.body').exists()).toBe(true);
+  });
+
+  it('emits closePreview from the top close button', async () => {
+    const wrapper = mountDrawer();
+
+    await wrapper.find('[data-testid="close-drawer-top-button"]').trigger('click');
+
+    expect(wrapper.emitted('closePreview')).toBeTruthy();
+  });
+
+  it('emits closePreview from the bottom Close button', async () => {
+    const wrapper = mountDrawer();
+
+    await wrapper.find('[data-testid="close-drawer-bottom-button"]').trigger('click');
+
+    expect(wrapper.emitted('closePreview')).toBeTruthy();
+  });
+
+  it('emits closePreview from the dialog close', async () => {
+    const wrapper = mountDrawer();
+
+    await wrapper.getComponent({ name: 'Dialog' }).vm.$emit('close');
+
+    expect(wrapper.emitted('closePreview')).toBeTruthy();
+  });
+});

--- a/components/IconButtonDropdown.spec.ts
+++ b/components/IconButtonDropdown.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import IconButtonDropdown from '@/components/IconButtonDropdown.vue';
+
+const h = vi.hoisted(() => ({ push: vi.fn() }));
+
+vi.mock('nuxt/app', () => ({ useRouter: () => ({ push: h.push }) }));
+vi.mock('@headlessui/vue', () => ({
+  Menu: { name: 'Menu', template: '<div><slot /></div>' },
+  MenuButton: { name: 'MenuButton', template: '<button class="menu-button"><slot /></button>' },
+  MenuItems: { name: 'MenuItems', template: '<div><slot /></div>' },
+  MenuItem: { name: 'MenuItem', template: '<div class="menu-item"><slot :active="false" /></div>' },
+}));
+
+const mountDropdown = (props: Record<string, unknown> = {}, slot = '') =>
+  mount(IconButtonDropdown, {
+    props: { items: [{ value: '/go', label: 'Go' }], ...props },
+    slots: { default: slot },
+    global: { stubs: { ClientOnly: { template: '<div><slot /></div>' } } },
+  });
+
+const items = (w: ReturnType<typeof mount>) => w.findAll('.menu-item');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('IconButtonDropdown rendering', () => {
+  it('renders the menu items', () => {
+    const wrapper = mountDropdown({ items: [{ value: '/a', label: 'Item A' }] });
+
+    expect(wrapper.text()).toContain('Item A');
+  });
+
+  it('renders a divider item', () => {
+    const wrapper = mountDropdown({ items: [{ value: 'Section', isDivider: true }] });
+
+    expect(wrapper.text()).toContain('Section');
+  });
+
+  it('renders the slot in the button when no icon is given', () => {
+    const wrapper = mountDropdown({}, '<span class="custom">menu</span>');
+
+    expect(wrapper.find('.custom').exists()).toBe(true);
+  });
+
+  it('applies the aria-label to the button', () => {
+    const wrapper = mountDropdown({ ariaLabel: 'Open menu' });
+
+    expect(wrapper.find('.menu-button').attributes('aria-label')).toBe('Open menu');
+  });
+});
+
+describe('IconButtonDropdown actions', () => {
+  it('navigates to the item value when there is no event', async () => {
+    const wrapper = mountDropdown({ items: [{ value: '/profile', label: 'Profile' }] });
+
+    await items(wrapper)[0].trigger('click');
+
+    expect(h.push).toHaveBeenCalledWith('/profile');
+  });
+
+  it('emits the item event with its value', async () => {
+    const wrapper = mountDropdown({
+      items: [{ value: 'logout-val', label: 'Log out', event: 'logout' }],
+    });
+
+    await items(wrapper)[0].trigger('click');
+
+    expect(wrapper.emitted('logout')?.[0]).toEqual(['logout-val']);
+  });
+
+  it('does not navigate for an event-based item', async () => {
+    const wrapper = mountDropdown({
+      items: [{ value: 'x', label: 'X', event: 'doX' }],
+    });
+
+    await items(wrapper)[0].trigger('click');
+
+    expect(h.push).not.toHaveBeenCalled();
+  });
+});

--- a/components/MarkdownLoader.spec.ts
+++ b/components/MarkdownLoader.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import MarkdownLoader from '@/components/MarkdownLoader.vue';
+
+const h = vi.hoisted(() => ({ get: vi.fn(), route: null as unknown }));
+
+vi.mock('axios', () => ({ default: { get: (...a: unknown[]) => h.get(...a) } }));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+
+const mountLoader = (props: Record<string, unknown> = {}) =>
+  mount(MarkdownLoader, {
+    props: { slug: 'about', ...props },
+    global: {
+      stubs: {
+        MarkdownPreview: { name: 'MarkdownPreview', props: ['text'], template: '<div class="md">{{ text }}</div>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.get = vi.fn(() => Promise.resolve({ data: '# Hello' }));
+  h.route = { params: {} };
+});
+
+describe('MarkdownLoader', () => {
+  it('fetches the markdown file for the slug', async () => {
+    mountLoader({ slug: 'about' });
+    await flushPromises();
+
+    expect(h.get).toHaveBeenCalledWith('/about.md');
+  });
+
+  it('renders the loaded markdown', async () => {
+    const wrapper = mountLoader();
+    await flushPromises();
+
+    expect(wrapper.find('.md').text()).toBe('# Hello');
+  });
+
+  it('loads from the route slug when present', async () => {
+    h.route = { params: { slug: 'terms' } };
+    mountLoader({ slug: '' });
+    await flushPromises();
+
+    expect(h.get).toHaveBeenCalledWith('/terms.md');
+  });
+
+  it('handles a fetch error without crashing', async () => {
+    h.get = vi.fn(() => Promise.reject(new Error('404')));
+    const wrapper = mountLoader();
+    await flushPromises();
+
+    expect(wrapper.find('.md').text()).toBe('');
+  });
+});

--- a/components/TagComponent.spec.ts
+++ b/components/TagComponent.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import TagComponent from '@/components/TagComponent.vue';
+
+const mountTag = (props: Record<string, unknown> = {}) =>
+  mount(TagComponent, {
+    props: { tag: 'pets', ...props },
+    global: { stubs: { AvatarComponent: { name: 'AvatarComponent', template: '<div class="avatar" />' }, XmarkIcon: true } },
+  });
+
+const tagEl = (w: ReturnType<typeof mount>) => w.find('span.tag');
+
+describe('TagComponent rendering', () => {
+  it('shows the tag text', () => {
+    const wrapper = mountTag();
+
+    expect(wrapper.text()).toContain('pets');
+  });
+
+  it('uses active styling when active', () => {
+    const wrapper = mountTag({ active: true });
+
+    expect(tagEl(wrapper).classes().join(' ')).toContain('bg-orange-400');
+  });
+
+  it('uses channel styling in channel mode', () => {
+    const wrapper = mountTag({ channelMode: true });
+
+    expect(tagEl(wrapper).classes().join(' ')).toContain('bg-gray-200');
+  });
+
+  it('shows the avatar in channel mode', () => {
+    const wrapper = mountTag({ channelMode: true });
+
+    expect(wrapper.find('.avatar').exists()).toBe(true);
+  });
+
+  it('hides the avatar when hideIcon is set', () => {
+    const wrapper = mountTag({ channelMode: true, hideIcon: true });
+
+    expect(wrapper.find('.avatar').exists()).toBe(false);
+  });
+});
+
+describe('TagComponent interaction', () => {
+  it('emits select when clicked while inactive', async () => {
+    const wrapper = mountTag();
+
+    await tagEl(wrapper).trigger('click');
+
+    expect(wrapper.emitted('select')?.[0]).toEqual(['pets']);
+  });
+
+  it('emits deselect when clicked while active', async () => {
+    const wrapper = mountTag({ active: true });
+
+    await tagEl(wrapper).trigger('click');
+
+    expect(wrapper.emitted('deselect')?.[0]).toEqual(['pets']);
+  });
+
+  it('shows the clear icon when clearable', () => {
+    const wrapper = mountTag({ clearable: true });
+
+    expect(wrapper.find('[data-testid="tag-delete"]').exists()).toBe(true);
+  });
+
+  it('emits delete with the index from the clear icon', async () => {
+    const wrapper = mountTag({ clearable: true, index: 3 });
+
+    await wrapper.find('[data-testid="tag-delete"]').trigger('click');
+
+    expect(wrapper.emitted('delete')?.[0]).toEqual([3]);
+  });
+});

--- a/components/admin/ServerSuspendedModList.spec.ts
+++ b/components/admin/ServerSuspendedModList.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ServerSuspendedModList from '@/components/admin/ServerSuspendedModList.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  loading: null as unknown,
+  error: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.result, loading: h.loading, error: h.error }),
+}));
+
+const suspension = (overrides: Record<string, unknown> = {}) => ({
+  id: 's1',
+  SuspendedMod: { displayName: 'mod1' },
+  username: 'alice',
+  suspendedIndefinitely: false,
+  suspendedUntil: '2024-06-01T00:00:00Z',
+  createdAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const withMods = (list: unknown[], count?: number) => ({
+  serverConfigs: [{ SuspendedMods: list, SuspendedModsAggregate: { count: count ?? list.length } }],
+});
+
+const mountList = () =>
+  mount(ServerSuspendedModList, {
+    global: {
+      stubs: {
+        AvatarComponent: true,
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref(withMods([suspension()]));
+  h.loading = ref(false);
+  h.error = ref(null);
+});
+
+describe('ServerSuspendedModList states', () => {
+  it('shows a loading message', () => {
+    h.loading = ref(true);
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('shows an error banner', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountList();
+
+    expect(wrapper.find('.err').text()).toContain('boom');
+  });
+
+  it('shows the empty message when there are none', () => {
+    h.result = ref(withMods([]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('no active server-scoped mod suspensions');
+  });
+});
+
+describe('ServerSuspendedModList content', () => {
+  it('shows the active suspension count', () => {
+    h.result = ref(withMods([suspension()], 1));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Active Suspensions (1)');
+  });
+
+  it('shows the mod name and username', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('mod1 (alice)');
+  });
+
+  it('shows a suspended-until date for a temporary suspension', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Suspended until');
+  });
+
+  it('shows an indefinite-suspension message', () => {
+    h.result = ref(withMods([suspension({ suspendedIndefinitely: true })]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Suspended indefinitely');
+  });
+
+  it('links to the related issue when present', () => {
+    h.result = ref(withMods([suspension({ RelatedIssue: { issueNumber: 9 } })]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Related Issue');
+  });
+});

--- a/components/admin/ServerSuspendedUserList.spec.ts
+++ b/components/admin/ServerSuspendedUserList.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ServerSuspendedUserList from '@/components/admin/ServerSuspendedUserList.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  loading: null as unknown,
+  error: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.result, loading: h.loading, error: h.error }),
+}));
+
+const suspension = (overrides: Record<string, unknown> = {}) => ({
+  id: 's1',
+  SuspendedUser: { username: 'alice' },
+  username: 'alice',
+  suspendedIndefinitely: false,
+  suspendedUntil: '2024-06-01T00:00:00Z',
+  createdAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const withUsers = (list: unknown[], count?: number) => ({
+  serverConfigs: [{ SuspendedUsers: list, SuspendedUsersAggregate: { count: count ?? list.length } }],
+});
+
+const mountList = () =>
+  mount(ServerSuspendedUserList, {
+    global: {
+      stubs: {
+        AvatarComponent: true,
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
+        UsernameWithTooltip: { name: 'UsernameWithTooltip', props: ['username'], template: '<span>{{ username }}</span>' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref(withUsers([suspension()]));
+  h.loading = ref(false);
+  h.error = ref(null);
+});
+
+describe('ServerSuspendedUserList states', () => {
+  it('shows a loading message', () => {
+    h.loading = ref(true);
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('shows an error banner', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountList();
+
+    expect(wrapper.find('.err').text()).toContain('boom');
+  });
+
+  it('shows the empty message when there are none', () => {
+    h.result = ref(withUsers([]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('no active server-scoped user suspensions');
+  });
+});
+
+describe('ServerSuspendedUserList content', () => {
+  it('shows the active suspension count', () => {
+    h.result = ref(withUsers([suspension()], 1));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Active Suspensions (1)');
+  });
+
+  it('shows the suspended username', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('alice');
+  });
+
+  it('shows a bot badge for a suspended bot', () => {
+    h.result = ref({
+      serverConfigs: [
+        {
+          SuspendedUsers: [suspension({ SuspendedUser: { username: 'botty', isBot: true } })],
+          SuspendedUsersAggregate: { count: 1 },
+        },
+      ],
+    });
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Bot');
+  });
+
+  it('shows a suspended-until date for a temporary suspension', () => {
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Suspended until');
+  });
+
+  it('shows an indefinite-suspension message', () => {
+    h.result = ref(withUsers([suspension({ suspendedIndefinitely: true })]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Suspended indefinitely');
+  });
+
+  it('links to the related issue when present', () => {
+    h.result = ref(withUsers([suspension({ RelatedIssue: { issueNumber: 9 } })]));
+    const wrapper = mountList();
+
+    expect(wrapper.text()).toContain('Related Issue');
+  });
+});

--- a/components/admin/ServerTabs.spec.ts
+++ b/components/admin/ServerTabs.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import ServerTabs from '@/components/admin/ServerTabs.vue';
+import type { Channel } from '@/__generated__/graphql';
+
+const h = vi.hoisted(() => ({ route: null as unknown }));
+
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+
+const tabButtonStub = {
+  name: 'TabButton',
+  props: ['to', 'label', 'isActive', 'vertical', 'showCount'],
+  template: '<a>{{ label }}</a>',
+};
+
+const mountTabs = (props: Record<string, unknown> = {}) =>
+  mount(ServerTabs, {
+    props: { serverConfig: {} as unknown as Channel, ...props },
+    global: {
+      stubs: {
+        TabButton: tabButtonStub,
+        FlagIcon: true,
+        LockClosedIcon: true,
+        CogIcon: true,
+        IdentificationIcon: true,
+        PlugIcon: true,
+        InfoIcon: true,
+        UserIcon: true,
+      },
+    },
+  });
+
+const tabs = (w: ReturnType<typeof mount>) => w.findAllComponents(tabButtonStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.route = { path: '/admin/issues' };
+});
+
+describe('ServerTabs', () => {
+  it('renders all admin tabs', () => {
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)).toHaveLength(8);
+  });
+
+  it('labels the first tab Issues', () => {
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('label')).toBe('Issues');
+  });
+
+  it('points the issues tab at the admin issues route', () => {
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('to')).toBe('/admin/issues');
+  });
+
+  it('marks the tab matching the route as active', () => {
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('isActive')).toBe(true);
+  });
+
+  it('does not mark a non-matching tab active', () => {
+    h.route = { path: '/admin/settings' };
+    const wrapper = mountTabs();
+
+    expect(tabs(wrapper)[0].props('isActive')).toBe(false);
+  });
+
+  it('passes the vertical flag to the tabs', () => {
+    const wrapper = mountTabs({ vertical: true });
+
+    expect(tabs(wrapper)[0].props('vertical')).toBe(true);
+  });
+});

--- a/components/channel/BecomeAdminModal.spec.ts
+++ b/components/channel/BecomeAdminModal.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import BecomeAdminModal from '@/components/channel/BecomeAdminModal.vue';
+
+const h = vi.hoisted(() => ({
+  becomeAdmin: vi.fn(),
+  error: null as unknown,
+  onDone: undefined as undefined | (() => void),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({
+    mutate: h.becomeAdmin,
+    loading: ref(false),
+    error: h.error,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const genericModalStub = {
+  name: 'GenericModal',
+  props: ['open', 'title', 'body', 'error', 'loading'],
+  emits: ['primary-button-click', 'secondary-button-click'],
+  template: '<div />',
+};
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(BecomeAdminModal, {
+    props: { channelUniqueName: 'cats', open: true, ...props },
+    global: { stubs: { GenericModal: genericModalStub } },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent(genericModalStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.becomeAdmin = vi.fn();
+  h.error = ref(null);
+  h.onDone = undefined;
+});
+
+describe('BecomeAdminModal', () => {
+  it('shows the title', () => {
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('title')).toBe('Become an admin of this forum?');
+  });
+
+  it('requests admin with the channel name', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.becomeAdmin).toHaveBeenCalledWith({ channelUniqueName: 'cats' });
+  });
+
+  it('emits success when the mutation completes', () => {
+    const wrapper = mountModal();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('success')).toBeTruthy();
+  });
+
+  it('emits close when the mutation completes', () => {
+    const wrapper = mountModal();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('emits close from the secondary button', async () => {
+    const wrapper = mountModal();
+
+    await modal(wrapper).vm.$emit('secondary-button-click');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('passes the mutation error to the modal', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountModal();
+
+    expect(modal(wrapper).props('error')).toBe('boom');
+  });
+});

--- a/components/channel/Rules.spec.ts
+++ b/components/channel/Rules.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import Rules from '@/components/channel/Rules.vue';
+
+const rulesJSON = (rules: { summary: string; detail: string }[]) => JSON.stringify(rules);
+
+const mountRules = (rules?: string) =>
+  mount(Rules, {
+    props: { rules },
+    global: {
+      stubs: {
+        MarkdownRenderer: { name: 'MarkdownRenderer', props: ['text'], template: '<div class="md">{{ text }}</div>' },
+      },
+    },
+  });
+
+describe('Rules rendering', () => {
+  it('renders a row per rule', () => {
+    const wrapper = mountRules(
+      rulesJSON([
+        { summary: 'Be nice', detail: 'No insults' },
+        { summary: 'No spam', detail: '' },
+      ])
+    );
+
+    expect(wrapper.text()).toContain('Be nice');
+  });
+
+  it('numbers the rules', () => {
+    const wrapper = mountRules(rulesJSON([{ summary: 'Be nice', detail: '' }]));
+
+    expect(wrapper.text()).toContain('1.');
+  });
+
+  it('renders nothing for unparseable rules', () => {
+    const wrapper = mountRules('not json');
+
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('renders nothing when there are no rules', () => {
+    const wrapper = mountRules();
+
+    expect(wrapper.text()).toBe('');
+  });
+});
+
+describe('Rules expansion', () => {
+  it('expands a rule with detail on click', async () => {
+    const wrapper = mountRules(rulesJSON([{ summary: 'Be nice', detail: 'No insults' }]));
+
+    await wrapper.find('.cursor-pointer').trigger('click');
+
+    expect(wrapper.find('.md').text()).toBe('No insults');
+  });
+
+  it('collapses an expanded rule on a second click', async () => {
+    const wrapper = mountRules(rulesJSON([{ summary: 'Be nice', detail: 'No insults' }]));
+    await wrapper.find('.cursor-pointer').trigger('click');
+
+    await wrapper.find('.cursor-pointer').trigger('click');
+
+    expect(wrapper.find('.md').exists()).toBe(false);
+  });
+
+  it('does not make a detail-less rule clickable', () => {
+    const wrapper = mountRules(rulesJSON([{ summary: 'No spam', detail: '' }]));
+
+    expect(wrapper.find('.cursor-pointer').exists()).toBe(false);
+  });
+});

--- a/components/collection/CollectionDownloadListItem.spec.ts
+++ b/components/collection/CollectionDownloadListItem.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import CollectionDownloadListItem from '@/components/collection/CollectionDownloadListItem.vue';
+import type { Discussion } from '@/__generated__/graphql';
+
+const discussion = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'd1',
+    title: 'A model',
+    createdAt: '2024-01-01T00:00:00Z',
+    DiscussionChannels: [{ channelUniqueName: 'cats' }],
+    Album: { Images: [{ id: 'i1', url: 'https://x/a.png' }] },
+    ...overrides,
+  }) as unknown as Partial<Discussion>;
+
+const mountItem = (props: Record<string, unknown> = {}) =>
+  mount(CollectionDownloadListItem, {
+    props: { discussion: discussion(), ...props },
+    global: {
+      stubs: {
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+describe('CollectionDownloadListItem content', () => {
+  it('shows the title', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('A model');
+  });
+
+  it('falls back to an untitled label', () => {
+    const wrapper = mountItem({ discussion: discussion({ title: '' }) });
+
+    expect(wrapper.text()).toContain('Untitled download');
+  });
+
+  it('shows the forum name', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('cats');
+  });
+
+  it('falls back to Unknown forum', () => {
+    const wrapper = mountItem({ discussion: discussion({ DiscussionChannels: [] }) });
+
+    expect(wrapper.text()).toContain('Unknown forum');
+  });
+
+  it('shows the created-ago time', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('ago');
+  });
+});
+
+describe('CollectionDownloadListItem preview image', () => {
+  it('shows the first album image', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.find('img').attributes('src')).toBe('https://x/a.png');
+  });
+
+  it('respects the album image order', () => {
+    const wrapper = mountItem({
+      discussion: discussion({
+        Album: {
+          Images: [
+            { id: 'i1', url: 'https://x/a.png' },
+            { id: 'i2', url: 'https://x/b.png' },
+          ],
+          imageOrder: ['i2', 'i1'],
+        },
+      }),
+    });
+
+    expect(wrapper.find('img').attributes('src')).toBe('https://x/b.png');
+  });
+
+  it('shows a no-preview placeholder without images', () => {
+    const wrapper = mountItem({ discussion: discussion({ Album: { Images: [] } }) });
+
+    expect(wrapper.text()).toContain('No preview');
+  });
+});

--- a/components/comments/PermalinkedComment.spec.ts
+++ b/components/comments/PermalinkedComment.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import PermalinkedComment from '@/components/comments/PermalinkedComment.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  error: null as unknown,
+  loading: null as unknown,
+  route: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.result, error: h.error, loading: h.loading }),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+
+const comment = (overrides: Record<string, unknown> = {}) => ({
+  id: 'c1',
+  text: 'A comment',
+  ParentComment: null,
+  ...overrides,
+});
+
+const mountComment = () =>
+  mount(PermalinkedComment, {
+    slots: {
+      comment: `<template #comment="{ commentData }"><div class="slot">{{ commentData.text }}</div></template>`,
+    },
+    global: {
+      stubs: {
+        ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref({ comments: [comment()] });
+  h.error = ref(null);
+  h.loading = ref(false);
+  h.route = { params: { commentId: 'c1', forumId: 'cats', discussionId: 'd1' } };
+});
+
+describe('PermalinkedComment states', () => {
+  it('shows a loading message', () => {
+    h.loading = ref(true);
+    const wrapper = mountComment();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('shows an error banner on query error', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountComment();
+
+    expect(wrapper.find('.err').text()).toContain('boom');
+  });
+
+  it('shows a not-found message when the comment is missing', () => {
+    h.result = ref({ comments: [] });
+    const wrapper = mountComment();
+
+    expect(wrapper.text()).toContain('does not exist');
+  });
+});
+
+describe('PermalinkedComment content', () => {
+  it('passes the comment to the slot', () => {
+    const wrapper = mountComment();
+
+    expect(wrapper.find('.slot').text()).toBe('A comment');
+  });
+
+  it('hides the context link without a parent comment', () => {
+    const wrapper = mountComment();
+
+    expect(wrapper.text()).not.toContain('View Context');
+  });
+
+  it('shows a context link for a discussion reply', () => {
+    h.result = ref({ comments: [comment({ ParentComment: { id: 'p1' } })] });
+    const wrapper = mountComment();
+
+    expect(wrapper.text()).toContain('View Context');
+  });
+
+  it('shows a context link for an event reply', () => {
+    h.route = { params: { commentId: 'c1', forumId: 'cats', eventId: 'e1' } };
+    h.result = ref({ comments: [comment({ ParentComment: { id: 'p1' } })] });
+    const wrapper = mountComment();
+
+    expect(wrapper.text()).toContain('View Context');
+  });
+});

--- a/components/discussion/detail/CrosspostedDiscussionEmbed.spec.ts
+++ b/components/discussion/detail/CrosspostedDiscussionEmbed.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import CrosspostedDiscussionEmbed from '@/components/discussion/detail/CrosspostedDiscussionEmbed.vue';
+import type { Discussion } from '@/__generated__/graphql';
+
+const discussion = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'd1',
+    title: 'A crosspost',
+    body: 'some body',
+    Author: { username: 'alice' },
+    DiscussionChannels: [{ channelUniqueName: 'cats', Channel: { displayName: 'Cats' } }],
+    Album: { Images: [] },
+    ...overrides,
+  }) as unknown as Discussion;
+
+const mountEmbed = (props: Record<string, unknown> = {}) =>
+  mount(CrosspostedDiscussionEmbed, {
+    props: { discussion: discussion(), ...props },
+    global: {
+      stubs: {
+        MarkdownPreview: { name: 'MarkdownPreview', props: ['text'], template: '<div class="md">{{ text }}</div>' },
+        DiscussionAlbum: { name: 'DiscussionAlbum', template: '<div class="album" />' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+describe('CrosspostedDiscussionEmbed content', () => {
+  it('shows the crosspost label', () => {
+    const wrapper = mountEmbed();
+
+    expect(wrapper.text()).toContain('Crossposted Discussion');
+  });
+
+  it('shows the title as a link when the discussion is linkable', () => {
+    const wrapper = mountEmbed();
+
+    expect(wrapper.find('a').text()).toContain('A crosspost');
+  });
+
+  it('shows the title as plain text without a channel', () => {
+    const wrapper = mountEmbed({
+      discussion: discussion({ DiscussionChannels: [] }),
+    });
+
+    expect(wrapper.find('a').exists()).toBe(false);
+  });
+
+  it('shows the author and channel', () => {
+    const wrapper = mountEmbed();
+
+    expect(wrapper.text()).toContain('alice');
+  });
+
+  it('shows the channel display name', () => {
+    const wrapper = mountEmbed();
+
+    expect(wrapper.text()).toContain('in Cats');
+  });
+
+  it('falls back to Unknown user for a missing author', () => {
+    const wrapper = mountEmbed({ discussion: discussion({ Author: null }) });
+
+    expect(wrapper.text()).toContain('Unknown user');
+  });
+});
+
+describe('CrosspostedDiscussionEmbed body', () => {
+  it('renders the body preview when there is a body', () => {
+    const wrapper = mountEmbed();
+
+    expect(wrapper.find('.md').text()).toBe('some body');
+  });
+
+  it('shows a no-description message when there is no body', () => {
+    const wrapper = mountEmbed({ discussion: discussion({ body: '' }) });
+
+    expect(wrapper.text()).toContain('No description provided');
+  });
+
+  it('renders the album when there are images', async () => {
+    const wrapper = mountEmbed({
+      discussion: discussion({ Album: { Images: [{ id: 'i1' }] } }),
+    });
+    await flushPromises();
+
+    expect(wrapper.find('.album').exists()).toBe(true);
+  });
+
+  it('shows the embed notice when requested', () => {
+    const wrapper = mountEmbed({ showEmbedNotice: true });
+
+    expect(wrapper.text()).toContain('will be embedded with your discussion');
+  });
+});

--- a/components/discussion/detail/DiscussionLayoutManager.spec.ts
+++ b/components/discussion/detail/DiscussionLayoutManager.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import DiscussionLayoutManager from '@/components/discussion/detail/DiscussionLayoutManager.vue';
+import type { Discussion } from '@/__generated__/graphql';
+
+const ALL_EVENTS = [
+  'discussion-refetch',
+  'discussion-channel-refetch',
+  'handle-click-add-album',
+  'edit-album',
+  'handle-click-edit-feedback',
+  'handle-click-give-feedback',
+  'handle-click-undo-feedback',
+];
+
+// [child kebab event, parent camel event]
+const REEMITS: [string, string][] = [
+  ['discussion-refetch', 'discussionRefetch'],
+  ['discussion-channel-refetch', 'discussionChannelRefetch'],
+  ['edit-album', 'editAlbum'],
+  ['handle-click-edit-feedback', 'handleClickEditFeedback'],
+  ['handle-click-give-feedback', 'handleClickGiveFeedback'],
+  ['handle-click-undo-feedback', 'handleClickUndoFeedback'],
+];
+
+const layoutStub = (name: string) => ({
+  name,
+  emits: ALL_EVENTS,
+  template: `<div class="${name}" />`,
+});
+
+const mountManager = (props: Record<string, unknown> = {}) =>
+  mount(DiscussionLayoutManager, {
+    props: {
+      discussion: { id: 'd1' } as unknown as Discussion,
+      discussionId: 'd1',
+      channelId: 'cats',
+      ...props,
+    },
+    global: {
+      stubs: {
+        DownloadModeLayout: layoutStub('DownloadModeLayout'),
+        RegularDiscussionLayout: layoutStub('RegularDiscussionLayout'),
+        DownloadTabNavigation: { name: 'DownloadTabNavigation', template: '<div class="tabs" />' },
+      },
+    },
+  });
+
+describe('DiscussionLayoutManager', () => {
+  it('renders the regular layout by default', () => {
+    const wrapper = mountManager();
+
+    expect(wrapper.find('.RegularDiscussionLayout').exists()).toBe(true);
+  });
+
+  it('does not render the download layout by default', () => {
+    const wrapper = mountManager();
+
+    expect(wrapper.find('.DownloadModeLayout').exists()).toBe(false);
+  });
+
+  it('renders the download layout in download mode', () => {
+    const wrapper = mountManager({ downloadMode: true });
+
+    expect(wrapper.find('.DownloadModeLayout').exists()).toBe(true);
+  });
+
+  it('renders the download tabs in download mode', () => {
+    const wrapper = mountManager({ downloadMode: true });
+
+    expect(wrapper.find('.tabs').exists()).toBe(true);
+  });
+
+  it('hides the download tabs in regular mode', () => {
+    const wrapper = mountManager();
+
+    expect(wrapper.find('.tabs').exists()).toBe(false);
+  });
+
+  it.each(REEMITS)(
+    're-emits %s as %s from the regular layout',
+    async (childEvent, parentEvent) => {
+      const wrapper = mountManager();
+
+      await wrapper.getComponent({ name: 'RegularDiscussionLayout' }).vm.$emit(childEvent);
+
+      expect(wrapper.emitted(parentEvent)).toBeTruthy();
+    }
+  );
+
+  it.each([...REEMITS, ['handle-click-add-album', 'handleClickAddAlbum']])(
+    're-emits %s as %s from the download layout',
+    async (childEvent, parentEvent) => {
+      const wrapper = mountManager({ downloadMode: true });
+
+      await wrapper.getComponent({ name: 'DownloadModeLayout' }).vm.$emit(childEvent);
+
+      expect(wrapper.emitted(parentEvent)).toBeTruthy();
+    }
+  );
+});

--- a/components/event/list/EventPreview.spec.ts
+++ b/components/event/list/EventPreview.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import EventPreview from '@/components/event/list/EventPreview.vue';
+
+vi.mock('@headlessui/vue', () => ({
+  TransitionRoot: { name: 'TransitionRoot', template: '<div><slot /></div>' },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>' },
+  Dialog: { name: 'Dialog', emits: ['close'], template: '<div><slot /></div>' },
+  DialogOverlay: { name: 'DialogOverlay', template: '<div />' },
+}));
+
+const mountPreview = (props: Record<string, unknown> = {}) =>
+  mount(EventPreview, {
+    props: { isOpen: true, ...props },
+    global: {
+      stubs: {
+        ClientOnly: { template: '<div><slot /></div>' },
+        EventDetail: { name: 'EventDetail', template: '<div class="event-detail" />' },
+        XmarkIcon: true,
+      },
+    },
+  });
+
+const closeButton = (w: ReturnType<typeof mount>) =>
+  w.findAll('button').find((b) => b.text() === 'Close');
+
+describe('EventPreview', () => {
+  it('renders the event detail', () => {
+    const wrapper = mountPreview();
+
+    expect(wrapper.find('.event-detail').exists()).toBe(true);
+  });
+
+  it('emits closePreview from the X button', async () => {
+    const wrapper = mountPreview();
+
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('closePreview')).toBeTruthy();
+  });
+
+  it('emits closePreview from the Close button', async () => {
+    const wrapper = mountPreview();
+
+    await closeButton(wrapper)!.trigger('click');
+
+    expect(wrapper.emitted('closePreview')).toBeTruthy();
+  });
+
+  it('emits closePreview from the dialog close', async () => {
+    const wrapper = mountPreview();
+
+    await wrapper.getComponent({ name: 'Dialog' }).vm.$emit('close');
+
+    expect(wrapper.emitted('closePreview')).toBeTruthy();
+  });
+});

--- a/components/event/list/PreviewContainer.spec.ts
+++ b/components/event/list/PreviewContainer.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import PreviewContainer from '@/components/event/list/PreviewContainer.vue';
+
+vi.mock('@headlessui/vue', () => ({
+  TransitionRoot: { name: 'TransitionRoot', template: '<div><slot /></div>' },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>' },
+  Dialog: { name: 'Dialog', emits: ['close'], template: '<div><slot /></div>' },
+  DialogOverlay: { name: 'DialogOverlay', template: '<div />' },
+  DialogTitle: { name: 'DialogTitle', template: '<div><slot /></div>' },
+}));
+
+const mountContainer = (props: Record<string, unknown> = {}, slot = '') =>
+  mount(PreviewContainer, {
+    props: { isOpen: true, ...props },
+    slots: { default: slot },
+    global: { stubs: { ClientOnly: { template: '<div><slot /></div>' }, XmarkIcon: true } },
+  });
+
+describe('PreviewContainer', () => {
+  it('renders the header', () => {
+    const wrapper = mountContainer({ header: 'Event preview' });
+
+    expect(wrapper.text()).toContain('Event preview');
+  });
+
+  it('renders the default slot', () => {
+    const wrapper = mountContainer({}, '<div class="body">content</div>');
+
+    expect(wrapper.find('.body').exists()).toBe(true);
+  });
+
+  it('emits closePreview from the close button', async () => {
+    const wrapper = mountContainer();
+
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('closePreview')).toBeTruthy();
+  });
+
+  it('emits closePreview from the dialog close', async () => {
+    const wrapper = mountContainer();
+
+    await wrapper.getComponent({ name: 'Dialog' }).vm.$emit('close');
+
+    expect(wrapper.emitted('closePreview')).toBeTruthy();
+  });
+
+  it('uses a lower z-index by default', () => {
+    const wrapper = mountContainer();
+
+    expect(wrapper.getComponent({ name: 'Dialog' }).classes()).toContain('z-20');
+  });
+
+  it('uses a higher z-index on the top layer', () => {
+    const wrapper = mountContainer({ topLayer: true });
+
+    expect(wrapper.getComponent({ name: 'Dialog' }).classes()).toContain('z-30');
+  });
+});

--- a/components/event/list/SeriesOccurrenceButtons.spec.ts
+++ b/components/event/list/SeriesOccurrenceButtons.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import SeriesOccurrenceButtons from '@/components/event/list/SeriesOccurrenceButtons.vue';
+
+const FUTURE = (month: number) => `2099-0${month}-15T18:00:00.000Z`;
+const PAST = '2000-01-01T18:00:00.000Z';
+
+const mountButtons = (props: Record<string, unknown> = {}) =>
+  mount(SeriesOccurrenceButtons, {
+    props: {
+      occurrences: [
+        { id: 'e2', startTime: FUTURE(2) },
+        { id: 'e3', startTime: FUTURE(3) },
+      ],
+      currentEventId: 'e1',
+      channelUniqueName: 'cats',
+      ...props,
+    },
+    global: {
+      stubs: {
+        NuxtLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a :href="to"><slot /></a>' },
+      },
+    },
+  });
+
+describe('SeriesOccurrenceButtons', () => {
+  it('shows the "Also on" label with upcoming occurrences', () => {
+    const wrapper = mountButtons();
+
+    expect(wrapper.text()).toContain('Also on:');
+  });
+
+  it('renders a link per upcoming occurrence', () => {
+    const wrapper = mountButtons();
+
+    expect(wrapper.findAll('a')).toHaveLength(2);
+  });
+
+  it('links to each occurrence', () => {
+    const wrapper = mountButtons();
+
+    expect(wrapper.find('a').attributes('href')).toBe('/forums/cats/events/e2');
+  });
+
+  it('filters out past occurrences', () => {
+    const wrapper = mountButtons({
+      occurrences: [
+        { id: 'e2', startTime: FUTURE(2) },
+        { id: 'old', startTime: PAST },
+      ],
+    });
+
+    expect(wrapper.findAll('a')).toHaveLength(1);
+  });
+
+  it('filters out the current event', () => {
+    const wrapper = mountButtons({
+      occurrences: [
+        { id: 'e1', startTime: FUTURE(2) },
+        { id: 'e2', startTime: FUTURE(3) },
+      ],
+    });
+
+    expect(wrapper.findAll('a')).toHaveLength(1);
+  });
+
+  it('renders nothing when there are no upcoming occurrences', () => {
+    const wrapper = mountButtons({ occurrences: [{ id: 'old', startTime: PAST }] });
+
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('limits visible occurrences and shows a +more count', () => {
+    const wrapper = mountButtons({
+      maxVisible: 2,
+      occurrences: [
+        { id: 'e2', startTime: FUTURE(2) },
+        { id: 'e3', startTime: FUTURE(3) },
+        { id: 'e4', startTime: FUTURE(4) },
+        { id: 'e5', startTime: FUTURE(5) },
+      ],
+    });
+
+    expect(wrapper.text()).toContain('+2 more');
+  });
+});

--- a/components/event/list/filters/LocationSearchBar.spec.ts
+++ b/components/event/list/filters/LocationSearchBar.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import LocationSearchBar from '@/components/event/list/filters/LocationSearchBar.vue';
+
+const h = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock('axios', () => ({ default: { get: (...a: unknown[]) => h.get(...a) } }));
+
+const result = { formatted: 'Paris, France', geometry: { lat: 48.8, lng: 2.3 } };
+
+const mountBar = (props: Record<string, unknown> = {}, slot = '') =>
+  mount(LocationSearchBar, {
+    props,
+    slots: { default: slot },
+    global: { stubs: { ClientOnly: { template: '<div><slot /></div>' }, LocationIcon: true } },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.get = vi.fn(() => Promise.resolve({ data: { results: [result] } }));
+});
+
+describe('LocationSearchBar rendering', () => {
+  it('shows the placeholder', () => {
+    const wrapper = mountBar({ searchPlaceholder: 'Where?' });
+
+    expect(wrapper.find('input').attributes('placeholder')).toBe('Where?');
+  });
+
+  it('uses the initial value', () => {
+    const wrapper = mountBar({ initialValue: 'Berlin' });
+
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('Berlin');
+  });
+
+  it('renders the default slot', () => {
+    const wrapper = mountBar({}, '<button class="my-btn" />');
+
+    expect(wrapper.find('.my-btn').exists()).toBe(true);
+  });
+});
+
+describe('LocationSearchBar search', () => {
+  it('searches when the query is long enough', async () => {
+    const wrapper = mountBar();
+
+    await wrapper.find('input').setValue('Paris');
+    await wrapper.find('input').trigger('input');
+    await flushPromises();
+
+    expect(h.get).toHaveBeenCalled();
+  });
+
+  it('does not search for a short query', async () => {
+    const wrapper = mountBar();
+
+    await wrapper.find('input').setValue('Pa');
+    await wrapper.find('input').trigger('input');
+    await flushPromises();
+
+    expect(h.get).not.toHaveBeenCalled();
+  });
+
+  it('renders the search results', async () => {
+    const wrapper = mountBar();
+    await wrapper.find('input').setValue('Paris');
+    await wrapper.find('input').trigger('input');
+    await flushPromises();
+
+    expect(wrapper.find('li').text()).toBe('Paris, France');
+  });
+});
+
+describe('LocationSearchBar selection', () => {
+  it('emits the selected location', async () => {
+    const wrapper = mountBar();
+    await wrapper.find('input').setValue('Paris');
+    await wrapper.find('input').trigger('input');
+    await flushPromises();
+
+    await wrapper.find('li').trigger('click');
+
+    expect(wrapper.emitted('updateLocationInput')?.[0]?.[0]).toEqual({
+      formatted_address: 'Paris, France',
+      name: 'Paris',
+      lat: 48.8,
+      lng: 2.3,
+    });
+  });
+
+  it('clears the results after selecting', async () => {
+    const wrapper = mountBar();
+    await wrapper.find('input').setValue('Paris');
+    await wrapper.find('input').trigger('input');
+    await flushPromises();
+
+    await wrapper.find('li').trigger('click');
+
+    expect(wrapper.find('li').exists()).toBe(false);
+  });
+});

--- a/components/mod/IssueRelatedContent.spec.ts
+++ b/components/mod/IssueRelatedContent.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import IssueRelatedContent from '@/components/mod/IssueRelatedContent.vue';
+import type { Issue } from '@/__generated__/graphql';
+
+const issue = (overrides: Record<string, unknown> = {}) =>
+  ({ issueNumber: 1, ...overrides }) as unknown as Issue;
+
+const childStub = (name: string) => ({
+  name,
+  props: ['activeIssue', 'commentId', 'imageId', 'issue', 'disabled'],
+  emits: ['fetched-original-author-username', 'suspended-successfully'],
+  template: `<div class="${name}" />`,
+});
+
+const mountContent = (props: Record<string, unknown> = {}) =>
+  mount(IssueRelatedContent, {
+    props: {
+      activeIssue: issue({ relatedDiscussionId: 'd1' }),
+      reportCount: 0,
+      reportCountLabel: '0 reports',
+      ...props,
+    },
+    global: {
+      stubs: {
+        DiscussionDetails: childStub('DiscussionDetails'),
+        EventDetail: childStub('EventDetail'),
+        CommentDetails: childStub('CommentDetails'),
+        ImageDetails: childStub('ImageDetails'),
+        SuspendModButton: childStub('SuspendModButton'),
+        FlagIcon: true,
+        ClientOnly: { template: '<div><slot /></div>' },
+      },
+    },
+  });
+
+describe('IssueRelatedContent content type', () => {
+  it.each([
+    [{ relatedDiscussionId: 'd1' }, 'Original discussion'],
+    [{ relatedEventId: 'e1' }, 'Original event'],
+    [{ relatedImageId: 'i1' }, 'Original image'],
+    [{ relatedWikiRevisionId: 'w1' }, 'Original wiki edit'],
+    [{ relatedWikiPageId: 'w1' }, 'Original wiki page'],
+    [{ relatedCommentId: 'c1' }, 'Original comment'],
+  ])('labels the content type %#', (related, label) => {
+    const wrapper = mountContent({ activeIssue: issue(related) });
+
+    expect(wrapper.text()).toContain(label);
+  });
+});
+
+describe('IssueRelatedContent rendering', () => {
+  it('renders discussion details for a discussion issue', () => {
+    const wrapper = mountContent();
+
+    expect(wrapper.find('.DiscussionDetails').exists()).toBe(true);
+  });
+
+  it('renders comment details for a comment issue', () => {
+    const wrapper = mountContent({ activeIssue: issue({ relatedCommentId: 'c1' }) });
+
+    expect(wrapper.find('.CommentDetails').exists()).toBe(true);
+  });
+
+  it('shows wiki info for a wiki issue', () => {
+    const wrapper = mountContent({ activeIssue: issue({ relatedWikiPageId: 'wp1' }) });
+
+    expect(wrapper.text()).toContain('Wiki page ID: wp1');
+  });
+
+  it('shows the report count badge', () => {
+    const wrapper = mountContent({ reportCount: 2, reportCountLabel: '2 reports' });
+
+    expect(wrapper.text()).toContain('2 reports');
+  });
+
+  it('hides the report badge when the count is null', () => {
+    const wrapper = mountContent({ reportCount: null });
+
+    expect(wrapper.text()).not.toContain('reports');
+  });
+});
+
+describe('IssueRelatedContent suspend mod', () => {
+  it('shows the suspend mod button for a mod issue', () => {
+    const wrapper = mountContent({
+      activeIssue: issue({ relatedDiscussionId: 'd1', relatedModProfileName: 'mod1' }),
+      isAuthorMod: true,
+    });
+
+    expect(wrapper.find('.SuspendModButton').exists()).toBe(true);
+  });
+
+  it('hides the suspend mod button for non-mod issues', () => {
+    const wrapper = mountContent({ isAuthorMod: false });
+
+    expect(wrapper.find('.SuspendModButton').exists()).toBe(false);
+  });
+});
+
+describe('IssueRelatedContent emits', () => {
+  it('re-emits fetchedOriginalAuthorUsername', async () => {
+    const wrapper = mountContent();
+
+    await wrapper.getComponent({ name: 'DiscussionDetails' }).vm.$emit('fetched-original-author-username', 'alice');
+
+    expect(wrapper.emitted('fetchedOriginalAuthorUsername')?.[0]).toEqual(['alice']);
+  });
+
+  it('re-emits suspendedModSuccessfully', async () => {
+    const wrapper = mountContent({
+      activeIssue: issue({ relatedDiscussionId: 'd1', relatedModProfileName: 'mod1' }),
+      isAuthorMod: true,
+    });
+
+    await wrapper.getComponent({ name: 'SuspendModButton' }).vm.$emit('suspended-successfully');
+
+    expect(wrapper.emitted('suspendedModSuccessfully')).toBeTruthy();
+  });
+});

--- a/components/mod/LockChannelDialog.spec.ts
+++ b/components/mod/LockChannelDialog.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import LockChannelDialog from '@/components/mod/LockChannelDialog.vue';
+
+const h = vi.hoisted(() => ({
+  lock: vi.fn(),
+  error: null as unknown,
+  onDone: undefined as undefined | (() => void),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({
+    mutate: h.lock,
+    loading: ref(false),
+    error: h.error,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const genericModalStub = {
+  name: 'GenericModal',
+  props: ['open', 'title', 'error', 'loading', 'primaryButtonDisabled'],
+  emits: ['primary-button-click', 'close'],
+  template: '<div><slot name="content" /></div>',
+};
+
+const mountDialog = (props: Record<string, unknown> = {}) =>
+  mount(LockChannelDialog, {
+    props: { channelUniqueName: 'cats', open: true, ...props },
+    global: { stubs: { GenericModal: genericModalStub, LockClosedIcon: true } },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent(genericModalStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.lock = vi.fn();
+  h.error = ref(null);
+  h.onDone = undefined;
+});
+
+describe('LockChannelDialog', () => {
+  it('titles the dialog with the display name', () => {
+    const wrapper = mountDialog({ channelDisplayName: 'Cats Forum' });
+
+    expect(modal(wrapper).props('title')).toBe('Lock Forum: Cats Forum');
+  });
+
+  it('falls back to the unique name in the title', () => {
+    const wrapper = mountDialog();
+
+    expect(modal(wrapper).props('title')).toBe('Lock Forum: cats');
+  });
+
+  it('disables the lock button until a reason is entered', () => {
+    const wrapper = mountDialog();
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(true);
+  });
+
+  it('enables the lock button once a reason is entered', async () => {
+    const wrapper = mountDialog();
+
+    await wrapper.find('textarea').setValue('spam');
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(false);
+  });
+
+  it('locks the channel with the reason', async () => {
+    const wrapper = mountDialog({ issueId: 'i1' });
+    await wrapper.find('textarea').setValue('spam');
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.lock).toHaveBeenCalledWith({
+      channelUniqueName: 'cats',
+      reason: 'spam',
+      issueId: 'i1',
+    });
+  });
+
+  it('does not lock without a reason', async () => {
+    const wrapper = mountDialog();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.lock).not.toHaveBeenCalled();
+  });
+
+  it('emits locked when the mutation completes', () => {
+    const wrapper = mountDialog();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('locked')).toBeTruthy();
+  });
+
+  it('emits close from the modal', async () => {
+    const wrapper = mountDialog();
+
+    await modal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('passes the mutation error to the modal', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountDialog();
+
+    expect(modal(wrapper).props('error')).toBe('boom');
+  });
+});

--- a/components/mod/UnlockChannelDialog.spec.ts
+++ b/components/mod/UnlockChannelDialog.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import UnlockChannelDialog from '@/components/mod/UnlockChannelDialog.vue';
+
+const h = vi.hoisted(() => ({
+  unlock: vi.fn(),
+  error: null as unknown,
+  onDone: undefined as undefined | (() => void),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({
+    mutate: h.unlock,
+    loading: ref(false),
+    error: h.error,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const genericModalStub = {
+  name: 'GenericModal',
+  props: ['open', 'title', 'error', 'loading', 'primaryButtonDisabled'],
+  emits: ['primary-button-click', 'close'],
+  template: '<div><slot name="content" /></div>',
+};
+
+const mountDialog = (props: Record<string, unknown> = {}) =>
+  mount(UnlockChannelDialog, {
+    props: { channelUniqueName: 'cats', open: true, ...props },
+    global: { stubs: { GenericModal: genericModalStub, LockOpenIcon: true } },
+  });
+
+const modal = (w: ReturnType<typeof mount>) => w.getComponent(genericModalStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.unlock = vi.fn();
+  h.error = ref(null);
+  h.onDone = undefined;
+});
+
+describe('UnlockChannelDialog', () => {
+  it('titles the dialog with the display name', () => {
+    const wrapper = mountDialog({ channelDisplayName: 'Cats Forum' });
+
+    expect(modal(wrapper).props('title')).toBe('Unlock Forum: Cats Forum');
+  });
+
+  it('falls back to the unique name in the title', () => {
+    const wrapper = mountDialog();
+
+    expect(modal(wrapper).props('title')).toBe('Unlock Forum: cats');
+  });
+
+  it('unlocks with a null reason when none is given', async () => {
+    const wrapper = mountDialog();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.unlock).toHaveBeenCalledWith({
+      channelUniqueName: 'cats',
+      reason: null,
+    });
+  });
+
+  it('unlocks with the entered reason', async () => {
+    const wrapper = mountDialog();
+    await wrapper.find('textarea').setValue('resolved');
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.unlock).toHaveBeenCalledWith({
+      channelUniqueName: 'cats',
+      reason: 'resolved',
+    });
+  });
+
+  it('emits unlocked when the mutation completes', () => {
+    const wrapper = mountDialog();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('unlocked')).toBeTruthy();
+  });
+
+  it('emits close from the modal', async () => {
+    const wrapper = mountDialog();
+
+    await modal(wrapper).vm.$emit('close');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('passes the mutation error to the modal', () => {
+    h.error = ref({ message: 'boom' });
+    const wrapper = mountDialog();
+
+    expect(modal(wrapper).props('error')).toBe('boom');
+  });
+});

--- a/components/nav/UserProfileDropdownMenu.spec.ts
+++ b/components/nav/UserProfileDropdownMenu.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import UserProfileDropdownMenu from '@/components/nav/UserProfileDropdownMenu.vue';
+
+const h = vi.hoisted(() => ({
+  username: null as unknown,
+  result: null as unknown,
+  push: vi.fn(),
+  logout: vi.fn(),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({ useUsername: () => h.username }));
+vi.mock('@vue/apollo-composable', () => ({ useQuery: () => ({ result: h.result }) }));
+vi.mock('nuxt/app', () => ({ useRouter: () => ({ push: h.push }) }));
+vi.mock('@/composables/useServerLogout', () => ({ useServerLogout: () => ({ logout: h.logout }) }));
+
+const dropdownStub = {
+  name: 'IconButtonDropdown',
+  props: ['items', 'ariaLabel'],
+  emits: ['go-to-mod-profile', 'go-to-user-profile', 'logout'],
+  template: '<div><slot /></div>',
+};
+
+const mountMenu = (props: Record<string, unknown> = {}) =>
+  mount(UserProfileDropdownMenu, {
+    props: { username: 'alice', ...props },
+    global: {
+      stubs: {
+        IconButtonDropdown: dropdownStub,
+        AvatarComponent: { name: 'AvatarComponent', props: ['src', 'text'], template: '<div class="avatar" />' },
+      },
+    },
+  });
+
+const dropdown = (w: ReturnType<typeof mount>) => w.getComponent(dropdownStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.username = ref('alice');
+  h.result = ref({ users: [{ profilePicURL: 'https://x/pic.png' }] });
+});
+
+describe('UserProfileDropdownMenu', () => {
+  it('passes the menu items to the dropdown', () => {
+    const wrapper = mountMenu();
+
+    const labels = dropdown(wrapper).props('items').map((i: { label: string }) => i.label);
+    expect(labels).toEqual(['My Profile', 'Account Settings', 'Sign out']);
+  });
+
+  it('passes the profile picture to the avatar', () => {
+    const wrapper = mountMenu();
+
+    expect(wrapper.getComponent({ name: 'AvatarComponent' }).props('src')).toBe(
+      'https://x/pic.png'
+    );
+  });
+
+  it('falls back to an empty avatar src without a user', () => {
+    h.result = ref({ users: [] });
+    const wrapper = mountMenu();
+
+    expect(wrapper.getComponent({ name: 'AvatarComponent' }).props('src')).toBe('');
+  });
+
+  it('logs out on the logout event', async () => {
+    const wrapper = mountMenu();
+
+    await dropdown(wrapper).vm.$emit('logout');
+
+    expect(h.logout).toHaveBeenCalled();
+  });
+
+  it('navigates to the mod profile', async () => {
+    const wrapper = mountMenu({ modName: 'mod1' });
+
+    await dropdown(wrapper).vm.$emit('go-to-mod-profile');
+
+    expect(h.push).toHaveBeenCalledWith('/mod/mod1');
+  });
+
+  it('navigates to the user profile', async () => {
+    const wrapper = mountMenu();
+
+    await dropdown(wrapper).vm.$emit('go-to-user-profile');
+
+    expect(h.push).toHaveBeenCalledWith('/u/alice/comments');
+  });
+});

--- a/components/plugins/PluginSettingsForm.spec.ts
+++ b/components/plugins/PluginSettingsForm.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import PluginSettingsForm from '@/components/plugins/PluginSettingsForm.vue';
+
+const fieldStub = (name: string) => ({
+  name,
+  props: ['field', 'modelValue', 'error', 'secretStatus'],
+  emits: ['update:model-value'],
+  template: `<div class="${name}" />`,
+});
+
+const section = (fields: { key: string; type: string }[], overrides = {}) => ({
+  title: 'General',
+  description: 'General settings',
+  fields,
+  ...overrides,
+});
+
+const mountForm = (props: Record<string, unknown> = {}) =>
+  mount(PluginSettingsForm, {
+    props: {
+      sections: [section([{ key: 'name', type: 'text' }])],
+      modelValue: {},
+      ...props,
+    },
+    global: {
+      stubs: {
+        PluginTextField: fieldStub('PluginTextField'),
+        PluginNumberField: fieldStub('PluginNumberField'),
+        PluginBooleanField: fieldStub('PluginBooleanField'),
+        PluginSelectField: fieldStub('PluginSelectField'),
+        PluginSecretField: fieldStub('PluginSecretField'),
+      },
+    },
+  });
+
+describe('PluginSettingsForm rendering', () => {
+  it('shows the section title', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('General');
+  });
+
+  it('shows the section description', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).toContain('General settings');
+  });
+
+  it('shows an empty message when there are no sections', () => {
+    const wrapper = mountForm({ sections: [] });
+
+    expect(wrapper.text()).toContain('No configuration options available');
+  });
+});
+
+describe('PluginSettingsForm field selection', () => {
+  it.each([
+    ['text', 'PluginTextField'],
+    ['textarea', 'PluginTextField'],
+    ['number', 'PluginNumberField'],
+    ['boolean', 'PluginBooleanField'],
+    ['toggle', 'PluginBooleanField'],
+    ['select', 'PluginSelectField'],
+    ['secret', 'PluginSecretField'],
+    ['unknown', 'PluginTextField'],
+  ])('renders %s fields with %s', (type, component) => {
+    const wrapper = mountForm({ sections: [section([{ key: 'f', type }])] });
+
+    expect(wrapper.find(`.${component}`).exists()).toBe(true);
+  });
+});
+
+describe('PluginSettingsForm values', () => {
+  it('passes the field value from the model', () => {
+    const wrapper = mountForm({ modelValue: { name: 'hi' } });
+
+    expect(wrapper.getComponent({ name: 'PluginTextField' }).props('modelValue')).toBe('hi');
+  });
+
+  it('passes the field error', () => {
+    const wrapper = mountForm({ errors: { name: 'Required' } });
+
+    expect(wrapper.getComponent({ name: 'PluginTextField' }).props('error')).toBe('Required');
+  });
+
+  it('emits update:modelValue with the merged value', async () => {
+    const wrapper = mountForm({ modelValue: { other: 1 } });
+
+    await wrapper.getComponent({ name: 'PluginTextField' }).vm.$emit('update:model-value', 'typed');
+
+    expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toEqual({
+      other: 1,
+      name: 'typed',
+    });
+  });
+
+  it('passes the secret status to secret fields', () => {
+    const wrapper = mountForm({
+      sections: [section([{ key: 'apiKey', type: 'secret' }])],
+      secretStatuses: [{ key: 'apiKey', status: 'SET' }],
+    });
+
+    expect(
+      wrapper.getComponent({ name: 'PluginSecretField' }).props('secretStatus')
+    ).toEqual({ key: 'apiKey', status: 'SET' });
+  });
+});

--- a/components/user/DiscussionItemInProfile.spec.ts
+++ b/components/user/DiscussionItemInProfile.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import DiscussionItemInProfile from '@/components/user/DiscussionItemInProfile.vue';
+import type { Discussion } from '@/__generated__/graphql';
+
+const h = vi.hoisted(() => ({ push: vi.fn() }));
+
+vi.mock('nuxt/app', () => ({ useRouter: () => ({ push: h.push }) }));
+
+const discussion = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'd1',
+    title: 'A discussion',
+    createdAt: '2024-01-01T00:00:00Z',
+    Author: { username: 'alice' },
+    Tags: [{ text: 'pets' }],
+    DiscussionChannels: [{ Channel: { uniqueName: 'cats' }, channelUniqueName: 'cats' }],
+    hasDownload: false,
+    ...overrides,
+  }) as unknown as Discussion;
+
+const highlightStub = { name: 'HighlightedSearchTerms', props: ['text', 'searchInput'], template: '<span>{{ text }}</span>' };
+const tagStub = { name: 'Tag', props: ['tag', 'active'], emits: ['click'], template: '<button class="tag" @click="$emit(\'click\')">{{ tag }}</button>' };
+
+const mountItem = (props: Record<string, unknown> = {}) =>
+  mount(DiscussionItemInProfile, {
+    props: { discussion: discussion(), ...props },
+    global: {
+      stubs: {
+        HighlightedSearchTerms: highlightStub,
+        Tag: tagStub,
+        TagComponent: tagStub,
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DiscussionItemInProfile content', () => {
+  it('shows the title', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('A discussion');
+  });
+
+  it('shows the posted-by line', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('by alice');
+  });
+
+  it('falls back to Deleted for a missing author', () => {
+    const wrapper = mountItem({ discussion: discussion({ Author: null }) });
+
+    expect(wrapper.text()).toContain('by Deleted');
+  });
+
+  it('renders the tags', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.find('.tag').text()).toBe('pets');
+  });
+
+  it('emits filterByTag when a tag is clicked', async () => {
+    const wrapper = mountItem();
+
+    await wrapper.find('.tag').trigger('click');
+
+    expect(wrapper.emitted('filterByTag')?.[0]).toEqual(['pets']);
+  });
+});
+
+describe('DiscussionItemInProfile navigation', () => {
+  it('navigates to the discussion on click', async () => {
+    const wrapper = mountItem();
+
+    await wrapper.find('li').trigger('click');
+
+    expect(h.push).toHaveBeenCalledWith('/forums/cats/discussions/d1');
+  });
+
+  it('navigates to the download path for a download', async () => {
+    const wrapper = mountItem({ discussion: discussion({ hasDownload: true }) });
+
+    await wrapper.find('li').trigger('click');
+
+    expect(h.push).toHaveBeenCalledWith('/forums/cats/downloads/d1');
+  });
+
+  it('does not navigate without a channel', async () => {
+    const wrapper = mountItem({ discussion: discussion({ DiscussionChannels: [] }) });
+
+    await wrapper.find('li').trigger('click');
+
+    expect(h.push).not.toHaveBeenCalled();
+  });
+
+  it('shows a download view link for downloads', () => {
+    const wrapper = mountItem({ discussion: discussion({ hasDownload: true }) });
+
+    expect(wrapper.text()).toContain('View this download in');
+  });
+});

--- a/components/user/EventItemInProfile.spec.ts
+++ b/components/user/EventItemInProfile.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import EventItemInProfile from '@/components/user/EventItemInProfile.vue';
+import type { Event } from '@/__generated__/graphql';
+
+const h = vi.hoisted(() => ({ push: vi.fn() }));
+
+vi.mock('nuxt/app', () => ({ useRouter: () => ({ push: h.push }) }));
+
+const event = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'e1',
+    title: 'An event',
+    createdAt: '2024-01-01T00:00:00Z',
+    Poster: { username: 'alice' },
+    Tags: [{ text: 'music' }],
+    EventChannels: [{ channelUniqueName: 'cats', Channel: { uniqueName: 'cats' } }],
+    ...overrides,
+  }) as unknown as Event;
+
+const highlightStub = { name: 'HighlightedSearchTerms', props: ['text', 'searchInput'], template: '<span>{{ text }}</span>' };
+const tagStub = { name: 'Tag', props: ['tag', 'active'], emits: ['click'], template: '<button class="tag" @click="$emit(\'click\')">{{ tag }}</button>' };
+
+const mountItem = (props: Record<string, unknown> = {}) =>
+  mount(EventItemInProfile, {
+    props: { event: event(), ...props },
+    global: {
+      stubs: {
+        HighlightedSearchTerms: highlightStub,
+        Tag: tagStub,
+        TagComponent: tagStub,
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('EventItemInProfile content', () => {
+  it('shows the title', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('An event');
+  });
+
+  it('shows the posted-by line', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('by alice');
+  });
+
+  it('falls back to Deleted for a missing poster', () => {
+    const wrapper = mountItem({ event: event({ Poster: null }) });
+
+    expect(wrapper.text()).toContain('by Deleted');
+  });
+
+  it('renders the tags', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.find('.tag').text()).toBe('music');
+  });
+
+  it('emits filterByTag when a tag is clicked', async () => {
+    const wrapper = mountItem();
+
+    await wrapper.find('.tag').trigger('click');
+
+    expect(wrapper.emitted('filterByTag')?.[0]).toEqual(['music']);
+  });
+
+  it('links to the event channel', () => {
+    const wrapper = mountItem();
+
+    expect(wrapper.text()).toContain('c/cats');
+  });
+});
+
+describe('EventItemInProfile navigation', () => {
+  it('navigates to the event on click', async () => {
+    const wrapper = mountItem();
+
+    await wrapper.find('li').trigger('click');
+
+    expect(h.push).toHaveBeenCalledWith('/forums/cats/events/e1');
+  });
+
+  it('does not navigate without a channel', async () => {
+    const wrapper = mountItem({ event: event({ EventChannels: [] }) });
+
+    await wrapper.find('li').trigger('click');
+
+    expect(h.push).not.toHaveBeenCalled();
+  });
+});

--- a/components/user/UserProfileChannelFilter.spec.ts
+++ b/components/user/UserProfileChannelFilter.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import UserProfileChannelFilter from '@/components/user/UserProfileChannelFilter.vue';
+
+const h = vi.hoisted(() => ({
+  route: null as unknown,
+  push: vi.fn(),
+  replace: vi.fn(),
+  selectedChannels: null as unknown,
+}));
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => h.route,
+  useRouter: () => ({ push: h.push, replace: h.replace }),
+}));
+vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
+  useSelectedChannelsFromQuery: () => ({ selectedChannels: h.selectedChannels }),
+}));
+
+const filterChipStub = {
+  name: 'FilterChip',
+  props: ['label', 'highlighted'],
+  template: '<div><slot name="icon" /><slot name="content" /></div>',
+};
+const forumListStub = {
+  name: 'SearchableForumList',
+  props: ['selectedChannels'],
+  emits: ['toggle-selection'],
+  template: '<div class="forum-list" />',
+};
+
+const mountFilter = () =>
+  mount(UserProfileChannelFilter, {
+    global: {
+      stubs: { FilterChip: filterChipStub, SearchableForumList: forumListStub, ChannelIcon: true },
+    },
+  });
+
+const chip = (w: ReturnType<typeof mount>) => w.getComponent(filterChipStub);
+const list = (w: ReturnType<typeof mount>) => w.getComponent(forumListStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.route = { query: {} };
+  h.selectedChannels = ref([]);
+});
+
+describe('UserProfileChannelFilter label', () => {
+  it('shows a default label with no channels selected', () => {
+    const wrapper = mountFilter();
+
+    expect(typeof chip(wrapper).props('label')).toBe('string');
+  });
+
+  it('is not highlighted with no channels selected', () => {
+    const wrapper = mountFilter();
+
+    expect(chip(wrapper).props('highlighted')).toBe(false);
+  });
+
+  it('is highlighted when channels are selected', () => {
+    h.selectedChannels = ref(['cats']);
+    const wrapper = mountFilter();
+
+    expect(chip(wrapper).props('highlighted')).toBe(true);
+  });
+});
+
+describe('UserProfileChannelFilter selection', () => {
+  it('adds a channel via the forum list', async () => {
+    const wrapper = mountFilter();
+
+    await list(wrapper).vm.$emit('toggle-selection', 'cats');
+
+    const calls = h.push.mock.calls.length + h.replace.mock.calls.length;
+    expect(calls).toBeGreaterThan(0);
+  });
+
+  it('passes the selected channels to the forum list', () => {
+    h.selectedChannels = ref(['cats', 'dogs']);
+    const wrapper = mountFilter();
+
+    expect(list(wrapper).props('selectedChannels')).toEqual(['cats', 'dogs']);
+  });
+
+  it('removes an already-selected channel on toggle', async () => {
+    h.selectedChannels = ref(['cats']);
+    const wrapper = mountFilter();
+
+    await list(wrapper).vm.$emit('toggle-selection', 'cats');
+
+    const calls = h.push.mock.calls.length + h.replace.mock.calls.length;
+    expect(calls).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Continues the unit-test coverage campaign (follows #126/#127/#128). Each commit adds a real-mount Vitest spec for a previously-untested component, validated to exit-0 with no unhandled errors and tsc clean.

## Components covered so far
| Component | After |
|-----------|-------|
| mod/LockChannelDialog | 86% |
| mod/UnlockChannelDialog | 76% |
| admin/ServerSuspendedModList | 94% |
| admin/ServerSuspendedUserList | 94% |

These are sibling clusters cloned from components covered in prior batches (GenericModal-driven dialogs, SuspendedModList). More pure-ish and apollo-mock tail components to follow on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)