### PR TITLE
test: extend page unit coverage (+16 pages)

### DIFF
--- a/pages/admin/plugins/[pluginId].spec.ts
+++ b/pages/admin/plugins/[pluginId].spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+describe('admin plugin detail page (alias)', () => {
+  it('renders the canonical plugin detail page', async () => {
+    const Page = (await import('./[pluginId].vue')).default;
+    const PluginDetailPage = (
+      await import('@/pages/admin/settings/plugins/[pluginId].vue')
+    ).default;
+    const wrapper = shallowMount(Page);
+    expect(wrapper.findComponent(PluginDetailPage).exists()).toBe(true);
+  });
+});

--- a/pages/admin/plugins/docs.spec.ts
+++ b/pages/admin/plugins/docs.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+describe('admin plugins docs page (alias)', () => {
+  it('renders the canonical plugins docs page', async () => {
+    const Page = (await import('./docs.vue')).default;
+    const PluginsDocsPage = (
+      await import('@/pages/admin/settings/plugins/docs.vue')
+    ).default;
+    const wrapper = shallowMount(Page);
+    expect(wrapper.findComponent(PluginsDocsPage).exists()).toBe(true);
+  });
+});

--- a/pages/admin/plugins/index.spec.ts
+++ b/pages/admin/plugins/index.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+describe('admin plugins index page (alias)', () => {
+  it('renders the canonical plugins settings page', async () => {
+    const Page = (await import('./index.vue')).default;
+    const PluginsIndexPage = (
+      await import('@/pages/admin/settings/plugins/index.vue')
+    ).default;
+    const wrapper = shallowMount(Page);
+    expect(wrapper.findComponent(PluginsIndexPage).exists()).toBe(true);
+  });
+});

--- a/pages/admin/plugins/pipelines.spec.ts
+++ b/pages/admin/plugins/pipelines.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+describe('admin plugins pipelines page (alias)', () => {
+  it('renders the canonical plugins pipelines page', async () => {
+    const Page = (await import('./pipelines.vue')).default;
+    const PluginsPipelinesPage = (
+      await import('@/pages/admin/settings/plugins/pipelines.vue')
+    ).default;
+    const wrapper = shallowMount(Page);
+    expect(wrapper.findComponent(PluginsPipelinesPage).exists()).toBe(true);
+  });
+});

