### PR TITLE
fix: consume getOwnEmail instead of the emails enumeration query

### DIFF
--- a/graphQLData/email/queries.js
+++ b/graphQLData/email/queries.js
@@ -1,19 +1,19 @@
 import { gql } from '@apollo/client/core';
 
-export const GET_EMAIL = gql`
-  query getEmail($emailAddress: String!) {
-    emails(where: { address: $emailAddress }) {
+// Self-scoped account lookup for the authenticated caller. Replaces the old
+// GET_EMAIL (`emails(where: { address })`) query — enumerating emails is now
+// admin-only on the backend. getOwnEmail takes no arguments and resolves the
+// caller's email from the verified token server-side, so it cannot leak anyone
+// else's account. Returns null when unauthenticated, and an object with
+// username: null when authenticated but no account exists yet (onboarding).
+export const GET_OWN_EMAIL = gql`
+  query getOwnEmail {
+    getOwnEmail {
       address
-      User {
-        username
-        profilePicURL
-        ModerationProfile {
-          displayName
-        }
-        NotificationsAggregate(where: { read: false }) {
-          count
-        }
-      }
+      username
+      profilePicURL
+      modProfileName
+      unreadNotificationCount
     }
   }
 `;

--- a/pages/create-username.vue
+++ b/pages/create-username.vue
@@ -2,8 +2,7 @@
 import { ref, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useQuery } from '@vue/apollo-composable';
-import { GET_EMAIL } from '@/graphQLData/email/queries';
-import type { Email } from '@/__generated__/graphql';
+import { GET_OWN_EMAIL } from '@/graphQLData/email/queries';
 import { userDataLoadingVar } from '@/cache';
 import {
   useUsername,
@@ -49,24 +48,27 @@ if (import.meta.client) {
     }
   });
 
-  // Only check email if we're authenticated and on the client side
+  // Only check email if we're authenticated and on the client side.
+  // getOwnEmail is self-scoped (resolves the caller's email from the token),
+  // so it needs no variables. A returned `username` means the account already
+  // exists; its absence means this verified email still needs a username.
   if (isAuthenticatedVar.value) {
-    const { onResult: onEmailResult } = useQuery(GET_EMAIL, {
-      emailAddress: emailVar.value,
-    });
+    const { onResult: onEmailResult } = useQuery(GET_OWN_EMAIL);
 
-    onEmailResult((result: { data?: { emails?: Email[] } }) => {
-      const emailData = result.data?.emails?.[0];
-      if (emailData?.User) {
-        // User already exists, redirect to home
-        router.push('/');
-      } else {
-        // User doesn't exist, show the create username form
-        emailNotInSystem.value = true;
+    onEmailResult(
+      (result: { data?: { getOwnEmail?: { username?: string | null } | null } }) => {
+        const ownEmail = result.data?.getOwnEmail;
+        if (ownEmail?.username) {
+          // User already exists, redirect to home
+          router.push('/');
+        } else {
+          // User doesn't exist, show the create username form
+          emailNotInSystem.value = true;
+        }
+        initialCheckComplete.value = true;
+        loading.value = false;
       }
-      initialCheckComplete.value = true;
-      loading.value = false;
-    });
+    );
   }
 }
 </script>

--- a/plugins/auth-username-fallback.client.spec.ts
+++ b/plugins/auth-username-fallback.client.spec.ts
@@ -39,14 +39,14 @@ const run = async () => {
 
 const resolvedUser = (user: Record<string, unknown> | null) => ({
   ok: true,
-  json: async () => ({ data: { emails: [{ User: user }] } }),
+  json: async () => ({ data: { getOwnEmail: user } }),
 });
 
 const fullUser = {
   username: 'cluse',
   profilePicURL: 'https://pics/cluse.png',
-  ModerationProfile: { displayName: 'mod-cluse' },
-  NotificationsAggregate: { count: 4 },
+  modProfileName: 'mod-cluse',
+  unreadNotificationCount: 4,
 };
 
 beforeEach(() => {
@@ -79,10 +79,12 @@ describe('auth-username-fallback plugin: resolves when authenticated but usernam
     expect(h.setNotificationCount).toHaveBeenCalledWith(4);
   });
 
-  it('looks the user up by their email address', async () => {
+  it('looks the user up via the self-scoped getOwnEmail query (no email variable)', async () => {
     await run();
     const body = JSON.parse(h.fetch.mock.calls[0][1].body as string);
-    expect(body.variables.emailAddress).toBe('cat@example.com');
+    expect(body.query).toContain('getOwnEmail');
+    // Identity now comes from the bearer token, not a client-supplied address.
+    expect(body.variables?.emailAddress).toBeUndefined();
   });
 });
 

--- a/plugins/auth-username-fallback.client.ts
+++ b/plugins/auth-username-fallback.client.ts
@@ -3,7 +3,7 @@
 // Client-side fallback for the app username.
 //
 // The app identity username (e.g. "cluse") is resolved server-side during SSR
-// in server/middleware/2.auth-session.ts (Auth0 email -> backend GET_EMAIL ->
+// in server/middleware/2.auth-session.ts (Auth0 email -> backend getOwnEmail ->
 // username) and travels to the client through the Nuxt payload. There is no
 // client-side resolver anymore — the SPA `useAuthManager` was removed when the
 // server-session migration landed.
@@ -18,7 +18,7 @@
 //
 // This plugin restores a minimal client fallback: when the session is
 // authenticated (we have a verified email) but username is still empty, resolve
-// it from the backend by email and seed the auth state. It mirrors GET_EMAIL
+// it from the backend by token and seed the auth state. It mirrors GET_OWN_EMAIL
 // (graphQLData/email/queries.js) and the SSR middleware. It is fire-and-forget
 // so it never delays app startup; the reactive `username` update lets the
 // favorite-status query and ownership-gated UI come to life once it lands.
@@ -34,37 +34,31 @@ import {
   setNotificationCount,
 } from '@/composables/useAuthState';
 
-const GET_EMAIL_QUERY = /* GraphQL */ `
-  query getEmail($emailAddress: String!) {
-    emails(where: { address: $emailAddress }) {
-      User {
-        username
-        profilePicURL
-        ModerationProfile {
-          displayName
-        }
-        NotificationsAggregate(where: { read: false }) {
-          count
-        }
-      }
+// Self-scoped: getOwnEmail resolves the caller's email from the verified token
+// on the backend, so it takes no arguments and can't look up anyone else.
+const GET_OWN_EMAIL_QUERY = /* GraphQL */ `
+  query getOwnEmail {
+    getOwnEmail {
+      username
+      profilePicURL
+      modProfileName
+      unreadNotificationCount
     }
   }
 `;
 
-type EmailLookupResponse = {
+type OwnEmailResponse = {
   data?: {
-    emails?: Array<{
-      User?: {
-        username?: string | null;
-        profilePicURL?: string | null;
-        ModerationProfile?: { displayName?: string | null } | null;
-        NotificationsAggregate?: { count?: number | null } | null;
-      } | null;
-    } | null> | null;
+    getOwnEmail?: {
+      username?: string | null;
+      profilePicURL?: string | null;
+      modProfileName?: string | null;
+      unreadNotificationCount?: number | null;
+    } | null;
   };
 };
 
-const resolveUsername = async (emailAddress: string) => {
+const resolveUsername = async () => {
   const endpoint = config?.graphqlUrl;
   if (!endpoint) return;
 
@@ -77,29 +71,28 @@ const resolveUsername = async (emailAddress: string) => {
         ...(token ? { authorization: `Bearer ${token}` } : {}),
       },
       body: JSON.stringify({
-        query: GET_EMAIL_QUERY,
-        variables: { emailAddress },
+        query: GET_OWN_EMAIL_QUERY,
       }),
     });
     if (!res.ok) return;
 
-    const json = (await res.json()) as EmailLookupResponse;
-    const user = json?.data?.emails?.[0]?.User;
-    if (!user?.username) return;
+    const json = (await res.json()) as OwnEmailResponse;
+    const ownEmail = json?.data?.getOwnEmail;
+    if (!ownEmail?.username) return;
 
     // Only seed if SSR still hasn't filled it in (avoid clobbering a value that
     // arrived between scheduling and resolving).
     if (!useUsername().value) {
-      setUsername(user.username);
+      setUsername(ownEmail.username);
     }
-    if (user.ModerationProfile?.displayName) {
-      setModProfileName(user.ModerationProfile.displayName);
+    if (ownEmail.modProfileName) {
+      setModProfileName(ownEmail.modProfileName);
     }
-    if (user.profilePicURL) {
-      setProfilePicURL(user.profilePicURL);
+    if (ownEmail.profilePicURL) {
+      setProfilePicURL(ownEmail.profilePicURL);
     }
-    if (typeof user.NotificationsAggregate?.count === 'number') {
-      setNotificationCount(user.NotificationsAggregate.count);
+    if (typeof ownEmail.unreadNotificationCount === 'number') {
+      setNotificationCount(ownEmail.unreadNotificationCount);
     }
   } catch {
     // Ignore — username stays empty and will be retried on the next load.
@@ -117,6 +110,8 @@ export default defineNuxtPlugin(() => {
   // SSR already resolved the username.
   if (!isAuthenticated.value || !email.value || username.value) return;
 
-  // Fire-and-forget: never block app startup on this network round-trip.
-  void resolveUsername(email.value);
+  // Fire-and-forget: never block app startup on this network round-trip. The
+  // backend resolves identity from the bearer token; email.value is just the
+  // "are we even signed in" gate.
+  void resolveUsername();
 });

--- a/server/middleware/2.auth-session.ts
+++ b/server/middleware/2.auth-session.ts
@@ -50,36 +50,31 @@ declare module 'h3' {
   }
 }
 
-// Mirror of GET_EMAIL (graphQLData/email/queries.js): everything useAuthManager
-// used to fetch client-side via the SPA. Resolving it here (server-side, from
-// the session) is what lets the SPA auth manager be removed entirely.
-const GET_EMAIL = /* GraphQL */ `
-  query getEmail($emailAddress: String!) {
-    emails(where: { address: $emailAddress }) {
-      User {
-        username
-        profilePicURL
-        ModerationProfile {
-          displayName
-        }
-        NotificationsAggregate(where: { read: false }) {
-          count
-        }
-      }
+// Mirror of GET_OWN_EMAIL (graphQLData/email/queries.js): everything
+// useAuthManager used to fetch client-side via the SPA. Resolving it here
+// (server-side, from the session) is what lets the SPA auth manager be removed
+// entirely. getOwnEmail is self-scoped — the backend resolves the caller's
+// email from the bearer token, so no $emailAddress variable is sent and the
+// top-level `emails` enumeration query (now admin-only) is never used.
+const GET_OWN_EMAIL = /* GraphQL */ `
+  query getOwnEmail {
+    getOwnEmail {
+      username
+      profilePicURL
+      modProfileName
+      unreadNotificationCount
     }
   }
 `;
 
-type EmailLookupResponse = {
+type OwnEmailResponse = {
   data?: {
-    emails?: Array<{
-      User?: {
-        username?: string | null;
-        profilePicURL?: string | null;
-        ModerationProfile?: { displayName?: string | null } | null;
-        NotificationsAggregate?: { count?: number | null } | null;
-      } | null;
-    } | null> | null;
+    getOwnEmail?: {
+      username?: string | null;
+      profilePicURL?: string | null;
+      modProfileName?: string | null;
+      unreadNotificationCount?: number | null;
+    } | null;
   };
 };
 
@@ -87,24 +82,18 @@ type EmailLookupResponse = {
 // fields come from the cache, so only the volatile unread-notification count
 // needs to be fetched fresh per request.
 const GET_NOTIFICATION_COUNT = /* GraphQL */ `
-  query getNotificationCount($emailAddress: String!) {
-    emails(where: { address: $emailAddress }) {
-      User {
-        NotificationsAggregate(where: { read: false }) {
-          count
-        }
-      }
+  query getOwnEmailNotificationCount {
+    getOwnEmail {
+      unreadNotificationCount
     }
   }
 `;
 
 type NotificationCountResponse = {
   data?: {
-    emails?: Array<{
-      User?: {
-        NotificationsAggregate?: { count?: number | null } | null;
-      } | null;
-    } | null> | null;
+    getOwnEmail?: {
+      unreadNotificationCount?: number | null;
+    } | null;
   };
 };
 
@@ -225,14 +214,13 @@ export default defineEventHandler(async (event) => {
                 GET_NOTIFICATION_COUNT
               );
             notificationCount =
-              countRes?.data?.emails?.[0]?.User?.NotificationsAggregate
-                ?.count || 0;
+              countRes?.data?.getOwnEmail?.unreadNotificationCount || 0;
           } else {
-            const res = await queryBackend<EmailLookupResponse>(GET_EMAIL);
-            const u = res?.data?.emails?.[0]?.User;
+            const res = await queryBackend<OwnEmailResponse>(GET_OWN_EMAIL);
+            const u = res?.data?.getOwnEmail;
             username = u?.username || '';
-            modProfileName = u?.ModerationProfile?.displayName || '';
-            notificationCount = u?.NotificationsAggregate?.count || 0;
+            modProfileName = u?.modProfileName || '';
+            notificationCount = u?.unreadNotificationCount || 0;
             profilePicURL = u?.profilePicURL || '';
 
             // Cache only a resolved user. An empty username means "no app

--- a/tests/playwright/mocked/events/createEditDeleteEvents.spec.ts
+++ b/tests/playwright/mocked/events/createEditDeleteEvents.spec.ts
@@ -115,19 +115,15 @@ const buildEvent = (overrides: Partial<{
 });
 
 const getCommonMocks = (username: string) => ({
-  getEmail: () => ({
+  getOwnEmail: () => ({
     data: {
-      emails: [
-        {
-          address: 'test@example.com',
-          User: {
-            username,
-            profilePicURL: '',
-            ModerationProfile: null,
-            NotificationsAggregate: { count: 0 },
-          },
-        },
-      ],
+      getOwnEmail: {
+        address: 'test@example.com',
+        username,
+        profilePicURL: '',
+        modProfileName: null,
+        unreadNotificationCount: 0,
+      },
     },
   }),
   getBasicUserInfo: () => ({

--- a/tests/playwright/mocked/feedback/giveFeedback.spec.ts
+++ b/tests/playwright/mocked/feedback/giveFeedback.spec.ts
@@ -65,21 +65,15 @@ const getFeedbackHandlers = (username: string, modProfileName: string) => ({
       ElevatedModRole: FEEDBACK_MOD_ROLE,
     },
   }),
-  getEmail: () => ({
+  getOwnEmail: () => ({
     data: {
-      emails: [
-        {
-          address: 'test@example.com',
-          User: {
-            username,
-            profilePicURL: '',
-            ModerationProfile: {
-              displayName: modProfileName,
-            },
-            NotificationsAggregate: { count: 0 },
-          },
-        },
-      ],
+      getOwnEmail: {
+        address: 'test@example.com',
+        username,
+        profilePicURL: '',
+        modProfileName,
+        unreadNotificationCount: 0,
+      },
     },
   }),
   getChannel: () => ({

--- a/tests/playwright/mocked/links/verifyLinks.spec.ts
+++ b/tests/playwright/mocked/links/verifyLinks.spec.ts
@@ -62,19 +62,15 @@ const buildEvent = (overrides: Partial<{
 });
 
 const getCommonMocks = (username: string) => ({
-  getEmail: () => ({
+  getOwnEmail: () => ({
     data: {
-      emails: [
-        {
-          address: 'test@example.com',
-          User: {
-            username,
-            profilePicURL: '',
-            ModerationProfile: null,
-            NotificationsAggregate: { count: 0 },
-          },
-        },
-      ],
+      getOwnEmail: {
+        address: 'test@example.com',
+        username,
+        profilePicURL: '',
+        modProfileName: null,
+        unreadNotificationCount: 0,
+      },
     },
   }),
   getBasicUserInfo: () => ({


### PR DESCRIPTION
## Summary

Companion to **gennit-project/multiforum-backend#64**, which locks the top-level `emails` query down to admins. The onboarding / auth-session lookups that resolved a user's profile via `emails(where: { address })` now use the new self-scoped **`getOwnEmail`** query. `getOwnEmail` resolves the caller's email from the verified bearer token server-side — no `$emailAddress` variable, no enumeration.

## Migrated call sites

| File | Path |
|---|---|
| SSR middleware (primary) | `server/middleware/2.auth-session.ts` — both the full-profile lookup and the count-only cache-hit variant |
| Client fallback | `plugins/auth-username-fallback.client.ts` |
| Onboarding gate | `pages/create-username.vue` |
| Shared query | `graphQLData/email/queries.js` (`GET_EMAIL` → `GET_OWN_EMAIL`) |

Response shape changes from `emails[0].User.{username, profilePicURL, ModerationProfile.displayName, NotificationsAggregate.count}` to a flat `getOwnEmail` object: `{ username, profilePicURL, modProfileName, unreadNotificationCount }`.

Onboarding semantics are preserved: `getOwnEmail` returns an object with `username: null` when the user is authenticated but hasn't created an account yet, which is what `create-username.vue` keys off to show the username picker.

## Tests

- Updated the plugin unit spec (`auth-username-fallback.client.spec.ts`) to the new response shape; **10/10 pass**.
- Updated the three Playwright mock handlers (`getEmail` → `getOwnEmail`, new shape) in the feedback / links / events mocked specs.
- Pre-commit hook ran `vue-tsc --noEmit` + eslint: **0 errors**.

## ⚠️ Coordinated deploy required

`getOwnEmail` does not exist on the API until **multiforum-backend#64** ships. **Deploy these two together** — otherwise the auth-session / onboarding lookups call a field that isn't there (or, in the interim, the old `emails` query that is now admin-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)