### PR TITLE
test: unit coverage for 18 moderate-complexity pages

### DIFF
--- a/pages/admin.spec.ts
+++ b/pages/admin.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { setActivePinia, createPinia } from 'pinia';
+import { useQuery } from '@vue/apollo-composable';
+import ServerTabs from '@/components/admin/ServerTabs.vue';
+
+const routeRef: { name: string } = { name: 'admin-issues' };
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => routeRef,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const NuxtLayoutStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (result: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(result),
+    error: ref(null),
+  });
+  const Page = (await import('./admin.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { NuxtLayout: NuxtLayoutStub, NuxtPage: true } },
+  });
+};
+
+describe('admin layout page', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    routeRef.name = 'admin-issues';
+  });
+
+  it('renders the server tabs when the server config loads', async () => {
+    const wrapper = await mountWith({ serverConfigs: [{ id: 's1' }] });
+    expect(wrapper.findComponent(ServerTabs).exists()).toBe(true);
+  });
+
+  it('shows a not-found message when the server config is missing', async () => {
+    const wrapper = await mountWith({ serverConfigs: [] });
+    expect(wrapper.text()).toContain('Server not found');
+  });
+
+  it('shows the issue detail pane on the issues route', async () => {
+    const wrapper = await mountWith({ serverConfigs: [{ id: 's1' }] });
+    expect(wrapper.text()).toContain('Select an issue to view details.');
+  });
+
+  it('hides the issue detail pane on other admin routes', async () => {
+    routeRef.name = 'admin-roles';
+    const wrapper = await mountWith({ serverConfigs: [{ id: 's1' }] });
+    expect(wrapper.text()).not.toContain('Select an issue to view details.');
+  });
+});

--- a/pages/admin/issues.spec.ts
+++ b/pages/admin/issues.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ name: 'admin-issues' }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const SlotStub = {
+  template: '<div><slot name="has-auth" /><slot /></div>',
+};
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountPage = async (open: number, closed: number) => {
+  mockedUseQuery
+    .mockReturnValueOnce({
+      result: ref({ issuesAggregate: { count: open } }),
+      error: ref(null),
+      loading: ref(false),
+    })
+    .mockReturnValueOnce({
+      result: ref({ issuesAggregate: { count: closed } }),
+      error: ref(null),
+      loading: ref(false),
+    });
+  const Page = (await import('./issues.vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        RequireAuth: SlotStub,
+        NuxtLink: { template: '<a><slot /></a>' },
+        NuxtPage: true,
+      },
+    },
+  });
+};
+
+describe('admin issues layout page', () => {
+  it('shows the open issue count from the aggregate', async () => {
+    const wrapper = await mountPage(5, 3);
+    expect(wrapper.text()).toContain('5 Open');
+  });
+
+  it('shows the closed issue count from the aggregate', async () => {
+    const wrapper = await mountPage(5, 3);
+    expect(wrapper.text()).toContain('3 Closed');
+  });
+});

--- a/pages/admin/issues/closed.spec.ts
+++ b/pages/admin/issues/closed.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { setActivePinia, createPinia } from 'pinia';
+import { useQuery } from '@vue/apollo-composable';
+import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: '' }, query: {} }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
+  const { loading = false, issues = [] } = opts;
+  mockedUseQuery.mockReturnValue({
+    result: ref({ issues }),
+    error: ref(null),
+    loading: ref(loading),
+    refetch: vi.fn(),
+  });
+  const Page = (await import('./closed.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('admin closed issues page', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('renders an item per closed issue', async () => {
+    const wrapper = await mountWith({ issues: [{ id: 'i1' }, { id: 'i2' }] });
+    expect(wrapper.findAllComponents(ModIssueListItem)).toHaveLength(2);
+  });
+
+  it('renders no issues while the query is loading', async () => {
+    const wrapper = await mountWith({ loading: true, issues: [{ id: 'i1' }] });
+    expect(wrapper.findAllComponents(ModIssueListItem)).toHaveLength(0);
+  });
+});

