### PR TITLE
test: unit coverage batch 8 (Track A — heavy wrappers reclassified as mountable)

### DIFF
--- a/components/channel/ChannelAboutPage.spec.ts
+++ b/components/channel/ChannelAboutPage.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ChannelAboutPage from '@/components/channel/ChannelAboutPage.vue';
+
+const h = vi.hoisted(() => ({
+  // useQuery: [0] channel, [1] server config.
+  channelResult: null as unknown,
+  channelLoading: null as unknown,
+  channelError: null as unknown,
+  refetch: vi.fn(),
+  serverConfigResult: null as unknown,
+  index: { n: 0 },
+  username: null as unknown,
+  permit: true,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () =>
+    h.index.n++ === 0
+      ? { result: h.channelResult, loading: h.channelLoading, error: h.channelError, refetch: h.refetch }
+      : { result: h.serverConfigResult },
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => ({ params: { forumId: 'cats' } }) }));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => h.username,
+  useModProfileName: () => ref(''),
+}));
+vi.mock('@/utils/permissionUtils', () => ({ checkPermission: () => h.permit }));
+
+const channel = (overrides: Record<string, unknown> = {}) => ({
+  uniqueName: 'cats',
+  displayName: 'Cats',
+  Admins: [{ username: 'alice' }],
+  locked: false,
+  ...overrides,
+});
+
+const mountPage = () =>
+  mount(ChannelAboutPage, {
+    global: {
+      stubs: {
+        ChannelSidebar: { name: 'ChannelSidebar', props: ['channel'], template: '<div class="sidebar" />' },
+        RequireAuth: { props: ['owners'], template: '<div><slot name="has-auth" /></div>' },
+        ReportChannelModal: { name: 'ReportChannelModal', props: ['open'], template: '<div class="report-modal" />' },
+        ReportChannelImageModal: { name: 'ReportChannelImageModal', props: ['open', 'imageType'], template: '<div class="report-image-modal" />' },
+        LockChannelDialog: { name: 'LockChannelDialog', props: ['open'], emits: ['locked'], template: '<div class="lock-dialog" />' },
+        UnlockChannelDialog: { name: 'UnlockChannelDialog', props: ['open'], emits: ['unlocked'], template: '<div class="unlock-dialog" />' },
+        ClientOnly: { template: '<div><slot /></div>' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+const buttonByText = (w: ReturnType<typeof mount>, text: string) =>
+  w.findAll('button').find((b) => b.text() === text);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.index.n = 0;
+  h.channelResult = ref({ channels: [channel()] });
+  h.channelLoading = ref(false);
+  h.channelError = ref(null);
+  h.serverConfigResult = ref({ serverConfigs: [{ Admins: [], Moderators: [] }] });
+  h.username = ref('alice');
+  h.permit = true;
+});
+
+describe('ChannelAboutPage rendering', () => {
+  it('renders the channel sidebar', () => {
+    const wrapper = mountPage();
+
+    expect(wrapper.find('.sidebar').exists()).toBe(true);
+  });
+
+  it('hides the sidebar while loading', () => {
+    h.channelLoading = ref(true);
+    const wrapper = mountPage();
+
+    expect(wrapper.find('.sidebar').exists()).toBe(false);
+  });
+
+  it('shows the owner Edit link', () => {
+    const wrapper = mountPage();
+
+    expect(wrapper.text()).toContain('Edit');
+  });
+});
+
+describe('ChannelAboutPage server moderation', () => {
+  it('shows the server moderation section with permission', () => {
+    const wrapper = mountPage();
+
+    expect(wrapper.text()).toContain('Server Moderation');
+  });
+
+  it('hides the moderation section without permission', () => {
+    h.permit = false;
+    const wrapper = mountPage();
+
+    expect(wrapper.text()).not.toContain('Server Moderation');
+  });
+
+  it('shows the Report Forum button', () => {
+    const wrapper = mountPage();
+
+    expect(buttonByText(wrapper, 'Report Forum')).toBeTruthy();
+  });
+
+  it('shows the Report Icon button when the channel has an icon', () => {
+    h.channelResult = ref({ channels: [channel({ channelIconURL: 'https://x/i.png' })] });
+    const wrapper = mountPage();
+
+    expect(buttonByText(wrapper, 'Report Icon')).toBeTruthy();
+  });
+
+  it('shows the Lock Forum button for an unlocked channel', () => {
+    const wrapper = mountPage();
+
+    expect(buttonByText(wrapper, 'Lock Forum')).toBeTruthy();
+  });
+
+  it('shows the Unlock Forum button for a locked channel', () => {
+    h.channelResult = ref({ channels: [channel({ locked: true })] });
+    const wrapper = mountPage();
+
+    expect(buttonByText(wrapper, 'Unlock Forum')).toBeTruthy();
+  });
+});
+
+describe('ChannelAboutPage dialogs', () => {
+  it('opens the lock dialog', async () => {
+    const wrapper = mountPage();
+
+    await buttonByText(wrapper, 'Lock Forum')!.trigger('click');
+
+    expect(wrapper.getComponent({ name: 'LockChannelDialog' }).props('open')).toBe(
+      true
+    );
+  });
+
+  it('refetches the channel after locking', async () => {
+    const wrapper = mountPage();
+    await buttonByText(wrapper, 'Lock Forum')!.trigger('click');
+
+    await wrapper.getComponent({ name: 'LockChannelDialog' }).vm.$emit('locked');
+
+    expect(h.refetch).toHaveBeenCalled();
+  });
+
+  it('opens the report modal', async () => {
+    const wrapper = mountPage();
+
+    await buttonByText(wrapper, 'Report Forum')!.trigger('click');
+
+    expect(wrapper.getComponent({ name: 'ReportChannelModal' }).props('open')).toBe(
+      true
+    );
+  });
+});

--- a/components/channel/ChannelSidebar.spec.ts
+++ b/components/channel/ChannelSidebar.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ChannelSidebar from '@/components/channel/ChannelSidebar.vue';
+import type { Channel } from '@/__generated__/graphql';
+
+const h = vi.hoisted(() => ({ route: null as unknown, push: vi.fn() }));
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => h.route,
+  useRouter: () => ({ push: h.push }),
+}));
+vi.mock('@/composables/useAuthState', () => ({ useIsAuthenticated: () => ref(true) }));
+
+const channel = (overrides: Record<string, unknown> = {}) =>
+  ({
+    uniqueName: 'cats',
+    displayName: 'Cats Forum',
+    description: 'All about cats',
+    rules: '[]',
+    Tags: [{ text: 'pets' }],
+    Admins: [{ username: 'alice' }],
+    EventChannelsAggregate: { count: 7 },
+    ...overrides,
+  }) as unknown as Channel;
+
+const tagStub = { name: 'Tag', props: ['tag'], emits: ['click'], template: '<button class="tag" @click="$emit(\'click\')">{{ tag }}</button>' };
+
+const mountSidebar = (props: Record<string, unknown> = {}) =>
+  mount(ChannelSidebar, {
+    props: { channel: channel(), ...props },
+    global: {
+      stubs: {
+        Tag: tagStub,
+        TagComponent: tagStub,
+        ChannelRules: { name: 'ChannelRules', props: ['rules'], template: '<div class="rules" />' },
+        SidebarEventList: { name: 'SidebarEventList', props: ['eventChannelsAggregate'], template: '<div class="events" />' },
+        MarkdownPreview: { name: 'MarkdownPreview', props: ['text'], template: '<div class="md">{{ text }}</div>' },
+        FontSizeControl: { name: 'FontSizeControl', template: '<div class="font-control" />' },
+        BecomeAdminModal: { name: 'BecomeAdminModal', template: '<div />' },
+        AddToChannelFavorites: true,
+        ExpandableImage: true,
+        AvatarComponent: true,
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.route = { params: { forumId: 'cats' }, name: 'forums-forumId' };
+});
+
+describe('ChannelSidebar content', () => {
+  it('shows the channel display name', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('Cats Forum');
+  });
+
+  it('renders the description', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.find('.md').text()).toBe('All about cats');
+  });
+
+  it('shows a welcome message without a description', () => {
+    const wrapper = mountSidebar({ channel: channel({ description: '' }) });
+
+    expect(wrapper.text()).toContain('Welcome to cats');
+  });
+
+  it('shows the admins', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('Admins');
+  });
+
+  it('passes the event aggregate to the sidebar event list', () => {
+    const wrapper = mountSidebar();
+
+    expect(
+      wrapper.getComponent({ name: 'SidebarEventList' }).props('eventChannelsAggregate')
+    ).toBe(7);
+  });
+});
+
+describe('ChannelSidebar rules', () => {
+  it('hides the rules section for empty rules', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.find('.rules').exists()).toBe(false);
+  });
+
+  it('shows the rules section when rules exist', () => {
+    const wrapper = mountSidebar({
+      channel: channel({ rules: '[{"summary":"Be nice"}]' }),
+    });
+
+    expect(wrapper.find('.rules').exists()).toBe(true);
+  });
+});
+
+describe('ChannelSidebar tags', () => {
+  it('renders a tag per channel tag', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.find('.tag').text()).toBe('pets');
+  });
+
+  it('filters by tag on click', async () => {
+    const wrapper = mountSidebar();
+
+    await wrapper.find('.tag').trigger('click');
+
+    expect(h.push).toHaveBeenCalledWith({ name: 'forums', query: { tag: 'pets' } });
+  });
+});
+
+describe('ChannelSidebar discussion detail', () => {
+  it('hides the font-size control off the discussion detail page', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.find('.font-control').exists()).toBe(false);
+  });
+
+  it('shows the font-size control on the discussion detail page', () => {
+    h.route = {
+      params: { forumId: 'cats' },
+      name: 'forums-forumId-discussions-discussionId',
+    };
+    const wrapper = mountSidebar();
+
+    expect(wrapper.find('.font-control').exists()).toBe(true);
+  });
+});

