### PR TITLE
test: cover favorite-discussions page via extracted display util

### DIFF
--- a/pages/library/favorite-discussions.spec.ts
+++ b/pages/library/favorite-discussions.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+vi.mock('@/composables/useServerRoleMembership', () => ({
+  useServerRoleMembership: () => ({ serverAdminUsernames: ref([]) }),
+}));
+
+const RequireAuthStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots['has-auth']?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (favorites: unknown[]) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ users: [{ FavoriteDiscussions: favorites }] }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./favorite-discussions.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { RequireAuth: RequireAuthStub, NuxtLink: { template: '<a><slot /></a>' } } },
+  });
+};
+
+describe('favorite discussions page', () => {
+  it('shows the empty state when there are no favorites', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.text()).toContain('No favorite discussions yet');
+  });
+
+  it('renders a favorited discussion title', async () => {
+    const wrapper = await mountWith([
+      {
+        id: 'd1',
+        title: 'My favorite post',
+        DiscussionChannels: [
+          { channelUniqueName: 'cats', CommentsAggregate: { count: 0 } },
+        ],
+        Tags: [],
+        Album: null,
+      },
+    ]);
+    expect(wrapper.text()).toContain('My favorite post');
+  });
+});

--- a/pages/library/favorite-discussions.vue
+++ b/pages/library/favorite-discussions.vue
@@ -10,9 +10,14 @@ import TagComponent from '@/components/TagComponent.vue';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
 import { relativeTime } from '@/utils';
