### PR TITLE
test: cover comment search page via extracted search util

### DIFF
--- a/pages/comments/search.spec.ts
+++ b/pages/comments/search.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+const routeQuery: Record<string, unknown> = {};
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ query: routeQuery }),
+  useRouter: () => ({ push: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const NuxtLayoutStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (opts: {
+  searchInput?: string;
+  comments?: unknown[];
+  count?: number;
+}) => {
+  routeQuery.searchInput = opts.searchInput;
+  mockedUseQuery.mockReturnValue({
+    result: ref({
+      comments: opts.comments ?? [],
+      commentsAggregate: { count: opts.count ?? 0 },
+    }),
+    loading: ref(false),
+    error: ref(null),
+    fetchMore: vi.fn(),
+  });
+  const Page = (await import('./search.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { NuxtLayout: NuxtLayoutStub } },
+  });
+};
+
+describe('comment search page', () => {
+  it('prompts for a search term when the input is empty', async () => {
+    const wrapper = await mountWith({ searchInput: '' });
+    expect(wrapper.text()).toContain('Enter a search term to find comments.');
+  });
+
+  it('shows the total result count for a search', async () => {
+    const wrapper = await mountWith({
+      searchInput: 'hello',
+      comments: [{ id: 'c1' }],
+      count: 1,
+    });
+    expect(wrapper.text()).toContain('1 comment found');
+  });
+
+  it('shows a no-results message when nothing matches', async () => {
+    const wrapper = await mountWith({
+      searchInput: 'zzz',
+      comments: [],
+      count: 0,
+    });
+    expect(wrapper.text()).toContain('No comments match your search.');
+  });
+});

--- a/pages/comments/search.vue
+++ b/pages/comments/search.vue
@@ -17,6 +17,13 @@ import {
   getCommentForumId,
   getCommentPermalinkRoute,
 } from '@/utils/commentPermalink';
+import {
+  getChannelsFromQuery,
+  buildCommentSearchWhere,
+  getCommentAuthorUsername as getAuthorUsername,
+  getCommentAuthorDisplayName as getAuthorDisplayName,
+  getCommentAuthorProfilePic as getAuthorProfilePic,
+} from '@/utils/commentSearch';
 
 const route = useRoute();
 const router = useRouter();
@@ -27,28 +34,16 @@ const searchInput = computed(() =>
   typeof route.query.searchInput === 'string' ? route.query.searchInput : ''
 );
 
-// Parse channels from route query
-const getChannelsFromRoute = (): string[] => {
-  const channels = route.query.channels;
-  if (typeof channels === 'string') {
-    return [channels];
-  }
-  if (Array.isArray(channels)) {
-    return channels.filter(
-      (value): value is string => typeof value === 'string'
-    );
-  }
-  return [];
-};
-
 // Use local ref for selected channels to handle rapid toggles properly
-const selectedChannels = ref<string[]>(getChannelsFromRoute());
+const selectedChannels = ref<string[]>(
+  getChannelsFromQuery(route.query.channels)
+);
 
 // Sync local state when route changes (e.g., browser back/forward)
 watch(
   () => route.query.channels,
   () => {
-    selectedChannels.value = getChannelsFromRoute();
+    selectedChannels.value = getChannelsFromQuery(route.query.channels);
   }
 );
 
@@ -98,41 +93,13 @@ const toggleSelectedChannel = (channelUniqueName: string) => {
   });
 };
 