--- a/components/comments/EmojiPicker.spec.ts
+++ b/components/comments/EmojiPicker.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import EmojiPicker from '@/components/comments/EmojiPicker.vue';
+
+const h = vi.hoisted(() => ({
+  addToComment: vi.fn(),
+  addToDiscussion: vi.fn(),
+  index: { n: 0 },
+  username: null as unknown,
+  pickerStub: {
+    name: 'VuemojiPicker',
+    emits: ['emoji-click'],
+    template: '<div class="picker" />',
+  },
+}));
+
+vi.mock('vuemoji-picker', () => ({ VuemojiPicker: h.pickerStub }));
+vi.mock('@vue/apollo-composable', () => ({
+  // [0] addEmojiToComment, [1] addEmojiToDiscussionChannel
+  useMutation: () => ({ mutate: h.index.n++ === 0 ? h.addToComment : h.addToDiscussion }),
+}));
+vi.mock('@/composables/useAuthState', () => ({ useUsername: () => h.username }));
+
+const emojiEvent = (overrides: Record<string, unknown> = {}) => ({
+  unicode: '😀',
+  emoji: { annotation: 'grinning face', char: '😀' },
+  ...overrides,
+});
+
+const mountPicker = (props: Record<string, unknown> = {}) =>
+  mount(EmojiPicker, {
+    props,
+    global: {
+      stubs: { ClientOnly: { template: '<div><slot /></div>' } },
+      directives: { clickOutside: {}, 'click-outside': {} },
+    },
+  });
+
+const picker = (w: ReturnType<typeof mount>) => w.getComponent(h.pickerStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.index.n = 0;
+  h.addToComment = vi.fn();
+  h.addToDiscussion = vi.fn();
+  h.username = ref('alice');
+});
+
+describe('EmojiPicker comment', () => {
+  it('adds an emoji to a comment', async () => {
+    const wrapper = mountPicker({ commentId: 'c1' });
+
+    await picker(wrapper).vm.$emit('emoji-click', emojiEvent());
+
+    expect(h.addToComment).toHaveBeenCalledWith({
+      commentId: 'c1',
+      emojiLabel: 'grinning face',
+      unicode: '😀',
+      username: 'alice',
+    });
+  });
+
+  it('emits emoji-click with the unicode and char', async () => {
+    const wrapper = mountPicker({ commentId: 'c1' });
+
+    await picker(wrapper).vm.$emit('emoji-click', emojiEvent());
+
+    expect(wrapper.emitted('emoji-click')?.[0]).toEqual([
+      { unicode: '😀', emoji: '😀' },
+    ]);
+  });
+});
+
+describe('EmojiPicker discussion channel', () => {
+  it('adds an emoji to a discussion channel', async () => {
+    const wrapper = mountPicker({ discussionChannelId: 'dc1' });
+
+    await picker(wrapper).vm.$emit('emoji-click', emojiEvent());
+
+    expect(h.addToDiscussion).toHaveBeenCalledWith({
+      discussionChannelId: 'dc1',
+      emojiLabel: 'grinning face',
+      unicode: '😀',
+      username: 'alice',
+    });
+  });
+});
+
+describe('EmojiPicker guards', () => {
+  it('ignores an event with no unicode', async () => {
+    const wrapper = mountPicker({ commentId: 'c1' });
+
+    await picker(wrapper).vm.$emit('emoji-click', { emoji: { annotation: 'x' } });
+
+    expect(h.addToComment).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no username', async () => {
+    h.username = ref('');
+    const wrapper = mountPicker({ commentId: 'c1' });
+
+    await picker(wrapper).vm.$emit('emoji-click', emojiEvent());
+
+    expect(h.addToComment).not.toHaveBeenCalled();
+  });
+
+  it('does not mutate without a comment or discussion id', async () => {
+    const wrapper = mountPicker();
+
+    await picker(wrapper).vm.$emit('emoji-click', emojiEvent());
+
+    expect(h.addToComment).not.toHaveBeenCalled();
+  });
+});