--- a/pages/admin/plugins.spec.ts
+++ b/pages/admin/plugins.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+
+const replace = vi.fn();
+const routeRef: { path: string; name: string } = {
+  path: '/admin/plugins',
+  name: 'admin-plugins',
+};
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => routeRef,
+  useRouter: () => ({ replace }),
+}));
+
+const SlotStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.());
+  },
+});
+
+const mountPage = async () => {
+  const Page = (await import('./plugins.vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        ClientOnly: SlotStub,
+        NuxtPage: true,
+        RouterLink: { template: '<a><slot /></a>' },
+      },
+    },
+  });
+};
+
+describe('admin plugins layout page', () => {
+  it('labels the current tab from the route path', async () => {
+    routeRef.path = '/admin/plugins/registries';
+    routeRef.name = 'admin-plugins-registries';
+    replace.mockClear();
+    expect((await mountPage()).text()).toContain('Registries');
+  });
+
+  it('defaults the tab label to plugin management on the base path', async () => {
+    routeRef.path = '/admin/plugins';
+    routeRef.name = 'admin-plugins';
+    replace.mockClear();
+    expect((await mountPage()).text()).toContain('Plugin Management');
+  });
+
+  it('redirects a name-only match to the canonical base path', async () => {
+    routeRef.path = '/admin/plugins/';
+    routeRef.name = 'admin-plugins';
+    replace.mockClear();
+    await mountPage();
+    expect(replace).toHaveBeenCalledWith('/admin/plugins');
+  });
+});

--- a/pages/admin/roles.spec.ts
+++ b/pages/admin/roles.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import RoleSection from '@/components/admin/RoleSection.vue';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const RequireAuthStub = {
+  template: '<div><slot name="has-auth" /></div>',
+};
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (result: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(result),
+    error: ref(null),
+    loading: ref(false),
+    refetch: vi.fn(),
+  });
+  const Page = (await import('./roles.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { RequireAuth: RequireAuthStub } },
+  });
+};
+
+describe('admin server roles page', () => {
+  it('renders a role section for each defined default role', async () => {
+    const wrapper = await mountWith({
+      serverConfigs: [
+        {
+          DefaultServerRole: { name: 'user', description: '' },
+          DefaultModRole: { name: 'mod', description: '' },
+          DefaultSuspendedRole: { name: 'suspended', description: '' },
+        },
+      ],
+    });
+    expect(wrapper.findAllComponents(RoleSection)).toHaveLength(3);
+  });
+
+  it('shows the server suspensions management section', async () => {
+    const wrapper = await mountWith({
+      serverConfigs: [{ DefaultServerRole: { name: 'user', description: '' } }],
+    });
+    expect(wrapper.text()).toContain('View Suspended Users');
+  });
+});

--- a/pages/admin/settings/downloads.spec.ts
+++ b/pages/admin/settings/downloads.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import DownloadsSettingsPage from './downloads.vue';
+import TextInput from '@/components/TextInput.vue';
+import CheckBox from '@/components/CheckBox.vue';
+
+const FormRowStub = {
+  template: '<div><slot name="content" /></div>',
+};
+
+const buildWrapper = (formValues: Record<string, unknown>) =>
+  shallowMount(DownloadsSettingsPage, {
+    props: { editMode: true, formValues },
+    global: { stubs: { FormRow: FormRowStub } },
+  });
+
+describe('admin downloads settings page', () => {
+  it('renders the allowed file types as a comma-separated string', () => {
+    const input = buildWrapper({
+      enableDownloads: true,
+      allowedFileTypes: ['.pdf', '.zip'],
+    }).findComponent(TextInput);
+    expect(input.props('value')).toBe('.pdf, .zip');
+  });
+
+  it('parses the input back into a trimmed, non-empty array on update', () => {
+    const wrapper = buildWrapper({ enableDownloads: true, allowedFileTypes: [] });
+    wrapper.findComponent(TextInput).vm.$emit('update', '.a, .b , , .c');
+    expect(wrapper.emitted('updateFormValues')?.[0]).toEqual([
+      { allowedFileTypes: ['.a', '.b', '.c'] },
+    ]);
+  });
+
+  it('disables the file-type input when downloads are off', () => {
+    const input = buildWrapper({ enableDownloads: false }).findComponent(
+      TextInput
+    );
+    expect(input.props('disabled')).toBe(true);
+  });
+
+  it('forwards the enable-downloads checkbox change', () => {
+    const wrapper = buildWrapper({ enableDownloads: false });
+    wrapper.findComponent(CheckBox).vm.$emit('update', true);
+    expect(wrapper.emitted('updateFormValues')?.[0]).toEqual([
+      { enableDownloads: true },
+    ]);
+  });
+});

