### PR TITLE
refactor: land stranded component decomposition onto main

### DIFF
--- a/components/event/form/CreateEditEventFields.vue
+++ b/components/event/form/CreateEditEventFields.vue
@@ -9,29 +9,12 @@ import CheckBox from '@/components/CheckBox.vue';
 import LocationSearchBar from '@/components/event/list/filters/LocationSearchBar.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
-import DateTimePickersRow from './DateTimePickersRow.vue';
-import OccurrencesList from './OccurrencesList.vue';
-import RepeatPatternPicker from './RepeatPatternPicker.vue';
-import type {
-  CreateEditEventFormValues,
-  DateMode,
-  DateOccurrence,
-  RepeatPattern,
-} from '@/types/Event';
-import { generateOccurrences } from '@/utils/generateOccurrences';
-import { DateTime } from 'luxon';
-import {
-  getDuration,
-  getUploadFileName,
-  uploadAndGetEmbeddedLink,
-  checkUrl,
-} from '@/utils';
-import AddImage from '@/components/AddImage.vue';
-import { useMutation } from '@vue/apollo-composable';
-import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
+import type { CreateEditEventFormValues } from '@/types/Event';
+import { checkUrl } from '@/utils';
+import EventCoverImageField from '@/components/event/form/EventCoverImageField.vue';
+import EventScheduleFields from '@/components/event/form/EventScheduleFields.vue';
 import ForumPicker from '@/components/channel/ForumPicker.vue';
 import TagPicker from '@/components/TagPicker.vue';