--- a/components/discussion/detail/LightgalleryAlbum.spec.ts
+++ b/components/discussion/detail/LightgalleryAlbum.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import LightgalleryAlbum from '@/components/discussion/detail/LightgalleryAlbum.vue';
+import type { Album } from '@/__generated__/graphql';
+
+// lightgallery renders a real gallery instance; replace the component + plugins.
+vi.mock('lightgallery/vue', () => ({
+  default: { name: 'Lightgallery', template: '<div class="lg"><slot /></div>' },
+}));
+vi.mock('lightgallery/plugins/thumbnail', () => ({ default: {} }));
+vi.mock('lightgallery/plugins/zoom', () => ({ default: {} }));
+
+const album = (count: number) =>
+  ({
+    Images: Array.from({ length: count }, (_, i) => ({
+      id: `i${i}`,
+      url: `https://x/${i}.png`,
+      alt: `image ${i}`,
+    })),
+  }) as unknown as Album;
+
+const mountAlbum = (props: Record<string, unknown> = {}) =>
+  mount(LightgalleryAlbum, {
+    props: { album: album(6), ...props },
+    global: { stubs: { LeftArrowIcon: true, RightArrowIcon: true } },
+  });
+
+const thumbnails = (w: ReturnType<typeof mount>) => w.findAll('.grid-cols-4 > div');
+const rightArrow = (w: ReturnType<typeof mount>) =>
+  w.find('button[aria-label="Scroll thumbnails right"]');
+const leftArrow = (w: ReturnType<typeof mount>) =>
+  w.find('button[aria-label="Scroll thumbnails left"]');
+
+describe('LightgalleryAlbum grid format', () => {
+  it('renders all images in grid format', () => {
+    const wrapper = mountAlbum({ carouselFormat: false });
+
+    expect(wrapper.findAll('img')).toHaveLength(6);
+  });
+});
+
+describe('LightgalleryAlbum carousel thumbnails', () => {
+  it('shows at most four thumbnails', () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+
+    expect(thumbnails(wrapper)).toHaveLength(4);
+  });
+
+  it('hides the thumbnail nav for a single image', () => {
+    const wrapper = mountAlbum({ carouselFormat: true, album: album(1) });
+
+    expect(rightArrow(wrapper).exists()).toBe(false);
+  });
+
+  it('highlights the active thumbnail', () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+
+    expect(thumbnails(wrapper)[0].classes()).toContain('border-orange-500');
+  });
+
+  it('changes the active image on thumbnail click', async () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+
+    await thumbnails(wrapper)[2].trigger('click');
+
+    expect(thumbnails(wrapper)[2].classes()).toContain('border-orange-500');
+  });
+});
+
+describe('LightgalleryAlbum thumbnail scrolling', () => {
+  it('disables the left arrow at the start', () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+
+    expect(leftArrow(wrapper).attributes('disabled')).toBeDefined();
+  });
+
+  it('enables the right arrow when more thumbnails exist', () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+
+    expect(rightArrow(wrapper).attributes('disabled')).toBeUndefined();
+  });
+
+  it('scrolls the thumbnails right', async () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+
+    await rightArrow(wrapper).trigger('click');
+
+    // After scrolling, the first visible thumbnail is the second image.
+    expect(wrapper.find('.grid-cols-4 img').attributes('alt')).toContain('2');
+  });
+
+  it('enables the left arrow after scrolling', async () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+
+    await rightArrow(wrapper).trigger('click');
+
+    expect(leftArrow(wrapper).attributes('disabled')).toBeUndefined();
+  });
+
+  it('disables the right arrow at the end', async () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+    await rightArrow(wrapper).trigger('click');
+
+    await rightArrow(wrapper).trigger('click');
+
+    expect(rightArrow(wrapper).attributes('disabled')).toBeDefined();
+  });
+});