--- a/pages/forums/[forumId]/discussions/[discussionId]/comments/[commentId].spec.ts
+++ b/pages/forums/[forumId]/discussions/[discussionId]/comments/[commentId].spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+import Comment from '@/components/comments/Comment.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { commentId: 'comment-1' } }),
+}));
+
+const PermalinkedStub = defineComponent({
+  name: 'PermalinkedComment',
+  props: ['commentId'],
+  setup(_props, { slots }) {
+    return () => h('div', slots.comment?.({ commentData: { id: 'comment-1' } }));
+  },
+});
+
+const mountPage = async (props: Record<string, unknown>) => {
+  const Page = (await import('./[commentId].vue')).default;
+  return shallowMount(Page, {
+    props,
+    global: { stubs: { PermalinkedComment: PermalinkedStub } },
+  });
+};
+
+const baseProps = {
+  aggregateCommentCount: 1,
+  enableFeedback: true,
+  locked: false,
+  loggedInUserModName: 'mod-1',
+  replyFormOpenAtCommentID: '',
+  originalPoster: 'alice',
+};
+
+describe('discussion comment permalink page', () => {
+  it('passes the route comment id to the permalinked comment', async () => {
+    const wrapper = await mountPage(baseProps);
+    expect(wrapper.findComponent(PermalinkedStub).props('commentId')).toBe(
+      'comment-1'
+    );
+  });
+
+  it('renders the permalinked comment as highlighted', async () => {
+    const wrapper = await mountPage(baseProps);
+    expect(wrapper.findComponent(Comment).props('isPermalinked')).toBe(true);
+  });
+
+  it('forwards the enableFeedback prop to the comment', async () => {
+    const wrapper = await mountPage({ ...baseProps, enableFeedback: true });
+    expect(wrapper.findComponent(Comment).props('enableFeedback')).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/downloads/[discussionId]/activity.spec.ts
+++ b/pages/forums/[forumId]/downloads/[discussionId]/activity.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import DiscussionTitleVersions from '@/components/discussion/detail/activityFeed/DiscussionTitleVersions.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { discussionId: 'd1', forumId: 'cats' } }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({ result: ref(null) }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ref('mod-1'),
+}));
+
+const mountWith = async (discussion: Record<string, unknown>) => {
+  const Page = (await import('./activity.vue')).default;
+  return shallowMount(Page, { props: { discussion } });
+};
+
+describe('download activity page', () => {
+  it('shows an empty-state message when there is no activity', async () => {
+    const wrapper = await mountWith({
+      PastTitleVersions: [],
+      DiscussionChannels: [],
+    });
+    expect(wrapper.text()).toContain('No activity to display yet.');
+  });
+
+  it('renders the title-version history when the download has title edits', async () => {
+    const wrapper = await mountWith({
+      PastTitleVersions: [{ id: 't1' }],
+      DiscussionChannels: [],
+    });
+    expect(wrapper.findComponent(DiscussionTitleVersions).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/edit/events.spec.ts
+++ b/pages/forums/[forumId]/edit/events.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import CheckBox from '@/components/CheckBox.vue';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (opts: {
+  serverEnableEvents: boolean;
+  formValues?: Record<string, unknown>;
+}) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ serverConfigs: [{ enableEvents: opts.serverEnableEvents }] }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./events.vue')).default;
+  return shallowMount(Page, {
+    props: { formValues: opts.formValues ?? {} },
+  });
+};
+
+describe('forum events settings page', () => {
+  it('disables the checkbox when the server has events disabled', async () => {
+    const wrapper = await mountWith({ serverEnableEvents: false });
+    expect(wrapper.findComponent(CheckBox).props('disabled')).toBe(true);
+  });
+
+  it('enables the checkbox when the server allows events', async () => {
+    const wrapper = await mountWith({ serverEnableEvents: true });
+    expect(wrapper.findComponent(CheckBox).props('disabled')).toBe(false);
+  });
+
+  it('forwards an enable change when the server allows events', async () => {
+    const wrapper = await mountWith({ serverEnableEvents: true });
+    wrapper.findComponent(CheckBox).vm.$emit('update', true);
+    expect(wrapper.emitted('updateFormValues')?.[0]).toEqual([
+      { eventsEnabled: true },
+    ]);
+  });
+
+  it('ignores an enable change when the server has events disabled', async () => {
+    const wrapper = await mountWith({ serverEnableEvents: false });
+    wrapper.findComponent(CheckBox).vm.$emit('update', true);
+    expect(wrapper.emitted('updateFormValues')).toBeUndefined();
+  });
+});

--- a/pages/forums/[forumId]/edit/roles.spec.ts
+++ b/pages/forums/[forumId]/edit/roles.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import RoleSection from '@/components/admin/RoleSection.vue';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (state: { result?: unknown; error?: unknown }) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(state.result ?? null),
+    error: ref(state.error ?? null),
+  });
+  const Page = (await import('./roles.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('forum roles page', () => {
+  it('renders a role section for each defined default role', async () => {
+    const wrapper = await mountWith({
+      result: {
+        serverConfigs: [
+          { DefaultServerRole: { name: 'user' }, DefaultModRole: { name: 'mod' } },
+        ],
+      },
+    });
+    expect(wrapper.findAllComponents(RoleSection)).toHaveLength(2);
+  });
+
+  it('shows a fallback message when the server config cannot load', async () => {
+    const wrapper = await mountWith({ error: new Error('boom') });
+    expect(wrapper.text()).toContain('Could not find the server config data.');
+  });
+});

--- a/pages/forums/[forumId]/edit/suspended-users.spec.ts
+++ b/pages/forums/[forumId]/edit/suspended-users.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' } }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (channel: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(channel ? { channels: [channel] } : { channels: [] }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./suspended-users.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('forum suspended users page', () => {
+  it('names the current forum in the description', async () => {
+    const wrapper = await mountWith({ SuspendedUsers: [] });
+    expect(wrapper.text()).toContain('active suspensions of users from cats');
+  });
+
+  it('shows the empty-state message when no users are suspended', async () => {
+    const wrapper = await mountWith({ SuspendedUsers: [] });
+    expect(wrapper.text()).toContain('This forum has no suspended users.');
+  });
+
+  it('shows the active suspension count from the aggregate', async () => {
+    const wrapper = await mountWith({
+      SuspendedUsers: [{ username: 'a' }],
+      SuspendedUsersAggregate: { count: 4 },
+    });
+    expect(wrapper.text()).toContain('Active Suspensions (4)');
+  });
+});

