### PR TITLE
refactor: extract EventCoverImageField (event-form decomposition, step 1)

### DIFF
--- a/components/event/form/CreateEditEventFields.vue
+++ b/components/event/form/CreateEditEventFields.vue
@@ -20,18 +20,10 @@ import type {
 } from '@/types/Event';
 import { generateOccurrences } from '@/utils/generateOccurrences';
 import { DateTime } from 'luxon';
-import {
-  getDuration,
-  getUploadFileName,
-  uploadAndGetEmbeddedLink,
-  checkUrl,
-} from '@/utils';
-import AddImage from '@/components/AddImage.vue';
-import { useMutation } from '@vue/apollo-composable';
-import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
+import { getDuration, checkUrl } from '@/utils';
+import EventCoverImageField from '@/components/event/form/EventCoverImageField.vue';
 import ForumPicker from '@/components/channel/ForumPicker.vue';
 import TagPicker from '@/components/TagPicker.vue';
-import { useUsername } from '@/composables/useAuthState';
 import {
   EVENT_TITLE_CHAR_LIMIT,
   MAX_CHARS_IN_EVENT_DESCRIPTION,
@@ -46,15 +38,7 @@ import {
   computeEndDateChange,
 } from '@/utils/eventDateTimeEditing';
 import type { PropType } from 'vue';
-import { isFileSizeValid } from '@/utils/index';
 
-const usernameVar = useUsername();
-
-type FileChangeInput = {
-  // event of HTMLInputElement;
-  event: Event;
-  fieldName: string;
-};
 // Props and Emits
 const props = defineProps({
   editMode: {
@@ -267,10 +251,6 @@ const endTime = computed(() => {
   return new Date(props.formValues.endTime);
 });
 
-const { mutate: createSignedStorageUrl } = useMutation(
-  CREATE_SIGNED_STORAGE_URL
-);
-
 // Computed Properties
 const datePickerErrorMessage = computed(() => {
   if (startTime.value < new Date()) {
@@ -423,63 +403,6 @@ const handleUpdateLocation = (event: UpdateLocationInput) => {
     latitude: event.lat,
     longitude: event.lng,
   });
-};
-
-const upload = async (file: File) => {
-  if (!usernameVar.value) {
-    console.error('No username found');
-    return;
-  }
-  const sizeCheck = isFileSizeValid({ file });
-  if (!sizeCheck.valid) {
-    alert(sizeCheck.message);
-    return;
-  }
-  try {
-    const filename = getUploadFileName({ username: usernameVar.value, file });
-    const signedUrlResult = await createSignedStorageUrl({
-      filename,
-      contentType: file.type,
-    });
-
-    const signedStorageURL =
-      signedUrlResult?.data?.createSignedStorageURL?.url || '';
-    const embeddedLink = uploadAndGetEmbeddedLink({
-      file,
-      filename,
-      fileType: file.type,
-      signedStorageURL,
-    });
-
-    return embeddedLink;
-  } catch (error) {
-    console.error('Error uploading file:', error);
-  }
-};
-
-const coverImageLoading = ref(false);
-
-const handleCoverImageChange = async (input: FileChangeInput) => {
-  if (!input.event || !input.event.target) {
-    return;
-  }
-  const { event, fieldName } = input;
-  const target = event?.target as HTMLInputElement;
-  if (!target.files || !target.files[0]) {
-    return;
-  }
-  const selectedFile = target.files[0];
-
-  if (fieldName === 'coverImageURL' && selectedFile) {
-    coverImageLoading.value = true;
-    const embeddedLink = await upload(selectedFile);
-
-    if (!embeddedLink) {
-      return;
-    }
-    emit('updateFormValues', { coverImageURL: embeddedLink });
-    coverImageLoading.value = false;
-  }
 };
 
 const touched = ref(false);
@@ -802,123 +725,12 @@ const touched = ref(false);
         </FormRow>
         <FormRow>
           <template #content>
-            <div v-if="formValues.coverImageURL" class="mb-3">
-              <div
-                class="relative overflow-hidden rounded-md border border-gray-200 dark:border-gray-600"
-              >
-                <img
-                  alt="Cover Image"
-                  :src="formValues.coverImageURL"
-                  class="h-auto max-h-64 w-full object-cover"
-                >
-
-                <!-- Image overlay when loading -->
-                <div
-                  v-if="coverImageLoading"
-                  class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50"
-                >
-                  <div class="flex flex-col items-center text-white">
-                    <div class="h-8 w-8 text-white">
-                      <svg
-                        class="h-8 w-8 animate-spin"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                      >
-                        <circle
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke-dasharray="42"
-                          stroke-dashoffset="12"
-                          stroke-linecap="round"
-                        />
-                      </svg>
-                    </div>
-                    <span class="mt-2">Uploading image...</span>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Image actions for when an image exists -->
-              <div class="mt-2 flex space-x-2">
-                <AddImage
-                  key="cover-image-replace"
-                  field-name="coverImageURL"
-                  label="Replace Image"
-                  :disabled="coverImageLoading"
-                  @file-change="handleCoverImageChange"
-                />
-
-                <button
-                  type="button"
-                  class="flex items-center text-sm text-red-500 hover:underline"
-                  :disabled="coverImageLoading"
-                  :class="{
-                    'cursor-not-allowed opacity-60': coverImageLoading,
-                  }"
-                  @click="emit('updateFormValues', { coverImageURL: '' })"
-                >
-                  <i class="fa fa-trash-can mr-2" /> Remove Image
-                </button>
-              </div>
-            </div>
-
-            <div
-              v-else-if="coverImageLoading"
-              class="bg-gray-50 mb-3 rounded-md border border-gray-200 p-6 dark:border-gray-600 dark:bg-gray-700"
-            >
-              <div
-                class="flex flex-col items-center justify-center space-y-2 text-gray-500 dark:text-gray-300"
-              >
-                <div class="h-8 w-8">
-                  <svg
-                    class="h-8 w-8 animate-spin"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke-dasharray="42"
-                      stroke-dashoffset="12"
-                      stroke-linecap="round"
-                    />
-                  </svg>
-                </div>
-                <span>Uploading image...</span>
-              </div>
-            </div>
-
-            <div v-else class="mb-3">
-              <div
-                class="bg-gray-50 rounded-md border border-dashed border-gray-300 p-8 text-center dark:border-gray-600 dark:bg-gray-800"
-              >
-                <i
-                  class="fa fa-image mb-3 text-3xl text-gray-400 dark:text-gray-500"
-                />
-                <span
-                  class="mb-3 block text-sm text-gray-500 dark:text-gray-400"
-                >
-                  No cover image uploaded
-                </span>
-                <div class="mt-2">
-                  <AddImage
-                    key="cover-image-url"
-                    field-name="coverImageURL"
-                    label="Add Cover Image"
-                    :disabled="coverImageLoading"
-                    @file-change="handleCoverImageChange"
-                  />
-                </div>
-              </div>
-            </div>
+            <EventCoverImageField
+              :image-url="formValues.coverImageURL"
+              @update="
+                (url) => emit('updateFormValues', { coverImageURL: url })
+              "
+            />
           </template>
         </FormRow>
         <FormRow>

--- a/components/event/form/EventCoverImageField.spec.ts
+++ b/components/event/form/EventCoverImageField.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import EventCoverImageField from './EventCoverImageField.vue';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+const mountField = (imageUrl: string | null) =>
+  shallowMount(EventCoverImageField, { props: { imageUrl } });
+
+describe('EventCoverImageField', () => {
+  it('renders the cover image when a url is provided', () => {
+    const wrapper = mountField('https://img.test/cover.png');
+    expect(wrapper.get('img').attributes('src')).toBe(
+      'https://img.test/cover.png'
+    );
+  });
+
+  it('shows the empty state when there is no image', () => {
+    expect(mountField('').text()).toContain('No cover image uploaded');
+  });
+
+  it('emits an empty url when the image is removed', async () => {
+    const wrapper = mountField('https://img.test/cover.png');
+    await wrapper.get('button').trigger('click');
+    expect(wrapper.emitted('update')?.[0]).toEqual(['']);
+  });
+});

--- a/components/event/form/EventCoverImageField.vue
+++ b/components/event/form/EventCoverImageField.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import {
+  getUploadFileName,
+  uploadAndGetEmbeddedLink,
+  isFileSizeValid,
+} from '@/utils';
+import { useUsername } from '@/composables/useAuthState';
+import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
+import AddImage from '@/components/AddImage.vue';
+
+defineProps<{
+  imageUrl?: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update', url: string): void;
+}>();
+
+type FileChangeInput = {
+  event: Event;
+  fieldName: string;
+};
+
+const usernameVar = useUsername();
+const { mutate: createSignedStorageUrl } = useMutation(
+  CREATE_SIGNED_STORAGE_URL
+);
+const coverImageLoading = ref(false);
+
+const upload = async (file: File) => {
+  if (!usernameVar.value) {
+    console.error('No username found');
+    return;
+  }
+  const sizeCheck = isFileSizeValid({ file });
+  if (!sizeCheck.valid) {
+    alert(sizeCheck.message);
+    return;
+  }
+  try {
+    const filename = getUploadFileName({ username: usernameVar.value, file });
+    const signedUrlResult = await createSignedStorageUrl({
+      filename,
+      contentType: file.type,
+    });
+
+    const signedStorageURL =
+      signedUrlResult?.data?.createSignedStorageURL?.url || '';
+    const embeddedLink = uploadAndGetEmbeddedLink({
+      file,
+      filename,
+      fileType: file.type,
+      signedStorageURL,
+    });
+
+    return embeddedLink;
+  } catch (error) {
+    console.error('Error uploading file:', error);
+  }
+};
+
+const handleCoverImageChange = async (input: FileChangeInput) => {
+  if (!input.event || !input.event.target) {
+    return;
+  }
+  const { event, fieldName } = input;
+  const target = event?.target as HTMLInputElement;
+  if (!target.files || !target.files[0]) {
+    return;
+  }
+  const selectedFile = target.files[0];
+
+  if (fieldName === 'coverImageURL' && selectedFile) {
+    coverImageLoading.value = true;
+    const embeddedLink = await upload(selectedFile);
+
+    if (!embeddedLink) {
+      coverImageLoading.value = false;
+      return;
+    }
+    emit('update', embeddedLink);
+    coverImageLoading.value = false;
+  }
+};
+
+const removeImage = () => {
+  emit('update', '');
+};
+</script>
+
+<template>
+  <div v-if="imageUrl" class="mb-3">
+    <div
+      class="relative overflow-hidden rounded-md border border-gray-200 dark:border-gray-600"
+    >
+      <img
+        alt="Cover Image"
+        :src="imageUrl"
+        class="h-auto max-h-64 w-full object-cover"
+      >
+
+      <!-- Image overlay when loading -->
+      <div
+        v-if="coverImageLoading"
+        class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50"
+      >
+        <div class="flex flex-col items-center text-white">
+          <div class="h-8 w-8 text-white">
+            <svg
+              class="h-8 w-8 animate-spin"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke-dasharray="42"
+                stroke-dashoffset="12"
+                stroke-linecap="round"
+              />
+            </svg>
+          </div>
+          <span class="mt-2">Uploading image...</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Image actions for when an image exists -->
+    <div class="mt-2 flex space-x-2">
+      <AddImage
+        key="cover-image-replace"
+        field-name="coverImageURL"
+        label="Replace Image"
+        :disabled="coverImageLoading"
+        @file-change="handleCoverImageChange"
+      />
+
+      <button
+        type="button"
+        class="flex items-center text-sm text-red-500 hover:underline"
+        :disabled="coverImageLoading"
+        :class="{
+          'cursor-not-allowed opacity-60': coverImageLoading,
+        }"
+        @click="removeImage"
+      >
+        <i class="fa fa-trash-can mr-2" /> Remove Image
+      </button>
+    </div>
+  </div>
+
+  <div
+    v-else-if="coverImageLoading"
+    class="bg-gray-50 mb-3 rounded-md border border-gray-200 p-6 dark:border-gray-600 dark:bg-gray-700"
+  >
+    <div
+      class="flex flex-col items-center justify-center space-y-2 text-gray-500 dark:text-gray-300"
+    >
+      <div class="h-8 w-8">
+        <svg
+          class="h-8 w-8 animate-spin"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            stroke-dasharray="42"
+            stroke-dashoffset="12"
+            stroke-linecap="round"
+          />
+        </svg>
+      </div>
+      <span>Uploading image...</span>
+    </div>
+  </div>
+
+  <div v-else class="mb-3">
+    <div
+      class="bg-gray-50 rounded-md border border-dashed border-gray-300 p-8 text-center dark:border-gray-600 dark:bg-gray-800"
+    >
+      <i class="fa fa-image mb-3 text-3xl text-gray-400 dark:text-gray-500" />
+      <span class="mb-3 block text-sm text-gray-500 dark:text-gray-400">
+        No cover image uploaded
+      </span>
+      <div class="mt-2">
+        <AddImage
+          key="cover-image-url"
+          field-name="coverImageURL"
+          label="Add Cover Image"
+          :disabled="coverImageLoading"
+          @file-change="handleCoverImageChange"
+        />
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
First increment of the **mega-component decomposition** roadmap item — splitting the large orchestrator components' templates into child components. **Stacked on #135** (it builds on #135's logic extraction; base retargets to `main` once #135 merges).

## What this does

Extracts the entire **cover-image concern** out of `CreateEditEventFields.vue` into a self-contained child, `EventCoverImageField.vue`:
- The 3-state UI (image present / uploading / empty) **and** its upload logic (signed-URL mutation + storage upload) now live in the child.
- Wired through one prop and one event: `<EventCoverImageField :image-url="formValues.coverImageURL" @update="(url) => emit('updateFormValues', { coverImageURL: url })" />`.
- The parent sheds ~190 lines (**1045 → 857**) and five now-unused imports (`AddImage`, `useMutation`/`CREATE_SIGNED_STORAGE_URL`, the upload utils, `useUsername`).

## Why this section first
It's the most self-contained part of the form — one input, one output, no shared state with the other fields — so it's the lowest-risk way to establish the decomposition pattern. The next increments (the date/time section, location, etc.) are more wiring-heavy and will follow as separate PRs.

## Bug fixed along the way
The original handler left the loading spinner stuck `true` when an upload returned no link. The child now resets it on that path.

## Verification
- Existing `CreateEditEventFields.spec.ts` (11 tests) still passes — behavior preserved.
- Adds `EventCoverImageField.spec.ts` (render states + remove-emit).
- `tsc` clean, ESLint clean, full unit suite green: **451 files / 4,214 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)