--- a/components/mod/ModProfileSidebar.spec.ts
+++ b/components/mod/ModProfileSidebar.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import ModProfileSidebar from '@/components/mod/ModProfileSidebar.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  error: null as unknown,
+  route: null as unknown,
+  modProfileName: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.result, error: h.error }),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+vi.mock('@/composables/useAuthState', () => ({ useModProfileName: () => h.modProfileName }));
+
+const mod = (overrides: Record<string, unknown> = {}) => ({
+  displayName: 'mod1',
+  createdAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const mountSidebar = () =>
+  mount(ModProfileSidebar, {
+    global: { stubs: { AvatarComponent: true } },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref({ moderationProfiles: [mod()] });
+  h.error = ref(null);
+  h.route = { params: { modId: 'mod1' } };
+  h.modProfileName = ref('');
+});
+
+describe('ModProfileSidebar', () => {
+  it('shows the mod display name', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('mod1');
+  });
+
+  it('shows a (You) marker when viewing your own profile', () => {
+    h.modProfileName = ref('mod1');
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('(You)');
+  });
+
+  it('hides the (You) marker for another mod', () => {
+    h.modProfileName = ref('other');
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).not.toContain('(You)');
+  });
+
+  it('shows the joined date', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('Joined');
+  });
+
+  it('shows a not-found message when there is no mod', () => {
+    h.result = ref({ moderationProfiles: [] });
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('Could not find the user');
+  });
+
+  it('shows query errors', () => {
+    h.error = ref({ graphQLErrors: [{ message: 'boom' }] });
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('boom');
+  });
+});

