### PR TITLE
test: cover heavy feature pages via tested logic extraction

### DIFF
--- a/pages/admin/issues/index.spec.ts
+++ b/pages/admin/issues/index.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { setActivePinia, createPinia } from 'pinia';
+import { useQuery } from '@vue/apollo-composable';
+import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
+
+const query: Record<string, string> = {};
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: '' }, query }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
+  const { loading = false, issues = [] } = opts;
+  mockedUseQuery.mockReturnValue({
+    result: ref({ issues }),
+    error: ref(null),
+    loading: ref(loading),
+    refetch: vi.fn(),
+  });
+  const Page = (await import('./index.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('admin server issues index page', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    query.showOnlyServerRuleViolations = '';
+  });
+
+  it('defaults the server-rule-violations checkbox to checked', async () => {
+    const wrapper = await mountWith({ issues: [] });
+    expect(
+      (wrapper.get('[data-testid="show-only-server-rule-violations"]')
+        .element as HTMLInputElement).checked
+    ).toBe(true);
+  });
+
+  it('unchecks the filter when the query opts out', async () => {
+    query.showOnlyServerRuleViolations = 'false';
+    const wrapper = await mountWith({ issues: [] });
+    expect(
+      (wrapper.get('[data-testid="show-only-server-rule-violations"]')
+        .element as HTMLInputElement).checked
+    ).toBe(false);
+  });
+
+  it('renders an item per issue', async () => {
+    const wrapper = await mountWith({ issues: [{ id: 'i1' }, { id: 'i2' }] });
+    expect(wrapper.findAllComponents(ModIssueListItem)).toHaveLength(2);
+  });
+
+  it('renders no issues while the query is loading', async () => {
+    const wrapper = await mountWith({ loading: true, issues: [{ id: 'i1' }] });
+    expect(wrapper.findAllComponents(ModIssueListItem)).toHaveLength(0);
+  });
+});

--- a/pages/admin/issues/index.vue
+++ b/pages/admin/issues/index.vue
@@ -7,7 +7,10 @@ import { useRoute, useRouter } from 'nuxt/app';
 import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
 import SearchBar from '@/components/SearchBar.vue';
 import { updateFilters } from '@/utils/routerUtils';
-import { createCaseInsensitivePattern } from '@/utils/searchUtils';
+import {
+  getDefaultServerRuleViolationsFilter,
+  buildServerIssuesWhere,
+} from '@/utils/serverIssueFilters';
 import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
 
@@ -23,47 +26,19 @@ const channelId = computed(() => {
   return route.params.forumId;
 });
 
-const getDefaultFilter = () => {
-  // If there is no query param at all, the default should be true.
-  // If the query param is given as false, that overrides that.
-
-  if (route.query.showOnlyServerRuleViolations === 'false') {
-    return false;
-  }
-  return true;
-};
-const showOnlyServerRuleViolations = ref(getDefaultFilter());
+const showOnlyServerRuleViolations = ref(
+  getDefaultServerRuleViolationsFilter(route.query.showOnlyServerRuleViolations)
+);
 const searchInput = ref(
   typeof route.query.searchInput === 'string' ? route.query.searchInput : ''
 );
 