--- a/pages/forums/[forumId]/events/[eventId]/comments/[commentId].spec.ts
+++ b/pages/forums/[forumId]/events/[eventId]/comments/[commentId].spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+import Comment from '@/components/comments/Comment.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { commentId: 'comment-1' } }),
+}));
+
+const PermalinkedStub = defineComponent({
+  name: 'PermalinkedComment',
+  props: ['commentId'],
+  setup(_props, { slots }) {
+    return () => h('div', slots.comment?.({ commentData: { id: 'comment-1' } }));
+  },
+});
+
+const mountPage = async () => {
+  const Page = (await import('./[commentId].vue')).default;
+  return shallowMount(Page, {
+    props: {
+      aggregateCommentCount: 1,
+      locked: false,
+      loggedInUserModName: 'mod-1',
+      replyFormOpenAtCommentID: '',
+    },
+    global: { stubs: { PermalinkedComment: PermalinkedStub } },
+  });
+};
+
+describe('event comment permalink page', () => {
+  it('passes the route comment id to the permalinked comment', async () => {
+    const wrapper = await mountPage();
+    expect(wrapper.findComponent(PermalinkedStub).props('commentId')).toBe(
+      'comment-1'
+    );
+  });
+
+  it('disables feedback for event comments', async () => {
+    const wrapper = await mountPage();
+    expect(wrapper.findComponent(Comment).props('enableFeedback')).toBe(false);
+  });
+});

--- a/pages/forums/[forumId]/issues.spec.ts
+++ b/pages/forums/[forumId]/issues.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' }, name: 'forums-forumId-issues' }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const RequireAuthStub = {
+  template: '<div><slot name="has-auth" /></div>',
+};
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountPage = async (open: number, closed: number) => {
+  mockedUseQuery
+    .mockReturnValueOnce({
+      result: ref({ issuesAggregate: { count: open } }),
+      error: ref(null),
+      loading: ref(false),
+    })
+    .mockReturnValueOnce({
+      result: ref({ issuesAggregate: { count: closed } }),
+      error: ref(null),
+      loading: ref(false),
+    });
+  const Page = (await import('./issues.vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        RequireAuth: RequireAuthStub,
+        NuxtLink: { template: '<a><slot /></a>' },
+        NuxtPage: true,
+      },
+    },
+  });
+};
+
+describe('forum issues layout page', () => {
+  it('shows the open issue count', async () => {
+    expect((await mountPage(7, 2)).text()).toContain('7 Open');
+  });
+
+  it('shows the closed issue count', async () => {
+    expect((await mountPage(7, 2)).text()).toContain('2 Closed');
+  });
+});