-import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
-import { getServerRoleBadge } from '@/utils/serverRoleBadges';
+import {
+  formatCount,
+  getDiscussionLink,
+  getChannelLink,
+  getTotalCommentCount,
+  buildFavoriteAuthorInfo,
+} from '@/utils/favoriteDiscussionDisplay';
 import type {
   Discussion,
   DiscussionChannel,
@@ -128,54 +133,12 @@ const favoriteDiscussions = computed(() => {
 });
 const { serverAdminUsernames } = useServerRoleMembership();
 
-const formatCount = (
-  count: number | undefined,
-  singular: string,
-  plural: string
-) => {
-  const value = count || 0;
-  return `${value} ${value === 1 ? singular : plural}`;
-};
-
-const getDiscussionLink = (discussion: FavoriteDiscussion) => {
-  const firstChannel = safeArrayFirst(discussion.DiscussionChannels) as
-    | FavoriteDiscussionChannel
-    | undefined;
-  if (!firstChannel?.channelUniqueName) return '/';
-
-  return `/forums/${firstChannel.channelUniqueName}/discussions/${discussion.id}`;
-};
-
-const getChannelLink = (channelUniqueName: string | undefined) => {
-  if (!channelUniqueName) return '/';
-  return `/forums/${channelUniqueName}`;
-};
-
-const getTotalCommentCount = (discussionChannels: FavoriteDiscussionChannel[]) => {
-  return discussionChannels.reduce((total, dc) => {
-    return total + (dc.CommentsAggregate?.count || 0);
-  }, 0);
-};
-
-const getAuthorInfo = (discussion: FavoriteDiscussion) => {
-  const author = discussion?.Author;
-  if (!author) return null;
-
-  const serverRoleBadge = getServerRoleBadge({
-    username: author.username,
+// Display helpers live in utils/favoriteDiscussionDisplay.ts (unit-tested).
+const getAuthorInfo = (discussion: FavoriteDiscussion) =>
+  buildFavoriteAuthorInfo({
+    author: discussion?.Author,
     adminUsernames: serverAdminUsernames.value,
   });
-
-  return {
-    username: author.username || '',
-    displayName: author.displayName || '',
-    profilePicURL: author.profilePicURL || '',
-    commentKarma: author.commentKarma ?? 0,
-    discussionKarma: author.discussionKarma ?? 0,
-    createdAt: author.createdAt || '',
-    isAdmin: serverRoleBadge === 'serverAdmin',
-  };
-};
 </script>
 
 <template>

--- a/utils/favoriteDiscussionDisplay.spec.ts
+++ b/utils/favoriteDiscussionDisplay.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatCount,
+  getDiscussionLink,
+  getChannelLink,
+  getTotalCommentCount,
+  buildFavoriteAuthorInfo,
+} from './favoriteDiscussionDisplay';
+
+describe('formatCount', () => {
+  it('uses the singular noun for a count of one', () => {
+    expect(formatCount(1, 'comment', 'comments')).toBe('1 comment');
+  });
+
+  it('uses the plural noun for other counts', () => {
+    expect(formatCount(3, 'comment', 'comments')).toBe('3 comments');
+  });
+
+  it('treats an undefined count as zero (plural)', () => {
+    expect(formatCount(undefined, 'comment', 'comments')).toBe('0 comments');
+  });
+});
+
+describe('getDiscussionLink', () => {
+  it('links to the discussion under its first forum', () => {
+    expect(
+      getDiscussionLink({
+        id: 'd1',
+        DiscussionChannels: [{ channelUniqueName: 'cats' }],
+      })
+    ).toBe('/forums/cats/discussions/d1');
+  });
+
+  it('falls back to root when there is no forum channel', () => {
+    expect(getDiscussionLink({ id: 'd1', DiscussionChannels: [] })).toBe('/');
+  });
+});
+
+describe('getChannelLink', () => {
+  it('links to the forum', () => {
+    expect(getChannelLink('cats')).toBe('/forums/cats');
+  });
+
+  it('falls back to root for a missing channel name', () => {
+    expect(getChannelLink(null)).toBe('/');
+  });
+});
+
+describe('getTotalCommentCount', () => {
+  it('sums comment counts across all channels', () => {
+    expect(
+      getTotalCommentCount([
+        { CommentsAggregate: { count: 2 } },
+        { CommentsAggregate: { count: 3 } },
+      ])
+    ).toBe(5);
+  });
+
+  it('treats missing aggregates as zero', () => {
+    expect(getTotalCommentCount([{}, { CommentsAggregate: { count: 4 } }])).toBe(
+      4
+    );
+  });
+
+  it('returns 0 for no channels', () => {
+    expect(getTotalCommentCount(null)).toBe(0);
+  });
+});
+
+describe('buildFavoriteAuthorInfo', () => {
+  it('returns null for a deleted (absent) author', () => {
+    expect(
+      buildFavoriteAuthorInfo({ author: null, adminUsernames: [] })
+    ).toBeNull();
+  });
+
+  it('flags the author as admin when they are a server admin', () => {
+    const info = buildFavoriteAuthorInfo({
+      author: { username: 'alice' },
+      adminUsernames: ['alice'],
+    });
+    expect(info?.isAdmin).toBe(true);
+  });
+
+  it('does not flag non-admins', () => {
+    const info = buildFavoriteAuthorInfo({
+      author: { username: 'bob' },
+      adminUsernames: ['alice'],
+    });
+    expect(info?.isAdmin).toBe(false);
+  });
+
+  it('defaults missing karma fields to zero', () => {
+    const info = buildFavoriteAuthorInfo({
+      author: { username: 'bob' },
+      adminUsernames: [],
+    });
+    expect(info?.commentKarma).toBe(0);
+  });
+});

--- a/utils/favoriteDiscussionDisplay.ts
+++ b/utils/favoriteDiscussionDisplay.ts
@@ -1,0 +1,99 @@
+import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
+import { getServerRoleBadge } from '@/utils/serverRoleBadges';
+
+/**
+ * Pure display helpers for the favorite-discussions library page: count
+ * pluralization, link building, comment-count aggregation, and author-info
+ * derivation. Extracted so the logic can be unit-tested without mounting the
+ * (large) page component.
+ */
+
+type FavoriteChannel = {
+  channelUniqueName?: string | null;
+  CommentsAggregate?: { count?: number | null } | null;
+};
+
+type FavoriteAuthor = {
+  username?: string | null;
+  displayName?: string | null;
+  profilePicURL?: string | null;
+  commentKarma?: number | null;
+  discussionKarma?: number | null;
+  createdAt?: string | null;
+} | null | undefined;
+
+/** "1 comment" / "3 comments" — pluralize a count with the matching noun. */
+export function formatCount(
+  count: number | undefined,
+  singular: string,
+  plural: string
+): string {
+  const value = count || 0;
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+/** Link to a discussion under its first forum, or '/' when none is available. */
+export function getDiscussionLink(discussion: {
+  id: string;
+  DiscussionChannels?: FavoriteChannel[];
+}): string {
+  const firstChannel = safeArrayFirst(discussion.DiscussionChannels) as
+    | FavoriteChannel
+    | undefined;
+  if (!firstChannel?.channelUniqueName) return '/';
+  return `/forums/${firstChannel.channelUniqueName}/discussions/${discussion.id}`;
+}
+
+/** Link to a forum, or '/' when no channel name is given. */
+export function getChannelLink(channelUniqueName: string | undefined | null): string {
+  if (!channelUniqueName) return '/';
+  return `/forums/${channelUniqueName}`;
+}
+
+/** Sum of comment counts across all of a discussion's forum channels. */
+export function getTotalCommentCount(
+  discussionChannels: FavoriteChannel[] | undefined | null
+): number {
+  return (discussionChannels || []).reduce(
+    (total, dc) => total + (dc.CommentsAggregate?.count || 0),
+    0
+  );
+}
+
+export type FavoriteAuthorInfo = {
+  username: string;
+  displayName: string;
+  profilePicURL: string;
+  commentKarma: number;
+  discussionKarma: number;
+  createdAt: string;
+  isAdmin: boolean;
+};
+
+/**
+ * Normalize a discussion author into the fields the card needs, including
+ * whether they hold the server-admin badge. Returns null when there is no
+ * author (deleted account).
+ */
+export function buildFavoriteAuthorInfo(params: {
+  author: FavoriteAuthor;
+  adminUsernames: string[];
+}): FavoriteAuthorInfo | null {
+  const { author, adminUsernames } = params;
+  if (!author) return null;
+
+  const serverRoleBadge = getServerRoleBadge({
+    username: author.username,
+    adminUsernames,
+  });
+
+  return {
+    username: author.username || '',
+    displayName: author.displayName || '',
+    profilePicURL: author.profilePicURL || '',
+    commentKarma: author.commentKarma ?? 0,
+    discussionKarma: author.discussionKarma ?? 0,
+    createdAt: author.createdAt || '',
+    isAdmin: serverRoleBadge === 'serverAdmin',
+  };
+}


### PR DESCRIPTION
Continues the **heavy-page coverage tier** (follows #144, now merged). Off `main`.

Covers `library/favorite-discussions.vue` (442 lines) by extracting its pure display logic into `utils/favoriteDiscussionDisplay.ts`:
- `formatCount` — count pluralization
- `getDiscussionLink` / `getChannelLink` — link building (first-forum fallback)
- `getTotalCommentCount` — sum comment counts across a discussion's forum channels
- `buildFavoriteAuthorInfo` — author info incl. the server-admin badge, null for deleted authors

The page now delegates to the util.

**Tests:** 14 util tests + 2 page render tests (empty state / favorited title).

## Verification
`tsc` clean, ESLint clean, util + page specs green (16 tests); full suite was green on the source branch at 4,295 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)