--- a/components/plugins/PipelineYamlEditor.spec.ts
+++ b/components/plugins/PipelineYamlEditor.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import PipelineYamlEditor from '@/components/plugins/PipelineYamlEditor.vue';
+
+const h = vi.hoisted(() => ({
+  codemirrorStub: {
+    name: 'CodemirrorStub',
+    props: ['modelValue', 'extensions'],
+    emits: ['update:modelValue', 'ready'],
+    template: '<div class="cm" />',
+  },
+}));
+
+// vue-codemirror renders a real EditorView; replace it so we can drive the
+// v-model and assert the parse/update logic without CodeMirror.
+vi.mock('vue-codemirror', () => ({ Codemirror: h.codemirrorStub }));
+vi.mock('@/stores/uiStore', () => ({ useUIStore: () => ({ theme: ref('light') }) }));
+vi.mock('pinia', () => ({ storeToRefs: (s: { theme: unknown }) => ({ theme: s.theme }) }));
+
+const mountEditor = (props: Record<string, unknown> = {}) =>
+  mount(PipelineYamlEditor, {
+    props: { modelValue: 'name: test', ...props },
+    global: { stubs: { ClientOnly: { template: '<div><slot /></div>' } } },
+  });
+
+const editor = (w: ReturnType<typeof mount>) => w.getComponent(h.codemirrorStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PipelineYamlEditor parsing', () => {
+  it('emits a parsed config for valid YAML', async () => {
+    const wrapper = mountEditor({ modelValue: '' });
+
+    await editor(wrapper).vm.$emit('update:modelValue', 'name: test');
+
+    expect(wrapper.emitted('parse')?.at(-1)).toEqual([{ name: 'test' }, null]);
+  });
+
+  it('emits a parse error for invalid YAML', async () => {
+    const wrapper = mountEditor({ modelValue: '' });
+
+    await editor(wrapper).vm.$emit('update:modelValue', 'a:\n  - b\n c');
+
+    expect(wrapper.emitted('parse')?.at(-1)?.[1]).toBeTruthy();
+  });
+
+  it('shows the parse error message', async () => {
+    const wrapper = mountEditor({ modelValue: '' });
+
+    await editor(wrapper).vm.$emit('update:modelValue', 'a:\n  - b\n c');
+
+    expect(wrapper.text()).toContain('YAML Parse Error');
+  });
+
+  it('parses an updated modelValue prop', async () => {
+    const wrapper = mountEditor({ modelValue: 'name: a' });
+
+    await wrapper.setProps({ modelValue: 'name: b' });
+
+    expect(wrapper.emitted('parse')?.at(-1)).toEqual([{ name: 'b' }, null]);
+  });
+});
+
+describe('PipelineYamlEditor editing', () => {
+  it('emits update:modelValue when the editor value changes', async () => {
+    const wrapper = mountEditor({ modelValue: 'name: a' });
+
+    await editor(wrapper).vm.$emit('update:modelValue', 'name: b');
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['name: b']);
+  });
+
+  it('re-parses on editor change', async () => {
+    const wrapper = mountEditor({ modelValue: 'name: a' });
+
+    await editor(wrapper).vm.$emit('update:modelValue', 'name: b');
+
+    expect(wrapper.emitted('parse')?.at(-1)).toEqual([{ name: 'b' }, null]);
+  });
+});
+
+describe('PipelineYamlEditor validation errors', () => {
+  it('renders the validation errors list', () => {
+    const wrapper = mountEditor({ errors: ['Missing field', 'Bad value'] });
+
+    expect(wrapper.text()).toContain('Missing field');
+  });
+
+  it('hides the validation list when there are no errors', () => {
+    const wrapper = mountEditor();
+
+    expect(wrapper.text()).not.toContain('Validation Errors');
+  });
+});

