### PR TITLE
test: cover favorite downloads/comments pages + albumUtils

### DIFF
--- a/pages/library/favorite-comments.spec.ts
+++ b/pages/library/favorite-comments.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
+
+vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
+
+vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+vi.mock('@/composables/useServerRoleMembership', () => ({
+  useServerRoleMembership: () => ({ serverAdminUsernames: ref([]) }),
+}));
+
+const RequireAuthStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots['has-auth']?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (comments: unknown[]) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ users: [{ FavoriteComments: comments }] }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./favorite-comments.vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: { RequireAuth: RequireAuthStub, NuxtLink: { template: '<a><slot /></a>' } },
+    },
+  });
+};
+
+describe('favorite comments page', () => {
+  it('shows the empty state when there are no favorites', async () => {
+    expect((await mountWith([])).text()).toContain('No favorite comments yet');
+  });
+
+  it('renders a favorited comment via the markdown renderer', async () => {
+    const wrapper = await mountWith([
+      {
+        id: 'c1',
+        text: 'A memorable comment',
+        createdAt: '2024-01-01T00:00:00Z',
+        CommentAuthor: { __typename: 'User', username: 'bob' },
+      },
+    ]);
+    expect(wrapper.findComponent(MarkdownRenderer).props('text')).toBe(
+      'A memorable comment'
+    );
+  });
+});

--- a/pages/library/favorite-downloads.spec.ts
+++ b/pages/library/favorite-downloads.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
+
+vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+vi.mock('@/composables/useServerRoleMembership', () => ({
+  useServerRoleMembership: () => ({ serverAdminUsernames: ref([]) }),
+}));
+
+const RequireAuthStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots['has-auth']?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (downloads: unknown[]) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ users: [{ FavoriteDiscussions: downloads }] }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./favorite-downloads.vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: { RequireAuth: RequireAuthStub, NuxtLink: { template: '<a><slot /></a>' } },
+    },
+  });
+};
+
+describe('favorite downloads page', () => {
+  it('shows the empty state when there are no favorites', async () => {
+    expect((await mountWith([])).text()).toContain('No favorite downloads yet');
+  });
+
+  it('renders a favorited download title', async () => {
+    const wrapper = await mountWith([
+      {
+        id: 'd1',
+        title: 'Cool tileset',
+        DiscussionChannels: [{ id: 'c', channelUniqueName: 'cats' }],
+        Tags: [],
+      },
+    ]);
+    expect(wrapper.text()).toContain('Cool tileset');
+  });
+});

--- a/utils/albumUtils.spec.ts
+++ b/utils/albumUtils.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import type { Album } from '@/__generated__/graphql';
+import {
+  getMainImageHeight,
+  getExpandedThumbnailDimensions,
+  getFirstAlbumImage,
+} from './albumUtils';
+
+describe('getMainImageHeight', () => {
+  it('uses the compact height when not in expanded view', () => {
+    expect(getMainImageHeight({ expandedView: false, downloadMode: true })).toBe(
+      256
+    );
+  });
+
+  it('is tallest for expanded download mode', () => {
+    expect(getMainImageHeight({ expandedView: true, downloadMode: true })).toBe(
+      500
+    );
+  });
+
+  it('is medium for expanded non-download mode', () => {
+    expect(
+      getMainImageHeight({ expandedView: true, downloadMode: false })
+    ).toBe(400);
+  });
+});
+
+describe('getExpandedThumbnailDimensions', () => {
+  it('uses wide thumbnails only for expanded non-download mode', () => {
+    expect(
+      getExpandedThumbnailDimensions({ expandedView: true, downloadMode: false })
+    ).toEqual({ width: 180, height: 120 });
+  });
+
+  it('uses square thumbnails otherwise', () => {
+    expect(
+      getExpandedThumbnailDimensions({ expandedView: true, downloadMode: true })
+    ).toEqual({ width: 120, height: 120 });
+  });
+});
+
+describe('getFirstAlbumImage', () => {
+  it('returns null when the album has no images', () => {
+    expect(getFirstAlbumImage({ Images: [] } as unknown as Album)).toBeNull();
+  });
+
+  it('returns null for a null album', () => {
+    expect(getFirstAlbumImage(null)).toBeNull();
+  });
+
+  it('uses the first image in imageOrder when it has a url', () => {
+    const album = {
+      imageOrder: ['b', 'a'],
+      Images: [
+        { id: 'a', url: 'a.png' },
+        { id: 'b', url: 'b.png' },
+      ],
+    } as unknown as Album;
+    expect(getFirstAlbumImage(album)).toBe('b.png');
+  });
+
+  it('falls back to the first stored image when the ordered image has no url', () => {
+    const album = {
+      imageOrder: ['b'],
+      Images: [
+        { id: 'a', url: 'a.png' },
+        { id: 'b', url: '' },
+      ],
+    } as unknown as Album;
+    expect(getFirstAlbumImage(album)).toBe('a.png');
+  });
+
+  it('uses the first stored image when there is no imageOrder', () => {
+    const album = {
+      Images: [{ id: 'a', url: 'a.png' }],
+    } as unknown as Album;
+    expect(getFirstAlbumImage(album)).toBe('a.png');
+  });
+});


### PR DESCRIPTION
Continues the heavy-page tier with the remaining `library` favorites pages. Independent off `main` (no dependency on the still-open #145).

## What's covered
- **`utils/albumUtils` spec (new)** — this shared util (used by album/download/lightbox components) had **no tests**. Adds coverage for `getFirstAlbumImage` (imageOrder-first with url fallback) and the view-mode dimension helpers.
- **`favorite-downloads.vue`** — page render tests (empty state + a rendered download).
- **`favorite-comments.vue`** — page render tests (empty state + comment rendered via MarkdownRenderer). This page already delegates to `commentUtils`, so it just needed coverage.

## Notes
- I deliberately did **not** reuse the favorites display helpers from #145 here (they're not on `main` yet), to keep this PR independent.
- Spotted: `favorite-downloads.vue`'s inline first-image logic duplicates `albumUtils.getFirstAlbumImage` — a good dedup once #145 lands and the favorites pages get a consolidation pass. Flagged, not changed here.

## Verification
`tsc` clean, ESLint clean, full unit suite green: **4,341 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)