-// Build the where clause for the GraphQL query
-const commentWhere = computed(() => {
-  const where: Record<string, unknown> = {
-    // Exclude feedback comments and issue comments from search
-    isFeedbackComment_NOT: true,
-    Issue: null,
-  };
-
-  // Text search (case-insensitive using regex)
-  if (searchInput.value.trim()) {
-    // Escape special regex characters and use (?i) for case-insensitive matching
-    const escapedSearch = searchInput.value.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    where.text_MATCHES = `(?i).*${escapedSearch}.*`;
-  }
-
-  // Channel filter - comments can be on discussions via DiscussionChannel or on events via Event
-  if (selectedChannels.value.length > 0) {
-    where.OR = [
-      {
-        DiscussionChannel: {
-          channelUniqueName_IN: selectedChannels.value,
-        },
-      },
-      {
-        Event: {
-          EventChannels_SOME: {
-            channelUniqueName_IN: selectedChannels.value,
-          },
-        },
-      },
-    ];
-  }
-
-  return where;
-});
+// Build the where clause for the GraphQL query (pure logic in utils/commentSearch).
+const commentWhere = computed(() =>
+  buildCommentSearchWhere({
+    searchInput: searchInput.value,
+    selectedChannels: selectedChannels.value,
+  })
+);
 
 const commentOptions = computed(() => ({
   limit: RESULTS_PER_PAGE,
@@ -192,34 +159,6 @@ const loadMore = async () => {
   } finally {
     loadingMore.value = false;
   }
-};
-
-// Get author info from comment
-const getAuthorUsername = (comment: Comment): string => {
-  if (comment.CommentAuthor?.__typename === 'User') {
-    return comment.CommentAuthor.username ?? 'Unknown';
-  }
-  if (comment.CommentAuthor?.__typename === 'ModerationProfile') {
-    return comment.CommentAuthor.displayName ?? 'Unknown';
-  }
-  return 'Unknown';
-};
-
-const getAuthorDisplayName = (comment: Comment): string => {
-  if (comment.CommentAuthor?.__typename === 'User') {
-    return comment.CommentAuthor.displayName || comment.CommentAuthor.username || 'Unknown';
-  }
-  if (comment.CommentAuthor?.__typename === 'ModerationProfile') {
-    return comment.CommentAuthor.displayName ?? 'Unknown';
-  }
-  return 'Unknown';
-};
-
-const getAuthorProfilePic = (comment: Comment): string => {
-  if (comment.CommentAuthor?.__typename === 'User') {
-    return comment.CommentAuthor.profilePicURL ?? '';
-  }
-  return '';
 };
 
 const getCommentPermalink = (comment: Comment) => {

--- a/utils/commentSearch.spec.ts
+++ b/utils/commentSearch.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getChannelsFromQuery,
+  buildCommentSearchWhere,
+  getCommentAuthorUsername,
+  getCommentAuthorDisplayName,
+  getCommentAuthorProfilePic,
+} from './commentSearch';
+
+describe('getChannelsFromQuery', () => {
+  it('wraps a single string value in an array', () => {
+    expect(getChannelsFromQuery('cats')).toEqual(['cats']);
+  });
+
+  it('keeps only string entries from an array', () => {
+    expect(getChannelsFromQuery(['cats', null, 'dogs'])).toEqual([
+      'cats',
+      'dogs',
+    ]);
+  });
+
+  it('returns an empty array for missing channels', () => {
+    expect(getChannelsFromQuery(undefined)).toEqual([]);
+  });
+});
+
+describe('buildCommentSearchWhere', () => {
+  it('always excludes feedback and issue comments', () => {
+    const where = buildCommentSearchWhere({
+      searchInput: '',
+      selectedChannels: [],
+    });
+    expect(where).toMatchObject({ isFeedbackComment_NOT: true, Issue: null });
+  });
+
+  it('adds a case-insensitive text match for the search term', () => {
+    const where = buildCommentSearchWhere({
+      searchInput: 'hello',
+      selectedChannels: [],
+    });
+    expect(where.text_MATCHES).toBe('(?i).*hello.*');
+  });
+
+  it('escapes regex metacharacters in the search term', () => {
+    const where = buildCommentSearchWhere({
+      searchInput: 'a.b(c)',
+      selectedChannels: [],
+    });
+    expect(where.text_MATCHES).toBe('(?i).*a\\.b\\(c\\).*');
+  });
+
+  it('omits the text match for a blank search', () => {
+    const where = buildCommentSearchWhere({
+      searchInput: '   ',
+      selectedChannels: [],
+    });
+    expect('text_MATCHES' in where).toBe(false);
+  });
+
+  it('adds a discussion+event channel filter when channels are selected', () => {
+    const where = buildCommentSearchWhere({
+      searchInput: '',
+      selectedChannels: ['cats'],
+    });
+    expect(where.OR).toEqual([
+      { DiscussionChannel: { channelUniqueName_IN: ['cats'] } },
+      { Event: { EventChannels_SOME: { channelUniqueName_IN: ['cats'] } } },
+    ]);
+  });
+
+  it('omits the channel filter when none are selected', () => {
+    const where = buildCommentSearchWhere({
+      searchInput: 'hi',
+      selectedChannels: [],
+    });
+    expect('OR' in where).toBe(false);
+  });
+});
+
+describe('comment author resolvers', () => {
+  it('reads the username from a User author', () => {
+    expect(
+      getCommentAuthorUsername({
+        CommentAuthor: { __typename: 'User', username: 'alice' },
+      })
+    ).toBe('alice');
+  });
+
+  it('reads the display name from a moderation profile author', () => {
+    expect(
+      getCommentAuthorUsername({
+        CommentAuthor: { __typename: 'ModerationProfile', displayName: 'modBob' },
+      })
+    ).toBe('modBob');
+  });
+
+  it('falls back to Unknown when there is no author', () => {
+    expect(getCommentAuthorUsername(null)).toBe('Unknown');
+  });
+
+  it('prefers displayName then username for the display name', () => {
+    expect(
+      getCommentAuthorDisplayName({
+        CommentAuthor: { __typename: 'User', username: 'alice', displayName: '' },
+      })
+    ).toBe('alice');
+  });
+
+  it('returns the profile pic only for User authors', () => {
+    expect(
+      getCommentAuthorProfilePic({
+        CommentAuthor: { __typename: 'User', profilePicURL: 'p.png' },
+      })
+    ).toBe('p.png');
+  });
+
+  it('returns an empty profile pic for moderation profiles', () => {
+    expect(
+      getCommentAuthorProfilePic({
+        CommentAuthor: { __typename: 'ModerationProfile', displayName: 'm' },
+      })
+    ).toBe('');
+  });
+});

--- a/utils/commentSearch.ts
+++ b/utils/commentSearch.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure helpers for the comment-search page: parsing the channel filter from the
+ * route, building the GraphQL `where` clause, and resolving author display
+ * fields off the CommentAuthor union. Extracted from comments/search.vue so the
+ * regex escaping and filter logic can be unit-tested without mounting the page.
+ */
+
+export type CommentSearchWhereParams = {
+  searchInput: string;
+  selectedChannels: string[];
+};
+
+/** Read the `channels` query param (string or array) into a clean string list. */
+export function getChannelsFromQuery(
+  channels: unknown
+): string[] {
+  if (typeof channels === 'string') return [channels];
+  if (Array.isArray(channels)) {
+    return channels.filter((v): v is string => typeof v === 'string');
+  }
+  return [];
+}
+
+/**
+ * Build the comment-search `where` filter: always excludes feedback and
+ * issue comments, adds a case-insensitive (regex-escaped) text match, and an
+ * optional channel filter spanning both discussion and event comments.
+ */
+export function buildCommentSearchWhere(
+  params: CommentSearchWhereParams
+): Record<string, unknown> {
+  const { searchInput, selectedChannels } = params;
+  const where: Record<string, unknown> = {
+    isFeedbackComment_NOT: true,
+    Issue: null,
+  };
+
+  const trimmed = searchInput.trim();
+  if (trimmed) {
+    const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    where.text_MATCHES = `(?i).*${escaped}.*`;
+  }
+
+  if (selectedChannels.length > 0) {
+    where.OR = [
+      { DiscussionChannel: { channelUniqueName_IN: selectedChannels } },
+      {
+        Event: {
+          EventChannels_SOME: { channelUniqueName_IN: selectedChannels },
+        },
+      },
+    ];
+  }
+
+  return where;
+}
+
+type CommentAuthorLike = {
+  __typename?: string;
+  username?: string | null;
+  displayName?: string | null;
+  profilePicURL?: string | null;
+} | null;
+
+type CommentLike = { CommentAuthor?: CommentAuthorLike } | null | undefined;
+
+/** Username (or mod display name) shown for a comment author; 'Unknown' fallback. */
+export function getCommentAuthorUsername(comment: CommentLike): string {
+  const author = comment?.CommentAuthor;
+  if (author?.__typename === 'User') return author.username ?? 'Unknown';
+  if (author?.__typename === 'ModerationProfile') {
+    return author.displayName ?? 'Unknown';
+  }
+  return 'Unknown';
+}
+
+/** Display name for a comment author, preferring displayName then username. */
+export function getCommentAuthorDisplayName(comment: CommentLike): string {
+  const author = comment?.CommentAuthor;
+  if (author?.__typename === 'User') {
+    return author.displayName || author.username || 'Unknown';
+  }
+  if (author?.__typename === 'ModerationProfile') {
+    return author.displayName ?? 'Unknown';
+  }
+  return 'Unknown';
+}
+
+/** Profile picture URL for a User author; empty string for mods/unknown. */
+export function getCommentAuthorProfilePic(comment: CommentLike): string {
+  const author = comment?.CommentAuthor;
+  if (author?.__typename === 'User') return author.profilePicURL ?? '';
+  return '';
+}


### PR DESCRIPTION
Begins **priority #2 — the heavy (≥150 line) page tier** — using the roadmap strategy of extracting logic into tested utils as I go. Off `main`.

Starts with `comments/search.vue` (442 lines), one of the richest. Its pure logic moves into `utils/commentSearch.ts`:
- `getChannelsFromQuery` — parse the channel filter from the route query
- `buildCommentSearchWhere` — the GraphQL `where` builder (regex-escaped case-insensitive text match + discussion/event channel filter, always excluding feedback/issue comments)
- `getCommentAuthorUsername` / `…DisplayName` / `…ProfilePic` — CommentAuthor-union resolvers

The page now delegates to the util.

**Tests:** 15 util tests (regex escaping, channel filter on/off, author union edge cases) + 3 page render-branch tests (empty prompt / result count / no matches).

## Verification
`tsc` clean, ESLint clean, full unit suite green: **4,279 tests**.

## Note on the tier
The heavy tier is 50 pages; this is the first. I'm doing them as focused PRs (extracting a tested util where each page has meaty logic) rather than one mega-PR, to keep review tractable. More to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)