--- a/pages/admin/plugins/registries.spec.ts
+++ b/pages/admin/plugins/registries.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+describe('admin plugins registries page (alias)', () => {
+  it('renders the canonical plugins registries page', async () => {
+    const Page = (await import('./registries.vue')).default;
+    const PluginsRegistriesPage = (
+      await import('@/pages/admin/settings/plugins/registries.vue')
+    ).default;
+    const wrapper = shallowMount(Page);
+    expect(wrapper.findComponent(PluginsRegistriesPage).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/accept-invite.spec.ts
+++ b/pages/forums/[forumId]/accept-invite.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+import AcceptInvitePage from './accept-invite.vue';
+import PendingInvite from '@/components/mod/PendingInvite.vue';
+
+const SlotStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.());
+  },
+});
+
+const RequireAuthStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots['has-auth']?.());
+  },
+});
+
+describe('forum accept invite page', () => {
+  it('shows the pending invite to authenticated users', () => {
+    const wrapper = shallowMount(AcceptInvitePage, {
+      global: {
+        stubs: { ClientOnly: SlotStub, RequireAuth: RequireAuthStub },
+      },
+    });
+    expect(wrapper.findComponent(PendingInvite).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/discussions/feedback/[discussionId]/feedbackPermalink/[feedbackId].spec.ts
+++ b/pages/forums/[forumId]/discussions/feedback/[discussionId]/feedbackPermalink/[feedbackId].spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+import CommentOnFeedbackPage from '@/components/comments/CommentOnFeedbackPage.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { commentId: 'comment-1' } }),
+}));
+
+// Render the #comment slot with stub comment data so we can assert the
+// feedback comment is wired up.
+const PermalinkedFeedbackCommentStub = defineComponent({
+  name: 'PermalinkedFeedbackComment',
+  props: ['commentId'],
+  setup(_props, { slots }) {
+    return () => h('div', slots.comment?.({ commentData: { id: 'comment-1' } }));
+  },
+});
+
+describe('discussion feedback permalink page', () => {
+  it('passes the route comment id to the permalinked feedback comment', async () => {
+    const Page = (await import('./[feedbackId].vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: {
+        stubs: { PermalinkedFeedbackComment: PermalinkedFeedbackCommentStub },
+      },
+    });
+    expect(
+      wrapper.findComponent(PermalinkedFeedbackCommentStub).props('commentId')
+    ).toBe('comment-1');
+  });
+
+  it('highlights the rendered feedback comment', async () => {
+    const Page = (await import('./[feedbackId].vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: {
+        stubs: { PermalinkedFeedbackComment: PermalinkedFeedbackCommentStub },
+      },
+    });
+    expect(
+      wrapper.findComponent(CommentOnFeedbackPage).props('isHighlighted')
+    ).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/edit/emoji.spec.ts
+++ b/pages/forums/[forumId]/edit/emoji.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import EmojiSettingsPage from './emoji.vue';
+import CheckBox from '@/components/CheckBox.vue';
+
+const buildWrapper = (formValues: Record<string, unknown>) =>
+  shallowMount(EmojiSettingsPage, { props: { formValues } });
+
+describe('forum emoji settings page', () => {
+  it('defaults the checkbox to enabled when emojiEnabled is unset', () => {
+    expect(buildWrapper({}).findComponent(CheckBox).props('checked')).toBe(true);
+  });
+
+  it('unchecks the box when emoji is explicitly disabled', () => {
+    expect(
+      buildWrapper({ emojiEnabled: false }).findComponent(CheckBox).props('checked')
+    ).toBe(false);
+  });
+
+  it('forwards checkbox changes as an emojiEnabled update', () => {
+    const wrapper = buildWrapper({ emojiEnabled: true });
+    wrapper.findComponent(CheckBox).vm.$emit('update', false);
+    expect(wrapper.emitted('updateFormValues')?.[0]).toEqual([
+      { emojiEnabled: false },
+    ]);
+  });
+});

--- a/pages/forums/[forumId]/edit/rules.spec.ts
+++ b/pages/forums/[forumId]/edit/rules.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import RulesSettingsPage from './rules.vue';
+
+// RulesEditor is a Nuxt auto-import; stub it so we can drive its emit.
+const RulesEditorStub = defineComponent({
+  name: 'RulesEditor',
+  props: ['formValues'],
+  emits: ['update-form-values'],
+  template: '<div />',
+});
+
+describe('forum rules settings page', () => {
+  it('passes the form values through to the rules editor', () => {
+    const formValues = { rules: [{ summary: 'Be kind', detail: '' }] };
+    const wrapper = shallowMount(RulesSettingsPage, {
+      props: { formValues },
+      global: { stubs: { RulesEditor: RulesEditorStub } },
+    });
+    expect(wrapper.findComponent(RulesEditorStub).props('formValues')).toEqual(
+      formValues
+    );
+  });
+
+  it('forwards rules editor updates to the parent form', () => {
+    const wrapper = shallowMount(RulesSettingsPage, {
+      props: { formValues: { rules: [] } },
+      global: { stubs: { RulesEditor: RulesEditorStub } },
+    });
+    const payload = { rules: [{ summary: 'New rule', detail: '' }] };
+    wrapper.findComponent(RulesEditorStub).vm.$emit('update-form-values', payload);
+    expect(wrapper.emitted('updateFormValues')?.[0]).toEqual([payload]);
+  });
+});

--- a/pages/forums/[forumId]/edit/suspended-mods.spec.ts
+++ b/pages/forums/[forumId]/edit/suspended-mods.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' } }),
+}));
+
+const FormRowStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.content?.() ?? slots.default?.());
+  },
+});
+
+const buildWrapper = async () => {
+  const Page = (await import('./suspended-mods.vue')).default;
+  return shallowMount(Page, { global: { stubs: { FormRow: FormRowStub } } });
+};
+
+describe('forum suspended mods page', () => {
+  it('names the current forum in the description', async () => {
+    const wrapper = await buildWrapper();
+    expect(wrapper.text()).toContain(
+      'These mods have been suspended from cats.'
+    );
+  });
+
+  it('renders the suspended mod list', async () => {
+    const wrapper = await buildWrapper();
+    const SuspendedModList = (
+      await import('@/components/channel/form/SuspendedModList.vue')
+    ).default;
+    expect(wrapper.findComponent(SuspendedModList).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/issues/closed.spec.ts
+++ b/pages/forums/[forumId]/issues/closed.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' }, query: {} }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
+  const { loading = false, issues = [] } = opts;
+  mockedUseQuery.mockReturnValue({
+    result: ref({ channels: [{ Issues: issues }] }),
+    error: ref(null),
+    loading: ref(loading),
+    refetch: vi.fn(),
+  });
+  const Page = (await import('./closed.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('forum closed issues page', () => {
+  it('shows an empty-state message when there are no closed issues', async () => {
+    const wrapper = await mountWith({ issues: [] });
+    expect(wrapper.text()).toContain('There are no closed issues.');
+  });
+
+  it('renders an item per closed issue', async () => {
+    const wrapper = await mountWith({ issues: [{ id: 'i1' }, { id: 'i2' }] });
+    expect(wrapper.findAllComponents(ModIssueListItem)).toHaveLength(2);
+  });
+
+  it('renders no issues while the query is loading', async () => {
+    const wrapper = await mountWith({ loading: true, issues: [{ id: 'i1' }] });
+    expect(wrapper.findAllComponents(ModIssueListItem)).toHaveLength(0);
+  });
+});

--- a/pages/logout.spec.ts
+++ b/pages/logout.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+
+const push = vi.fn();
+const setIsAuthenticated = vi.fn();
+const setUsername = vi.fn();
+
+vi.mock('nuxt/app', () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  setIsAuthenticated,
+  setUsername,
+}));
+
+const NuxtLayoutStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.());
+  },
+});
+
+const mountLogout = async () => {
+  const Page = (await import('./logout.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { NuxtLayout: NuxtLayoutStub } },
+  });
+};
+
+describe('logout page', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears the authenticated flag on mount', async () => {
+    await mountLogout();
+    expect(setIsAuthenticated).toHaveBeenCalledWith(false);
+  });
+
+  it('removes the stored auth token', async () => {
+    localStorage.setItem('token', 'abc');
+    await mountLogout();
+    expect(localStorage.getItem('token')).toBeNull();
+  });
+
+  it('redirects to the stored post-logout path', async () => {
+    localStorage.setItem('postLogoutRedirect', '/dashboard');
+    await mountLogout();
+    vi.advanceTimersByTime(500);
+    expect(push).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('defaults the redirect to home when no path is stored', async () => {
+    await mountLogout();
+    vi.advanceTimersByTime(500);
+    expect(push).toHaveBeenCalledWith('/');
+  });
+});

