### PR TITLE
polish: dark-mode UI cleanup + theme single-source-of-truth

### DIFF
--- a/components/AvatarComponent.vue
+++ b/components/AvatarComponent.vue
@@ -2,8 +2,6 @@
 import { computed } from 'vue';
 import Identicon from 'identicon.js';
 import sha256 from 'crypto-js/sha256';
-import { useAppTheme } from '@/composables/useTheme';
-const { theme } = useAppTheme();
 
 const props = defineProps({
   text: {
@@ -42,21 +40,22 @@ const props = defineProps({
   },
 });
 
-// Generate Identicon based on text and theme
+// Generate the identicon with a TRANSPARENT background. The themed background
+// is applied via CSS (bg-white / dark:bg-black) on the <img> below, driven by
+// the `dark` class on <html>. This keeps the generated SVG identical on the
+// server and client (no hydration mismatch) and guarantees the avatar always
+// matches the visible theme — both on first load and when the user toggles —
+// without depending on any JS theme state.
 const identiconData = computed(() => {
-  // Hash the text
   const hash = sha256(props.text).toString();
 
-  // Generate the identicon and get the data for the img src
   const data = new Identicon(hash, {
-    // If theme is dark, use a dark background
-    background: theme.value === 'dark' ? [0, 0, 0, 255] : [255, 255, 255, 255],
+    background: [0, 0, 0, 0],
     margin: 0.2,
     size: 420,
     format: 'svg',
   }).toString();
 
-  // Return the data as a base64 SVG for the src of the img
   return 'data:image/svg+xml;base64,' + data;
 });
 </script>
@@ -77,7 +76,7 @@ const identiconData = computed(() => {
     >
     <img
       v-else
-      class="border dark:border-gray-600"
+      class="border bg-white dark:border-gray-600 dark:bg-black"
       :class="[
         isLarge ? 'h-48 w-48' : '',
         isMedium ? 'h-12 w-12' : '',

--- a/components/TextButtonDropdown.vue
+++ b/components/TextButtonDropdown.vue
@@ -39,7 +39,7 @@ function handleClick(item: MenuItemType) {
       <div>
         <MenuButton
           :data-testid="`text-dropdown-${label}`"
-          class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-100 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white hover:dark:bg-gray-700"
+          class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-100 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
         >
           <SortIcon v-if="showSortIcon" class="h-4 w-4" aria-hidden="true" />
           {{ label }}
@@ -87,7 +87,7 @@ function handleClick(item: MenuItemType) {
     <template #fallback>
       <button
         :data-testid="`text-dropdown-${label}`"
-        class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-200 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white hover:dark:bg-gray-600"
+        class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-200 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
       >
         <SortIcon v-if="showSortIcon" class="h-4 w-4" aria-hidden="true" />
         {{ label }}

--- a/components/discussion/list/DiscussionFilterBar.vue
+++ b/components/discussion/list/DiscussionFilterBar.vue
@@ -202,7 +202,7 @@ const isExpanded = computed(() => {
               ? 'border-gray-500 bg-gray-100 text-gray-900 dark:border-gray-400 dark:bg-gray-800 dark:text-white'
               : 'border-gray-300 text-gray-800 dark:border-gray-600 dark:text-gray-300'
           "
-          class="flex h-9 items-center gap-1 rounded-md border px-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          class="flex h-9 items-center gap-1 rounded-md border px-2 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-900 dark:hover:bg-gray-700 dark:hover:text-gray-200"
           @click="
             (event) => {
               event.preventDefault();
@@ -221,7 +221,7 @@ const isExpanded = computed(() => {
               ? 'border-gray-500 bg-gray-100 text-gray-900 dark:border-gray-400 dark:bg-gray-800 dark:text-white'
               : 'border-gray-300 text-gray-800 dark:border-gray-600 dark:text-gray-300'
           "
-          class="flex h-9 items-center gap-1 rounded-md border px-1.5 text-gray-800 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          class="flex h-9 items-center gap-1 rounded-md border px-2 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-900 dark:hover:bg-gray-700 dark:hover:text-gray-200"
           @click="
             (event) => {
               event.preventDefault();

--- a/components/discussion/list/SitewideDiscussionListItem.vue
+++ b/components/discussion/list/SitewideDiscussionListItem.vue
@@ -364,39 +364,48 @@ const revealSensitiveContent = () => {
             >
               +{{ channelCount - 1 }}
             </span>
-            <span aria-hidden="true">•</span>
-            <span>{{ relative }}</span>
-            <span aria-hidden="true">•</span>
-            <UsernameWithTooltip
-              v-if="authorUsername"
-              :is-admin="authorIsAdmin"
-              :username="authorUsername"
-              :src="discussion?.Author?.profilePicURL || ''"
-              :display-name="discussion?.Author?.displayName || ''"
-              :comment-karma="discussion?.Author?.commentKarma ?? 0"
-              :discussion-karma="discussion?.Author?.discussionKarma ?? 0"
-              :account-created="discussion?.Author?.createdAt"
-            />
-            <span aria-hidden="true">•</span>
-            <template v-if="discussion && !submittedToMultipleChannels">
+            <span class="inline-flex items-center gap-x-1.5 whitespace-nowrap">
+              <span aria-hidden="true">•</span>
+              <span>{{ relative }}</span>
+            </span>
+            <span class="inline-flex items-center gap-x-1.5 whitespace-nowrap">
+              <span aria-hidden="true">•</span>
+              <UsernameWithTooltip
+                v-if="authorUsername"
+                :is-admin="authorIsAdmin"
+                :username="authorUsername"
+                :src="discussion?.Author?.profilePicURL || ''"
+                :display-name="discussion?.Author?.displayName || ''"
+                :comment-karma="discussion?.Author?.commentKarma ?? 0"
+                :discussion-karma="discussion?.Author?.discussionKarma ?? 0"
+                :account-created="discussion?.Author?.createdAt"
+              />
+            </span>
+            <span
+              v-if="discussion"
+              class="inline-flex items-center gap-x-1.5 whitespace-nowrap"
+            >
+              <span aria-hidden="true">•</span>
               <nuxt-link
+                v-if="!submittedToMultipleChannels"
                 :to="getDetailLink()"
                 class="flex items-center gap-1 hover:underline"
               >
                 <i class="fa-regular fa-comment" aria-hidden="true" />
                 {{ commentCount }}
               </nuxt-link>
-            </template>
-            <template v-else-if="discussion">
-              <MenuButton :items="discussionDetailOptions">
+              <MenuButton v-else :items="discussionDetailOptions">
                 <span class="flex cursor-pointer items-center gap-1">
                   <i class="fa-regular fa-comment" aria-hidden="true" />
                   {{ commentCount }} in {{ channelCount }}
                   <ChevronDownIcon class="h-3 w-3" aria-hidden="true" />
                 </span>
               </MenuButton>
-            </template>
-            <template v-if="discussion && (discussion.body || discussion.Album)">
+            </span>
+            <span
+              v-if="discussion && (discussion.body || discussion.Album)"
+              class="inline-flex items-center gap-x-1.5 whitespace-nowrap"
+            >
               <span aria-hidden="true">•</span>
               <button
                 type="button"
@@ -411,7 +420,7 @@ const revealSensitiveContent = () => {
                 />
                 {{ isExpanded ? 'Collapse' : 'Expand' }}
               </button>
-            </template>
+            </span>
           </div>
         </div>
         <nuxt-link

--- a/components/event/list/EventListView.vue
+++ b/components/event/list/EventListView.vue
@@ -19,6 +19,8 @@ import {
 import EventFilterBar from './filters/EventFilterBar.vue';
 import TimeShortcuts from './filters/TimeShortcuts.vue';
 import OnlineInPersonShortcuts from './filters/OnlineInPersonShortcuts.vue';
+import FilterIcon from '@/components/icons/FilterIcon.vue';
+import MapIcon from '@/components/icons/MapIcon.vue';
 import { LocationFilterTypes } from './filters/locationFilterTypes';
 import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
@@ -269,7 +271,7 @@ watch(isSearchListRoute, (isSearchRoute) => {
     >
       <div
         v-if="isSearchListRoute"
-        class="flex items-center justify-between px-4 pt-1"
+        class="flex items-center justify-between px-4 py-2"
       >
         <h1
           class="font-semibold text-sm tracking-wide text-gray-900 dark:text-gray-100"
@@ -278,23 +280,33 @@ watch(isSearchListRoute, (isSearchRoute) => {
         </h1>
         <div class="flex items-center gap-2">
           <button
-            class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-800 hover:bg-gray-200 dark:border-gray-300 dark:text-gray-300 dark:hover:bg-gray-700"
-            :class="[showMainFilters ? 'bg-gray-200 dark:bg-gray-700' : '']"
+            class="inline-flex h-8 items-center gap-1.5 rounded-md border border-gray-300 px-2.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+            :class="[
+              showMainFilters
+                ? 'border-gray-400 bg-gray-100 text-gray-900 dark:border-gray-500 dark:bg-gray-800 dark:text-white'
+                : '',
+            ]"
             data-testid="toggle-main-filters-button"
             type="button"
             @click="toggleShowMainFilters"
           >
+            <FilterIcon class="h-3.5 w-3.5" aria-hidden="true" />
             {{ showMainFilters ? 'Hide filters' : 'Show filters' }}
           </button>
           <button
-            class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-800 hover:bg-gray-200 dark:border-gray-300 dark:text-gray-300 dark:hover:bg-gray-700"
+            class="inline-flex h-8 items-center gap-1.5 rounded-md border border-gray-300 px-2.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
             type="button"
             @click="goToInPersonMap"
           >
+            <MapIcon class="h-3.5 w-3.5" aria-hidden="true" />
             In-person map
           </button>
         </div>
       </div>
+      <hr
+        v-if="isSearchListRoute"
+        class="mx-4 -mt-2 border-t border-gray-200 dark:border-gray-700"
+      >
       <EventFilterBar
         :show-distance-filters="false"
         :allow-hiding-main-filters="true"

--- a/components/event/list/filters/EventFilterBar.vue
+++ b/components/event/list/filters/EventFilterBar.vue
@@ -295,17 +295,9 @@ const IN_PERSON_FEATURED_FORUMS: ChannelOption[] = [
       "
       class="mb-2 border border-t-gray-500 dark:border-t-gray-600"
     >
-    <div
-      v-if="showMainFilters"
-      class="flex flex-col gap-2 rounded-lg p-2 dark:bg-gray-800"
-      :class="[
-        allowHidingMainFilters
-          ? 'border border-gray-400 dark:border-gray-600'
-          : '',
-      ]"
-    >
+    <div v-if="showMainFilters" class="flex flex-col gap-2 p-2">
       <div v-if="route.name !== 'EventDetail'" class="mb-2 w-full">
-        <div class="flex items-center space-x-1">
+        <div class="flex items-center gap-2">
           <div
             class="align-items flex hidden justify-center space-x-2 md:block"
           >
@@ -342,6 +334,7 @@ const IN_PERSON_FEATURED_FORUMS: ChannelOption[] = [
             :initial-value="filterValues.searchInput"
             :right-side-is-rounded="!showLocationSearchBarAndDistanceButtons"
             :search-placeholder="'Search'"
+            :small="true"
             :test-id="'event-search-bar'"
             @update-search-input="updateSearchInput"
           >
@@ -480,14 +473,14 @@ const IN_PERSON_FEATURED_FORUMS: ChannelOption[] = [
           <RequireAuth v-if="showNewEventNextToSearchBar" :full-width="false">
             <template #has-auth>
               <PrimaryButton
-                class="ml-2 whitespace-nowrap"
+                class="h-9 whitespace-nowrap"
                 :label="'New Event'"
                 @click="$router.push(createEventLink)"
               />
             </template>
             <template #does-not-have-auth>
               <PrimaryButton
-                class="ml-2 whitespace-nowrap"
+                class="h-9 whitespace-nowrap"
                 :label="'New Event'"
               />
             </template>

--- a/components/nav/VerticalIconNav.vue
+++ b/components/nav/VerticalIconNav.vue
@@ -183,29 +183,40 @@ watch(
   { immediate: true }
 );
 
+// Active treatment: a tinted fill + an INSET accent ring so the highlight stays
+// within the circle and never crowds the label sitting just below it.
+const ACTIVE_CIRCLE =
+  'bg-orange-100 ring-1 ring-inset ring-orange-300 dark:bg-orange-500/20 dark:ring-orange-500/40';
+
 const getIconCircleClasses = (isActive: boolean) => {
   const baseClasses =
     'w-12 h-12 rounded-full bg-transparent hover:bg-gray-200 dark:hover:bg-gray-800 flex items-center justify-center transition-all duration-200 cursor-pointer';
-  return isActive
-    ? `${baseClasses} bg-gray-200 dark:bg-gray-800 ring-1 ring-gray-400 ring-offset-1 ring-offset-gray-100 dark:ring-gray-500 dark:ring-offset-gray-900 shadow-sm`
-    : baseClasses;
+  return isActive ? `${baseClasses} ${ACTIVE_CIRCLE}` : baseClasses;
 };
 
 const getForumIconClasses = (isActive: boolean) => {
   const baseClasses =
     'w-12 h-12 rounded-full bg-transparent hover:bg-gray-200 dark:hover:bg-gray-800 flex items-center justify-center transition-all duration-200 cursor-pointer overflow-hidden';
-  return isActive
-    ? `${baseClasses} bg-gray-200 dark:bg-gray-800 ring-2 ring-gray-400 dark:ring-gray-500 shadow-sm`
-    : baseClasses;
+  return isActive ? `${baseClasses} ${ACTIVE_CIRCLE}` : baseClasses;
 };
 
 const getUserActionClasses = (isActive: boolean) => {
   const baseClasses =
     'rounded-full my-2 bg-transparent hover:bg-gray-200 dark:hover:bg-gray-800 flex items-center justify-center transition-all duration-200 cursor-pointer';
-  return isActive
-    ? `${baseClasses} bg-gray-200 dark:bg-gray-800 ring-1 ring-gray-400 ring-offset-1 ring-offset-gray-100 dark:ring-gray-500 dark:ring-offset-gray-900 shadow-sm`
-    : baseClasses;
+  return isActive ? `${baseClasses} ${ACTIVE_CIRCLE}` : baseClasses;
 };
+
+// Icon + label pick up the accent colour when active so the highlight reads
+// clearly even at this small size.
+const getNavIconClasses = (isActive: boolean) =>
+  isActive
+    ? 'h-6 w-6 text-orange-600 dark:text-orange-400'
+    : 'h-6 w-6 text-gray-500 dark:text-gray-300';
+
+const getNavLabelClasses = (isActive: boolean) =>
+  isActive
+    ? 'mt-1 w-12 text-center text-[10px] leading-[10px] font-medium text-orange-600 dark:text-orange-400'
+    : 'mt-1 w-12 text-center text-[10px] leading-[10px] text-gray-600 dark:text-gray-300';
 </script>
 
 <template>
@@ -247,13 +258,11 @@ const getUserActionClasses = (isActive: boolean) => {
             >
               <component
                 :is="item.icon"
-                class="h-6 w-6 text-gray-500 dark:text-gray-300"
+                :class="getNavIconClasses(isActiveNavItem(item.routerName))"
                 aria-hidden="true"
               />
             </NuxtLink>
-            <span
-              class="w-12 text-center text-[10px] leading-[10px] text-gray-600 dark:text-gray-300"
-            >
+            <span :class="getNavLabelClasses(isActiveNavItem(item.routerName))">
               {{ item.name }}
             </span>
           </div>
@@ -300,7 +309,10 @@ const getUserActionClasses = (isActive: boolean) => {
                 />
               </NuxtLink>
               <span
-                class="w-12 truncate text-center text-[10px] leading-[10px] text-gray-600 dark:text-gray-300"
+                :class="[
+                  getNavLabelClasses(currentForumId === forum.uniqueName),
+                  'truncate',
+                ]"
               >
                 {{ forum.uniqueName }}
               </span>
@@ -321,7 +333,7 @@ const getUserActionClasses = (isActive: boolean) => {
               </button>
             </IconTooltip>
             <span
-              class="text-[10px] leading-[10px] text-gray-600 dark:text-gray-300"
+              class="mt-1 text-[10px] leading-[10px] text-gray-600 dark:text-gray-300"
               >More</span
             >
           </div>
@@ -353,9 +365,7 @@ const getUserActionClasses = (isActive: boolean) => {
             >
               <AdminIcon />
             </NuxtLink>
-            <span
-              class="w-12 text-center text-[10px] leading-[10px] text-gray-600 dark:text-gray-300"
-            >
+            <span :class="getNavLabelClasses(isActiveUserAction('admin-issues'))">
               Admin
             </span>
           </div>
@@ -370,9 +380,7 @@ const getUserActionClasses = (isActive: boolean) => {
                 <div :class="getUserActionClasses(false)">
                   <LoginIcon />
                 </div>
-                <span
-                  class="w-12 text-center text-[10px] leading-[10px] text-gray-600 dark:text-gray-300"
-                >
+                <span :class="getNavLabelClasses(false)">
                   Log in
                 </span>
               </div>

--- a/composables/useTheme.spec.ts
+++ b/composables/useTheme.spec.ts
@@ -1,94 +1,50 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { defineComponent } from 'vue';
-import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ref } from 'vue';
 
-// This is a simplified version that focuses on observable behavior
-// rather than implementation details
-describe('useTheme composable - Core functionality', () => {
+// Reactive stand-in for the uiStore theme, so we can verify that useAppTheme
+// reflects store changes and delegates writes back to the store.
+const themeRef = ref<'light' | 'dark'>('dark');
+const setThemeMock = vi.fn((mode: 'light' | 'dark') => {
+  themeRef.value = mode;
+});
+
+describe('useAppTheme - delegates to the uiStore', () => {
   beforeEach(() => {
     vi.resetModules();
+    themeRef.value = 'dark';
+    setThemeMock.mockClear();
 
-    // Mock Nuxt composables
-    vi.mock('nuxt/app', () => ({
-      useCookie: () => ({
-        value: null,
-      }),
-      useRoute: () => ({
-        query: {},
-      }),
-      useRouter: () => ({
-        replace: vi.fn(),
+    vi.mock('@/stores/uiStore', () => ({
+      useUIStore: () => ({
+        get theme() {
+          return themeRef.value;
+        },
+        setTheme: setThemeMock,
       }),
     }));
-
-    // Mock localStorage
-    vi.stubGlobal('localStorage', {
-      getItem: vi.fn(),
-      setItem: vi.fn(),
-    });
-
-    // Mock matchMedia
-    vi.stubGlobal('matchMedia', () => ({
-      matches: false,
-      addEventListener: vi.fn(),
-    }));
-
-    // Mock document.documentElement.classList
-    document.documentElement.classList = {
-      add: vi.fn(),
-      remove: vi.fn(),
-      contains: vi.fn(),
-    } as any;
-
-    // Mock import.meta.client
-    vi.stubGlobal('import', {
-      meta: { client: true },
-    });
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('should allow toggling between themes', async () => {
-    // Import useAppTheme inside test to ensure mocks are applied
+  it('exposes the current store theme', async () => {
     const { useAppTheme } = await import('@/composables/useTheme');
+    expect(useAppTheme().theme.value).toBe('dark');
+  });
 
-    // Create a simple test component
-    const TestComponent = defineComponent({
-      template: `
-        <div>
-          <div class="theme-display">{{ theme }}</div>
-          <button data-testid="light-btn" @click="setTheme('light')">Light</button>
-          <button data-testid="dark-btn" @click="setTheme('dark')">Dark</button>
-        </div>
-      `,
-      setup() {
-        const { theme, setTheme } = useAppTheme();
+  it('reacts to store theme changes', async () => {
+    const { useAppTheme } = await import('@/composables/useTheme');
+    const { theme } = useAppTheme();
+    themeRef.value = 'light';
+    expect(theme.value).toBe('light');
+  });
 
-        // Force light theme initially
-        setTheme('light');
+  it('delegates a valid setTheme call to the store', async () => {
+    const { useAppTheme } = await import('@/composables/useTheme');
+    useAppTheme().setTheme('light');
+    expect(setThemeMock).toHaveBeenCalledWith('light');
+  });
 
-        return { theme, setTheme };
-      },
-    });
-
-    // Mount the component
-    const wrapper = mount(TestComponent);
-
-    // Initial theme should be light (we set it explicitly)
-    expect(wrapper.find('.theme-display').text()).toBe('light');
-
-    // Click dark theme button
-    await wrapper.find('[data-testid="dark-btn"]').trigger('click');
-
-    // Theme should update to dark
-    expect(wrapper.find('.theme-display').text()).toBe('dark');
-
-    // Click light theme button
-    await wrapper.find('[data-testid="light-btn"]').trigger('click');
-
-    // Theme should update back to light
-    expect(wrapper.find('.theme-display').text()).toBe('light');
+  it('ignores invalid setTheme values', async () => {
+    const { useAppTheme } = await import('@/composables/useTheme');
+    useAppTheme().setTheme('system');
+    expect(setThemeMock).not.toHaveBeenCalled();
   });
 });

--- a/composables/useTheme.ts
+++ b/composables/useTheme.ts
@@ -1,91 +1,28 @@
-import { computed, ref, watch, nextTick } from 'vue';
-import { useCookie, useRoute, useRouter, useHead } from 'nuxt/app';
+import { computed } from 'vue';
+import { useUIStore } from '@/stores/uiStore';
 
+/**
+ * Theme accessor backed by the single source of truth: the UI store.
+ *
+ * Previously this composable kept its OWN reactive theme state (per-call refs +
+ * a separate cookie read), which meant it never reflected changes made by the
+ * theme toggle — the toggle drives `uiStore.setTheme`, so any component reading
+ * this composable showed a stale theme. It now delegates entirely to the store
+ * so every consumer reacts to the same state.
+ */
 export const useAppTheme = () => {
-  const themeCookie = useCookie('theme', {
-    default: () => 'system',
-  });
+  const uiStore = useUIStore();
 
-  const currentThemeValue = ref(themeCookie.value);
-  const systemThemeIsDark = ref(true);
-
-  if (import.meta.client) {
-    const localTheme = localStorage.getItem('theme');
-    if (localTheme) {
-      currentThemeValue.value = localTheme;
-      themeCookie.value = localTheme;
-    }
-
-    systemThemeIsDark.value = window.matchMedia(
-      '(prefers-color-scheme: dark)'
-    ).matches;
-
-    window
-      .matchMedia('(prefers-color-scheme: dark)')
-      .addEventListener('change', (e) => {
-        systemThemeIsDark.value = e.matches;
-      });
-  }
+  const theme = computed(() => uiStore.theme);
 
   const setTheme = (newTheme: string) => {
-    // Only get route and router when needed
-    const route = useRoute();
-    const router = useRouter();
-
-    // Capture current query params before theme change
-    const currentQuery = { ...route.query };
-
-    currentThemeValue.value = newTheme;
-    themeCookie.value = newTheme;
-
-    if (import.meta.client) {
-      localStorage.setItem('theme', newTheme);
-
-      // Use nextTick to ensure query params are preserved after theme update
-      nextTick(() => {
-        if (Object.keys(currentQuery).length) {
-          router.replace({
-            path: route.path,
-            query: currentQuery,
-          });
-        }
-      });
+    if (newTheme === 'light' || newTheme === 'dark') {
+      uiStore.setTheme(newTheme);
     }
   };
 
-  const computedTheme = computed(() => {
-    if (currentThemeValue.value === 'system') {
-      return systemThemeIsDark.value ? 'dark' : 'light';
-    }
-    return currentThemeValue.value;
-  });
-
-  // Apply theme class during SSR and client
-  if (import.meta.server) {
-    useHead({
-      htmlAttrs: {
-        class: computedTheme.value === 'dark' ? 'dark' : '',
-      },
-    });
-  }
-
-  // Watch for theme changes and apply class to html element
-  if (import.meta.client) {
-    watch(
-      computedTheme,
-      (newTheme) => {
-        if (newTheme === 'dark') {
-          document.documentElement.classList.add('dark');
-        } else {
-          document.documentElement.classList.remove('dark');
-        }
-      },
-      { immediate: true }
-    );
-  }
-
   return {
-    theme: computedTheme,
+    theme,
     setTheme,
   };
 };

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,7 +22,10 @@ export default defineNuxtConfig({
       ],
       htmlAttrs: {
         lang: 'en',
-        class: 'dark dark-mode-ready', // Default to dark mode for initial SSR
+        // The `dark` class is applied per-request by the uiStore (from the
+        // `theme` cookie) during SSR, so it is NOT hardcoded here — otherwise
+        // light-mode users would get a dark server render and a flash on load.
+        class: 'dark-mode-ready',
       },
     },
   },
@@ -159,8 +162,11 @@ export default defineNuxtConfig({
         },
       },
     ],
-    // Light/dark mode support
-    '@nuxtjs/color-mode',
+    // Light/dark mode is handled by the uiStore (single source of truth):
+    // it reads the `theme` cookie on the server to set the initial <html> class
+    // and toggles it on the client. @nuxtjs/color-mode was unused (Tailwind uses
+    // darkMode: 'class', and nothing referenced color-mode's API), so it was
+    // removed to eliminate a competing theme system.
     // The order matters in this list. Tailwind must come last
     // to avoid its styles being overridden by other styles.
     [

--- a/stores/uiStore.ts
+++ b/stores/uiStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { ref, computed, watch } from 'vue';
 import { config } from '@/config';
-import { useCookie, useRoute, useRouter } from 'nuxt/app';
+import { useCookie, useRoute, useRouter, useHead } from 'nuxt/app';
 
 export type FontSize = 'small' | 'medium' | 'large';
 type ThemeMode = 'light' | 'dark';
@@ -25,37 +25,45 @@ export const useUIStore = defineStore('ui', () => {
   const selectedIssueTitle = ref('');
   const selectedIssueChannelId = ref('');
 
-  // Theme state
+  // Theme state — this store is the single source of truth for the app's theme.
   const themeMode = ref<ThemeMode>('dark');
   const systemThemeIsDark = ref(false); // Kept for backward compatibility
 
-  // Initialize theme from cookie/localStorage on client side - default to dark mode
-  if (import.meta.client) {
-    const themeCookie = useCookie('theme', { default: () => 'dark' });
-    const localTheme = localStorage.getItem('theme');
+  // Server: read the persisted theme from the cookie so server-rendered markup
+  // matches the user's preference (no light-mode flash on load). useCookie is
+  // only called inside the server/client guards so plain unit tests — which run
+  // without a Nuxt context — fall back to the default instead of throwing.
+  if (import.meta.server) {
+    const themeCookie = useCookie<string>('theme', { default: () => 'dark' });
+    if (themeCookie.value === 'light' || themeCookie.value === 'dark') {
+      themeMode.value = themeCookie.value;
+    }
+  }
 
-    // Set initial theme preference - default to dark
-    if (localTheme && ['light', 'dark'].includes(localTheme)) {
-      themeMode.value = localTheme as ThemeMode;
+  // Client: localStorage takes precedence and is reconciled into the cookie;
+  // also track the OS preference for backward compatibility.
+  if (import.meta.client) {
+    const themeCookie = useCookie<string>('theme', { default: () => 'dark' });
+    const localTheme = localStorage.getItem('theme');
+    if (localTheme === 'light' || localTheme === 'dark') {
+      themeMode.value = localTheme;
       themeCookie.value = localTheme;
     } else if (
-      themeCookie.value &&
-      ['light', 'dark'].includes(themeCookie.value)
+      themeCookie.value === 'light' ||
+      themeCookie.value === 'dark'
     ) {
-      themeMode.value = themeCookie.value as ThemeMode;
+      themeMode.value = themeCookie.value;
+      localStorage.setItem('theme', themeMode.value);
     } else {
-      // Default to dark mode if nothing is set
-      themeMode.value = 'dark';
-      themeCookie.value = 'dark';
-      localStorage.setItem('theme', 'dark');
+      // Nothing stored yet — seed cookie + localStorage so it persists.
+      themeCookie.value = themeMode.value;
+      localStorage.setItem('theme', themeMode.value);
     }
 
-    // Check if system prefers dark mode - for backward compatibility
     systemThemeIsDark.value = window.matchMedia(
       '(prefers-color-scheme: dark)'
     ).matches;
 
-    // Listen for system preference changes
     window
       .matchMedia('(prefers-color-scheme: dark)')
       .addEventListener('change', (e) => {
@@ -66,16 +74,22 @@ export const useUIStore = defineStore('ui', () => {
   // Computed theme value (light or dark)
   const theme = computed(() => themeMode.value);
 
-  // Apply theme class to HTML element
+  // Server: emit the initial <html> class so server-rendered markup already
+  // matches the user's theme (eliminates the hydration flash).
+  if (import.meta.server) {
+    useHead({
+      htmlAttrs: {
+        class: theme.value === 'dark' ? 'dark' : '',
+      },
+    });
+  }
+
+  // Client: keep the <html> class in sync as the theme changes at runtime.
   if (import.meta.client) {
     watch(
       theme,
       (newTheme) => {
-        if (newTheme === 'dark') {
-          document.documentElement.classList.add('dark');
-        } else {
-          document.documentElement.classList.remove('dark');
-        }
+        document.documentElement.classList.toggle('dark', newTheme === 'dark');
       },
       { immediate: true }
     );


### PR DESCRIPTION
## Summary

Dark-mode UI polish across discussions, the side nav, and events, plus a consolidation of the app's theme handling into a single source of truth. All changes verified with the full unit suite (4061 tests) and `vue-tsc`.

## Discussions list
- Fix the separator `•` getting stranded at the end of a line when the meta row wraps (group each separator with its following segment).
- Make the filter-bar icon buttons consistent (uniform padding, resolved conflicting base text colors).
- Align the sort dropdown's dark background with the other toolbar controls.

## Side nav (`VerticalIconNav`)
- Clearer active state: inset accent ring + tinted fill + orange icon/label, instead of a gray ring that haloed outward into the label.
- Add spacing so the active circle no longer crowds its label.

## Theme: single source of truth (`uiStore`)
The app had three overlapping theme mechanisms. This consolidates them:
- `useAppTheme` now **delegates to `uiStore`** instead of holding parallel per-call state — so identicon avatars (and other consumers) actually react to the theme toggle.
- `AvatarComponent` generates a **transparent identicon** and applies the light/dark background via CSS (`bg-white dark:bg-black`), so avatars match the theme on first load *and* on toggle, with no JS theme dependency or hydration mismatch.
- `uiStore` reads the `theme` cookie **on the server** and emits the `<html>` `dark` class via SSR `useHead` — fixing the light-mode flash for dark-mode users (verified: `theme=light` → no `dark` class, `theme=dark`/none → `dark`).
- Removed the hardcoded `dark` in `nuxt.config` `htmlAttrs` that forced every SSR render dark.
- Removed the unused `@nuxtjs/color-mode` module (redundant third system; Tailwind uses `darkMode: 'class'` and nothing referenced color-mode's API).

> Note: `@nuxtjs/color-mode` is still listed in `package.json`; it can be fully removed later with `npm uninstall @nuxtjs/color-mode`. This may also help the long-standing discussion-detail hydration flash — worth re-testing on a Vercel deploy.

## Events filter bar
- Minimal, borderless layout with a subtle divider (matches the discussions bar).
- Center the "Online events" title with equal padding above/below.
- Equal-height header buttons with icons (Hide filters / In-person map).
- Consistent height and spacing for All Forums / Search / New Event.

## Test plan
- [x] `npm run tsc` — 0 errors
- [x] `npm run test:unit` — 392 files / 4061 tests pass
- [x] Manually verified in-browser (dark + light): theme toggle flips page and avatars, SSR respects the theme cookie, and the events/discussions filter bars render as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