--- a/pages/forums/[forumId]/issues/[issueNumber]/comments/[commentId].spec.ts
+++ b/pages/forums/[forumId]/issues/[issueNumber]/comments/[commentId].spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+import ActivityFeedListItem from '@/components/mod/ActivityFeedListItem.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { commentId: 'comment-1' } }),
+}));
+
+const PermalinkedStub = defineComponent({
+  name: 'PermalinkedActivityFeedItem',
+  props: ['commentId'],
+  setup(_props, { slots }) {
+    return () =>
+      h('div', slots['moderation-action']?.({ moderationAction: { id: 'm1' } }));
+  },
+});
+
+describe('issue comment permalink page', () => {
+  it('passes the route comment id to the permalinked feed item', async () => {
+    const Page = (await import('./[commentId].vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: { stubs: { PermalinkedActivityFeedItem: PermalinkedStub } },
+    });
+    expect(
+      wrapper.findComponent(PermalinkedStub).props('commentId')
+    ).toBe('comment-1');
+  });
+
+  it('renders the activity feed item from the slot', async () => {
+    const Page = (await import('./[commentId].vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: { stubs: { PermalinkedActivityFeedItem: PermalinkedStub } },
+    });
+    expect(wrapper.findComponent(ActivityFeedListItem).exists()).toBe(true);
+  });
+});

--- a/pages/mod/[modId].spec.ts
+++ b/pages/mod/[modId].spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import ModProfileTabs from '@/components/mod/ModProfileTabs.vue';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+const useHead = vi.fn();
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { modId: 'coolmod' } }),
+  useHead: (...args: unknown[]) => useHead(...args),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const SlotStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountPage = async (mod: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(mod ? { moderationProfiles: [mod] } : { moderationProfiles: [] }),
+    error: ref(null),
+  });
+  const Page = (await import('./[modId].vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: { NuxtLayout: SlotStub, ClientOnly: SlotStub, NuxtPage: true },
+    },
+  });
+};
+
+describe('mod profile layout page', () => {
+  it('sets the page title from the mod display name', async () => {
+    await mountPage({ displayName: 'Cool Mod' });
+    expect(useHead).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('Cool Mod - Mod Profile'),
+      })
+    );
+  });
+
+  it('renders the mod profile tabs when the mod loads', async () => {
+    const wrapper = await mountPage({ displayName: 'Cool Mod' });
+    expect(wrapper.findComponent(ModProfileTabs).exists()).toBe(true);
+  });
+
+  it('hides the tabs when no mod is found', async () => {
+    const wrapper = await mountPage(null);
+    expect(wrapper.findComponent(ModProfileTabs).exists()).toBe(false);
+  });
+});

--- a/pages/mod/[modId]/actions.spec.ts
+++ b/pages/mod/[modId]/actions.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { modId: 'coolmod' } }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (contributions: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ getModContributions: contributions }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./actions.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { NuxtLink: { template: '<a><slot /></a>' } } },
+  });
+};
+
+describe('mod profile actions page', () => {
+  it('shows the empty-state message when there are no contributions', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.text()).toContain('No moderation actions yet.');
+  });
+
+  it('flattens activities across days into a list item each', async () => {
+    const wrapper = await mountWith([
+      { date: '2024-01-01', activities: [{ id: 'a1' }, { id: 'a2' }] },
+      { date: '2024-01-02', activities: [{ id: 'a3' }] },
+    ]);
+    expect(wrapper.findAll('li')).toHaveLength(3);
+  });
+
+  it('orders activities newest first by createdAt', async () => {
+    const wrapper = await mountWith([
+      {
+        date: '2024-01-01',
+        activities: [
+          { id: 'older', actionDescription: 'OLDER', createdAt: '2024-01-01T00:00:00Z' },
+          { id: 'newer', actionDescription: 'NEWER', createdAt: '2024-02-01T00:00:00Z' },
+        ],
+      },
+    ]);
+    const text = wrapper.text();
+    expect(text.indexOf('NEWER')).toBeLessThan(text.indexOf('OLDER'));
+  });
+});