--- a/pages/u/[username]/discussions.spec.ts
+++ b/pages/u/[username]/discussions.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import DiscussionItemInProfile from '@/components/user/DiscussionItemInProfile.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { username: 'alice' }, query: {} }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
+  useSelectedChannelsFromQuery: () => ({
+    selectedChannels: ref([]),
+    hasSelectedChannels: ref(false),
+  }),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (result: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(result),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./discussions.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('user discussions profile page', () => {
+  it('shows an empty-state message when the user has no discussions', async () => {
+    const wrapper = await mountWith({ users: [{ Discussions: [] }] });
+    expect(wrapper.text()).toContain('No discussions yet');
+  });
+
+  it('renders an item per discussion', async () => {
+    const wrapper = await mountWith({
+      users: [{ Discussions: [{ id: 'd1' }, { id: 'd2' }] }],
+    });
+    expect(wrapper.findAllComponents(DiscussionItemInProfile)).toHaveLength(2);
+  });
+});

--- a/pages/u/[username]/downloads.spec.ts
+++ b/pages/u/[username]/downloads.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import SitewideDownloadListItem from '@/components/discussion/list/SitewideDownloadListItem.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { username: 'alice' }, query: {} }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
+  useSelectedChannelsFromQuery: () => ({
+    selectedChannels: ref([]),
+    hasSelectedChannels: ref(false),
+  }),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (result: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(result),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./downloads.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('user downloads profile page', () => {
+  it('shows an empty-state message when the user has no downloads', async () => {
+    const wrapper = await mountWith({ users: [{ Discussions: [] }] });
+    expect(wrapper.text()).toContain('No downloads yet');
+  });
+
+  it('renders an item per download', async () => {
+    const wrapper = await mountWith({
+      users: [{ Discussions: [{ id: 'd1' }, { id: 'd2' }] }],
+    });
+    expect(wrapper.findAllComponents(SitewideDownloadListItem)).toHaveLength(2);
+  });
+});

--- a/pages/u/[username]/events.spec.ts
+++ b/pages/u/[username]/events.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import EventItemInProfile from '@/components/user/EventItemInProfile.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { username: 'alice' }, query: {} }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
+  useSelectedChannelsFromQuery: () => ({
+    selectedChannels: ref([]),
+    hasSelectedChannels: ref(false),
+  }),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (result: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(result),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./events.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('user events profile page', () => {
+  it('shows an empty-state message when the user has no events', async () => {
+    const wrapper = await mountWith({ users: [{ Events: [] }] });
+    expect(wrapper.text()).toContain('No events yet');
+  });
+
+  it('renders an item per event', async () => {
+    const wrapper = await mountWith({
+      users: [{ Events: [{ id: 'e1' }, { id: 'e2' }] }],
+    });
+    expect(wrapper.findAllComponents(EventItemInProfile)).toHaveLength(2);
+  });
+});

--- a/pages/u/[username]/scratchpad.spec.ts
+++ b/pages/u/[username]/scratchpad.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { username: 'alice' } }),
+}));
+
+describe('user scratchpad page', () => {
+  it('passes the username from the route to the scratchpad section', async () => {
+    const Page = (await import('./scratchpad.vue')).default;
+    const ScratchpadSection = (
+      await import('@/components/scratchpad/ScratchpadSection.vue')
+    ).default;
+    const section = shallowMount(Page).findComponent(ScratchpadSection);
+    expect(section.props('username')).toBe('alice');
+  });
+});


### PR DESCRIPTION
Follow-up to #135 — keeps extending page-level unit coverage. **Stacked on `health/recommendations`** (#135); base will retarget to `main` once that merges.

Adds specs for **16 more pages**, taking pages-with-tests from 47 → **63**. Coverage targets real logic, not just rendering:

- **Checkbox-state derivation** — `forums/[forumId]/edit/emoji` (defaults enabled unless explicitly `false`)
- **Emit forwarding** — `forums/[forumId]/edit/rules`
- **Route-param props** — `u/[username]/scratchpad`, `forums/[forumId]/edit/suspended-mods` (forum name in copy)
- **Logout flow** — auth-state reset, token cleanup, and stored/default redirect (fake timers)
- **Query loading/empty/list branches** — `u/[username]/events`, `discussions`, `downloads`; `forums/[forumId]/issues/closed` (incl. "empty while loading")
- **Auth-gated slot** — `forums/[forumId]/accept-invite`
- **Feedback permalink wiring** — comment id + highlight passthrough
- **Alias pages** — the five `admin/plugins/*` re-export wrappers

Verified: `tsc` clean, full unit suite green — **450 files / 4,208 tests passing** (+29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)