-const variables = computed(() => {
-  const searchPattern = createCaseInsensitivePattern(searchInput.value);
-  const searchFilter = searchPattern
-    ? {
-        OR: [
-          { title_MATCHES: searchPattern },
-          { body_MATCHES: searchPattern },
-        ],
-      }
-    : {};
-
-  if (showOnlyServerRuleViolations.value) {
-    return {
-      issueWhere: {
-        isOpen: true,
-        flaggedServerRuleViolation: true,
-        ...searchFilter,
-      },
-    };
-  }
-  return {
-    issueWhere: {
-      isOpen: true,
-      ...searchFilter,
-    },
-  };
-});
+const variables = computed(() =>
+  buildServerIssuesWhere({
+    searchInput: searchInput.value,
+    showOnlyServerRuleViolations: showOnlyServerRuleViolations.value,
+  })
+);
 
 const {
   result: getIssuesResult,

--- a/pages/collections/[collectionId].spec.ts
+++ b/pages/collections/[collectionId].spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h, ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import ErrorBanner from '@/components/ErrorBanner.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { collectionId: 'col-1' } }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const NuxtLayoutStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (state: {
+  result?: unknown;
+  loading?: boolean;
+  error?: unknown;
+}) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(state.result ?? null),
+    loading: ref(state.loading ?? false),
+    error: ref(state.error ?? null),
+    refetch: vi.fn(),
+  });
+  const Page = (await import('./[collectionId].vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { NuxtLayout: NuxtLayoutStub } },
+  });
+};
+
+describe('public collection detail page', () => {
+  it('shows the collection name when a public collection loads', async () => {
+    const wrapper = await mountWith({
+      result: {
+        collections: [
+          { id: 'col-1', name: 'Cat GIFs', Downloads: [], DownloadsAggregate: { count: 0 } },
+        ],
+      },
+    });
+    expect(wrapper.text()).toContain('Cat GIFs');
+  });
+
+  it('shows an error banner when the query fails', async () => {
+    const wrapper = await mountWith({ error: { message: 'boom' } });
+    expect(wrapper.findComponent(ErrorBanner).props('text')).toBe('boom');
+  });
+
+  it('shows an unavailable message when the collection is not public', async () => {
+    const wrapper = await mountWith({ result: { collections: [] } });
+    expect(wrapper.text()).toContain(
+      'This collection is not available or is not public.'
+    );
+  });
+});

--- a/pages/collections/[collectionId].vue
+++ b/pages/collections/[collectionId].vue
@@ -4,6 +4,7 @@ import { useRoute } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import type { Discussion } from '@/__generated__/graphql';
 import { GET_PUBLIC_COLLECTION_BY_ID } from '@/graphQLData/collection/queries';
+import { mergeUniqueById } from '@/utils/mergeUniqueById';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import CollectionDownloadListItem from '@/components/collection/CollectionDownloadListItem.vue';
@@ -44,15 +45,10 @@ watch(
 
     totalDownloads.value = collectionData.DownloadsAggregate?.count || 0;
 
-    const newDownloads = collectionData.Downloads || [];
-    const existingIds = new Set(downloads.value.map((d) => d.id));
-    const merged = [...downloads.value];
-    newDownloads.forEach((d: Discussion) => {
-      if (d && !existingIds.has(d.id)) {
-        merged.push(d);
-      }
-    });
-    downloads.value = merged;
+    downloads.value = mergeUniqueById<Discussion>(
+      downloads.value,
+      collectionData.Downloads
+    );
   },
   { immediate: true }
 );

