### PR TITLE
refactor: Track B — extract heavy-wrapper logic into tested utils

### DIFF
--- a/components/ModelViewer.spec.ts
+++ b/components/ModelViewer.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import ModelViewer from '@/components/ModelViewer.vue';
+
+// The component dynamically imports the heavy web component in onMounted.
+vi.mock('@google/model-viewer', () => ({}));
+
+// showFullscreenButton is a type-only boolean prop, so an absent value is cast
+// to false and the button is hidden; enable it by default for these tests.
+const mountViewer = (props: Record<string, unknown> = {}) =>
+  mount(ModelViewer, {
+    props: { modelUrl: 'https://x/model.glb', showFullscreenButton: true, ...props },
+  });
+
+const fullscreenButton = (w: ReturnType<typeof mount>) =>
+  w.find('button[title="View in fullscreen"]');
+const closeButton = (w: ReturnType<typeof mount>) =>
+  w.find('button[title="Close fullscreen"]');
+
+beforeEach(() => {
+  document.body.style.overflow = '';
+});
+
+describe('ModelViewer rendering', () => {
+  it('shows the model when a url is provided', () => {
+    const wrapper = mountViewer();
+
+    expect(wrapper.find('model-viewer').exists()).toBe(true);
+  });
+
+  it('omits the model when there is no url', () => {
+    const wrapper = mountViewer({ modelUrl: '' });
+
+    expect(wrapper.find('model-viewer').exists()).toBe(false);
+  });
+
+  it('shows the fullscreen button when enabled', () => {
+    const wrapper = mountViewer({ showFullscreenButton: true });
+
+    expect(fullscreenButton(wrapper).exists()).toBe(true);
+  });
+
+  it('hides the fullscreen button when disabled', () => {
+    const wrapper = mountViewer({ showFullscreenButton: false });
+
+    expect(fullscreenButton(wrapper).exists()).toBe(false);
+  });
+});
+
+describe('ModelViewer fullscreen', () => {
+  it('opens the fullscreen modal', async () => {
+    const wrapper = mountViewer();
+
+    await fullscreenButton(wrapper).trigger('click');
+
+    expect(closeButton(wrapper).exists()).toBe(true);
+  });
+
+  it('locks body scroll while fullscreen', async () => {
+    const wrapper = mountViewer();
+
+    await fullscreenButton(wrapper).trigger('click');
+
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('closes the fullscreen modal via the close button', async () => {
+    const wrapper = mountViewer();
+    await fullscreenButton(wrapper).trigger('click');
+
+    await closeButton(wrapper).trigger('click');
+
+    expect(closeButton(wrapper).exists()).toBe(false);
+  });
+
+  it('restores body scroll when closed', async () => {
+    const wrapper = mountViewer();
+    await fullscreenButton(wrapper).trigger('click');
+
+    await closeButton(wrapper).trigger('click');
+
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('closes fullscreen on the Escape key', async () => {
+    const wrapper = mountViewer();
+    await fullscreenButton(wrapper).trigger('click');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.vm.$nextTick();
+
+    expect(closeButton(wrapper).exists()).toBe(false);
+  });
+
+  it('ignores other keys', async () => {
+    const wrapper = mountViewer();
+    await fullscreenButton(wrapper).trigger('click');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await wrapper.vm.$nextTick();
+
+    expect(closeButton(wrapper).exists()).toBe(true);
+  });
+});

--- a/components/download/StlViewer.vue
+++ b/components/download/StlViewer.vue
@@ -31,6 +31,11 @@ import { STLLoader } from 'three/examples/jsm/loaders/STLLoader';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 
 import type { CSSProperties } from 'vue';
+import {
+  buildContainerStyle,
+  calculateCameraDistance,
+  computeLoadProgressPercent,
+} from '@/utils/stlViewer';
 
 interface Props {
   src: string;
@@ -55,34 +60,9 @@ const props = withDefaults(defineProps<Props>(), {
   showGrid: false,
 });
 
-const containerStyle = computed((): CSSProperties => {
-  const style: CSSProperties = {};
-
-  // Handle width
-  if (typeof props.width === 'number') {
-    style.width = props.width + 'px';
-  } else {
-    style.width = props.width;
-  }
-
-  // Handle height
-  if (typeof props.height === 'number') {
-    style.height = props.height + 'px';
-  } else {
-    style.height = props.height;
-  }
-
-  // Handle max-width for responsive behavior
-  if (props.maxWidth) {
-    if (typeof props.maxWidth === 'number') {
-      style.maxWidth = props.maxWidth + 'px';
-    } else {
-      style.maxWidth = props.maxWidth;
-    }
-  }
-
-  return style;
-});
+const containerStyle = computed((): CSSProperties =>
+  buildContainerStyle(props.width, props.height, props.maxWidth)
+);
 
 const emit = defineEmits<{
   load: [data: { geometry: unknown; mesh: unknown }];
@@ -195,8 +175,7 @@ function initViewer(stlUrl: string) {
         const box = new THREE.Box3().setFromObject(mesh);
         const size = box.getSize(new THREE.Vector3());
         const maxDim = Math.max(size.x, size.y, size.z);
-        const fov = camera.fov * (Math.PI / 180);
-        const distance = Math.abs(maxDim / Math.sin(fov / 2)) * 1.5;
+        const distance = calculateCameraDistance(maxDim, camera.fov);
 
         camera.position.set(distance, distance, distance);
         camera.lookAt(0, 0, 0);
@@ -206,8 +185,10 @@ function initViewer(stlUrl: string) {
         emit('load', { geometry, mesh });
       },
       (progress: { loaded: number; total: number }) => {
-        const percent =
-          progress.total > 0 ? (progress.loaded / progress.total) * 100 : 0;
+        const percent = computeLoadProgressPercent(
+          progress.loaded,
+          progress.total
+        );
         emit('progress', percent);
       },
       (loadError: Error) => {
@@ -244,8 +225,7 @@ function resetCamera() {
     const box = new THREE.Box3().setFromObject(mesh);
     const size = box.getSize(new THREE.Vector3());
     const maxDim = Math.max(size.x, size.y, size.z);
-    const fov = camera.fov * (Math.PI / 180);
-    const distance = Math.abs(maxDim / Math.sin(fov / 2)) * 1.5;
+    const distance = calculateCameraDistance(maxDim, camera.fov);
 
     camera.position.set(distance, distance, distance);
     camera.lookAt(0, 0, 0);

--- a/components/event/map/Map.vue
+++ b/components/event/map/Map.vue
@@ -6,6 +6,13 @@ import { useRouter } from 'nuxt/app';
 import { config } from '@/config';
 import { useAppTheme } from '@/composables/useTheme';
 import type { Event } from '@/__generated__/graphql';
+import {
+  groupEventsByLocation,
+  buildMarkerTitle,
+  buildMarkerHoverContent,
+  buildClusterColor,
+  calculateClusterZoom,
+} from '@/utils/mapMarkerLogic';
 
 // Type for Google Maps markers - can be legacy or advanced markers
 type GoogleMapMarker = google.maps.Marker | google.maps.marker.AdvancedMarkerElement;
@@ -153,23 +160,9 @@ const renderMap = async () => {
   const infowindow = new google.maps.InfoWindow();
   const markers: google.maps.marker.AdvancedMarkerElement[] = [];
 
-  // First pass: group events by location and build markerMap
-  props.events.forEach((event) => {
-    if (!event.location) return;
-
-    const eventLocationId = `${event.location.latitude}${event.location.longitude}`;
-
-    if (markerMap.markers[eventLocationId]) {
-      markerMap.markers[eventLocationId].events[event.id] = event;
-      markerMap.markers[eventLocationId].numberOfEvents += 1;
-    } else {
-      markerMap.markers[eventLocationId] = {
-        marker: null, // Will be created in second pass
-        events: { [event.id]: event },
-        numberOfEvents: 1,
-      };
-    }
-  });
+  // First pass: group events by location and build markerMap. Markers are
+  // created in the second pass below.
+  markerMap.markers = groupEventsByLocation(props.events);
 
   // Second pass: create one marker per location with proper click handlers
   Object.keys(markerMap.markers).forEach((eventLocationId) => {
@@ -186,10 +179,7 @@ const renderMap = async () => {
     };
 
     // Create marker title based on number of events
-    const title =
-      markerData.numberOfEvents === 1
-        ? `Click to view event: ${firstEvent?.title || 'Untitled Event'}`
-        : `Click to view ${markerData.numberOfEvents} events at this location`;
+    const title = buildMarkerTitle(markerData.numberOfEvents, firstEvent?.title);
 
     // Use an AdvancedMarkerElement. On a vector (mapId-based) map these render
     // as real DOM elements, so we can attach native hover listeners to the
@@ -236,10 +226,11 @@ const renderMap = async () => {
           const currentMarkerData = markerMap.markers[eventLocationId];
           if (currentMarkerData) {
             // Show tooltip with event info on hover
-            const content =
-              currentMarkerData.numberOfEvents === 1
-                ? `<div style="text-align:center"><b>${firstEvent?.title || 'Untitled Event'}</b>${firstEvent?.locationName ? `<br>at ${firstEvent.locationName}` : ''}</div>`
-                : `<div style="text-align:center"><b>${currentMarkerData.numberOfEvents} events</b>${firstEvent?.locationName ? `<br>at ${firstEvent.locationName}` : ''}</div>`;
+            const content = buildMarkerHoverContent(
+              currentMarkerData.numberOfEvents,
+              firstEvent?.title,
+              firstEvent?.locationName
+            );
 
             infowindow.setContent(content);
             infowindow.open({
@@ -298,10 +289,11 @@ const renderMap = async () => {
           const currentMarkerData = markerMap.markers[eventLocationId];
           if (currentMarkerData) {
             // Show tooltip with event info on hover
-            const content =
-              currentMarkerData.numberOfEvents === 1
-                ? `<div style="text-align:center"><b>${firstEvent?.title || 'Untitled Event'}</b>${firstEvent?.locationName ? `<br>at ${firstEvent.locationName}` : ''}</div>`
-                : `<div style="text-align:center"><b>${currentMarkerData.numberOfEvents} events</b>${firstEvent?.locationName ? `<br>at ${firstEvent.locationName}` : ''}</div>`;
+            const content = buildMarkerHoverContent(
+              currentMarkerData.numberOfEvents,
+              firstEvent?.title,
+              firstEvent?.locationName
+            );
 
             infowindow.setContent(content);
             infowindow.open({
@@ -352,7 +344,7 @@ const renderMap = async () => {
   const clusterRenderer = {
     render: (cluster: { count: number; position: google.maps.LatLng }) => {
       const { count, position } = cluster;
-      const color = count > 10 ? '#ef4444' : '#3b82f6';
+      const color = buildClusterColor(count);
       const div = document.createElement('div');
       div.textContent = String(count);
       div.style.cssText = [
@@ -384,7 +376,7 @@ const renderMap = async () => {
         if (b) {
           clustererMap.fitBounds(b);
           const currentZoom = clustererMap.getZoom() || 0;
-          const maxZoom = Math.min(currentZoom + 1, 18);
+          const maxZoom = calculateClusterZoom(currentZoom);
           setTimeout(() => clustererMap.setZoom(maxZoom), 200);
         }
       },

--- a/components/event/map/MapView.vue
+++ b/components/event/map/MapView.vue
@@ -20,6 +20,11 @@ import {
   reverseChronologicalOrder,
 } from '../list/filters/filterStrings';
 import { timeShortcutValues } from '../list/filters/eventSearchOptions';
+import {
+  toggleArrayItem,
+  cleanQueryParams,
+  buildInfowindowContent,
+} from '@/utils/eventMap';
 import type { Event as EventData } from '@/__generated__/graphql';
 import type { SearchEventValues } from '@/types/Event';
 import type { Ref, PropType } from 'vue';
@@ -153,14 +158,7 @@ const selectedEvents = ref<EventData[]>([]);
 
 const updateFilters = (params: SearchEventValues) => {
   const existingQuery = route.query;
-  const cleanedParams: Record<string, string> = {};
-
-  for (const key in params) {
-    const value = params[key as keyof SearchEventValues];
-    if (value) {
-      cleanedParams[key] = value as string;
-    }
-  }
+  const cleanedParams = cleanQueryParams(params);
   router.replace({
     query: {
       ...existingQuery,
@@ -177,40 +175,18 @@ const goToOnlineList = () => {
 };
 
 const filterByChannel = (channel: string) => {
-  const alreadySelected = filterValues.value.channels?.includes(channel);
-  if (alreadySelected) {
-    if (!filterValues.value.channels) {
-      // I know we already checked this in the if-statement above, but this
-      // is just to fix a TypeScript error.
-      return;
-    }
-    filterValues.value.channels = filterValues.value.channels.filter(
-      (c) => c !== channel
-    );
-  } else {
-    if (!filterValues.value.channels) {
-      filterValues.value.channels = [];
-    }
-    filterValues.value.channels.push(channel);
-  }
+  filterValues.value.channels = toggleArrayItem(
+    filterValues.value.channels ?? [],
+    channel
+  );
   updateFilters({ channels: [channel] });
 };
 
 const filterByTag = (tag: string) => {
-  const alreadySelected = filterValues.value.tags?.includes(tag);
-  if (alreadySelected) {
-    if (!filterValues.value.tags) {
-      // I know we already checked this in the if-statement above, but this
-      // is just to fix a TypeScript error.
-      return;
-    }
-    filterValues.value.tags = filterValues.value.tags.filter((t) => t !== tag);
-  } else {
-    if (!filterValues.value.tags) {
-      filterValues.value.tags = [];
-    }
-    filterValues.value.tags.push(tag);
-  }
+  filterValues.value.tags = toggleArrayItem(
+    filterValues.value.tags ?? [],
+    tag
+  );
   updateFilters({ tags: [tag] });
 };
 
@@ -278,11 +254,7 @@ const highlightEventOnMap = (input: HighlightEventInput) => {
         markerMap.markers[eventLocationId]?.events?.[highlightedEventId.value]
           ?.locationName;
 
-      let infowindowContent = `<b>${eventTitle}</b>`;
-
-      if (eventLocation) {
-        infowindowContent = `<div data-testid="infowindow" style="text-align:center"><b>${eventTitle}</b></div></div><div style="text-align:center">at ${eventLocation}</div>`;
-      }
+      const infowindowContent = buildInfowindowContent(eventTitle, eventLocation);
       markerMap.infowindow?.setContent(infowindowContent);
       markerMap.infowindow?.open({
         anchor: markerMap.markers[eventLocationId]?.marker,

--- a/utils/eventMap.spec.ts
+++ b/utils/eventMap.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toggleArrayItem,
+  cleanQueryParams,
+  buildInfowindowContent,
+} from '@/utils/eventMap';
+
+describe('toggleArrayItem', () => {
+  it('adds an item that is not present', () => {
+    expect(toggleArrayItem(['a'], 'b')).toEqual(['a', 'b']);
+  });
+
+  it('removes an item that is present', () => {
+    expect(toggleArrayItem(['a', 'b'], 'a')).toEqual(['b']);
+  });
+
+  it('adds to an empty array', () => {
+    expect(toggleArrayItem([], 'a')).toEqual(['a']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = ['a'];
+    toggleArrayItem(input, 'b');
+
+    expect(input).toEqual(['a']);
+  });
+});
+
+describe('cleanQueryParams', () => {
+  it('keeps truthy values', () => {
+    expect(cleanQueryParams({ a: 'x', b: 'y' })).toEqual({ a: 'x', b: 'y' });
+  });
+
+  it('drops empty strings', () => {
+    expect(cleanQueryParams({ a: 'x', b: '' })).toEqual({ a: 'x' });
+  });
+
+  it('drops null and undefined', () => {
+    expect(cleanQueryParams({ a: 'x', b: null, c: undefined })).toEqual({ a: 'x' });
+  });
+
+  it('returns an empty object for all-falsy params', () => {
+    expect(cleanQueryParams({ a: '', b: 0 })).toEqual({});
+  });
+});
+
+describe('buildInfowindowContent', () => {
+  it('returns just the title when there is no location', () => {
+    expect(buildInfowindowContent('Cat Meetup')).toBe('<b>Cat Meetup</b>');
+  });
+
+  it('includes the location name when present', () => {
+    expect(buildInfowindowContent('Cat Meetup', 'Downtown')).toContain(
+      'at Downtown'
+    );
+  });
+
+  it('marks the located variant with the infowindow test id', () => {
+    expect(buildInfowindowContent('Cat Meetup', 'Downtown')).toContain(
+      'data-testid="infowindow"'
+    );
+  });
+});

--- a/utils/eventMap.ts
+++ b/utils/eventMap.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure helpers extracted from components/event/map/MapView.vue so the filter
+ * and infowindow logic can be unit-tested without the router or Google Maps.
+ */
+
+/** Toggle an item in an array: remove it if present, otherwise append it. */
+export function toggleArrayItem(items: string[], item: string): string[] {
+  return items.includes(item)
+    ? items.filter((existing) => existing !== item)
+    : [...items, item];
+}
+
+/** Drop falsy values from a params object, returning string-valued entries. */
+export function cleanQueryParams(
+  params: Record<string, unknown>
+): Record<string, string> {
+  const cleaned: Record<string, string> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      cleaned[key] = value as string;
+    }
+  }
+  return cleaned;
+}
+
+/**
+ * Infowindow HTML for a highlighted event — title only, or title plus the
+ * location name. (The markup mirrors the original component output verbatim.)
+ */
+export function buildInfowindowContent(
+  title?: string | null,
+  locationName?: string | null
+): string {
+  if (locationName) {
+    return `<div data-testid="infowindow" style="text-align:center"><b>${title}</b></div></div><div style="text-align:center">at ${locationName}</div>`;
+  }
+  return `<b>${title}</b>`;
+}

--- a/utils/mapMarkerLogic.spec.ts
+++ b/utils/mapMarkerLogic.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import type { Event } from '@/__generated__/graphql';
+import {
+  buildEventLocationId,
+  groupEventsByLocation,
+  buildMarkerTitle,
+  buildMarkerHoverContent,
+  buildClusterColor,
+  calculateClusterZoom,
+} from '@/utils/mapMarkerLogic';
+
+const event = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'e1',
+    title: 'Cat Meetup',
+    location: { latitude: 33.4, longitude: -111.9 },
+    ...overrides,
+  }) as unknown as Event;
+
+describe('buildEventLocationId', () => {
+  it('combines latitude and longitude', () => {
+    expect(buildEventLocationId(event())).toBe('33.4-111.9');
+  });
+
+  it('returns null when there is no location', () => {
+    expect(buildEventLocationId(event({ location: null }))).toBeNull();
+  });
+});
+
+describe('groupEventsByLocation', () => {
+  it('creates one group per distinct location', () => {
+    const result = groupEventsByLocation([
+      event({ id: 'a', location: { latitude: 1, longitude: 2 } }),
+      event({ id: 'b', location: { latitude: 3, longitude: 4 } }),
+    ]);
+
+    expect(Object.keys(result)).toHaveLength(2);
+  });
+
+  it('groups events at the same location', () => {
+    const result = groupEventsByLocation([
+      event({ id: 'a', location: { latitude: 1, longitude: 2 } }),
+      event({ id: 'b', location: { latitude: 1, longitude: 2 } }),
+    ]);
+
+    expect(result['12'].numberOfEvents).toBe(2);
+  });
+
+  it('keeps every event at a shared location keyed by id', () => {
+    const result = groupEventsByLocation([
+      event({ id: 'a', location: { latitude: 1, longitude: 2 } }),
+      event({ id: 'b', location: { latitude: 1, longitude: 2 } }),
+    ]);
+
+    expect(Object.keys(result['12'].events)).toEqual(['a', 'b']);
+  });
+
+  it('initializes the marker as null', () => {
+    const result = groupEventsByLocation([event()]);
+
+    expect(result['33.4-111.9'].marker).toBeNull();
+  });
+
+  it('skips events without a location', () => {
+    const result = groupEventsByLocation([event({ location: null })]);
+
+    expect(result).toEqual({});
+  });
+});
+
+describe('buildMarkerTitle', () => {
+  it('names the single event', () => {
+    expect(buildMarkerTitle(1, 'Cat Meetup')).toBe(
+      'Click to view event: Cat Meetup'
+    );
+  });
+
+  it('falls back to Untitled Event', () => {
+    expect(buildMarkerTitle(1, '')).toBe('Click to view event: Untitled Event');
+  });
+
+  it('summarizes multiple events', () => {
+    expect(buildMarkerTitle(3)).toBe('Click to view 3 events at this location');
+  });
+});
+
+describe('buildMarkerHoverContent', () => {
+  it('shows the single event title', () => {
+    expect(buildMarkerHoverContent(1, 'Cat Meetup')).toContain('<b>Cat Meetup</b>');
+  });
+
+  it('shows the event count for multiple events', () => {
+    expect(buildMarkerHoverContent(2)).toContain('<b>2 events</b>');
+  });
+
+  it('appends the location name when present', () => {
+    expect(buildMarkerHoverContent(1, 'Cat Meetup', 'Downtown')).toContain(
+      '<br>at Downtown'
+    );
+  });
+
+  it('omits the location suffix when absent', () => {
+    expect(buildMarkerHoverContent(1, 'Cat Meetup')).not.toContain('<br>at');
+  });
+});
+
+describe('buildClusterColor', () => {
+  it('uses red for large clusters', () => {
+    expect(buildClusterColor(11)).toBe('#ef4444');
+  });
+
+  it('uses blue for small clusters', () => {
+    expect(buildClusterColor(10)).toBe('#3b82f6');
+  });
+});
+
+describe('calculateClusterZoom', () => {
+  it('zooms in by one level', () => {
+    expect(calculateClusterZoom(7)).toBe(8);
+  });
+
+  it('caps the zoom at the maximum', () => {
+    expect(calculateClusterZoom(18)).toBe(18);
+  });
+});

--- a/utils/mapMarkerLogic.ts
+++ b/utils/mapMarkerLogic.ts
@@ -1,0 +1,82 @@
+import type { Event } from '@/__generated__/graphql';
+
+/**
+ * Pure helpers extracted from components/event/map/Map.vue so the marker
+ * data-shaping and label/content building can be unit-tested without loading
+ * the Google Maps SDK.
+ */
+
+export type LocationGroup = {
+  marker: null;
+  events: Record<string, Event>;
+  numberOfEvents: number;
+};
+
+/** Stable id for a marker location, or null when the event has no location. */
+export function buildEventLocationId(event: Pick<Event, 'location'>): string | null {
+  if (!event.location) return null;
+  return `${event.location.latitude}${event.location.longitude}`;
+}
+
+/**
+ * Group events that share a location into one entry each, recording every
+ * event at the location and the count. Events without a location are skipped.
+ */
+export function groupEventsByLocation(
+  events: Event[]
+): Record<string, LocationGroup> {
+  const markers: Record<string, LocationGroup> = {};
+
+  events.forEach((event) => {
+    const locationId = buildEventLocationId(event);
+    if (locationId === null) return;
+
+    const existing = markers[locationId];
+    if (existing) {
+      existing.events[event.id] = event;
+      existing.numberOfEvents += 1;
+    } else {
+      markers[locationId] = {
+        marker: null,
+        events: { [event.id]: event },
+        numberOfEvents: 1,
+      };
+    }
+  });
+
+  return markers;
+}
+
+/** Marker title text, depending on how many events share the location. */
+export function buildMarkerTitle(
+  numberOfEvents: number,
+  firstEventTitle?: string | null
+): string {
+  return numberOfEvents === 1
+    ? `Click to view event: ${firstEventTitle || 'Untitled Event'}`
+    : `Click to view ${numberOfEvents} events at this location`;
+}
+
+/** Hover-tooltip HTML for a marker (single event title vs an event count). */
+export function buildMarkerHoverContent(
+  numberOfEvents: number,
+  firstEventTitle?: string | null,
+  locationName?: string | null
+): string {
+  const heading =
+    numberOfEvents === 1
+      ? `<b>${firstEventTitle || 'Untitled Event'}</b>`
+      : `<b>${numberOfEvents} events</b>`;
+  const locationSuffix = locationName ? `<br>at ${locationName}` : '';
+  return `<div style="text-align:center">${heading}${locationSuffix}</div>`;
+}
+
+/** Cluster bubble color: red for large clusters, blue otherwise. */
+export function buildClusterColor(count: number): string {
+  return count > 10 ? '#ef4444' : '#3b82f6';
+}
+
+/** Zoom level to apply when a cluster is clicked, capped at maxZoom. */
+export function calculateClusterZoom(currentZoom: number, maxZoom = 18): number {
+  return Math.min(currentZoom + 1, maxZoom);
+}

--- a/utils/stlViewer.spec.ts
+++ b/utils/stlViewer.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildContainerStyle,
+  calculateCameraDistance,
+  computeLoadProgressPercent,
+} from '@/utils/stlViewer';
+
+describe('buildContainerStyle', () => {
+  it('converts a numeric width to pixels', () => {
+    expect(buildContainerStyle(400, 300).width).toBe('400px');
+  });
+
+  it('passes a string width through unchanged', () => {
+    expect(buildContainerStyle('100%', 300).width).toBe('100%');
+  });
+
+  it('converts a numeric height to pixels', () => {
+    expect(buildContainerStyle(400, 300).height).toBe('300px');
+  });
+
+  it('omits max-width when not provided', () => {
+    expect(buildContainerStyle(400, 300)).not.toHaveProperty('maxWidth');
+  });
+
+  it('converts a numeric max-width to pixels', () => {
+    expect(buildContainerStyle(400, 300, 800).maxWidth).toBe('800px');
+  });
+
+  it('passes a string max-width through unchanged', () => {
+    expect(buildContainerStyle(400, 300, '50rem').maxWidth).toBe('50rem');
+  });
+
+  it('ignores a null max-width', () => {
+    expect(buildContainerStyle(400, 300, null)).not.toHaveProperty('maxWidth');
+  });
+});
+
+describe('calculateCameraDistance', () => {
+  it('scales the distance with the object size', () => {
+    const small = calculateCameraDistance(1, 45);
+    const large = calculateCameraDistance(2, 45);
+
+    expect(large).toBeCloseTo(small * 2);
+  });
+
+  it('applies the default 1.5 scale factor', () => {
+    // distance = |maxDim / sin(fov/2)| * 1.5
+    const expected = Math.abs(1 / Math.sin((45 * Math.PI) / 180 / 2)) * 1.5;
+
+    expect(calculateCameraDistance(1, 45)).toBeCloseTo(expected);
+  });
+
+  it('honors a custom scale factor', () => {
+    const base = calculateCameraDistance(1, 45, 1);
+
+    expect(calculateCameraDistance(1, 45, 2)).toBeCloseTo(base * 2);
+  });
+
+  it('returns a positive distance', () => {
+    expect(calculateCameraDistance(5, 45)).toBeGreaterThan(0);
+  });
+});
+
+describe('computeLoadProgressPercent', () => {
+  it('computes a mid-load percentage', () => {
+    expect(computeLoadProgressPercent(50, 200)).toBe(25);
+  });
+
+  it('returns 100 when fully loaded', () => {
+    expect(computeLoadProgressPercent(200, 200)).toBe(100);
+  });
+
+  it('returns 0 when the total is zero', () => {
+    expect(computeLoadProgressPercent(0, 0)).toBe(0);
+  });
+});

--- a/utils/stlViewer.ts
+++ b/utils/stlViewer.ts
@@ -1,0 +1,42 @@
+import type { CSSProperties } from 'vue';
+
+/**
+ * Pure helpers extracted from components/download/StlViewer.vue so the
+ * dimension/camera math can be unit-tested without mounting three.js.
+ */
+
+/** Build the container inline style from numeric (px) or string dimensions. */
+export function buildContainerStyle(
+  width: number | string,
+  height: number | string,
+  maxWidth?: number | string | null
+): CSSProperties {
+  const style: CSSProperties = {};
+
+  style.width = typeof width === 'number' ? `${width}px` : width;
+  style.height = typeof height === 'number' ? `${height}px` : height;
+
+  if (maxWidth) {
+    style.maxWidth = typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
+  }
+
+  return style;
+}
+
+/**
+ * Distance to place the camera so an object of the given size fits the view,
+ * derived from the largest object dimension and the camera field of view.
+ */
+export function calculateCameraDistance(
+  maxDimension: number,
+  fieldOfViewDegrees: number,
+  scaleFactor = 1.5
+): number {
+  const fov = fieldOfViewDegrees * (Math.PI / 180);
+  return Math.abs(maxDimension / Math.sin(fov / 2)) * scaleFactor;
+}
+
+/** Loading progress as a 0-100 percentage, guarding against a zero total. */
+export function computeLoadProgressPercent(loaded: number, total: number): number {
+  return total > 0 ? (loaded / total) * 100 : 0;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,18 @@ import Vue from '@vitejs/plugin-vue';
 import path from 'path';
 
 export default defineConfig({
-  plugins: [Vue()],
+  // `model-viewer` is a web component (registered at runtime via
+  // @google/model-viewer); tell the template compiler it is a custom element
+  // so it renders as a native tag in tests instead of an unresolved component.
+  plugins: [
+    Vue({
+      template: {
+        compilerOptions: {
+          isCustomElement: (tag) => tag === 'model-viewer',
+        },
+      },
+    }),
+  ],
   test: {
     globals: true,
     environment: 'happy-dom',


### PR DESCRIPTION
The final phase of the unit-test coverage campaign (follows #126–#130). The "heavy 3rd-party wrappers" that genuinely can't be unit-mounted (three.js / Google Maps) have their **pure logic extracted into `utils/` modules**, which are then unit-tested. Each component change is a **behavior-preserving substitution** (verified by `npm run tsc` + the full unit suite); the extracted util carries the new coverage.

## Extractions
| Component (untestable) | New util | Util coverage |
|---|---|---|
| `download/StlViewer` (three.js) | `utils/stlViewer.ts` — container style, camera distance, load %| 100% (14 tests) |
| `event/map/Map` (Google Maps) | `utils/mapMarkerLogic.ts` — event grouping, marker title/hover, cluster color/zoom | 100% (18 tests) |
| `event/map/MapView` (Google Maps) | `utils/eventMap.ts` — filter toggle, query-param cleaning, infowindow content | 100% (11 tests) |

Each refactor also removed real duplication: StlViewer's camera-distance formula was copy-pasted between `initViewer`/`resetCamera`; Map's marker hover-content was byte-identical across the mobile/desktop branches; MapView's two filter functions collapsed into one toggle.

## Bonus: ModelViewer reclassified as mountable
`ModelViewer` turned out not to need extraction — its `<model-viewer>` is an inert web component. Added a mounted spec (fullscreen toggle / escape / body-scroll), enabled by telling the **test** Vue compiler that `model-viewer` is a custom element (one-line `vitest.config.ts` change; test-only).

`ModelViewer.vue`: ~0% → 86%.

## Verification
- `npm run tsc`: clean (type-checks every refactored component).
- Full unit suite: 3830 passing, 0 unhandled.
- These map/viewer components have no unit mount, so the safety net is tsc + behavior-identical substitution + the new util tests. The substitutions are mechanical (inline expression → equivalent helper call).

This closes out the coverage campaign: every remaining uncovered block was either reclassified-and-mounted (Track A, #130) or extracted-and-tested here (Track B). What's left is irreducibly untestable renderer glue (Track C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)