### PR TITLE
refactor: extract IssueSubscriptionPanel (IssueDetail decomposition, step 1)

### DIFF
--- a/components/mod/IssueDetail.vue
+++ b/components/mod/IssueDetail.vue
@@ -53,8 +53,7 @@ import {
   UNSUBSCRIBE_FROM_ISSUE,
 } from '@/graphQLData/issue/mutations';
 import NotificationComponent from '@/components/NotificationComponent.vue';
-import PrimaryButton from '@/components/PrimaryButton.vue';
-import GenericButton from '@/components/GenericButton.vue';
+import IssueSubscriptionPanel from '@/components/mod/IssueSubscriptionPanel.vue';
 import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
 import { provideForumRoleMembership } from '@/composables/useForumRoleMembership';
 import { useResolvedModPermissions } from '@/composables/useResolvedModPermissions';
@@ -834,48 +833,15 @@ useAutoUnsubscribe({
     <v-row v-if="issue" class="flex justify-center dark:text-white">
       <v-col>
         <div class="px-4">
-          <div
+          <IssueSubscriptionPanel
             v-if="usernameVar && activeIssue"
-            class="mb-4 flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/60"
-          >
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <h2 class="text-base font-semibold">Issue notifications</h2>
-                <p class="text-sm text-gray-600 dark:text-gray-300">
-                  Subscribe to replies and moderator updates on this issue.
-                </p>
-              </div>
-              <GenericButton
-                :text="isIssueSubscribed ? 'Unsubscribe' : 'Subscribe'"
-                :loading="
-                  subscribeToIssueLoading || unsubscribeFromIssueLoading
-                "
-                :active="isIssueSubscribed"
-                test-id="toggle-issue-subscription"
-                @click="toggleIssueSubscription"
-              />
-            </div>
-
-            <div
-              v-if="showSubscribeCta && !isIssueSubscribed"
-              class="rounded-lg border border-orange-200 bg-orange-50 p-3 text-sm dark:border-orange-500/40 dark:bg-orange-500/10"
-            >
-              <p class="font-medium text-gray-900 dark:text-gray-100">
-                Subscribe to updates on this issue?
-              </p>
-              <p class="mt-1 text-gray-700 dark:text-gray-300">
-                You can get notifications for replies and moderator actions.
-              </p>
-              <div class="mt-3 flex gap-2">
-                <PrimaryButton
-                  :label="'Subscribe'"
-                  :loading="subscribeToIssueLoading"
-                  @click="toggleIssueSubscription"
-                />
-                <GenericButton :text="'Not now'" @click="dismissSubscribeCta" />
-              </div>
-            </div>
-          </div>
+            :is-subscribed="isIssueSubscribed"
+            :subscribe-loading="subscribeToIssueLoading"
+            :unsubscribe-loading="unsubscribeFromIssueLoading"
+            :show-cta="showSubscribeCta"
+            @toggle="toggleIssueSubscription"
+            @dismiss-cta="dismissSubscribeCta"
+          />
 
           <h2 v-if="activeIssue" class="text-xl font-bold">Activity Feed</h2>
 

--- a/components/mod/IssueSubscriptionPanel.spec.ts
+++ b/components/mod/IssueSubscriptionPanel.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import IssueSubscriptionPanel from './IssueSubscriptionPanel.vue';
+import GenericButton from '@/components/GenericButton.vue';
+
+const mountPanel = (props: Record<string, unknown> = {}) =>
+  shallowMount(IssueSubscriptionPanel, { props });
+
+describe('IssueSubscriptionPanel', () => {
+  it('labels the toggle "Subscribe" when not subscribed', () => {
+    const wrapper = mountPanel({ isSubscribed: false });
+    expect(wrapper.findComponent(GenericButton).props('text')).toBe('Subscribe');
+  });
+
+  it('labels the toggle "Unsubscribe" when subscribed', () => {
+    const wrapper = mountPanel({ isSubscribed: true });
+    expect(wrapper.findComponent(GenericButton).props('text')).toBe(
+      'Unsubscribe'
+    );
+  });
+
+  it('emits toggle when the subscribe button is clicked', () => {
+    const wrapper = mountPanel({ isSubscribed: false });
+    wrapper.findComponent(GenericButton).vm.$emit('click');
+    expect(wrapper.emitted('toggle')).toHaveLength(1);
+  });
+
+  it('shows the call-to-action when showCta is set and not subscribed', () => {
+    const wrapper = mountPanel({ isSubscribed: false, showCta: true });
+    expect(wrapper.text()).toContain('Subscribe to updates on this issue?');
+  });
+
+  it('hides the call-to-action once subscribed', () => {
+    const wrapper = mountPanel({ isSubscribed: true, showCta: true });
+    expect(wrapper.text()).not.toContain('Subscribe to updates on this issue?');
+  });
+
+  it('emits dismiss-cta from the "Not now" button', () => {
+    const wrapper = mountPanel({ isSubscribed: false, showCta: true });
+    // The CTA's "Not now" is the second GenericButton in the panel.
+    const buttons = wrapper.findAllComponents(GenericButton);
+    buttons[buttons.length - 1].vm.$emit('click');
+    expect(wrapper.emitted('dismiss-cta')).toHaveLength(1);
+  });
+});

--- a/components/mod/IssueSubscriptionPanel.vue
+++ b/components/mod/IssueSubscriptionPanel.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import GenericButton from '@/components/GenericButton.vue';
+import PrimaryButton from '@/components/PrimaryButton.vue';
+
+defineProps({
+  isSubscribed: {
+    type: Boolean,
+    default: false,
+  },
+  subscribeLoading: {
+    type: Boolean,
+    default: false,
+  },
+  unsubscribeLoading: {
+    type: Boolean,
+    default: false,
+  },
+  /** Whether to show the one-time "subscribe?" call-to-action prompt. */
+  showCta: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+defineEmits(['toggle', 'dismiss-cta']);
+</script>
+
+<template>
+  <div
+    class="mb-4 flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/60"
+  >
+    <div
+      class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div>
+        <h2 class="text-base font-semibold">Issue notifications</h2>
+        <p class="text-sm text-gray-600 dark:text-gray-300">
+          Subscribe to replies and moderator updates on this issue.
+        </p>
+      </div>
+      <GenericButton
+        :text="isSubscribed ? 'Unsubscribe' : 'Subscribe'"
+        :loading="subscribeLoading || unsubscribeLoading"
+        :active="isSubscribed"
+        test-id="toggle-issue-subscription"
+        @click="$emit('toggle')"
+      />
+    </div>
+
+    <div
+      v-if="showCta && !isSubscribed"
+      class="rounded-lg border border-orange-200 bg-orange-50 p-3 text-sm dark:border-orange-500/40 dark:bg-orange-500/10"
+    >
+      <p class="font-medium text-gray-900 dark:text-gray-100">
+        Subscribe to updates on this issue?
+      </p>
+      <p class="mt-1 text-gray-700 dark:text-gray-300">
+        You can get notifications for replies and moderator actions.
+      </p>
+      <div class="mt-3 flex gap-2">
+        <PrimaryButton
+          :label="'Subscribe'"
+          :loading="subscribeLoading"
+          @click="$emit('toggle')"
+        />
+        <GenericButton :text="'Not now'" @click="$emit('dismiss-cta')" />
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Starts decomposing the next orchestrator, `IssueDetail`. A **new PR** (not stacked on the event-form decomposition chain) — based on #135 because it builds on #135's `issueDetailDisplay` extraction. It touches only `IssueDetail` files, so it's independent of #139/#140.

## What this does
Extracts the **issue-notification subscription UI** out of `IssueDetail.vue` into a self-contained presentational child, `IssueSubscriptionPanel.vue`:
- The subscribe/unsubscribe button row **and** the one-time "subscribe to updates?" call-to-action.
- Wired by props in (`isSubscribed`, `subscribeLoading`, `unsubscribeLoading`, `showCta`) and events out (`toggle`, `dismiss-cta`).
- The subscription mutations and the route-query / auto-unsubscribe / notification logic **stay in the parent** — only the view moves, which keeps this increment low-risk.

## Note on IssueDetail
Unlike the event form, `IssueDetail`'s bulk is its ~750-line **script**, not its template (the template already delegates to many child components). So template extractions here yield smaller line wins; the larger future opportunity is pulling script concerns into composables (the repo already has `useIssueLock`, `useIssueBodyEdit`, etc.). This PR does the clean presentational slice first; a `useIssueSubscription` composable is a natural follow-up.

## Verification
- Existing `IssueDetail.spec.ts` still passes.
- Adds `IssueSubscriptionPanel.spec.ts` (button label by state, toggle/dismiss emits, CTA visibility).
- `tsc` clean, ESLint clean, full suite green: **451 files / 4,217 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)