--- a/pages/forums/[forumId]/discussions/[discussionId].spec.ts
+++ b/pages/forums/[forumId]/discussions/[discussionId].spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import DiscussionDetailContent from '@/components/discussion/detail/DiscussionDetailContent.vue';
+import ErrorBanner from '@/components/ErrorBanner.vue';
+
+const useHead = vi.fn();
+const routeParams: { discussionId?: string; forumId?: string } = {
+  discussionId: 'd1',
+  forumId: 'cats',
+};
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: routeParams }),
+  useHead: (...args: unknown[]) => useHead(...args),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ref('mod-1'),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountPage = async () => {
+  mockedUseQuery.mockReturnValue({ result: ref({ discussions: [] }) });
+  const Page = (await import('./[discussionId].vue')).default;
+  return shallowMount(Page);
+};
+
+describe('discussion detail page', () => {
+  it('renders the discussion detail content when an id is present', async () => {
+    routeParams.discussionId = 'd1';
+    const wrapper = await mountPage();
+    expect(wrapper.findComponent(DiscussionDetailContent).props('discussionId')).toBe(
+      'd1'
+    );
+  });
+
+  it('shows an error banner when there is no discussion id', async () => {
+    routeParams.discussionId = '';
+    const wrapper = await mountPage();
+    expect(wrapper.findComponent(ErrorBanner).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/discussions/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/[discussionId].vue
@@ -7,6 +7,7 @@ import { useModProfileName } from '@/composables/useAuthState';
 import { useRoute, useHead } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
+import { buildDiscussionHead } from '@/utils/discussionSeo';
 
 const modProfileNameVar = useModProfileName();
 
@@ -37,88 +38,17 @@ const { result: discussionResult } = useQuery(GET_DISCUSSION, {
   channelUniqueName: channelId.value,
 });
 
-// Reactive meta data that updates when discussion data changes
+// Reactive meta data that updates when discussion data changes. The pure
+// tag-building logic lives in utils/discussionSeo.ts (unit-tested).
 const metaData = computed(() => {
   try {
-    if (!discussionResult.value?.discussions) {
-      return {
-        title: `Discussion | ${channelId.value}`,
-        description: `View this discussion on ${import.meta.env.VITE_SERVER_DISPLAY_NAME}`,
-      };
-    }
-
-    if (discussionResult.value.discussions.length === 0) {
-      return {
-        title: `Discussion Not Found${channelId.value ? ` | ${channelId.value}` : ''}`,
-        description: 'The requested discussion could not be found.',
-      };
-    }
-
-    const discussion = discussionResult.value.discussions[0];
-    const title = discussion.title || 'Discussion';
-    const description = discussion.body
-      ? discussion.body.substring(0, 160) +
-        (discussion.body.length > 160 ? '...' : '')
-      : `View this discussion on ${import.meta.env.VITE_SERVER_DISPLAY_NAME}`;
-    const baseUrl = import.meta.env.VITE_BASE_URL;
-    const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
-    const imageUrl = discussion.coverImageURL || '';
-
-    return {
-      title: `${title} | ${channelId.value} | ${serverName}`,
-      meta: [
-        { name: 'description', content: description },
-
-        // OpenGraph tags
-        { property: 'og:title', content: title },
-        { property: 'og:description', content: description },
-        { property: 'og:type', content: 'article' },
-        {
-          property: 'og:url',
-          content: `${baseUrl}/forums/${channelId.value}/discussions/${discussionId.value}`,
-        },
-        { property: 'og:site_name', content: serverName },
-        ...(imageUrl ? [{ property: 'og:image', content: imageUrl }] : []),
-
-        // Twitter Card tags
-        {
-          name: 'twitter:card',
-          content: imageUrl ? 'summary_large_image' : 'summary',
-        },
-        { name: 'twitter:title', content: title },
-        { name: 'twitter:description', content: description },
-        ...(imageUrl ? [{ name: 'twitter:image', content: imageUrl }] : []),
-      ],
-      script: [
-        {
-          type: 'application/ld+json',
-          children: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'DiscussionForumPosting',
-            headline: title,
-            description: description,
-            author: {
-              '@type': 'Person',
-              name:
-                discussion.Author?.displayName ||
-                discussion.Author?.username ||
-                'Anonymous',
-            },
-            datePublished: discussion.createdAt,
-            dateModified: discussion.updatedAt || discussion.createdAt,
-            publisher: {
-              '@type': 'Organization',
-              name: serverName,
-              url: baseUrl,
-            },
-            mainEntityOfPage: {
-              '@type': 'WebPage',
-              '@id': `${baseUrl}/forums/${channelId.value}/discussions/${discussionId.value}`,
-            },
-          }),
-        },
-      ],
-    };
+    return buildDiscussionHead({
+      discussions: discussionResult.value?.discussions,
+      channelId: channelId.value,
+      discussionId: discussionId.value,
+      serverDisplayName: import.meta.env.VITE_SERVER_DISPLAY_NAME,
+      baseUrl: import.meta.env.VITE_BASE_URL,
+    });
   } catch (error) {
     console.error('Error setting meta tags:', error);
     return {

--- a/utils/discussionSeo.spec.ts
+++ b/utils/discussionSeo.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  truncateDescription,
+  buildDiscussionHead,
+  buildDiscussionStructuredData,
+  DESCRIPTION_MAX_LENGTH,
+} from './discussionSeo';
+
+const BASE = {
+  channelId: 'cats',
+  discussionId: 'd1',
+  serverDisplayName: 'Topical',
+  baseUrl: 'https://example.test',
+};
+
+describe('truncateDescription', () => {
+  it('leaves short text untouched', () => {
+    expect(truncateDescription('hello')).toBe('hello');
+  });
+
+  it('truncates and appends an ellipsis past the max length', () => {
+    const long = 'a'.repeat(DESCRIPTION_MAX_LENGTH + 10);
+    expect(truncateDescription(long)).toBe(`${'a'.repeat(160)}...`);
+  });
+});
+
+describe('buildDiscussionHead - loading state', () => {
+  it('uses a channel-scoped fallback title when data has not loaded', () => {
+    const head = buildDiscussionHead({ ...BASE, discussions: null });
+    expect(head.title).toBe('Discussion | cats');
+  });
+
+  it('uses the server fallback description when data has not loaded', () => {
+    const head = buildDiscussionHead({ ...BASE, discussions: undefined });
+    expect(head.description).toBe('View this discussion on Topical');
+  });
+});
+
+describe('buildDiscussionHead - not found', () => {
+  it('reports a not-found title for an empty result', () => {
+    const head = buildDiscussionHead({ ...BASE, discussions: [] });
+    expect(head.title).toBe('Discussion Not Found | cats');
+  });
+
+  it('omits the channel suffix when there is no channel id', () => {
+    const head = buildDiscussionHead({
+      ...BASE,
+      channelId: '',
+      discussions: [],
+    });
+    expect(head.title).toBe('Discussion Not Found');
+  });
+});
+
+describe('buildDiscussionHead - loaded', () => {
+  const discussion = {
+    title: 'My post',
+    body: 'Hello world',
+    coverImageURL: 'https://img.test/x.png',
+    createdAt: '2024-01-01T00:00:00Z',
+    Author: { username: 'alice', displayName: 'Alice' },
+  };
+
+  it('formats the title with channel and server name', () => {
+    const head = buildDiscussionHead({ ...BASE, discussions: [discussion] });
+    expect(head.title).toBe('My post | cats | Topical');
+  });
+
+  it('uses a summary_large_image twitter card when a cover image exists', () => {
+    const head = buildDiscussionHead({ ...BASE, discussions: [discussion] });
+    const card = head.meta?.find((m) => m.name === 'twitter:card');
+    expect(card?.content).toBe('summary_large_image');
+  });
+
+  it('falls back to a summary twitter card without a cover image', () => {
+    const head = buildDiscussionHead({
+      ...BASE,
+      discussions: [{ ...discussion, coverImageURL: '' }],
+    });
+    const card = head.meta?.find((m) => m.name === 'twitter:card');
+    expect(card?.content).toBe('summary');
+  });
+
+  it('omits og:image when there is no cover image', () => {
+    const head = buildDiscussionHead({
+      ...BASE,
+      discussions: [{ ...discussion, coverImageURL: null }],
+    });
+    expect(head.meta?.some((m) => m.property === 'og:image')).toBe(false);
+  });
+
+  it('truncates a long body for the description meta', () => {
+    const head = buildDiscussionHead({
+      ...BASE,
+      discussions: [{ ...discussion, body: 'x'.repeat(200) }],
+    });
+    const desc = head.meta?.find((m) => m.name === 'description');
+    expect(desc?.content).toBe(`${'x'.repeat(160)}...`);
+  });
+
+  it('emits a JSON-LD structured-data script', () => {
+    const head = buildDiscussionHead({ ...BASE, discussions: [discussion] });
+    expect(head.script?.[0].type).toBe('application/ld+json');
+  });
+});
+
+describe('buildDiscussionStructuredData', () => {
+  it('falls back to Anonymous when the author has no name', () => {
+    const data = buildDiscussionStructuredData({
+      discussion: { Author: null },
+      title: 'T',
+      description: 'D',
+      ...BASE,
+    });
+    expect((data.author as { name: string }).name).toBe('Anonymous');
+  });
+
+  it('uses createdAt as dateModified when updatedAt is absent', () => {
+    const data = buildDiscussionStructuredData({
+      discussion: { createdAt: '2024-01-01T00:00:00Z' },
+      title: 'T',
+      description: 'D',
+      ...BASE,
+    });
+    expect(data.dateModified).toBe('2024-01-01T00:00:00Z');
+  });
+});

--- a/utils/discussionSeo.ts
+++ b/utils/discussionSeo.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure builders for the discussion detail page's SEO/social metadata and
+ * schema.org structured data, extracted from the page's `metaData` computed so
+ * the title formatting, description truncation, and tag generation can be
+ * unit-tested without mounting the page or wiring up useHead.
+ */
+
+export const DESCRIPTION_MAX_LENGTH = 160;
+
+export function truncateDescription(
+  text: string,
+  max: number = DESCRIPTION_MAX_LENGTH
+): string {
+  return text.length > max ? `${text.substring(0, max)}...` : text;
+}
+
+export type DiscussionSeoSource = {
+  title?: string | null;
+  body?: string | null;
+  coverImageURL?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  Author?: { username?: string | null; displayName?: string | null } | null;
+};
+
+export type BuildDiscussionHeadParams = {
+  /** The `discussions` array from the GraphQL result (null while loading). */
+  discussions: DiscussionSeoSource[] | null | undefined;
+  channelId: string;
+  discussionId: string;
+  serverDisplayName: string;
+  baseUrl: string;
+};
+
+type HeadMeta = { name?: string; property?: string; content: string };
+type HeadObject = {
+  title: string;
+  description?: string;
+  meta?: HeadMeta[];
+  script?: { type: string; children: string }[];
+};
+
+const fallbackDescription = (serverDisplayName: string): string =>
+  `View this discussion on ${serverDisplayName}`;
+
+/** schema.org DiscussionForumPosting JSON-LD for a discussion. */
+export function buildDiscussionStructuredData(params: {
+  discussion: DiscussionSeoSource;
+  title: string;
+  description: string;
+  channelId: string;
+  discussionId: string;
+  serverDisplayName: string;
+  baseUrl: string;
+}): Record<string, unknown> {
+  const {
+    discussion,
+    title,
+    description,
+    channelId,
+    discussionId,
+    serverDisplayName,
+    baseUrl,
+  } = params;
+  const url = `${baseUrl}/forums/${channelId}/discussions/${discussionId}`;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'DiscussionForumPosting',
+    headline: title,
+    description,
+    author: {
+      '@type': 'Person',
+      name:
+        discussion.Author?.displayName ||
+        discussion.Author?.username ||
+        'Anonymous',
+    },
+    datePublished: discussion.createdAt,
+    dateModified: discussion.updatedAt || discussion.createdAt,
+    publisher: {
+      '@type': 'Organization',
+      name: serverDisplayName,
+      url: baseUrl,
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': url,
+    },
+  };
+}
+
+/**
+ * Build the `useHead` object for the discussion detail page, covering the
+ * loading (no data), not-found (empty array), and loaded states.
+ */
+export function buildDiscussionHead(
+  params: BuildDiscussionHeadParams
+): HeadObject {
+  const { discussions, channelId, discussionId, serverDisplayName, baseUrl } =
+    params;
+
+  if (!discussions) {
+    return {
+      title: `Discussion | ${channelId}`,
+      description: fallbackDescription(serverDisplayName),
+    };
+  }
+
+  const discussion = discussions[0];
+  if (!discussion) {
+    return {
+      title: `Discussion Not Found${channelId ? ` | ${channelId}` : ''}`,
+      description: 'The requested discussion could not be found.',
+    };
+  }
+
+  const title = discussion.title || 'Discussion';
+  const description = discussion.body
+    ? truncateDescription(discussion.body)
+    : fallbackDescription(serverDisplayName);
+  const imageUrl = discussion.coverImageURL || '';
+  const url = `${baseUrl}/forums/${channelId}/discussions/${discussionId}`;
+
+  return {
+    title: `${title} | ${channelId} | ${serverDisplayName}`,
+    meta: [
+      { name: 'description', content: description },
+
+      // OpenGraph tags
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { property: 'og:type', content: 'article' },
+      { property: 'og:url', content: url },
+      { property: 'og:site_name', content: serverDisplayName },
+      ...(imageUrl ? [{ property: 'og:image', content: imageUrl }] : []),
+
+      // Twitter Card tags
+      {
+        name: 'twitter:card',
+        content: imageUrl ? 'summary_large_image' : 'summary',
+      },
+      { name: 'twitter:title', content: title },
+      { name: 'twitter:description', content: description },
+      ...(imageUrl ? [{ name: 'twitter:image', content: imageUrl }] : []),
+    ],
+    script: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify(
+          buildDiscussionStructuredData({
+            discussion,
+            title,
+            description,
+            channelId,
+            discussionId,
+            serverDisplayName,
+            baseUrl,
+          })
+        ),
+      },
+    ],
+  };
+}

--- a/utils/mergeUniqueById.spec.ts
+++ b/utils/mergeUniqueById.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { mergeUniqueById } from './mergeUniqueById';
+
+describe('mergeUniqueById', () => {
+  it('appends new items onto the existing list', () => {
+    expect(
+      mergeUniqueById([{ id: 'a' }], [{ id: 'b' }, { id: 'c' }])
+    ).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+  });
+
+  it('skips items whose id is already present', () => {
+    expect(mergeUniqueById([{ id: 'a' }], [{ id: 'a' }, { id: 'b' }])).toEqual([
+      { id: 'a' },
+      { id: 'b' },
+    ]);
+  });
+
+  it('dedupes ids within the incoming batch', () => {
+    expect(
+      mergeUniqueById([], [{ id: 'a' }, { id: 'a' }, { id: 'b' }])
+    ).toEqual([{ id: 'a' }, { id: 'b' }]);
+  });
+
+  it('ignores falsy incoming entries', () => {
+    expect(
+      mergeUniqueById([], [null, { id: 'a' }, undefined])
+    ).toEqual([{ id: 'a' }]);
+  });
+
+  it('returns the existing list unchanged when incoming is null', () => {
+    expect(mergeUniqueById([{ id: 'a' }], null)).toEqual([{ id: 'a' }]);
+  });
+
+  it('preserves existing-then-new ordering', () => {
+    expect(
+      mergeUniqueById([{ id: 'b' }], [{ id: 'a' }]).map((i) => i.id)
+    ).toEqual(['b', 'a']);
+  });
+});

--- a/utils/mergeUniqueById.ts
+++ b/utils/mergeUniqueById.ts
@@ -1,0 +1,21 @@
+/**
+ * Append `incoming` items onto `existing`, skipping any whose `id` is already
+ * present. Used to accumulate paginated lists (e.g. a collection's downloads)
+ * without introducing duplicates when pages overlap. Order is preserved:
+ * existing items first, then new items in arrival order. Falsy incoming entries
+ * are ignored.
+ */
+export function mergeUniqueById<T extends { id: string }>(
+  existing: T[],
+  incoming: (T | null | undefined)[] | null | undefined
+): T[] {
+  const seen = new Set(existing.map((item) => item.id));
+  const merged = [...existing];
+  for (const item of incoming || []) {
+    if (item && !seen.has(item.id)) {
+      seen.add(item.id);
+      merged.push(item);
+    }
+  }
+  return merged;
+}

--- a/utils/serverIssueFilters.spec.ts
+++ b/utils/serverIssueFilters.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getDefaultServerRuleViolationsFilter,
+  buildServerIssuesWhere,
+} from './serverIssueFilters';
+
+describe('getDefaultServerRuleViolationsFilter', () => {
+  it('defaults to true when the query param is absent', () => {
+    expect(getDefaultServerRuleViolationsFilter(undefined)).toBe(true);
+  });
+
+  it('is false only when explicitly set to "false"', () => {
+    expect(getDefaultServerRuleViolationsFilter('false')).toBe(false);
+  });
+
+  it('stays true for the explicit "true" value', () => {
+    expect(getDefaultServerRuleViolationsFilter('true')).toBe(true);
+  });
+});
+
+describe('buildServerIssuesWhere', () => {
+  it('always filters to open issues', () => {
+    const { issueWhere } = buildServerIssuesWhere({
+      searchInput: '',
+      showOnlyServerRuleViolations: false,
+    });
+    expect(issueWhere.isOpen).toBe(true);
+  });
+
+  it('adds the server-rule-violation flag when enabled', () => {
+    const { issueWhere } = buildServerIssuesWhere({
+      searchInput: '',
+      showOnlyServerRuleViolations: true,
+    });
+    expect(issueWhere.flaggedServerRuleViolation).toBe(true);
+  });
+
+  it('omits the violation flag when disabled', () => {
+    const { issueWhere } = buildServerIssuesWhere({
+      searchInput: '',
+      showOnlyServerRuleViolations: false,
+    });
+    expect('flaggedServerRuleViolation' in issueWhere).toBe(false);
+  });
+
+  it('adds a title/body OR search filter when search input is present', () => {
+    const { issueWhere } = buildServerIssuesWhere({
+      searchInput: 'spam',
+      showOnlyServerRuleViolations: false,
+    });
+    expect(issueWhere.OR).toHaveLength(2);
+  });
+
+  it('omits the search filter for blank input', () => {
+    const { issueWhere } = buildServerIssuesWhere({
+      searchInput: '   ',
+      showOnlyServerRuleViolations: false,
+    });
+    expect('OR' in issueWhere).toBe(false);
+  });
+});

--- a/utils/serverIssueFilters.ts
+++ b/utils/serverIssueFilters.ts
@@ -1,0 +1,49 @@
+import { createCaseInsensitivePattern } from '@/utils/searchUtils';
+
+/**
+ * Pure filter helpers for the server-wide moderation issue list, extracted from
+ * the admin issues page so the default-filter and where-clause rules can be
+ * unit-tested in isolation.
+ */
+
+type RouteQueryValue = string | null | undefined | (string | null)[];
+
+/**
+ * The "show only server rule violations" filter defaults to on. It is only off
+ * when the query string explicitly opts out with `showOnlyServerRuleViolations=false`.
+ */
+export function getDefaultServerRuleViolationsFilter(
+  showOnlyServerRuleViolations: RouteQueryValue
+): boolean {
+  return showOnlyServerRuleViolations !== 'false';
+}
+
+export type ServerIssuesWhereParams = {
+  searchInput: string;
+  showOnlyServerRuleViolations: boolean;
+};
+
+/**
+ * Build the `issueWhere` filter for the open server-issue list: always open,
+ * optionally restricted to flagged server-rule violations, and optionally
+ * matched against a case-insensitive title/body search.
+ */
+export function buildServerIssuesWhere(
+  params: ServerIssuesWhereParams
+): { issueWhere: Record<string, unknown> } {
+  const { searchInput, showOnlyServerRuleViolations } = params;
+  const searchPattern = createCaseInsensitivePattern(searchInput);
+  const searchFilter = searchPattern
+    ? { OR: [{ title_MATCHES: searchPattern }, { body_MATCHES: searchPattern }] }
+    : {};
+
+  return {
+    issueWhere: {
+      isOpen: true,
+      ...(showOnlyServerRuleViolations
+        ? { flaggedServerRuleViolation: true }
+        : {}),
+      ...searchFilter,
+    },
+  };
+}


### PR DESCRIPTION
Tackles the **"heaviest feature pages still untested"** roadmap gap, starting with the three pages called out explicitly. Off `main`; independent of the open health PRs (touches different files).

Each page's pure logic is extracted into a focused, unit-tested utility (behavior preserved), then the page gets render/branch tests — the same high-value, low-risk pattern used for the earlier mega-component work.

| Page | Extracted util | What's now tested |
|---|---|---|
| `forums/[forumId]/discussions/[discussionId].vue` | `utils/discussionSeo.ts` | title formatting, 160-char description truncation, conditional `og:image`/Twitter-card, JSON-LD structured data, loading/not-found/loaded states |
| `admin/issues/index.vue` | `utils/serverIssueFilters.ts` | default "server rule violations" filter (on unless `?...=false`), open-issue where-clause with optional search |
| `collections/[collectionId].vue` | `utils/mergeUniqueById.ts` | dedupe-by-id pagination merge (used by the collection's "load more") |

**Totals:** 3 new utils (28 unit tests) + 3 page specs (9 tests) = **37 tests**. `tsc` clean, ESLint clean, full unit suite green (**456 files / 4,248 tests**).

### Scope note — mega-component decomposition (the *other* gap)
I deliberately did **not** include the full template-splitting decomposition of `CreateEditEventFields` / `IssueDetail` / `CommentSection` / `Comment` here. That work builds directly on the **logic-extraction commits in #135** (which aren't on `main` yet), so doing it off `main` would conflict with #135 and throw away that refactor. It's best done as a follow-up **stacked on #135** once it merges — I can pick that up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)