-import { useUsername } from '@/composables/useAuthState';
 import {
   EVENT_TITLE_CHAR_LIMIT,
   MAX_CHARS_IN_EVENT_DESCRIPTION,
@@ -40,21 +23,8 @@ import {
   eventFormNeedsChanges,
   getEventFormValidationMessage,
 } from '@/utils/eventFormValidation';
-import {
-  applyTimeToTimestamp,
-  computeStartDateChange,
-  computeEndDateChange,
-} from '@/utils/eventDateTimeEditing';
 import type { PropType } from 'vue';
-import { isFileSizeValid } from '@/utils/index';
 
-const usernameVar = useUsername();
-
-type FileChangeInput = {
-  // event of HTMLInputElement;
-  event: Event;
-  fieldName: string;
-};
 // Props and Emits
 const props = defineProps({
   editMode: {
@@ -142,117 +112,6 @@ const updateEventType = (type: string) => {
   selectedEventType.value = type;
 };
 
-// Date mode options for single, multiple, or recurring events
-const dateModeOptions = [
-  { label: 'Single', value: 'single' as DateMode, description: 'One date' },
-  {
-    label: 'Multiple',
-    value: 'multiple' as DateMode,
-    description: 'Multiple dates',
-  },
-  {
-    label: 'Recurring',
-    value: 'recurring' as DateMode,
-    description: 'Repeat pattern',
-  },
-];
-
-// Current date mode from form values
-const currentDateMode = computed(() => props.formValues.dateMode || 'single');
-
-// Function to update date mode
-const updateDateMode = (mode: DateMode) => {
-  emit('updateFormValues', { dateMode: mode });
-
-  // Initialize occurrences array if switching to multiple dates mode
-  if (mode === 'multiple' && props.formValues.occurrences.length === 0) {
-    const defaultOccurrence: DateOccurrence = {
-      startTime: props.formValues.startTime,
-      endTime: props.formValues.endTime,
-    };
-    emit('updateFormValues', { occurrences: [defaultOccurrence] });
-  }
-
-  // Initialize repeat pattern if switching to recurring mode
-  if (mode === 'recurring' && !props.formValues.repeatPattern) {
-    const defaultPattern: RepeatPattern = {
-      type: 'WEEKLY',
-      count: 1,
-      daysOfWeek: [],
-      endType: 'AFTER_COUNT',
-      endCount: 10,
-    };
-    emit('updateFormValues', { repeatPattern: defaultPattern });
-  }
-};
-
-// Handlers for OccurrencesList
-const handleOccurrenceUpdate = (index: number, occurrence: DateOccurrence) => {
-  const newOccurrences = [...props.formValues.occurrences];
-  newOccurrences[index] = occurrence;
-  emit('updateFormValues', { occurrences: newOccurrences });
-};
-
-const handleOccurrenceAdd = (occurrence: DateOccurrence) => {
-  const newOccurrences = [...props.formValues.occurrences, occurrence];
-  emit('updateFormValues', { occurrences: newOccurrences });
-};
-
-const handleOccurrenceRemove = (index: number) => {
-  const newOccurrences = props.formValues.occurrences.filter(
-    (_, i) => i !== index
-  );
-  emit('updateFormValues', { occurrences: newOccurrences });
-};
-
-// Handler for RepeatPatternPicker
-const handleRepeatPatternUpdate = (pattern: RepeatPattern) => {
-  emit('updateFormValues', { repeatPattern: pattern });
-};
-
-// Computed: Generate preview of occurrences from repeat pattern
-const generatedOccurrencesPreview = computed(() => {
-  if (currentDateMode.value !== 'recurring' || !props.formValues.repeatPattern) {
-    return [];
-  }
-
-  const pattern = props.formValues.repeatPattern;
-  if (pattern.type === 'MANUAL') {
-    return [];
-  }
-
-  const occurrences = generateOccurrences({
-    pattern,
-    startTime: props.formValues.startTime,
-    endTime: props.formValues.endTime,
-    maxOccurrences: 10, // Limit preview to first 10
-  });
-
-  return occurrences;
-});
-
-// Format a date for display in the preview
-const formatOccurrenceDate = (isoString: string): string => {
-  const dt = DateTime.fromISO(isoString);
-  return dt.toFormat('EEE, MMM d, yyyy h:mm a');
-};
-
-// Track if the event spans multiple days
-const isMultiDayEvent = ref(false);
-
-// Check if start and end dates are different
-const initializeMultiDayState = () => {
-  const startDateTime = DateTime.fromISO(props.formValues.startTime);
-  const endDateTime = DateTime.fromISO(props.formValues.endTime);
-
-  // If the dates are the same, it's a single-day event
-  // If they're different, it's a multi-day event
-  isMultiDayEvent.value = !startDateTime.hasSame(endDateTime, 'day');
-};
-
-// Initialize multi-day state when component mounts
-initializeMultiDayState();
-
 export type UpdateLocationInput = {
   name: string;
   formatted_address: string;
@@ -260,42 +119,14 @@ export type UpdateLocationInput = {
   lng: number;
 };
 
-const startTime = computed(() => {
-  return new Date(props.formValues.startTime);
-});
-const endTime = computed(() => {
-  return new Date(props.formValues.endTime);
-});
-
-const { mutate: createSignedStorageUrl } = useMutation(
-  CREATE_SIGNED_STORAGE_URL
-);
-
-// Computed Properties
-const datePickerErrorMessage = computed(() => {
-  if (startTime.value < new Date()) {
-    return 'Are you sure you want the start time to be in the past?';
-  }
-  if (startTime.value >= endTime.value) {
-    return 'The start time must be before the end time.';
-  }
-  return '';
-});
-
-const duration = computed(() => {
-  return getDuration(
-    startTime.value.toISOString(),
-    endTime.value.toISOString()
-  );
-});
-
 const eventFormValidationInput = computed(() => ({
   selectedChannelsCount: props.formValues.selectedChannels.length,
   title: props.formValues.title,
   description: props.formValues.description,
   virtualEventUrl: props.formValues.virtualEventUrl,
   urlIsValid: urlIsValid.value,
-  startBeforeEnd: startTime.value < endTime.value,
+  startBeforeEnd:
+    new Date(props.formValues.startTime) < new Date(props.formValues.endTime),
 }));
 
 const needsChanges = computed(() =>
@@ -320,41 +151,6 @@ nextTick(() => {
   }
 });
 
-// The pure date math lives in utils/eventDateTimeEditing.ts (unit-tested).
-// Each picker edits one axis (time-of-day or calendar date) of the timestamp.
-const handleStartTimeTimeChange = (timeValue: string) => {
-  const startTime = applyTimeToTimestamp(props.formValues.startTime, timeValue);
-  if (startTime) emit('updateFormValues', { startTime });
-};
-
-const handleEndTimeTimeChange = (timeValue: string) => {
-  const endTime = applyTimeToTimestamp(props.formValues.endTime, timeValue);
-  if (endTime) emit('updateFormValues', { endTime });
-};
-
-const handleStartTimeDateChange = (dateValue: string) => {
-  const updates = computeStartDateChange({
-    startISO: props.formValues.startTime,
-    endISO: props.formValues.endTime,
-    dateValue,
-    isMultiDay: isMultiDayEvent.value,
-  });
-  if (updates) emit('updateFormValues', updates);
-};
-
-const handleEndTimeDateChange = (dateValue: string) => {
-  const result = computeEndDateChange({
-    startISO: props.formValues.startTime,
-    endISO: props.formValues.endTime,
-    dateValue,
-  });
-  if (result) {
-    // End date differing from the start date flips the event to multi-day.
-    isMultiDayEvent.value = result.isMultiDay;
-    emit('updateFormValues', { endTime: result.endTime });
-  }
-};
-
 const toggleCostField = () => {
   // Just toggle the free flag but keep cost details
   emit('updateFormValues', { free: !props.formValues.free });
@@ -364,58 +160,6 @@ const toggleHostedByOPField = () => {
   emit('updateFormValues', { isHostedByOP: !props.formValues.isHostedByOP });
 };
 
-const toggleIsAllDayField = () => {
-  // Toggle the isAllDay flag
-  const newAllDayValue = !props.formValues.isAllDay;
-  emit('updateFormValues', { isAllDay: newAllDayValue });
-
-  // If switching to All Day, set times to the full day
-  if (newAllDayValue) {
-    const startDate = DateTime.fromISO(props.formValues.startTime);
-    const endDate = isMultiDayEvent.value
-      ? DateTime.fromISO(props.formValues.endTime)
-      : startDate; // Use same date if not multi-day
-
-    const newStartTime = startDate.set({
-      hour: 0,
-      minute: 0,
-      second: 0,
-      millisecond: 0,
-    });
-
-    const newEndTime = endDate.set({
-      hour: 23,
-      minute: 59,
-      second: 59,
-      millisecond: 999,
-    });
-
-    emit('updateFormValues', {
-      startTime: newStartTime.toISO(),
-      endTime: newEndTime.toISO(),
-    });
-  }
-};
-
-const toggleMultiDayEvent = () => {
-  isMultiDayEvent.value = !isMultiDayEvent.value;
-
-  // If switching to single-day event, update end date to match start date
-  if (!isMultiDayEvent.value) {
-    const startDateTime = DateTime.fromJSDate(startTime.value);
-    const currentEndTime = DateTime.fromJSDate(endTime.value);
-
-    // Keep the same time but set date to match start date
-    const newEndTime = currentEndTime.set({
-      year: startDateTime.year,
-      month: startDateTime.month,
-      day: startDateTime.day,
-    });
-
-    emit('updateFormValues', { endTime: newEndTime.toISO() });
-  }
-};
-
 const handleUpdateLocation = (event: UpdateLocationInput) => {
   emit('updateFormValues', {
     locationName: event.name,
@@ -423,63 +167,6 @@ const handleUpdateLocation = (event: UpdateLocationInput) => {
     latitude: event.lat,
     longitude: event.lng,
   });
-};
-
-const upload = async (file: File) => {
-  if (!usernameVar.value) {
-    console.error('No username found');
-    return;
-  }
-  const sizeCheck = isFileSizeValid({ file });
-  if (!sizeCheck.valid) {
-    alert(sizeCheck.message);
-    return;
-  }
-  try {
-    const filename = getUploadFileName({ username: usernameVar.value, file });
-    const signedUrlResult = await createSignedStorageUrl({
-      filename,
-      contentType: file.type,
-    });
-
-    const signedStorageURL =
-      signedUrlResult?.data?.createSignedStorageURL?.url || '';
-    const embeddedLink = uploadAndGetEmbeddedLink({
-      file,
-      filename,
-      fileType: file.type,
-      signedStorageURL,
-    });
-
-    return embeddedLink;
-  } catch (error) {
-    console.error('Error uploading file:', error);
-  }
-};
-
-const coverImageLoading = ref(false);
-
-const handleCoverImageChange = async (input: FileChangeInput) => {
-  if (!input.event || !input.event.target) {
-    return;
-  }
-  const { event, fieldName } = input;
-  const target = event?.target as HTMLInputElement;
-  if (!target.files || !target.files[0]) {
-    return;
-  }
-  const selectedFile = target.files[0];
-
-  if (fieldName === 'coverImageURL' && selectedFile) {
-    coverImageLoading.value = true;
-    const embeddedLink = await upload(selectedFile);
-
-    if (!embeddedLink) {
-      return;
-    }
-    emit('updateFormValues', { coverImageURL: embeddedLink });
-    coverImageLoading.value = false;
-  }
 };
 
 const touched = ref(false);
@@ -527,161 +214,12 @@ const touched = ref(false);
 
         <FormRow>
           <template #content>
-            <div class="flex flex-col dark:text-white">
-              <!-- Date Mode Selector -->
-              <fieldset class="mb-4">
-                <legend class="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Event Schedule
-                </legend>
-                <div
-                  class="flex flex-wrap gap-2"
-                  role="radiogroup"
-                  aria-label="Date mode"
-                >
-                  <label
-                    v-for="option in dateModeOptions"
-                    :key="option.value"
-                    :class="[
-                      'cursor-pointer rounded-md border px-3 py-2 text-sm transition-colors',
-                      currentDateMode === option.value
-                        ? 'border-orange-500 bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300'
-                        : 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600',
-                    ]"
-                    :data-testid="`date-mode-${option.value}`"
-                  >
-                    <input
-                      type="radio"
-                      name="date-mode"
-                      :value="option.value"
-                      :checked="currentDateMode === option.value"
-                      class="sr-only"
-                      @change="updateDateMode(option.value)"
-                    >
-                    <span class="font-medium">{{ option.label }}</span>
-                    <span class="ml-1 text-xs text-gray-500 dark:text-gray-400">
-                      ({{ option.description }})
-                    </span>
-                  </label>
-                </div>
-              </fieldset>
-
-              <!-- Single date mode: Original date/time pickers -->
-              <div v-if="currentDateMode === 'single'">
-                <DateTimePickersRow
-                  :is-all-day="formValues.isAllDay"
-                  :is-multi-day="isMultiDayEvent"
-                  :start-time="startTime"
-                  :end-time="endTime"
-                  @update-start-date="handleStartTimeDateChange"
-                  @update-start-time="handleStartTimeTimeChange"
-                  @update-end-date="handleEndTimeDateChange"
-                  @update-end-time="handleEndTimeTimeChange"
-                />
-
-                <!-- Duration Display -->
-                <div class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                  Duration: {{ duration }}
-                </div>
-
-                <!-- Checkboxes for event options -->
-                <div class="mt-3 flex flex-wrap gap-x-6 gap-y-2">
-                  <!-- All-day checkbox -->
-                  <CheckBox
-                    test-id="all-day-input"
-                    :checked="formValues.isAllDay"
-                    label="All day"
-                    @update="toggleIsAllDayField"
-                  />
-
-                  <!-- Multi-day checkbox -->
-                  <CheckBox
-                    test-id="multi-day-input"
-                    :checked="isMultiDayEvent"
-                    label="Multi-day event"
-                    @update="toggleMultiDayEvent"
-                  />
-                </div>
-
-                <ErrorMessage :text="datePickerErrorMessage" class="mt-1" />
-              </div>
-
-              <!-- Multiple dates mode: OccurrencesList -->
-              <div v-else-if="currentDateMode === 'multiple'">
-                <OccurrencesList
-                  :occurrences="formValues.occurrences"
-                  :is-all-day="formValues.isAllDay"
-                  @update="handleOccurrenceUpdate"
-                  @add="handleOccurrenceAdd"
-                  @remove="handleOccurrenceRemove"
-                />
-
-                <!-- All-day checkbox for multiple dates -->
-                <div class="mt-3">
-                  <CheckBox
-                    test-id="all-day-input-multiple"
-                    :checked="formValues.isAllDay"
-                    label="All day events"
-                    @update="toggleIsAllDayField"
-                  />
-                </div>
-              </div>
-
-              <!-- Recurring mode: RepeatPatternPicker -->
-              <div v-else-if="currentDateMode === 'recurring'">
-                <!-- Base date/time for pattern -->
-                <div class="mb-4">
-                  <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                    Starting from
-                  </label>
-                  <DateTimePickersRow
-                    :is-all-day="formValues.isAllDay"
-                    :is-multi-day="false"
-                    :start-time="startTime"
-                    :end-time="endTime"
-                    @update-start-date="handleStartTimeDateChange"
-                    @update-start-time="handleStartTimeTimeChange"
-                    @update-end-date="handleEndTimeDateChange"
-                    @update-end-time="handleEndTimeTimeChange"
-                  />
-                </div>
-
-                <!-- Repeat pattern picker -->
-                <RepeatPatternPicker
-                  :pattern="formValues.repeatPattern"
-                  @update="handleRepeatPatternUpdate"
-                />
-
-                <!-- Preview of generated occurrences -->
-                <div
-                  v-if="generatedOccurrencesPreview.length > 0"
-                  class="mt-4 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800"
-                >
-                  <p class="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
-                    Upcoming dates (first {{ generatedOccurrencesPreview.length }})
-                  </p>
-                  <ul class="space-y-1 text-sm text-gray-600 dark:text-gray-400">
-                    <li
-                      v-for="(occurrence, index) in generatedOccurrencesPreview"
-                      :key="index"
-                      class="flex items-center gap-2"
-                    >
-                      <span class="text-orange-500">•</span>
-                      {{ formatOccurrenceDate(occurrence.startTime) }}
-                    </li>
-                  </ul>
-                </div>
-
-                <!-- All-day checkbox for recurring -->
-                <div class="mt-3">
-                  <CheckBox
-                    test-id="all-day-input-recurring"
-                    :checked="formValues.isAllDay"
-                    label="All day events"
-                    @update="toggleIsAllDayField"
-                  />
-                </div>
-              </div>
-            </div>
+            <EventScheduleFields
+              :form-values="formValues"
+              @update-form-values="
+                (updates) => emit('updateFormValues', updates)
+              "
+            />
           </template>
         </FormRow>
         <FormRow :required="true">
@@ -802,123 +340,12 @@ const touched = ref(false);
         </FormRow>
         <FormRow>
           <template #content>
-            <div v-if="formValues.coverImageURL" class="mb-3">
-              <div
-                class="relative overflow-hidden rounded-md border border-gray-200 dark:border-gray-600"
-              >
-                <img
-                  alt="Cover Image"
-                  :src="formValues.coverImageURL"
-                  class="h-auto max-h-64 w-full object-cover"
-                >
-
-                <!-- Image overlay when loading -->
-                <div
-                  v-if="coverImageLoading"
-                  class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50"
-                >
-                  <div class="flex flex-col items-center text-white">
-                    <div class="h-8 w-8 text-white">
-                      <svg
-                        class="h-8 w-8 animate-spin"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                      >
-                        <circle
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke-dasharray="42"
-                          stroke-dashoffset="12"
-                          stroke-linecap="round"
-                        />
-                      </svg>
-                    </div>
-                    <span class="mt-2">Uploading image...</span>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Image actions for when an image exists -->
-              <div class="mt-2 flex space-x-2">
-                <AddImage
-                  key="cover-image-replace"
-                  field-name="coverImageURL"
-                  label="Replace Image"
-                  :disabled="coverImageLoading"
-                  @file-change="handleCoverImageChange"
-                />
-
-                <button
-                  type="button"
-                  class="flex items-center text-sm text-red-500 hover:underline"
-                  :disabled="coverImageLoading"
-                  :class="{
-                    'cursor-not-allowed opacity-60': coverImageLoading,
-                  }"
-                  @click="emit('updateFormValues', { coverImageURL: '' })"
-                >
-                  <i class="fa fa-trash-can mr-2" /> Remove Image
-                </button>
-              </div>
-            </div>
-
-            <div
-              v-else-if="coverImageLoading"
-              class="bg-gray-50 mb-3 rounded-md border border-gray-200 p-6 dark:border-gray-600 dark:bg-gray-700"
-            >
-              <div
-                class="flex flex-col items-center justify-center space-y-2 text-gray-500 dark:text-gray-300"
-              >
-                <div class="h-8 w-8">
-                  <svg
-                    class="h-8 w-8 animate-spin"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke-dasharray="42"
-                      stroke-dashoffset="12"
-                      stroke-linecap="round"
-                    />
-                  </svg>
-                </div>
-                <span>Uploading image...</span>
-              </div>
-            </div>
-
-            <div v-else class="mb-3">
-              <div
-                class="bg-gray-50 rounded-md border border-dashed border-gray-300 p-8 text-center dark:border-gray-600 dark:bg-gray-800"
-              >
-                <i
-                  class="fa fa-image mb-3 text-3xl text-gray-400 dark:text-gray-500"
-                />
-                <span
-                  class="mb-3 block text-sm text-gray-500 dark:text-gray-400"
-                >
-                  No cover image uploaded
-                </span>
-                <div class="mt-2">
-                  <AddImage
-                    key="cover-image-url"
-                    field-name="coverImageURL"
-                    label="Add Cover Image"
-                    :disabled="coverImageLoading"
-                    @file-change="handleCoverImageChange"
-                  />
-                </div>
-              </div>
-            </div>
+            <EventCoverImageField
+              :image-url="formValues.coverImageURL"
+              @update="
+                (url) => emit('updateFormValues', { coverImageURL: url })
+              "
+            />
           </template>
         </FormRow>
         <FormRow>

--- a/components/event/form/EventCoverImageField.spec.ts
+++ b/components/event/form/EventCoverImageField.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import EventCoverImageField from './EventCoverImageField.vue';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+const mountField = (imageUrl: string | null) =>
+  shallowMount(EventCoverImageField, { props: { imageUrl } });
+
+describe('EventCoverImageField', () => {
+  it('renders the cover image when a url is provided', () => {
+    const wrapper = mountField('https://img.test/cover.png');
+    expect(wrapper.get('img').attributes('src')).toBe(
+      'https://img.test/cover.png'
+    );
+  });
+
+  it('shows the empty state when there is no image', () => {
+    expect(mountField('').text()).toContain('No cover image uploaded');
+  });
+
+  it('emits an empty url when the image is removed', async () => {
+    const wrapper = mountField('https://img.test/cover.png');
+    await wrapper.get('button').trigger('click');
+    expect(wrapper.emitted('update')?.[0]).toEqual(['']);
+  });
+});

--- a/components/event/form/EventCoverImageField.vue
+++ b/components/event/form/EventCoverImageField.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import {
+  getUploadFileName,
+  uploadAndGetEmbeddedLink,
+  isFileSizeValid,
+} from '@/utils';
+import { useUsername } from '@/composables/useAuthState';
+import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
+import AddImage from '@/components/AddImage.vue';
+
+defineProps<{
+  imageUrl?: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update', url: string): void;
+}>();
+
+type FileChangeInput = {
+  event: Event;
+  fieldName: string;
+};
+
+const usernameVar = useUsername();
+const { mutate: createSignedStorageUrl } = useMutation(
+  CREATE_SIGNED_STORAGE_URL
+);
+const coverImageLoading = ref(false);
+
+const upload = async (file: File) => {
+  if (!usernameVar.value) {
+    console.error('No username found');
+    return;
+  }
+  const sizeCheck = isFileSizeValid({ file });
+  if (!sizeCheck.valid) {
+    alert(sizeCheck.message);
+    return;
+  }
+  try {
+    const filename = getUploadFileName({ username: usernameVar.value, file });
+    const signedUrlResult = await createSignedStorageUrl({
+      filename,
+      contentType: file.type,
+    });
+
+    const signedStorageURL =
+      signedUrlResult?.data?.createSignedStorageURL?.url || '';
+    const embeddedLink = uploadAndGetEmbeddedLink({
+      file,
+      filename,
+      fileType: file.type,
+      signedStorageURL,
+    });
+
+    return embeddedLink;
+  } catch (error) {
+    console.error('Error uploading file:', error);
+  }
+};
+
+const handleCoverImageChange = async (input: FileChangeInput) => {
+  if (!input.event || !input.event.target) {
+    return;
+  }
+  const { event, fieldName } = input;
+  const target = event?.target as HTMLInputElement;
+  if (!target.files || !target.files[0]) {
+    return;
+  }
+  const selectedFile = target.files[0];
+
+  if (fieldName === 'coverImageURL' && selectedFile) {
+    coverImageLoading.value = true;
+    const embeddedLink = await upload(selectedFile);
+
+    if (!embeddedLink) {
+      coverImageLoading.value = false;
+      return;
+    }
+    emit('update', embeddedLink);
+    coverImageLoading.value = false;
+  }
+};
+
+const removeImage = () => {
+  emit('update', '');
+};
+</script>
+
+<template>
+  <div v-if="imageUrl" class="mb-3">
+    <div
+      class="relative overflow-hidden rounded-md border border-gray-200 dark:border-gray-600"
+    >
+      <img
+        alt="Cover Image"
+        :src="imageUrl"
+        class="h-auto max-h-64 w-full object-cover"
+      >
+
+      <!-- Image overlay when loading -->
+      <div
+        v-if="coverImageLoading"
+        class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50"
+      >
+        <div class="flex flex-col items-center text-white">
+          <div class="h-8 w-8 text-white">
+            <svg
+              class="h-8 w-8 animate-spin"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke-dasharray="42"
+                stroke-dashoffset="12"
+                stroke-linecap="round"
+              />
+            </svg>
+          </div>
+          <span class="mt-2">Uploading image...</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Image actions for when an image exists -->
+    <div class="mt-2 flex space-x-2">
+      <AddImage
+        key="cover-image-replace"
+        field-name="coverImageURL"
+        label="Replace Image"
+        :disabled="coverImageLoading"
+        @file-change="handleCoverImageChange"
+      />
+
+      <button
+        type="button"
+        class="flex items-center text-sm text-red-500 hover:underline"
+        :disabled="coverImageLoading"
+        :class="{
+          'cursor-not-allowed opacity-60': coverImageLoading,
+        }"
+        @click="removeImage"
+      >
+        <i class="fa fa-trash-can mr-2" /> Remove Image
+      </button>
+    </div>
+  </div>
+
+  <div
+    v-else-if="coverImageLoading"
+    class="bg-gray-50 mb-3 rounded-md border border-gray-200 p-6 dark:border-gray-600 dark:bg-gray-700"
+  >
+    <div
+      class="flex flex-col items-center justify-center space-y-2 text-gray-500 dark:text-gray-300"
+    >
+      <div class="h-8 w-8">
+        <svg
+          class="h-8 w-8 animate-spin"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            stroke-dasharray="42"
+            stroke-dashoffset="12"
+            stroke-linecap="round"
+          />
+        </svg>
+      </div>
+      <span>Uploading image...</span>
+    </div>
+  </div>
+
+  <div v-else class="mb-3">
+    <div
+      class="bg-gray-50 rounded-md border border-dashed border-gray-300 p-8 text-center dark:border-gray-600 dark:bg-gray-800"
+    >
+      <i class="fa fa-image mb-3 text-3xl text-gray-400 dark:text-gray-500" />
+      <span class="mb-3 block text-sm text-gray-500 dark:text-gray-400">
+        No cover image uploaded
+      </span>
+      <div class="mt-2">
+        <AddImage
+          key="cover-image-url"
+          field-name="coverImageURL"
+          label="Add Cover Image"
+          :disabled="coverImageLoading"
+          @file-change="handleCoverImageChange"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/event/form/EventScheduleFields.spec.ts
+++ b/components/event/form/EventScheduleFields.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { DateTime } from 'luxon';
+import EventScheduleFields from './EventScheduleFields.vue';
+import ErrorMessage from '@/components/ErrorMessage.vue';
+import type { CreateEditEventFormValues } from '@/types/Event';
+
+const baseFormValues = (
+  overrides: Partial<CreateEditEventFormValues> = {}
+): CreateEditEventFormValues =>
+  ({
+    title: '',
+    description: '',
+    selectedTags: [],
+    selectedChannels: [],
+    address: '',
+    latitude: 0,
+    longitude: 0,
+    locationName: '',
+    isInPrivateResidence: false,
+    virtualEventUrl: '',
+    startTime: DateTime.now().plus({ hours: 1 }).toISO(),
+    startTimeDayOfWeek: '',
+    startTimeHourOfDay: 0,
+    endTime: DateTime.now().plus({ hours: 2 }).toISO(),
+    canceled: false,
+    deleted: false,
+    cost: '',
+    free: false,
+    isHostedByOP: false,
+    isAllDay: false,
+    occurrences: [],
+    ...overrides,
+  }) as CreateEditEventFormValues;
+
+const mountFields = (overrides: Partial<CreateEditEventFormValues> = {}) =>
+  shallowMount(EventScheduleFields, {
+    props: { formValues: baseFormValues(overrides) },
+  });
+
+describe('EventScheduleFields', () => {
+  it('renders a radio option for each date mode', () => {
+    const wrapper = mountFields();
+    expect(wrapper.find('[data-testid="date-mode-recurring"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('emits a date mode change when a different mode is selected', async () => {
+    const wrapper = mountFields();
+    await wrapper
+      .get('[data-testid="date-mode-multiple"]')
+      .find('input')
+      .trigger('change');
+    expect(wrapper.emitted('updateFormValues')?.[0]).toEqual([
+      { dateMode: 'multiple' },
+    ]);
+  });
+
+  it('warns when the start time is in the past', () => {
+    const wrapper = mountFields({
+      startTime: DateTime.now().minus({ days: 1 }).toISO(),
+    });
+    expect(wrapper.findComponent(ErrorMessage).props('text')).toContain(
+      'in the past'
+    );
+  });
+
+  it('warns when the start time is not before the end time', () => {
+    const wrapper = mountFields({
+      startTime: DateTime.now().plus({ days: 2 }).toISO(),
+      endTime: DateTime.now().plus({ days: 1 }).toISO(),
+    });
+    expect(wrapper.findComponent(ErrorMessage).props('text')).toBe(
+      'The start time must be before the end time.'
+    );
+  });
+});

--- a/components/event/form/EventScheduleFields.vue
+++ b/components/event/form/EventScheduleFields.vue
@@ -1,0 +1,408 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { PropType } from 'vue';
+import { DateTime } from 'luxon';
+import type {
+  CreateEditEventFormValues,
+  DateMode,
+  DateOccurrence,
+  RepeatPattern,
+} from '@/types/Event';
+import { getDuration } from '@/utils';
+import { generateOccurrences } from '@/utils/generateOccurrences';
+import {
+  applyTimeToTimestamp,
+  computeStartDateChange,
+  computeEndDateChange,
+} from '@/utils/eventDateTimeEditing';
+import DateTimePickersRow from './DateTimePickersRow.vue';
+import OccurrencesList from './OccurrencesList.vue';
+import RepeatPatternPicker from './RepeatPatternPicker.vue';
+import CheckBox from '@/components/CheckBox.vue';
+import ErrorMessage from '@/components/ErrorMessage.vue';
+
+const props = defineProps({
+  formValues: {
+    type: Object as PropType<CreateEditEventFormValues>,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['updateFormValues']);
+
+// Date mode options for single, multiple, or recurring events
+const dateModeOptions = [
+  { label: 'Single', value: 'single' as DateMode, description: 'One date' },
+  {
+    label: 'Multiple',
+    value: 'multiple' as DateMode,
+    description: 'Multiple dates',
+  },
+  {
+    label: 'Recurring',
+    value: 'recurring' as DateMode,
+    description: 'Repeat pattern',
+  },
+];
+
+// Current date mode from form values
+const currentDateMode = computed(() => props.formValues.dateMode || 'single');
+
+// Function to update date mode
+const updateDateMode = (mode: DateMode) => {
+  emit('updateFormValues', { dateMode: mode });
+
+  // Initialize occurrences array if switching to multiple dates mode
+  if (mode === 'multiple' && props.formValues.occurrences.length === 0) {
+    const defaultOccurrence: DateOccurrence = {
+      startTime: props.formValues.startTime,
+      endTime: props.formValues.endTime,
+    };
+    emit('updateFormValues', { occurrences: [defaultOccurrence] });
+  }
+
+  // Initialize repeat pattern if switching to recurring mode
+  if (mode === 'recurring' && !props.formValues.repeatPattern) {
+    const defaultPattern: RepeatPattern = {
+      type: 'WEEKLY',
+      count: 1,
+      daysOfWeek: [],
+      endType: 'AFTER_COUNT',
+      endCount: 10,
+    };
+    emit('updateFormValues', { repeatPattern: defaultPattern });
+  }
+};
+
+// Handlers for OccurrencesList
+const handleOccurrenceUpdate = (index: number, occurrence: DateOccurrence) => {
+  const newOccurrences = [...props.formValues.occurrences];
+  newOccurrences[index] = occurrence;
+  emit('updateFormValues', { occurrences: newOccurrences });
+};
+
+const handleOccurrenceAdd = (occurrence: DateOccurrence) => {
+  const newOccurrences = [...props.formValues.occurrences, occurrence];
+  emit('updateFormValues', { occurrences: newOccurrences });
+};
+
+const handleOccurrenceRemove = (index: number) => {
+  const newOccurrences = props.formValues.occurrences.filter(
+    (_, i) => i !== index
+  );
+  emit('updateFormValues', { occurrences: newOccurrences });
+};
+
+// Handler for RepeatPatternPicker
+const handleRepeatPatternUpdate = (pattern: RepeatPattern) => {
+  emit('updateFormValues', { repeatPattern: pattern });
+};
+
+// Computed: Generate preview of occurrences from repeat pattern
+const generatedOccurrencesPreview = computed(() => {
+  if (currentDateMode.value !== 'recurring' || !props.formValues.repeatPattern) {
+    return [];
+  }
+
+  const pattern = props.formValues.repeatPattern;
+  if (pattern.type === 'MANUAL') {
+    return [];
+  }
+
+  const occurrences = generateOccurrences({
+    pattern,
+    startTime: props.formValues.startTime,
+    endTime: props.formValues.endTime,
+    maxOccurrences: 10, // Limit preview to first 10
+  });
+
+  return occurrences;
+});
+
+// Format a date for display in the preview
+const formatOccurrenceDate = (isoString: string): string => {
+  const dt = DateTime.fromISO(isoString);
+  return dt.toFormat('EEE, MMM d, yyyy h:mm a');
+};
+
+// Track if the event spans multiple days
+const isMultiDayEvent = ref(false);
+
+// Check if start and end dates are different
+const initializeMultiDayState = () => {
+  const startDateTime = DateTime.fromISO(props.formValues.startTime);
+  const endDateTime = DateTime.fromISO(props.formValues.endTime);
+
+  // If the dates are the same, it's a single-day event
+  // If they're different, it's a multi-day event
+  isMultiDayEvent.value = !startDateTime.hasSame(endDateTime, 'day');
+};
+
+// Initialize multi-day state when component mounts
+initializeMultiDayState();
+
+const startTime = computed(() => {
+  return new Date(props.formValues.startTime);
+});
+const endTime = computed(() => {
+  return new Date(props.formValues.endTime);
+});
+
+const datePickerErrorMessage = computed(() => {
+  if (startTime.value < new Date()) {
+    return 'Are you sure you want the start time to be in the past?';
+  }
+  if (startTime.value >= endTime.value) {
+    return 'The start time must be before the end time.';
+  }
+  return '';
+});
+
+const duration = computed(() => {
+  return getDuration(
+    startTime.value.toISOString(),
+    endTime.value.toISOString()
+  );
+});
+
+// The pure date math lives in utils/eventDateTimeEditing.ts (unit-tested).
+// Each picker edits one axis (time-of-day or calendar date) of the timestamp.
+const handleStartTimeTimeChange = (timeValue: string) => {
+  const startTime = applyTimeToTimestamp(props.formValues.startTime, timeValue);
+  if (startTime) emit('updateFormValues', { startTime });
+};
+
+const handleEndTimeTimeChange = (timeValue: string) => {
+  const endTime = applyTimeToTimestamp(props.formValues.endTime, timeValue);
+  if (endTime) emit('updateFormValues', { endTime });
+};
+
+const handleStartTimeDateChange = (dateValue: string) => {
+  const updates = computeStartDateChange({
+    startISO: props.formValues.startTime,
+    endISO: props.formValues.endTime,
+    dateValue,
+    isMultiDay: isMultiDayEvent.value,
+  });
+  if (updates) emit('updateFormValues', updates);
+};
+
+const handleEndTimeDateChange = (dateValue: string) => {
+  const result = computeEndDateChange({
+    startISO: props.formValues.startTime,
+    endISO: props.formValues.endTime,
+    dateValue,
+  });
+  if (result) {
+    // End date differing from the start date flips the event to multi-day.
+    isMultiDayEvent.value = result.isMultiDay;
+    emit('updateFormValues', { endTime: result.endTime });
+  }
+};
+
+const toggleIsAllDayField = () => {
+  // Toggle the isAllDay flag
+  const newAllDayValue = !props.formValues.isAllDay;
+  emit('updateFormValues', { isAllDay: newAllDayValue });
+
+  // If switching to All Day, set times to the full day
+  if (newAllDayValue) {
+    const startDate = DateTime.fromISO(props.formValues.startTime);
+    const endDate = isMultiDayEvent.value
+      ? DateTime.fromISO(props.formValues.endTime)
+      : startDate; // Use same date if not multi-day
+
+    const newStartTime = startDate.set({
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+    });
+
+    const newEndTime = endDate.set({
+      hour: 23,
+      minute: 59,
+      second: 59,
+      millisecond: 999,
+    });
+
+    emit('updateFormValues', {
+      startTime: newStartTime.toISO(),
+      endTime: newEndTime.toISO(),
+    });
+  }
+};
+
+const toggleMultiDayEvent = () => {
+  isMultiDayEvent.value = !isMultiDayEvent.value;
+
+  // If switching to single-day event, update end date to match start date
+  if (!isMultiDayEvent.value) {
+    const startDateTime = DateTime.fromJSDate(startTime.value);
+    const currentEndTime = DateTime.fromJSDate(endTime.value);
+
+    // Keep the same time but set date to match start date
+    const newEndTime = currentEndTime.set({
+      year: startDateTime.year,
+      month: startDateTime.month,
+      day: startDateTime.day,
+    });
+
+    emit('updateFormValues', { endTime: newEndTime.toISO() });
+  }
+};
+</script>
+
+<template>
+  <div class="flex flex-col dark:text-white">
+    <!-- Date Mode Selector -->
+    <fieldset class="mb-4">
+      <legend class="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+        Event Schedule
+      </legend>
+      <div class="flex flex-wrap gap-2" role="radiogroup" aria-label="Date mode">
+        <label
+          v-for="option in dateModeOptions"
+          :key="option.value"
+          :class="[
+            'cursor-pointer rounded-md border px-3 py-2 text-sm transition-colors',
+            currentDateMode === option.value
+              ? 'border-orange-500 bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300'
+              : 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600',
+          ]"
+          :data-testid="`date-mode-${option.value}`"
+        >
+          <input
+            type="radio"
+            name="date-mode"
+            :value="option.value"
+            :checked="currentDateMode === option.value"
+            class="sr-only"
+            @change="updateDateMode(option.value)"
+          >
+          <span class="font-medium">{{ option.label }}</span>
+          <span class="ml-1 text-xs text-gray-500 dark:text-gray-400">
+            ({{ option.description }})
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <!-- Single date mode: Original date/time pickers -->
+    <div v-if="currentDateMode === 'single'">
+      <DateTimePickersRow
+        :is-all-day="formValues.isAllDay"
+        :is-multi-day="isMultiDayEvent"
+        :start-time="startTime"
+        :end-time="endTime"
+        @update-start-date="handleStartTimeDateChange"
+        @update-start-time="handleStartTimeTimeChange"
+        @update-end-date="handleEndTimeDateChange"
+        @update-end-time="handleEndTimeTimeChange"
+      />
+
+      <!-- Duration Display -->
+      <div class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+        Duration: {{ duration }}
+      </div>
+
+      <!-- Checkboxes for event options -->
+      <div class="mt-3 flex flex-wrap gap-x-6 gap-y-2">
+        <!-- All-day checkbox -->
+        <CheckBox
+          test-id="all-day-input"
+          :checked="formValues.isAllDay"
+          label="All day"
+          @update="toggleIsAllDayField"
+        />
+
+        <!-- Multi-day checkbox -->
+        <CheckBox
+          test-id="multi-day-input"
+          :checked="isMultiDayEvent"
+          label="Multi-day event"
+          @update="toggleMultiDayEvent"
+        />
+      </div>
+
+      <ErrorMessage :text="datePickerErrorMessage" class="mt-1" />
+    </div>
+
+    <!-- Multiple dates mode: OccurrencesList -->
+    <div v-else-if="currentDateMode === 'multiple'">
+      <OccurrencesList
+        :occurrences="formValues.occurrences"
+        :is-all-day="formValues.isAllDay"
+        @update="handleOccurrenceUpdate"
+        @add="handleOccurrenceAdd"
+        @remove="handleOccurrenceRemove"
+      />
+
+      <!-- All-day checkbox for multiple dates -->
+      <div class="mt-3">
+        <CheckBox
+          test-id="all-day-input-multiple"
+          :checked="formValues.isAllDay"
+          label="All day events"
+          @update="toggleIsAllDayField"
+        />
+      </div>
+    </div>
+
+    <!-- Recurring mode: RepeatPatternPicker -->
+    <div v-else-if="currentDateMode === 'recurring'">
+      <!-- Base date/time for pattern -->
+      <div class="mb-4">
+        <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+          Starting from
+        </label>
+        <DateTimePickersRow
+          :is-all-day="formValues.isAllDay"
+          :is-multi-day="false"
+          :start-time="startTime"
+          :end-time="endTime"
+          @update-start-date="handleStartTimeDateChange"
+          @update-start-time="handleStartTimeTimeChange"
+          @update-end-date="handleEndTimeDateChange"
+          @update-end-time="handleEndTimeTimeChange"
+        />
+      </div>
+
+      <!-- Repeat pattern picker -->
+      <RepeatPatternPicker
+        :pattern="formValues.repeatPattern"
+        @update="handleRepeatPatternUpdate"
+      />
+
+      <!-- Preview of generated occurrences -->
+      <div
+        v-if="generatedOccurrencesPreview.length > 0"
+        class="mt-4 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800"
+      >
+        <p class="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+          Upcoming dates (first {{ generatedOccurrencesPreview.length }})
+        </p>
+        <ul class="space-y-1 text-sm text-gray-600 dark:text-gray-400">
+          <li
+            v-for="(occurrence, index) in generatedOccurrencesPreview"
+            :key="index"
+            class="flex items-center gap-2"
+          >
+            <span class="text-orange-500">•</span>
+            {{ formatOccurrenceDate(occurrence.startTime) }}
+          </li>
+        </ul>
+      </div>
+
+      <!-- All-day checkbox for recurring -->
+      <div class="mt-3">
+        <CheckBox
+          test-id="all-day-input-recurring"
+          :checked="formValues.isAllDay"
+          label="All day events"
+          @update="toggleIsAllDayField"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/mod/IssueDetail.vue
+++ b/components/mod/IssueDetail.vue
@@ -53,8 +53,7 @@ import {
   UNSUBSCRIBE_FROM_ISSUE,
 } from '@/graphQLData/issue/mutations';
 import NotificationComponent from '@/components/NotificationComponent.vue';
-import PrimaryButton from '@/components/PrimaryButton.vue';
-import GenericButton from '@/components/GenericButton.vue';
+import IssueSubscriptionPanel from '@/components/mod/IssueSubscriptionPanel.vue';
 import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
 import { provideForumRoleMembership } from '@/composables/useForumRoleMembership';
 import { useResolvedModPermissions } from '@/composables/useResolvedModPermissions';
@@ -834,48 +833,15 @@ useAutoUnsubscribe({
     <v-row v-if="issue" class="flex justify-center dark:text-white">
       <v-col>
         <div class="px-4">
-          <div
+          <IssueSubscriptionPanel
             v-if="usernameVar && activeIssue"
-            class="mb-4 flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/60"
-          >
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <h2 class="text-base font-semibold">Issue notifications</h2>
-                <p class="text-sm text-gray-600 dark:text-gray-300">
-                  Subscribe to replies and moderator updates on this issue.
-                </p>
-              </div>
-              <GenericButton
-                :text="isIssueSubscribed ? 'Unsubscribe' : 'Subscribe'"
-                :loading="
-                  subscribeToIssueLoading || unsubscribeFromIssueLoading
-                "
-                :active="isIssueSubscribed"
-                test-id="toggle-issue-subscription"
-                @click="toggleIssueSubscription"
-              />
-            </div>
-
-            <div
-              v-if="showSubscribeCta && !isIssueSubscribed"
-              class="rounded-lg border border-orange-200 bg-orange-50 p-3 text-sm dark:border-orange-500/40 dark:bg-orange-500/10"
-            >
-              <p class="font-medium text-gray-900 dark:text-gray-100">
-                Subscribe to updates on this issue?
-              </p>
-              <p class="mt-1 text-gray-700 dark:text-gray-300">
-                You can get notifications for replies and moderator actions.
-              </p>
-              <div class="mt-3 flex gap-2">
-                <PrimaryButton
-                  :label="'Subscribe'"
-                  :loading="subscribeToIssueLoading"
-                  @click="toggleIssueSubscription"
-                />
-                <GenericButton :text="'Not now'" @click="dismissSubscribeCta" />
-              </div>
-            </div>
-          </div>
+            :is-subscribed="isIssueSubscribed"
+            :subscribe-loading="subscribeToIssueLoading"
+            :unsubscribe-loading="unsubscribeFromIssueLoading"
+            :show-cta="showSubscribeCta"
+            @toggle="toggleIssueSubscription"
+            @dismiss-cta="dismissSubscribeCta"
+          />
 
           <h2 v-if="activeIssue" class="text-xl font-bold">Activity Feed</h2>
 

--- a/components/mod/IssueSubscriptionPanel.spec.ts
+++ b/components/mod/IssueSubscriptionPanel.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import IssueSubscriptionPanel from './IssueSubscriptionPanel.vue';
+import GenericButton from '@/components/GenericButton.vue';
+
+const mountPanel = (props: Record<string, unknown> = {}) =>
+  shallowMount(IssueSubscriptionPanel, { props });
+
+describe('IssueSubscriptionPanel', () => {
+  it('labels the toggle "Subscribe" when not subscribed', () => {
+    const wrapper = mountPanel({ isSubscribed: false });
+    expect(wrapper.findComponent(GenericButton).props('text')).toBe('Subscribe');
+  });
+
+  it('labels the toggle "Unsubscribe" when subscribed', () => {
+    const wrapper = mountPanel({ isSubscribed: true });
+    expect(wrapper.findComponent(GenericButton).props('text')).toBe(
+      'Unsubscribe'
+    );
+  });
+
+  it('emits toggle when the subscribe button is clicked', () => {
+    const wrapper = mountPanel({ isSubscribed: false });
+    wrapper.findComponent(GenericButton).vm.$emit('click');
+    expect(wrapper.emitted('toggle')).toHaveLength(1);
+  });
+
+  it('shows the call-to-action when showCta is set and not subscribed', () => {
+    const wrapper = mountPanel({ isSubscribed: false, showCta: true });
+    expect(wrapper.text()).toContain('Subscribe to updates on this issue?');
+  });
+
+  it('hides the call-to-action once subscribed', () => {
+    const wrapper = mountPanel({ isSubscribed: true, showCta: true });
+    expect(wrapper.text()).not.toContain('Subscribe to updates on this issue?');
+  });
+
+  it('emits dismiss-cta from the "Not now" button', () => {
+    const wrapper = mountPanel({ isSubscribed: false, showCta: true });
+    // The CTA's "Not now" is the second GenericButton in the panel.
+    const buttons = wrapper.findAllComponents(GenericButton);
+    buttons[buttons.length - 1].vm.$emit('click');
+    expect(wrapper.emitted('dismiss-cta')).toHaveLength(1);
+  });
+});

--- a/components/mod/IssueSubscriptionPanel.vue
+++ b/components/mod/IssueSubscriptionPanel.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import GenericButton from '@/components/GenericButton.vue';
+import PrimaryButton from '@/components/PrimaryButton.vue';
+
+defineProps({
+  isSubscribed: {
+    type: Boolean,
+    default: false,
+  },
+  subscribeLoading: {
+    type: Boolean,
+    default: false,
+  },
+  unsubscribeLoading: {
+    type: Boolean,
+    default: false,
+  },
+  /** Whether to show the one-time "subscribe?" call-to-action prompt. */
+  showCta: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+defineEmits(['toggle', 'dismiss-cta']);
+</script>
+
+<template>
+  <div
+    class="mb-4 flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/60"
+  >
+    <div
+      class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div>
+        <h2 class="text-base font-semibold">Issue notifications</h2>
+        <p class="text-sm text-gray-600 dark:text-gray-300">
+          Subscribe to replies and moderator updates on this issue.
+        </p>
+      </div>
+      <GenericButton
+        :text="isSubscribed ? 'Unsubscribe' : 'Subscribe'"
+        :loading="subscribeLoading || unsubscribeLoading"
+        :active="isSubscribed"
+        test-id="toggle-issue-subscription"
+        @click="$emit('toggle')"
+      />
+    </div>
+
+    <div
+      v-if="showCta && !isSubscribed"
+      class="rounded-lg border border-orange-200 bg-orange-50 p-3 text-sm dark:border-orange-500/40 dark:bg-orange-500/10"
+    >
+      <p class="font-medium text-gray-900 dark:text-gray-100">
+        Subscribe to updates on this issue?
+      </p>
+      <p class="mt-1 text-gray-700 dark:text-gray-300">
+        You can get notifications for replies and moderator actions.
+      </p>
+      <div class="mt-3 flex gap-2">
+        <PrimaryButton
+          :label="'Subscribe'"
+          :loading="subscribeLoading"
+          @click="$emit('toggle')"
+        />
+        <GenericButton :text="'Not now'" @click="$emit('dismiss-cta')" />
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Why this PR exists

The component-decomposition work from #139, #140, and #141 **never actually reached `main`**, even though #139/#140 show as "merged."

They were merged into **intermediate stacked branches** (`health/recommendations` → `refactor/decompose-event-fields`) that had *already* been squash-merged to `main` as #135. Merging into those branches after the fact didn't propagate to `main`. Net result: `main` still has the original 1045-line `CreateEditEventFields.vue` and 1009-line `IssueDetail.vue`, with none of the extracted child components.

I couldn't just re-merge the old branches — they predate #137 (docs reorg) and #138 (heavy-page utils), so merging them whole would **revert** that work. Instead this PR re-applies *only* the self-contained decomposition files on top of current `main`.

## What lands

- **Event form** (was #139 + #140): `CreateEditEventFields.vue` **1045 → 472 lines** — cover-image and date/time-schedule sections extracted into `EventCoverImageField.vue` and `EventScheduleFields.vue`.
- **Issue detail** (was #141): `IssueDetail.vue` **1009 → 975 lines** — subscription UI extracted into `IssueSubscriptionPanel.vue`.

All three child components ship with their unit tests. No doc/util files touched.

## Verification
- `tsc` clean, ESLint clean.
- Full unit suite green: **459 files / 4,261 tests** (+13 from the three new child specs).

Supersedes #141 (which targets a now-stale base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)