--- a/pages/mod/[modId]/issues.spec.ts
+++ b/pages/mod/[modId]/issues.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { modId: 'coolmod' } }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (authoredIssues: unknown[]) => {
+  mockedUseQuery
+    .mockReturnValueOnce({
+      result: ref({
+        moderationProfiles: [{ AuthoredIssuesAggregate: { count: authoredIssues.length } }],
+      }),
+      error: ref(null),
+    })
+    .mockReturnValueOnce({
+      result: ref({ moderationProfiles: [{ AuthoredIssues: authoredIssues }] }),
+      loading: ref(false),
+      error: ref(null),
+      fetchMore: vi.fn(),
+    });
+  const Page = (await import('./issues.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { ErrorBanner: true, LoadMore: true } },
+  });
+};
+
+describe('mod profile issues page', () => {
+  it('shows the empty-state message when the mod has opened no issues', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.text()).toContain('This mod has not opened any issues');
+  });
+
+  it('renders an item per authored issue', async () => {
+    const wrapper = await mountWith([{ id: 'i1' }, { id: 'i2' }]);
+    expect(wrapper.findAllComponents(ModIssueListItem)).toHaveLength(2);
+  });
+});

--- a/pages/u/[username]/wiki-edits.spec.ts
+++ b/pages/u/[username]/wiki-edits.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { username: 'alice' }, query: {} }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
+  useSelectedChannelsFromQuery: () => ({
+    selectedChannels: ref([]),
+    hasSelectedChannels: ref(false),
+  }),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (wikiPages: unknown[]) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ wikiPages }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./wiki-edits.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { NuxtLink: { template: '<a><slot /></a>' } } },
+  });
+};
+
+describe('user wiki edits page', () => {
+  it('shows the empty-state message when there are no edits', async () => {
+    expect((await mountWith([])).text()).toContain('No wiki edits yet');
+  });
+
+  it('flattens past versions across wiki pages into one item each', async () => {
+    const wrapper = await mountWith([
+      {
+        id: 'w1',
+        title: 'Page 1',
+        slug: 'page-1',
+        channelUniqueName: 'cats',
+        PastVersions: [
+          { id: 'v1', createdAt: '2024-01-01T00:00:00Z' },
+          { id: 'v2', createdAt: '2024-02-01T00:00:00Z' },
+        ],
+      },
+    ]);
+    expect(wrapper.findAll('li')).toHaveLength(2);
+  });
+
+  it('orders edits newest first', async () => {
+    const wrapper = await mountWith([
+      {
+        id: 'w1',
+        title: 'OLDER',
+        slug: 'older',
+        channelUniqueName: 'cats',
+        PastVersions: [{ id: 'v1', createdAt: '2024-01-01T00:00:00Z' }],
+      },
+      {
+        id: 'w2',
+        title: 'NEWER',
+        slug: 'newer',
+        channelUniqueName: 'cats',
+        PastVersions: [{ id: 'v2', createdAt: '2024-02-01T00:00:00Z' }],
+      },
+    ]);
+    const text = wrapper.text();
+    expect(text.indexOf('NEWER')).toBeLessThan(text.indexOf('OLDER'));
+  });
+});


### PR DESCRIPTION
Priority #1 from the coverage roadmap — the **moderate (40–149 line) tier** of untested pages. Off `main`, no stacking.

Lifts pages-with-tests from **64 → 82 / 136**. Tests target real logic, not just rendering:

- **Query-count tabs** — `admin/issues`, `forums/[forumId]/issues` (open/closed aggregate counts)
- **Server-gated behavior** — `forums/[forumId]/edit/events` (checkbox disabled + enable-change blocked when server events are off)
- **Input parsing** — `admin/settings/downloads` (comma-string ↔ file-type array)
- **Flatten + sort** — `mod/[modId]/actions`, `u/[username]/wiki-edits` (nested days/versions → newest-first list)
- **Role rendering** — `admin/roles`, `forums/[forumId]/edit/roles`
- **Route-driven UI** — `admin` (issue-detail pane by route), `admin/plugins` (active tab + canonical redirect)
- **Empty/list/loading branches** — `admin/issues/closed`, `mod/[modId]/issues`, `forums/[forumId]/edit/suspended-users`, `forums/[forumId]/downloads/[discussionId]/activity`
- **Permalink wiring** — issue / discussion / event comment permalink pages
- Plus `mod/[modId]` (head title) and `admin/issues` layout

**2 pages deferred** (noted in the commit): `create-username` (auth flow gated on `import.meta.client`, not exercisable under happy-dom) and the event feedback permalink page.

## Verification
`tsc` clean, ESLint clean, full unit suite green: **477 files / 4,309 tests** (+48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)