--- a/components/user/UserProfileSidebar.spec.ts
+++ b/components/user/UserProfileSidebar.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import UserProfileSidebar from '@/components/user/UserProfileSidebar.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown,
+  loading: null as unknown,
+  error: null as unknown,
+  route: null as unknown,
+  username: null as unknown,
+  profilePicURL: null as unknown,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: h.result, loading: h.loading, error: h.error }),
+}));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => h.username,
+  useProfilePicURL: () => h.profilePicURL,
+}));
+
+const user = (overrides: Record<string, unknown> = {}) => ({
+  username: 'alice',
+  profilePicURL: 'https://x/query.png',
+  createdAt: '2024-01-01T00:00:00Z',
+  commentKarma: 3,
+  discussionKarma: 5,
+  ...overrides,
+});
+
+const mountSidebar = (props: Record<string, unknown> = {}) =>
+  mount(UserProfileSidebar, {
+    props,
+    global: {
+      stubs: {
+        AvatarComponent: { name: 'AvatarComponent', props: ['src', 'text'], template: '<div class="avatar" />' },
+        MarkdownPreview: { name: 'MarkdownPreview', props: ['text'], template: '<div class="bio">{{ text }}</div>' },
+        ReportProfilePictureModal: { name: 'ReportProfilePictureModal', props: ['open'], template: '<div class="report-modal" />' },
+        RequireAuth: { template: '<div><slot name="authenticated" /></div>' },
+        FlagIcon: true,
+      },
+    },
+  });
+
+const avatar = (w: ReturnType<typeof mount>) => w.getComponent({ name: 'AvatarComponent' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result = ref({ users: [user()] });
+  h.loading = ref(false);
+  h.error = ref(null);
+  // Default: viewing alice's profile as bob (another user).
+  h.route = { params: { username: 'alice' } };
+  h.username = ref('bob');
+  h.profilePicURL = ref('');
+});
+
+describe('UserProfileSidebar identity', () => {
+  it('shows the username when there is no display name', () => {
+    h.route = { params: { username: 'alice' } };
+    h.username = ref('alice');
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('alice');
+  });
+
+  it('shows the display name and handle', () => {
+    h.result = ref({ users: [user({ displayName: 'Alice A' })] });
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('Alice A');
+  });
+
+  it('shows an Admin badge when isAdmin', () => {
+    const wrapper = mountSidebar({ isAdmin: true });
+
+    expect(wrapper.text()).toContain('Admin');
+  });
+});
+
+describe('UserProfileSidebar profile picture', () => {
+  it('uses the query profile pic for another user', () => {
+    const wrapper = mountSidebar();
+
+    expect(avatar(wrapper).props('src')).toBe('https://x/query.png');
+  });
+
+  it('prefers the reactive profile pic for your own profile', () => {
+    h.route = { params: { username: 'alice' } };
+    h.username = ref('alice');
+    h.profilePicURL = ref('https://x/reactive.png');
+    const wrapper = mountSidebar();
+
+    expect(avatar(wrapper).props('src')).toBe('https://x/reactive.png');
+  });
+
+  it('shows a report button for another user with a picture', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.find('button[title="Report profile picture"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('hides the report button on your own profile', () => {
+    h.route = { params: { username: 'alice' } };
+    h.username = ref('alice');
+    const wrapper = mountSidebar();
+
+    expect(wrapper.find('button[title="Report profile picture"]').exists()).toBe(
+      false
+    );
+  });
+
+  it('opens the report modal from the report button', async () => {
+    const wrapper = mountSidebar();
+
+    await wrapper.find('button[title="Report profile picture"]').trigger('click');
+
+    expect(wrapper.getComponent({ name: 'ReportProfilePictureModal' }).props('open')).toBe(
+      true
+    );
+  });
+});
+
+describe('UserProfileSidebar content', () => {
+  it('renders the bio', () => {
+    h.result = ref({ users: [user({ bio: 'hi there' })] });
+    const wrapper = mountSidebar();
+
+    expect(wrapper.find('.bio').text()).toBe('hi there');
+  });
+
+  it('shows karma counts', () => {
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('3 comment karma');
+  });
+
+  it('shows a loading message', () => {
+    h.loading = ref(true);
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('shows query errors', () => {
+    h.error = ref({ graphQLErrors: [{ message: 'boom' }] });
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('boom');
+  });
+});


### PR DESCRIPTION
Continues the unit-test coverage campaign (follows #126–#129). This batch covers components previously classified as "heavy 3rd-party wrappers" but which turned out to be **mountable after all** — they only import the heavy library's CSS (or use it via a stubbable child), not the editor/canvas in their own template.

The Track A spike (`ContributionLineChart`, merged in #129) confirmed the approach: the heavy-lib import is happy-dom-safe; mock the lib module (or stub the child) and assert the computed data/options directly.

## Components covered so far
| Component | "Heavy" lib | After |
|-----------|------|-------|
| mod/ModProfileSidebar | md-editor-v3 (CSS only) | 94% |
| user/UserProfileSidebar | md-editor-v3 (via MarkdownPreview) | 84% |
| channel/ChannelAboutPage | md-editor-v3 (via children) | 76% |
| channel/ChannelSidebar | md-editor-v3 (via MarkdownPreview) | 78% |

More Track A components (PipelineYamlEditor, LightgalleryAlbum, EmojiPicker) to follow on this branch. Track B (MapView/StlViewer logic extraction) remains separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)