### PR TITLE
test: heavy-page coverage via extracted, tested utils (10 pages)

### DIFF
--- a/pages/forums/[forumId].spec.ts
+++ b/pages/forums/[forumId].spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { setActivePinia, createPinia } from 'pinia';
+import { useQuery } from '@vue/apollo-composable';
+import PageNotFound from '@/components/PageNotFound.vue';
+import ChannelTabs from '@/components/channel/ChannelTabs.vue';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+const routeRef = { params: { forumId: 'cats' }, name: 'forums-forumId', query: {} };
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => routeRef,
+  useRouter: () => ({ push: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (channels: unknown[]) => {
+  mockedUseQuery
+    .mockReturnValueOnce({
+      result: ref({ channels }),
+      onResult: vi.fn(),
+      loading: ref(false),
+      refetch: vi.fn(),
+    })
+    .mockReturnValueOnce({ result: ref(null) });
+  const Page = (await import('./[forumId].vue')).default;
+  return shallowMount(Page);
+};
+
+describe('forum shell page', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    routeRef.name = 'forums-forumId';
+  });
+
+  it('shows the not-found page when the channel does not exist', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.findComponent(PageNotFound).exists()).toBe(true);
+  });
+
+  it('renders the channel tabs on the plain forum route', async () => {
+    const wrapper = await mountWith([{ uniqueName: 'cats', displayName: 'Cats' }]);
+    expect(wrapper.findComponent(ChannelTabs).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -28,6 +28,7 @@ import {
   getLocalStorageItem,
   setLocalStorageItem,
 } from '@/utils/localStorageUtils';
+import { getForumShellVisibility } from '@/utils/forumShellVisibility';
 import type { ForumItem } from '@/types/forum';
 
 const route = useRoute();
@@ -48,77 +49,45 @@ const selectedChannelDiscussionId = computed(() => {
     : '';
 });
 
-const showDiscussionTitle = computed(() =>
-  route.name?.toString().includes('forums-forumId-discussions-discussionId')
-);
-const showDownloadTitle = computed(() =>
-  route.name?.toString().includes('forums-forumId-downloads-discussionId')
-);
-const showEventTitle = computed(() =>
-  route.name?.toString().includes('forums-forumId-events-eventId')
-);
-const showIssueTitle = computed(() =>
-  route.name?.toString().includes('forums-forumId-issues-issueNumber')
+// Which title bar / panel / sidebar / split-scroll to show is a pure function
+// of the route name; the logic lives in utils/forumShellVisibility.ts (tested).
+const shellVisibility = computed(() =>
+  getForumShellVisibility(route.name?.toString())
 );
 
-const showChannelTabs = computed(() => {
-  const routeName = String(route.name);
-  const isCreatePage = routeName.includes('create');
-
-  // Forum settings pages where we want to show channel tabs
-  const isForumSettingsPage =
-    routeName.startsWith('forums-forumId-edit') &&
-    (routeName === 'forums-forumId-edit' ||
-      routeName.match(
-        /^forums-forumId-edit-(basic|rules|mods|owners|roles|suspended-users|suspended-mods|events|downloads|images|emoji|feedback|wiki-settings|pipelines|plugins(-pluginId)?)$/
-      ));
-
-  // Only hide tabs for content editing (discussions, events, etc), not forum settings
-  const isContentEditPage = routeName.includes('edit') && !isForumSettingsPage;
-
-  return (
-    !showDiscussionTitle.value &&
-    !showDownloadTitle.value &&
-    !showEventTitle.value &&
-    !showIssueTitle.value &&
-    !isCreatePage &&
-    !isContentEditPage
-  );
-});
-
-const showChannelDiscussionPanel = computed(() => {
-  return route.name === 'forums-forumId-discussions';
-});
-
-const showChannelEventPanel = computed(() => {
-  return route.name === 'forums-forumId-events';
-});
-
-const enableDiscussionSplitScroll = computed(() => {
-  return route.name === 'forums-forumId-discussions';
-});
-
-const enableEventSplitScroll = computed(() => {
-  return route.name === 'forums-forumId-events';
-});
-
-const showChannelSidebarOnDetail = computed(() => {
-  return showDiscussionTitle.value || showEventTitle.value;
-});
-
-const showChannelSidebarOnIssueDetail = computed(() => {
-  return route.name
-    ?.toString()
-    .includes('forums-forumId-issues-issueNumber');
-});
-
-const enableIssueSplitScroll = computed(() => {
-  return route.name === 'forums-forumId-issues';
-});
-
-const showChannelIssuePanel = computed(() => {
-  return route.name === 'forums-forumId-issues';
-});
+const showDiscussionTitle = computed(
+  () => shellVisibility.value.showDiscussionTitle
+);
+const showDownloadTitle = computed(
+  () => shellVisibility.value.showDownloadTitle
+);
+const showEventTitle = computed(() => shellVisibility.value.showEventTitle);
+const showIssueTitle = computed(() => shellVisibility.value.showIssueTitle);
+const showChannelTabs = computed(() => shellVisibility.value.showChannelTabs);
+const showChannelDiscussionPanel = computed(
+  () => shellVisibility.value.showChannelDiscussionPanel
+);
+const showChannelEventPanel = computed(
+  () => shellVisibility.value.showChannelEventPanel
+);
+const enableDiscussionSplitScroll = computed(
+  () => shellVisibility.value.enableDiscussionSplitScroll
+);
+const enableEventSplitScroll = computed(
+  () => shellVisibility.value.enableEventSplitScroll
+);
+const showChannelSidebarOnDetail = computed(
+  () => shellVisibility.value.showChannelSidebarOnDetail
+);
+const showChannelSidebarOnIssueDetail = computed(
+  () => shellVisibility.value.showChannelSidebarOnIssueDetail
+);
+const enableIssueSplitScroll = computed(
+  () => shellVisibility.value.enableIssueSplitScroll
+);
+const showChannelIssuePanel = computed(
+  () => shellVisibility.value.showChannelIssuePanel
+);
 
 const channelId = computed(() => {
   return typeof route.params.forumId === 'string' ? route.params.forumId : '';

--- a/pages/forums/[forumId]/discussions/edit/[discussionId].spec.ts
+++ b/pages/forums/[forumId]/discussions/edit/[discussionId].spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import CreateEditDiscussionFields from '@/components/discussion/form/CreateEditDiscussionFields.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats', discussionId: 'd1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: () => ({
+    mutate: vi.fn(),
+    loading: ref(false),
+    error: ref(null),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+  }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ref('mod-1'),
+}));
+
+const RequireAuthStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots['has-auth']?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+describe('discussion edit page', () => {
+  it('renders the discussion edit form for authenticated users', async () => {
+    mockedUseQuery.mockReturnValue({
+      result: ref({
+        discussions: [
+          {
+            id: 'd1',
+            title: 'Hello',
+            body: '',
+            Tags: [],
+            DiscussionChannels: [],
+            Author: { username: 'alice' },
+            Album: { Images: [], imageOrder: [] },
+          },
+        ],
+      }),
+      onResult: vi.fn(),
+      loading: ref(false),
+      error: ref(null),
+    });
+    const Page = (await import('./[discussionId].vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: { stubs: { RequireAuth: RequireAuthStub } },
+    });
+    expect(wrapper.findComponent(CreateEditDiscussionFields).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/discussions/edit/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/edit/[discussionId].vue
@@ -17,6 +17,7 @@ import type {
   Image,
 } from '@/__generated__/graphql';
 import { useModProfileName } from '@/composables/useAuthState';
+import { buildDiscussionEditFormValues } from '@/utils/discussionEditForm';
 
 const modProfileNameVar = useModProfileName();
 
@@ -156,52 +157,9 @@ onGetDiscussionResult((value) => {
     ],
   });
 
-  // Create a map of valid images with their IDs
-  const validImages = (discussion.Album?.Images ?? [])
-    .filter((image: Image) => image.id && image.url) // Only include images with valid IDs and URLs
-    .map((image: Image) => ({
-      id: image.id,
-      url: image.url,
-      alt: image.alt || '',
-      caption: image.caption || '',
-      copyright: image.copyright || '',
-    }));
-
-  // Filter out any null or undefined values from imageOrder and ensure they exist in images
-  const validImageOrder = (discussion.Album?.imageOrder ?? []).filter(
-    (id: string | null | undefined): id is string =>
-      typeof id === 'string' &&
-      id.length > 0 &&
-      validImages.some(
-        (img: {
-          id: string;
-          url: string;
-          alt: string;
-          caption: string;
-          copyright: string;
-        }) => img.id === id
-      )
-  );
-
-  const formFields: CreateEditDiscussionFormValues = {
-    title: discussion.title,
-    body: discussion.body,
-    selectedTags: discussion.Tags.map((tag: TagData) => {
-      return tag.text;
-    }),
-    selectedChannels: discussion.DiscussionChannels.map(
-      (discussionChannel: DiscussionChannel) => {
-        return discussionChannel?.Channel?.uniqueName;
-      }
-    ),
-    author: discussion.Author.username,
-    album: {
-      images: validImages,
-      imageOrder: validImageOrder, // Add the validated imageOrder
-    },
-    crosspostId: discussion.CrosspostedDiscussion?.id || null,
-  };
-  formValues.value = formFields;
+  // Field mapping (incl. the validImageOrder cross-check) lives in
+  // utils/discussionEditForm.ts (unit-tested).
+  formValues.value = buildDiscussionEditFormValues(discussion);
   dataLoaded.value = true;
 });
 

--- a/pages/forums/[forumId]/discussions/feedback/[discussionId].spec.ts
+++ b/pages/forums/[forumId]/discussions/feedback/[discussionId].spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import FeedbackSection from '@/components/comments/FeedbackSection.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({
+    name: 'forums-forumId-discussions-feedback-discussionId',
+    params: { forumId: 'cats', discussionId: 'd1', commentId: '', feedbackId: '' },
+    query: {},
+  }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: () => ({
+    mutate: vi.fn(),
+    loading: ref(false),
+    error: ref(null),
+    onDone: vi.fn(),
+  }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ref('mod-1'),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+describe('discussion feedback page', () => {
+  it('renders the feedback section when the discussion loads', async () => {
+    mockedUseQuery
+      .mockReturnValueOnce({
+        result: ref({
+          discussions: [
+            {
+              id: 'd1',
+              title: 'Hello',
+              body: 'Body',
+              DownloadableFiles: [],
+              Album: { Images: [] },
+              FeedbackComments: [],
+              FeedbackCommentsAggregate: { count: 0 },
+              Author: { username: 'alice' },
+            },
+          ],
+        }),
+        error: ref(null),
+        loading: ref(false),
+        fetchMore: vi.fn(),
+      })
+      .mockReturnValueOnce({
+        result: ref({ comments: [] }),
+        error: ref(null),
+        loading: ref(false),
+      });
+    const Page = (await import('./[discussionId].vue')).default;
+    const wrapper = shallowMount(Page);
+    expect(wrapper.findComponent(FeedbackSection).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/discussions/feedback/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/feedback/[discussionId].vue
@@ -12,6 +12,7 @@ import { ADD_FEEDBACK_COMMENT_TO_COMMENT } from '@/graphQLData/comment/mutations
 import { GET_FEEDBACK_ON_COMMENT } from '@/graphQLData/comment/queries';
 import { useModProfileName } from '@/composables/useAuthState';
 import { useRoute } from 'nuxt/app';
+import { buildFeedbackContextLink } from '@/utils/feedbackContextLink';
 import type { Comment, DownloadableFile } from '@/__generated__/graphql';
 import CrosspostedDiscussionEmbed from '@/components/discussion/detail/CrosspostedDiscussionEmbed.vue';
 
@@ -142,42 +143,15 @@ const contextOfFeedbackComment = computed(() => {
   );
 });
 
-const updateContextLink = () => {
-  if (discussion.value) {
-    if (route.name === 'forums-forumId-discussions-feedback-discussionId') {
-      // If we are on the page that collects feedback on a discussion, go to the
-      // discussion page for the original context.
-      return {
-        name: 'forums-forumId-discussions-discussionId',
-        params: {
-          discussionId: route.params.discussionId,
-          forumId: route.params.forumId,
-        },
-      };
-    }
-    if (
-      route.name ===
-      'forums-forumId-discussions-feedback-discussionId-feedbackPermalink-feedbackId'
-    ) {
-      // If we are on a page that collects feedback on a feedback comment,
-      // go to the original feedback comment's permalink.
-      // (It's the same route with different params.)
-      if (!contextOfFeedbackComment.value) {
-        console.warn('No context of feedback comment found');
-        return '';
-      }
-      return {
-        name: 'forums-forumId-discussions-feedback-discussionId-feedbackPermalink-feedbackId',
-        params: {
-          discussionId: route.params.discussionId,
-          forumId: route.params.forumId,
-          feedbackId: contextOfFeedbackComment.value.id,
-        },
-      };
-    }
-  }
-  return '';
-};
+// Route-driven "back to context" link; logic lives in utils/feedbackContextLink.
+const updateContextLink = () =>
+  buildFeedbackContextLink({
+    routeName: route.name?.toString(),
+    discussionId: route.params.discussionId,
+    forumId: route.params.forumId,
+    hasDiscussion: !!discussion.value,
+    contextFeedbackId: contextOfFeedbackComment.value?.id,
+  });
 
 const reachedEndOfResults = computed(() => {
   if (getDiscussionLoading.value || getDiscussionError.value) return false;

--- a/pages/forums/[forumId]/downloads/edit/[discussionId].spec.ts
+++ b/pages/forums/[forumId]/downloads/edit/[discussionId].spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import CreateEditDiscussionFields from '@/components/discussion/form/CreateEditDiscussionFields.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats', discussionId: 'd1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: () => ({
+    mutate: vi.fn(),
+    loading: ref(false),
+    error: ref(null),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+  }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ref('mod-1'),
+}));
+
+const RequireAuthStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots['has-auth']?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+describe('download edit page', () => {
+  it('renders the download edit form for authenticated users', async () => {
+    mockedUseQuery
+      .mockReturnValueOnce({
+        result: ref({
+          discussions: [
+            {
+              id: 'd1',
+              title: 'Cool model',
+              body: '',
+              Tags: [],
+              DiscussionChannels: [],
+              Author: { username: 'alice' },
+              Album: { Images: [], imageOrder: [] },
+              DownloadableFiles: [],
+            },
+          ],
+        }),
+        onResult: vi.fn(),
+        loading: ref(false),
+        error: ref(null),
+      })
+      .mockReturnValueOnce({
+        result: ref({ channels: [] }),
+        loading: ref(false),
+        error: ref(null),
+      });
+    const Page = (await import('./[discussionId].vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: { stubs: { RequireAuth: RequireAuthStub } },
+    });
+    expect(wrapper.findComponent(CreateEditDiscussionFields).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/downloads/edit/[discussionId].vue
+++ b/pages/forums/[forumId]/downloads/edit/[discussionId].vue
@@ -14,7 +14,6 @@ import RequireAuth from '@/components/auth/RequireAuth.vue';
 import type {
   Discussion,
   DiscussionChannel,
-  DownloadableFile,
   Tag as TagData,
   DiscussionTagsConnectOrCreateFieldInput,
   DiscussionTagsDisconnectFieldInput,
@@ -25,6 +24,11 @@ import type {
 import { useModProfileName } from '@/composables/useAuthState';
 import { resolveSelectedLabelOptionIds } from '@/utils/downloadLabelUtils';
 import { buildAlbumUpdateInput } from '@/utils/albumUpdateInput';
+import { buildDiscussionEditFormValues } from '@/utils/discussionEditForm';
+import {
+  extractDownloadLabels,
+  mapDownloadableFiles,
+} from '@/utils/downloadEditForm';
 
 const modProfileNameVar = useModProfileName();
 
@@ -217,95 +221,23 @@ onGetDiscussionResult((value) => {
     ],
   });
 
-  // Create a map of valid images with their IDs
-  const validImages = (discussion.Album?.Images ?? [])
-    .filter((image: Image): image is Image & { id: string; url: string } =>
-      Boolean(image.id && image.url)
-    )
-    .map((image: Image) => ({
-      id: image.id,
-      url: image.url,
-      alt: image.alt || '',
-      caption: image.caption || '',
-      copyright: image.copyright || '',
-    }));
-
-  // Filter out any null or undefined values from imageOrder and ensure they exist in images
-  const validImageOrder = (discussion.Album?.imageOrder ?? []).filter(
-    (id: string | null | undefined): id is string =>
-      typeof id === 'string' &&
-      id.length > 0 &&
-      validImages.some(
-        (img: {
-          id: string;
-          url: string;
-          alt: string;
-          caption: string;
-          copyright: string;
-        }) => img.id === id
-      )
-  );
-
-  // Extract existing download labels from DiscussionChannel
-  const downloadLabels: Record<string, string[]> = {};
-  const primaryDiscussionChannel = discussion.DiscussionChannels.find(
-    (dc: DiscussionChannel) => dc.Channel?.uniqueName === channelId.value
-  );
-
-  if (primaryDiscussionChannel?.LabelOptions) {
-    // Group labels by their filter group key
-    primaryDiscussionChannel.LabelOptions.forEach(
-      (option: FilterOption) => {
-        const groupKey = option.group?.key;
-        if (groupKey) {
-          if (!downloadLabels[groupKey]) {
-            downloadLabels[groupKey] = [];
-          }
-          downloadLabels[groupKey].push(option.value);
-        }
-      }
-    );
-  }
-
-  // Preserve any existing downloadLabels that the user might have changed
+  // Preserve any existing downloadLabels the user might have changed; otherwise
+  // derive them from the discussion's primary channel (utils/downloadEditForm).
   const existingDownloadLabels = formValues.value.downloadLabels || {};
   const hasExistingLabels = Object.keys(existingDownloadLabels).length > 0;
 
-  const formFields: CreateEditDiscussionFormValues = {
-    title: discussion.title,
-    body: discussion.body,
-    selectedTags: discussion.Tags.map((tag: TagData) => {
-      return tag.text;
-    }),
-    selectedChannels: discussion.DiscussionChannels.map(
-      (discussionChannel: DiscussionChannel) => {
-        return discussionChannel?.Channel?.uniqueName;
-      }
-    ),
-    author: discussion.Author.username,
-    album: {
-      images: validImages,
-      imageOrder: validImageOrder,
-    },
-    crosspostId: discussion.CrosspostedDiscussion?.id || null,
-    downloadableFiles:
-      discussion.DownloadableFiles?.map((file: DownloadableFile) => ({
-        id: file.id || '',
-        fileName: file.fileName || '',
-        url: file.url || '',
-        kind: file.kind || 'OTHER',
-        size: file.size || 0,
-        license: file.license?.id || '',
-        priceModel: file.priceModel || 'FREE',
-        priceCents: file.priceCents || 0,
-        priceCurrency: file.priceCurrency || 'USD',
-      })) || [],
-    // Use existing labels if the user has made changes, otherwise use labels from discussion data
+  // Base field mapping is shared with the discussion edit page; the download
+  // extras (files + labels) come from utils/downloadEditForm.
+  formValues.value = {
+    ...buildDiscussionEditFormValues(discussion),
+    downloadableFiles: mapDownloadableFiles(discussion.DownloadableFiles),
     downloadLabels: hasExistingLabels
       ? existingDownloadLabels
-      : downloadLabels,
+      : extractDownloadLabels({
+          discussionChannels: discussion.DiscussionChannels,
+          channelUniqueName: channelId.value,
+        }),
   };
-  formValues.value = formFields;
   dataLoaded.value = true;
 });
 

--- a/pages/forums/[forumId]/events/edit/[eventId].spec.ts
+++ b/pages/forums/[forumId]/events/edit/[eventId].spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import CreateEditEventFields from '@/components/event/form/CreateEditEventFields.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats', eventId: 'e1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: () => ({
+    mutate: vi.fn(),
+    loading: ref(false),
+    error: ref(null),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+  }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useModProfileName: () => ref('mod-1'),
+}));
+
+const RequireAuthStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots['has-auth']?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+describe('event edit page', () => {
+  it('renders the event edit form for authenticated users', async () => {
+    mockedUseQuery.mockReturnValue({
+      result: ref({
+        events: [
+          {
+            id: 'e1',
+            title: 'Meetup',
+            description: '',
+            Tags: [],
+            EventChannels: [],
+            startTime: '2024-01-01T18:00:00Z',
+            endTime: '2024-01-01T20:00:00Z',
+            canceled: false,
+          },
+        ],
+      }),
+      onResult: vi.fn(),
+      loading: ref(false),
+      error: ref(null),
+    });
+    const Page = (await import('./[eventId].vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: { stubs: { RequireAuth: RequireAuthStub } },
+    });
+    expect(wrapper.findComponent(CreateEditEventFields).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/events/edit/[eventId].vue
+++ b/pages/forums/[forumId]/events/edit/[eventId].vue
@@ -10,6 +10,7 @@ import { useRoute, useRouter } from 'nuxt/app';
 import type { CreateEditEventFormValues } from '@/types/Event';
 import { DateTime } from 'luxon';
 import getDefaultEventFormValues from '@/utils/defaultEventFormValues';
+import { buildEventEditFormValues } from '@/utils/eventEditForm';
 import EditScopeModal from '@/components/event/form/EditScopeModal.vue';
 import CreateEditEventFields from '@/components/event/form/CreateEditEventFields.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
@@ -99,42 +100,10 @@ const isPartOfSeries = computed(() => {
 // Edit scope modal state
 const showEditScopeModal = ref(false);
 
-function getFormValuesFromEventData(
+// Field mapping lives in utils/eventEditForm.ts (unit-tested).
+const getFormValuesFromEventData = (
   eventData: Event
-): CreateEditEventFormValues {
-  return {
-    title: eventData.title,
-    description: eventData.description || '',
-    selectedTags: (eventData.Tags || []).map((tag: TagData) => {
-      return tag.text;
-    }),
-    selectedChannels: (eventData.EventChannels || []).map(
-      (ec: EventChannel) => {
-        return ec.channelUniqueName;
-      }
-    ),
-    address: eventData.address || '',
-    locationName: eventData.locationName || '',
-    isInPrivateResidence: eventData.isInPrivateResidence || false,
-    virtualEventUrl: eventData.virtualEventUrl || '',
-    startTime: eventData.startTime,
-    startTimeDayOfWeek: eventData.startTimeDayOfWeek || '',
-    startTimeHourOfDay: eventData.startTimeHourOfDay || 0,
-    endTime: eventData.endTime,
-    canceled: eventData.canceled,
-    deleted: eventData.deleted || false,
-    cost: eventData.cost || '',
-    free: eventData.free || false,
-    isHostedByOP: eventData.isHostedByOP || false,
-    isAllDay: eventData.isAllDay || false,
-    coverImageURL: eventData.coverImageURL || '',
-    // Multi-date / recurring event fields
-    dateMode: 'single',
-    occurrences: [],
-    dateRangeGroups: [],
-    repeatPattern: undefined,
-  };
-}
+): CreateEditEventFormValues => buildEventEditFormValues(eventData);
 
 function getDefaultFormValues(): CreateEditEventFormValues {
   // If the event data is already loaded, start with

--- a/pages/forums/[forumId]/wiki/[slug].spec.ts
+++ b/pages/forums/[forumId]/wiki/[slug].spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { setActivePinia, createPinia } from 'pinia';
+import { useQuery } from '@vue/apollo-composable';
+import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats', slug: 'intro' } }),
+  useRouter: () => ({ push: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (wikiPage: unknown) => {
+  mockedUseQuery
+    // wiki page data
+    .mockReturnValueOnce({
+      result: ref({ wikiPages: wikiPage ? [wikiPage] : [] }),
+      loading: ref(false),
+      error: ref(null),
+    })
+    // channel (wikiEnabled)
+    .mockReturnValueOnce({
+      result: ref({ channels: [{ wikiEnabled: true }] }),
+      loading: ref(false),
+      error: ref(null),
+    })
+    // SEO query (onResult callback)
+    .mockReturnValueOnce({ onResult: vi.fn() });
+  const Page = (await import('./[slug].vue')).default;
+  return shallowMount(Page);
+};
+
+describe('wiki page', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('renders the wiki body through the markdown renderer', async () => {
+    const wrapper = await mountWith({ title: 'Intro', body: 'Welcome to the wiki' });
+    expect(wrapper.findComponent(MarkdownRenderer).props('text')).toBe(
+      'Welcome to the wiki'
+    );
+  });
+});

--- a/pages/forums/[forumId]/wiki/[slug].vue
+++ b/pages/forums/[forumId]/wiki/[slug].vue
@@ -12,6 +12,7 @@ import FontSizeControl from '@/components/channel/FontSizeControl.vue';
 import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
 import { timeAgo } from '@/utils';
+import { buildWikiPageHead } from '@/utils/wikiSeo';
 
 const route = useRoute();
 const router = useRouter();
@@ -67,87 +68,15 @@ const { onResult: onGetWikiPageResult } = useQuery(
 
 onGetWikiPageResult((result) => {
   try {
-    if (!result?.data?.wikiPages) {
-      return;
-    }
-    if (result.data.wikiPages.length === 0) {
-      // Handle the case where the wiki page is not found
-      useHead({
-        title: `Wiki Page Not Found${forumId ? ` | ${forumId}` : ''}`,
-        meta: [
-          {
-            name: 'description',
-            content: 'The requested wiki page could not be found.',
-          },
-          { name: 'robots', content: 'noindex' },
-        ],
-      });
-      return;
-    } else {
-      const wikiPage = result.data.wikiPages[0];
-      const title = wikiPage.title || 'Wiki Page';
-      const description = wikiPage.body
-        ? wikiPage.body.substring(0, 160) +
-          (wikiPage.body.length > 160 ? '...' : '')
-        : `View this wiki page on ${import.meta.env.VITE_SERVER_DISPLAY_NAME}`;
-      const baseUrl = import.meta.env.VITE_BASE_URL;
-      const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
-      const pageUrl = `${baseUrl}/forums/${forumId}/wiki/${slug}`;
-
-      // Set all meta tags using useHead
-      useHead({
-        title: `${title} | ${forumId} Wiki | ${serverName}`,
-        meta: [
-          { name: 'description', content: description },
-
-          // OpenGraph tags
-          { property: 'og:title', content: title },
-          { property: 'og:description', content: description },
-          { property: 'og:type', content: 'article' },
-          { property: 'og:url', content: pageUrl },
-          { property: 'og:site_name', content: serverName },
-
-          // Twitter Card tags
-          { name: 'twitter:card', content: 'summary' },
-          { name: 'twitter:title', content: title },
-          { name: 'twitter:description', content: description },
-
-          // Additional meta tags for wiki pages
-          { name: 'article:section', content: 'Wiki' },
-          { name: 'article:tag', content: 'wiki' },
-        ],
-        script: [
-          {
-            type: 'application/ld+json',
-            children: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'Article',
-              headline: title,
-              description: description,
-              author: {
-                '@type': 'Person',
-                name:
-                  wikiPage.VersionAuthor?.displayName ||
-                  wikiPage.VersionAuthor?.username ||
-                  'Anonymous',
-              },
-              datePublished: wikiPage.createdAt,
-              dateModified: wikiPage.updatedAt || wikiPage.createdAt,
-              publisher: {
-                '@type': 'Organization',
-                name: serverName,
-              },
-              mainEntityOfPage: {
-                '@type': 'WebPage',
-                '@id': pageUrl,
-              },
-              articleSection: 'Wiki',
-              keywords: ['wiki', forumId, title],
-            }),
-          },
-        ],
-      });
-    }
+    // The pure head-building logic lives in utils/wikiSeo.ts (unit-tested).
+    const head = buildWikiPageHead({
+      wikiPages: result?.data?.wikiPages,
+      forumId,
+      slug,
+      serverDisplayName: import.meta.env.VITE_SERVER_DISPLAY_NAME,
+      baseUrl: import.meta.env.VITE_BASE_URL,
+    });
+    if (head) useHead(head);
   } catch (error) {
     console.error('Error setting wiki page SEO metadata:', error);
   }

--- a/pages/forums/[forumId]/wiki/index.spec.ts
+++ b/pages/forums/[forumId]/wiki/index.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { setActivePinia, createPinia } from 'pinia';
+import { useQuery } from '@vue/apollo-composable';
+import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' } }),
+  useRouter: () => ({ push: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+vi.mock('@/composables/useSuspensionNotice', () => ({
+  useChannelSuspensionNotice: () => ({
+    activeSuspension: ref(null),
+    issueNumber: ref(null),
+    suspendedUntil: ref(null),
+    suspendedIndefinitely: ref(false),
+    channelId: ref('cats'),
+  }),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (channel: unknown) => {
+  mockedUseQuery
+    .mockReturnValueOnce({
+      result: ref({ channels: [channel] }),
+      loading: ref(false),
+      error: ref(null),
+    })
+    .mockReturnValueOnce({ onResult: vi.fn() });
+  const Page = (await import('./index.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('wiki home page', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('renders the wiki home page body when one exists', async () => {
+    const wrapper = await mountWith({
+      wikiEnabled: true,
+      WikiHomePage: { title: 'Home', body: 'Welcome home' },
+    });
+    expect(wrapper.findComponent(MarkdownRenderer).props('text')).toBe(
+      'Welcome home'
+    );
+  });
+
+  it('shows a create prompt when there is no home page', async () => {
+    const wrapper = await mountWith({ wikiEnabled: true, WikiHomePage: null });
+    expect(wrapper.findComponent(MarkdownRenderer).exists()).toBe(false);
+  });
+});

--- a/pages/forums/[forumId]/wiki/index.vue
+++ b/pages/forums/[forumId]/wiki/index.vue
@@ -17,6 +17,7 @@ import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
 import { timeAgo } from '@/utils';
 import { useUsername } from '@/composables/useAuthState';
+import { buildWikiHomeHead } from '@/utils/wikiSeo';
 
 const usernameVar = useUsername();
 
@@ -89,154 +90,14 @@ const { onResult: onGetChannelResult } = useQuery(
 
 onGetChannelResult((result) => {
   try {
-    if (!result?.data?.channels) {
-      return;
-    }
-    if (result.data.channels.length === 0) {
-      // Handle the case where the channel is not found
-      useHead({
-        title: `Wiki Not Found${forumId ? ` | ${forumId}` : ''}`,
-        meta: [
-          {
-            name: 'description',
-            content: 'The requested wiki could not be found.',
-          },
-          { name: 'robots', content: 'noindex' },
-        ],
-      });
-      return;
-    } else {
-      const channel = result.data.channels[0];
-      const wikiHomePage = channel.WikiHomePage;
-      const baseUrl = import.meta.env.VITE_BASE_URL;
-      const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
-      const pageUrl = `${baseUrl}/forums/${forumId}/wiki`;
-
-      if (!channel.wikiEnabled) {
-        // Wiki is disabled
-        useHead({
-          title: `Wiki Disabled | ${forumId} | ${serverName}`,
-          meta: [
-            {
-              name: 'description',
-              content: `The wiki feature is not enabled for ${forumId}.`,
-            },
-            { name: 'robots', content: 'noindex' },
-          ],
-        });
-        return;
-      }
-
-      if (!wikiHomePage) {
-        // No wiki home page exists yet
-        const title = `${forumId} Wiki`;
-        const description = `Create and explore wiki pages for ${forumId} on ${serverName}`;
-
-        useHead({
-          title: `${title} | ${serverName}`,
-          meta: [
-            { name: 'description', content: description },
-
-            // OpenGraph tags
-            { property: 'og:title', content: title },
-            { property: 'og:description', content: description },
-            { property: 'og:type', content: 'website' },
-            { property: 'og:url', content: pageUrl },
-            { property: 'og:site_name', content: serverName },
-
-            // Twitter Card tags
-            { name: 'twitter:card', content: 'summary' },
-            { name: 'twitter:title', content: title },
-            { name: 'twitter:description', content: description },
-
-            // Additional meta tags for wiki pages
-            { name: 'article:section', content: 'Wiki' },
-            { name: 'article:tag', content: 'wiki' },
-          ],
-          script: [
-            {
-              type: 'application/ld+json',
-              children: JSON.stringify({
-                '@context': 'https://schema.org',
-                '@type': 'WebSite',
-                name: title,
-                description: description,
-                url: pageUrl,
-                publisher: {
-                  '@type': 'Organization',
-                  name: serverName,
-                },
-                mainEntityOfPage: {
-                  '@type': 'WebPage',
-                  '@id': pageUrl,
-                },
-                keywords: ['wiki', forumId],
-              }),
-            },
-          ],
-        });
-      } else {
-        // Wiki home page exists
-        const title = wikiHomePage.title || `${forumId} Wiki`;
-        const description = wikiHomePage.body
-          ? wikiHomePage.body.substring(0, 160) +
-            (wikiHomePage.body.length > 160 ? '...' : '')
-          : `Explore the wiki for ${forumId} on ${serverName}`;
-
-        useHead({
-          title: `${title} | ${forumId} Wiki | ${serverName}`,
-          meta: [
-            { name: 'description', content: description },
-
-            // OpenGraph tags
-            { property: 'og:title', content: title },
-            { property: 'og:description', content: description },
-            { property: 'og:type', content: 'article' },
-            { property: 'og:url', content: pageUrl },
-            { property: 'og:site_name', content: serverName },
-
-            // Twitter Card tags
-            { name: 'twitter:card', content: 'summary' },
-            { name: 'twitter:title', content: title },
-            { name: 'twitter:description', content: description },
-
-            // Additional meta tags for wiki pages
-            { name: 'article:section', content: 'Wiki' },
-            { name: 'article:tag', content: 'wiki' },
-          ],
-          script: [
-            {
-              type: 'application/ld+json',
-              children: JSON.stringify({
-                '@context': 'https://schema.org',
-                '@type': 'Article',
-                headline: title,
-                description: description,
-                author: {
-                  '@type': 'Person',
-                  name:
-                    wikiHomePage.VersionAuthor?.displayName ||
-                    wikiHomePage.VersionAuthor?.username ||
-                    'Anonymous',
-                },
-                datePublished: wikiHomePage.createdAt,
-                dateModified: wikiHomePage.updatedAt || wikiHomePage.createdAt,
-                publisher: {
-                  '@type': 'Organization',
-                  name: serverName,
-                },
-                mainEntityOfPage: {
-                  '@type': 'WebPage',
-                  '@id': pageUrl,
-                },
-                articleSection: 'Wiki',
-                keywords: ['wiki', forumId, title],
-              }),
-            },
-          ],
-        });
-      }
-    }
+    // The pure head-building logic lives in utils/wikiSeo.ts (unit-tested).
+    const head = buildWikiHomeHead({
+      channels: result?.data?.channels,
+      forumId,
+      serverDisplayName: import.meta.env.VITE_SERVER_DISPLAY_NAME,
+      baseUrl: import.meta.env.VITE_BASE_URL,
+    });
+    if (head) useHead(head);
   } catch (error) {
     console.error('Error setting wiki index SEO metadata:', error);
   }

--- a/pages/forums/[forumId]/wiki/revisions/diff/[slug]/[revisionId].spec.ts
+++ b/pages/forums/[forumId]/wiki/revisions/diff/[slug]/[revisionId].spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import RevisionDiffContent from '@/components/revision/RevisionDiffContent.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({
+    params: { forumId: 'cats', slug: 'intro', revisionId: 'most-recent-edit' },
+  }),
+  useRouter: () => ({ push: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: () => ({
+    mutate: vi.fn(),
+    loading: ref(false),
+    error: ref(null),
+    onDone: vi.fn(),
+  }),
+}));
+
+vi.mock('@/composables/useModerationOutcomeUI', () => ({
+  useModerationOutcomeUI: () => ({
+    showReportModal: ref(false),
+    showSuccessfullyReported: ref(false),
+    openReportModal: vi.fn(),
+    closeReportModal: vi.fn(),
+    handleReportedSuccessfully: vi.fn(),
+    dismissReportedNotification: vi.fn(),
+  }),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (wikiPage: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ wikiPages: [wikiPage] }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./[revisionId].vue')).default;
+  return shallowMount(Page);
+};
+
+describe('wiki revision diff page', () => {
+  it('renders the diff for the selected revision', async () => {
+    const wrapper = await mountWith({
+      body: 'current body',
+      updatedAt: '2024-03-01',
+      createdAt: '2024-01-01',
+      VersionAuthor: { username: 'carol' },
+      PastVersions: [
+        { id: 'p1', body: 'older body', createdAt: '2024-02-01' },
+      ],
+    });
+    expect(wrapper.findComponent(RevisionDiffContent).exists()).toBe(true);
+  });
+});

--- a/pages/forums/index.spec.ts
+++ b/pages/forums/index.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, defineComponent, h } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import ChannelList from '@/components/channel/ChannelList.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+
+const SlotStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (opts: {
+  channels: unknown[];
+  total?: number;
+  downloads?: unknown[];
+}) => {
+  mockedUseQuery
+    .mockReturnValueOnce({
+      result: ref({
+        getSortedChannels: {
+          channels: opts.channels,
+          aggregateChannelCount: opts.total ?? opts.channels.length,
+        },
+      }),
+      loading: ref(false),
+      error: ref(null),
+      fetchMore: vi.fn(),
+    })
+    .mockReturnValueOnce({
+      result: ref({ getSortedChannels: { channels: opts.downloads ?? [] } }),
+      fetchMore: vi.fn(),
+    });
+  const Page = (await import('./index.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { NuxtLayout: SlotStub, ClientOnly: SlotStub, RequireAuth: true } },
+  });
+};
+
+describe('forums index page', () => {
+  it('renders the channel list with the result count', async () => {
+    const wrapper = await mountWith({
+      channels: [{ uniqueName: 'cats', DiscussionChannelsAggregate: { count: 0 } }],
+      total: 1,
+    });
+    expect(wrapper.findComponent(ChannelList).props('resultCount')).toBe(1);
+  });
+
+  it('merges download counts onto the channels', async () => {
+    const wrapper = await mountWith({
+      channels: [{ uniqueName: 'cats', DiscussionChannelsAggregate: { count: 0 } }],
+      downloads: [{ uniqueName: 'cats', DiscussionChannelsAggregate: { count: 2 } }],
+    });
+    const channels = wrapper.findComponent(ChannelList).props('channels') as Array<{
+      downloadCount: number;
+    }>;
+    expect(channels[0].downloadCount).toBe(2);
+  });
+});

--- a/pages/forums/index.vue
+++ b/pages/forums/index.vue
@@ -15,6 +15,11 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import PrimaryButton from '@/components/PrimaryButton.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import { getTagLabel } from '@/utils';
+import {
+  buildChannelCountMap,
+  mergeChannelCounts,
+  toggleSelectedTag,
+} from '@/utils/forumListChannels';
 import type { LocationQueryValue } from 'vue-router';
 import type { Channel } from '@/__generated__/graphql';
 
@@ -41,14 +46,7 @@ const setSearchInput = (input: string) => {
 };
 
 const setSelectedTags = (tag: string) => {
-  // Check if the tag is already selected
-  if (selectedTags.value.includes(tag)) {
-    // If it is, remove it (deselect)
-    selectedTags.value = selectedTags.value.filter((t) => t !== tag);
-  } else {
-    // If it's not, add it (select)
-    selectedTags.value.push(tag);
-  }
+  selectedTags.value = toggleSelectedTag(selectedTags.value, tag);
 
   // Update query params in URL to reflect selected tags
   router.push({
@@ -116,58 +114,22 @@ const { result: downloadCountsResult, fetchMore: fetchMoreDownloadCounts } =
     }
   );
 
-// Create map of channel name -> discussion count from the discussions query
-const discussionCountMap = computed(() => {
-  const map = new Map<string, number>();
-  const discussionChannels =
-    channelResult.value?.getSortedChannels?.channels || [];
+// Channel count maps + merge logic live in utils/forumListChannels.ts (tested).
+const discussionCountMap = computed(() =>
+  buildChannelCountMap(channelResult.value?.getSortedChannels?.channels)
+);
 
-  discussionChannels.forEach((channel: Channel) => {
-    if (channel.uniqueName) {
-      const discussionCount = channel.DiscussionChannelsAggregate?.count || 0;
-      map.set(channel.uniqueName, discussionCount);
-    }
-  });
+const downloadCountMap = computed(() =>
+  buildChannelCountMap(downloadCountsResult.value?.getSortedChannels?.channels)
+);
 
-  return map;
-});
-
-// Create map of channel name -> download count from the downloads query
-const downloadCountMap = computed(() => {
-  const map = new Map<string, number>();
-  const downloadChannels =
-    downloadCountsResult.value?.getSortedChannels?.channels || [];
-
-  downloadChannels.forEach((channel: Channel) => {
-    if (channel.uniqueName) {
-      const downloadCount = channel.DiscussionChannelsAggregate?.count || 0;
-      map.set(channel.uniqueName, downloadCount);
-    }
-  });
-
-  return map;
-});
-
-// Merge channels by injecting both counts from the maps
-const mergedChannels = computed(() => {
-  const baseChannels = channelResult.value?.getSortedChannels?.channels || [];
-
-  return baseChannels.map((channel: Channel) => {
-    const discussionCount =
-      discussionCountMap.value.get(channel.uniqueName) || 0;
-    const downloadCount = downloadCountMap.value.get(channel.uniqueName) || 0;
-
-    // Create new channel object with corrected discussion count and added download count
-    return {
-      ...channel,
-      DiscussionChannelsAggregate: {
-        ...channel.DiscussionChannelsAggregate,
-        count: discussionCount,
-      },
-      downloadCount,
-    };
-  });
-});
+const mergedChannels = computed(() =>
+  mergeChannelCounts<Channel>({
+    baseChannels: channelResult.value?.getSortedChannels?.channels,
+    discussionCountMap: discussionCountMap.value,
+    downloadCountMap: downloadCountMap.value,
+  })
+);
 
 // Function to load more channels
 const loadMore = () => {

--- a/pages/u/[username]/images/[imageId].spec.ts
+++ b/pages/u/[username]/images/[imageId].spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { username: 'alice', imageId: 'img1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: () => ({ mutate: vi.fn(), loading: ref(false), onDone: vi.fn() }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+vi.mock('@/composables/useImageZoomPan', () => ({
+  useImageZoomPan: () => ({
+    isLightboxOpen: ref(false),
+    zoomLevel: ref(1),
+    isZoomed: ref(false),
+    isDragging: ref(false),
+    translateX: ref(0),
+    translateY: ref(0),
+    startDrag: vi.fn(),
+    onDrag: vi.fn(),
+    stopDrag: vi.fn(),
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    resetZoom: vi.fn(),
+    handleKeyDown: vi.fn(),
+  }),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (image: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ images: image ? [image] : [] }),
+    error: ref(null),
+    loading: ref(false),
+  });
+  const Page = (await import('./[imageId].vue')).default;
+  return shallowMount(Page);
+};
+
+describe('user image detail page', () => {
+  it('renders the image with its url', async () => {
+    const wrapper = await mountWith({
+      id: 'img1',
+      url: 'https://img.test/photo.jpg',
+      caption: 'A photo',
+      Uploader: { username: 'alice' },
+      Album: { Images: [], imageOrder: [] },
+    });
+    expect(wrapper.find('img').attributes('src')).toBe(
+      'https://img.test/photo.jpg'
+    );
+  });
+});

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -13,6 +13,7 @@ import LinkIcon from '@/components/icons/LinkIcon.vue';
 import Notification from '@/components/NotificationComponent.vue';
 import AddImageToFavorites from '@/components/favorites/AddImageToFavorites.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
+import { orderImagesByOrder } from '@/utils/albumImageOrder';
 import { useUsername } from '@/composables/useAuthState';
 import TextEditor from '@/components/TextEditor.vue';
 import SaveButton from '@/components/SaveButton.vue';
@@ -164,27 +165,16 @@ const albumDiscussions = computed(() => {
   return image.value?.Album?.Discussions || [];
 });
 
-// Album images - ordered according to imageOrder, excluding current image
+// Album images - ordered according to imageOrder (utils/albumImageOrder),
+// excluding the current image.
 const albumImages = computed(() => {
   const album = image.value?.Album;
   if (!album?.Images) return [];
 
-  const images = album.Images;
-  const imageOrder = album.imageOrder;
-
-  // Order images according to imageOrder if available
-  let orderedImages;
-  if (imageOrder && imageOrder.length > 0) {
-    orderedImages = imageOrder
-      .filter((imgId): imgId is string => imgId !== null && imgId !== undefined)
-      .map((imgId) => images.find((img) => img.id === imgId))
-      .filter((img): img is NonNullable<typeof img> => img !== undefined);
-  } else {
-    orderedImages = images;
-  }
-
-  // Exclude the current image from the list
-  return orderedImages.filter((img) => img.id !== image.value?.id);
+  return orderImagesByOrder({
+    images: album.Images,
+    imageOrder: album.imageOrder,
+  }).filter((img) => img.id !== image.value?.id);
 });
 
 // Lightbox zoom + pan state (extracted to a composable). The open guard keeps

--- a/utils/albumImageOrder.spec.ts
+++ b/utils/albumImageOrder.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  orderImagesByOrder,
+  getImageIdOrder,
+  moveImageOrderUp,
+  moveImageOrderDown,
+} from './albumImageOrder';
+
+describe('orderImagesByOrder', () => {
+  const images = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+  it('returns images sorted by the id order', () => {
+    expect(
+      orderImagesByOrder({ images, imageOrder: ['c', 'a', 'b'] }).map((i) => i.id)
+    ).toEqual(['c', 'a', 'b']);
+  });
+
+  it('keeps the original order when no imageOrder is set', () => {
+    expect(orderImagesByOrder({ images, imageOrder: [] }).map((i) => i.id)).toEqual(
+      ['a', 'b', 'c']
+    );
+  });
+
+  it('drops ids in the order with no matching image', () => {
+    expect(
+      orderImagesByOrder({ images, imageOrder: ['c', 'missing', 'a'] }).map(
+        (i) => i.id
+      )
+    ).toEqual(['c', 'a']);
+  });
+
+  it('returns an empty array for null images', () => {
+    expect(orderImagesByOrder({ images: null, imageOrder: ['a'] })).toEqual([]);
+  });
+});
+
+describe('getImageIdOrder', () => {
+  it('returns the list of non-null image ids', () => {
+    expect(
+      getImageIdOrder([{ id: 'a' }, { id: null }, { id: 'b' }])
+    ).toEqual(['a', 'b']);
+  });
+});
+
+describe('moveImageOrderUp', () => {
+  it('swaps an item with the one before it', () => {
+    expect(moveImageOrderUp(['a', 'b', 'c'], 2)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('is a no-op at the start', () => {
+    expect(moveImageOrderUp(['a', 'b'], 0)).toEqual(['a', 'b']);
+  });
+});
+
+describe('moveImageOrderDown', () => {
+  it('swaps an item with the one after it', () => {
+    expect(moveImageOrderDown(['a', 'b', 'c'], 0)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('is a no-op at the end', () => {
+    expect(moveImageOrderDown(['a', 'b'], 1)).toEqual(['a', 'b']);
+  });
+});

--- a/utils/albumImageOrder.ts
+++ b/utils/albumImageOrder.ts
@@ -8,7 +8,8 @@ export type OrderableImage = { id?: string | null };
 
 export type OrderImagesParams<T> = {
   images: T[] | null | undefined;
-  imageOrder: string[] | null | undefined;
+  // Accepts GraphQL `Maybe<string>[]`; null/undefined ids simply match nothing.
+  imageOrder: (string | null | undefined)[] | null | undefined;
 };
 
 /**

--- a/utils/discussionEditForm.spec.ts
+++ b/utils/discussionEditForm.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { buildDiscussionEditFormValues } from './discussionEditForm';
+
+describe('buildDiscussionEditFormValues', () => {
+  it('maps the basic fields', () => {
+    const values = buildDiscussionEditFormValues({
+      title: 'Hello',
+      body: 'World',
+      Author: { username: 'alice' },
+    });
+    expect(values).toMatchObject({
+      title: 'Hello',
+      body: 'World',
+      author: 'alice',
+    });
+  });
+
+  it('maps tags to their text', () => {
+    const values = buildDiscussionEditFormValues({
+      Tags: [{ text: 'cats' }, { text: 'dogs' }],
+    });
+    expect(values.selectedTags).toEqual(['cats', 'dogs']);
+  });
+
+  it('maps discussion channels to their unique names', () => {
+    const values = buildDiscussionEditFormValues({
+      DiscussionChannels: [{ Channel: { uniqueName: 'cats' } }],
+    });
+    expect(values.selectedChannels).toEqual(['cats']);
+  });
+
+  it('keeps only images with both an id and a url', () => {
+    const values = buildDiscussionEditFormValues({
+      Album: {
+        Images: [
+          { id: 'a', url: 'a.png' },
+          { id: 'b', url: '' },
+          { id: '', url: 'c.png' },
+        ],
+      },
+    });
+    expect(values.album.images.map((i) => i.id)).toEqual(['a']);
+  });
+
+  it('drops order ids that do not reference a kept image', () => {
+    const values = buildDiscussionEditFormValues({
+      Album: {
+        Images: [{ id: 'a', url: 'a.png' }],
+        imageOrder: ['a', 'missing', null, ''],
+      },
+    });
+    expect(values.album.imageOrder).toEqual(['a']);
+  });
+
+  it('defaults missing fields to empty values', () => {
+    const values = buildDiscussionEditFormValues({});
+    expect(values).toMatchObject({
+      title: '',
+      body: '',
+      author: '',
+      selectedTags: [],
+      selectedChannels: [],
+      crosspostId: null,
+    });
+  });
+
+  it('reads the crosspost id when present', () => {
+    const values = buildDiscussionEditFormValues({
+      CrosspostedDiscussion: { id: 'x1' },
+    });
+    expect(values.crosspostId).toBe('x1');
+  });
+});

--- a/utils/discussionEditForm.ts
+++ b/utils/discussionEditForm.ts
@@ -1,0 +1,69 @@
+import type { CreateEditDiscussionFormValues } from '@/types/Discussion';
+
+/**
+ * Map a loaded discussion into the edit form's values. Extracted from
+ * discussions/edit/[discussionId].vue so the field mapping — and the
+ * validImageOrder cross-check (drop ids that don't reference a kept image) —
+ * is unit-testable.
+ */
+
+type EditImage = {
+  id?: string | null;
+  url?: string | null;
+  alt?: string | null;
+  caption?: string | null;
+  copyright?: string | null;
+};
+
+export type DiscussionEditSource = {
+  title?: string | null;
+  body?: string | null;
+  Tags?: { text: string }[] | null;
+  DiscussionChannels?:
+    | { Channel?: { uniqueName?: string | null } | null }[]
+    | null;
+  Author?: { username?: string | null } | null;
+  Album?: {
+    Images?: EditImage[] | null;
+    imageOrder?: (string | null | undefined)[] | null;
+  } | null;
+  CrosspostedDiscussion?: { id?: string | null } | null;
+};
+
+export function buildDiscussionEditFormValues(
+  discussion: DiscussionEditSource
+): CreateEditDiscussionFormValues {
+  // Only keep images that have both an id and a url.
+  const validImages = (discussion.Album?.Images ?? [])
+    .filter((image) => image.id && image.url)
+    .map((image) => ({
+      id: image.id ?? undefined,
+      url: image.url ?? '',
+      alt: image.alt ?? '',
+      caption: image.caption ?? '',
+      copyright: image.copyright ?? '',
+    }));
+
+  // Drop order ids that are empty or don't reference a kept image.
+  const validImageOrder = (discussion.Album?.imageOrder ?? []).filter(
+    (id): id is string =>
+      typeof id === 'string' &&
+      id.length > 0 &&
+      validImages.some((image) => image.id === id)
+  );
+
+  return {
+    title: discussion.title ?? '',
+    body: discussion.body ?? '',
+    selectedTags: (discussion.Tags ?? []).map((tag) => tag.text),
+    selectedChannels: (discussion.DiscussionChannels ?? []).map(
+      (discussionChannel) => discussionChannel?.Channel?.uniqueName ?? ''
+    ),
+    author: discussion.Author?.username ?? '',
+    album: {
+      images: validImages,
+      imageOrder: validImageOrder,
+    },
+    crosspostId: discussion.CrosspostedDiscussion?.id || null,
+  };
+}

--- a/utils/downloadEditForm.spec.ts
+++ b/utils/downloadEditForm.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { extractDownloadLabels, mapDownloadableFiles } from './downloadEditForm';
+
+describe('extractDownloadLabels', () => {
+  it('groups the primary channel label options by group key', () => {
+    const labels = extractDownloadLabels({
+      channelUniqueName: 'cats',
+      discussionChannels: [
+        {
+          Channel: { uniqueName: 'cats' },
+          LabelOptions: [
+            { value: 'pdf', group: { key: 'format' } },
+            { value: 'zip', group: { key: 'format' } },
+            { value: 'free', group: { key: 'price' } },
+          ],
+        },
+      ],
+    });
+    expect(labels).toEqual({ format: ['pdf', 'zip'], price: ['free'] });
+  });
+
+  it('only reads the channel matching the current forum', () => {
+    const labels = extractDownloadLabels({
+      channelUniqueName: 'cats',
+      discussionChannels: [
+        {
+          Channel: { uniqueName: 'dogs' },
+          LabelOptions: [{ value: 'pdf', group: { key: 'format' } }],
+        },
+      ],
+    });
+    expect(labels).toEqual({});
+  });
+
+  it('ignores options without a group key', () => {
+    const labels = extractDownloadLabels({
+      channelUniqueName: 'cats',
+      discussionChannels: [
+        {
+          Channel: { uniqueName: 'cats' },
+          LabelOptions: [{ value: 'orphan', group: null }],
+        },
+      ],
+    });
+    expect(labels).toEqual({});
+  });
+
+  it('returns an empty object when there are no channels', () => {
+    expect(
+      extractDownloadLabels({ channelUniqueName: 'cats', discussionChannels: [] })
+    ).toEqual({});
+  });
+});
+
+describe('mapDownloadableFiles', () => {
+  it('maps a file to the form shape', () => {
+    const [file] = mapDownloadableFiles([
+      {
+        id: 'f1',
+        fileName: 'model.stl',
+        url: 'u',
+        kind: 'STL',
+        size: 100,
+        license: { id: 'cc' },
+        priceModel: 'PAID',
+        priceCents: 500,
+        priceCurrency: 'EUR',
+      },
+    ]);
+    expect(file).toEqual({
+      id: 'f1',
+      fileName: 'model.stl',
+      url: 'u',
+      kind: 'STL',
+      size: 100,
+      license: 'cc',
+      priceModel: 'PAID',
+      priceCents: 500,
+      priceCurrency: 'EUR',
+    });
+  });
+
+  it('applies defaults for missing fields', () => {
+    const [file] = mapDownloadableFiles([{ fileName: 'x' }]);
+    expect(file).toMatchObject({
+      id: '',
+      kind: 'OTHER',
+      size: 0,
+      license: '',
+      priceModel: 'FREE',
+      priceCents: 0,
+      priceCurrency: 'USD',
+    });
+  });
+
+  it('returns an empty array for no files', () => {
+    expect(mapDownloadableFiles(null)).toEqual([]);
+  });
+});

--- a/utils/downloadEditForm.ts
+++ b/utils/downloadEditForm.ts
@@ -1,0 +1,74 @@
+import type { CreateEditDiscussionFormValues } from '@/types/Discussion';
+
+/**
+ * Pure helpers for the download edit page (downloads are discussions with
+ * hasDownload). The base field mapping is shared with the discussion edit page
+ * (utils/discussionEditForm); these cover the download-specific extras —
+ * grouping the channel's selected label options and mapping the downloadable
+ * files into the form shape.
+ */
+
+type LabelOption = { value: string; group?: { key?: string | null } | null };
+
+type LabelDiscussionChannel = {
+  Channel?: { uniqueName?: string | null } | null;
+  LabelOptions?: LabelOption[] | null;
+};
+
+/**
+ * Group the primary channel's selected label options by their filter-group key
+ * (filterGroupKey -> selected option values).
+ */
+export function extractDownloadLabels(params: {
+  discussionChannels: LabelDiscussionChannel[] | null | undefined;
+  channelUniqueName: string;
+}): Record<string, string[]> {
+  const { discussionChannels, channelUniqueName } = params;
+  const labels: Record<string, string[]> = {};
+
+  const primaryChannel = (discussionChannels ?? []).find(
+    (dc) => dc.Channel?.uniqueName === channelUniqueName
+  );
+
+  for (const option of primaryChannel?.LabelOptions ?? []) {
+    const groupKey = option.group?.key;
+    if (groupKey) {
+      (labels[groupKey] ??= []).push(option.value);
+    }
+  }
+
+  return labels;
+}
+
+type DownloadFileSource = {
+  id?: string | null;
+  fileName?: string | null;
+  url?: string | null;
+  kind?: string | null;
+  size?: number | null;
+  license?: { id?: string | null } | null;
+  priceModel?: string | null;
+  priceCents?: number | null;
+  priceCurrency?: string | null;
+};
+
+type DownloadableFormFile = NonNullable<
+  CreateEditDiscussionFormValues['downloadableFiles']
+>[number];
+
+/** Map the discussion's downloadable files into the form's file shape. */
+export function mapDownloadableFiles(
+  files: DownloadFileSource[] | null | undefined
+): DownloadableFormFile[] {
+  return (files ?? []).map((file) => ({
+    id: file.id || '',
+    fileName: file.fileName || '',
+    url: file.url || '',
+    kind: file.kind || 'OTHER',
+    size: file.size || 0,
+    license: file.license?.id || '',
+    priceModel: file.priceModel || 'FREE',
+    priceCents: file.priceCents || 0,
+    priceCurrency: file.priceCurrency || 'USD',
+  }));
+}

--- a/utils/eventEditForm.spec.ts
+++ b/utils/eventEditForm.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { buildEventEditFormValues } from './eventEditForm';
+
+describe('buildEventEditFormValues', () => {
+  it('maps the title and times', () => {
+    const values = buildEventEditFormValues({
+      title: 'Meetup',
+      startTime: '2024-01-01T18:00:00Z',
+      endTime: '2024-01-01T20:00:00Z',
+    });
+    expect(values).toMatchObject({
+      title: 'Meetup',
+      startTime: '2024-01-01T18:00:00Z',
+      endTime: '2024-01-01T20:00:00Z',
+    });
+  });
+
+  it('maps tags to their text', () => {
+    expect(
+      buildEventEditFormValues({ Tags: [{ text: 'music' }, { text: 'art' }] })
+        .selectedTags
+    ).toEqual(['music', 'art']);
+  });
+
+  it('maps event channels to their unique names', () => {
+    expect(
+      buildEventEditFormValues({
+        EventChannels: [{ channelUniqueName: 'cats' }],
+      }).selectedChannels
+    ).toEqual(['cats']);
+  });
+
+  it('preserves the canceled flag', () => {
+    expect(buildEventEditFormValues({ canceled: true }).canceled).toBe(true);
+  });
+
+  it('defaults optional fields', () => {
+    const values = buildEventEditFormValues({});
+    expect(values).toMatchObject({
+      title: '',
+      description: '',
+      selectedTags: [],
+      selectedChannels: [],
+      free: false,
+      isAllDay: false,
+      canceled: false,
+      dateMode: 'single',
+      occurrences: [],
+    });
+  });
+
+  it('always starts in single-date mode with no recurrence', () => {
+    const values = buildEventEditFormValues({ title: 'X' });
+    expect(values.repeatPattern).toBeUndefined();
+  });
+});

--- a/utils/eventEditForm.ts
+++ b/utils/eventEditForm.ts
@@ -1,0 +1,62 @@
+import type { CreateEditEventFormValues } from '@/types/Event';
+
+/**
+ * Map a loaded event into the edit form's values. Extracted from
+ * events/edit/[eventId].vue so the field mapping (tags, channels, and the many
+ * optional fields with their defaults) is unit-testable.
+ */
+
+export type EventEditSource = {
+  title?: string | null;
+  description?: string | null;
+  Tags?: { text: string }[] | null;
+  EventChannels?: { channelUniqueName?: string | null }[] | null;
+  address?: string | null;
+  locationName?: string | null;
+  isInPrivateResidence?: boolean | null;
+  virtualEventUrl?: string | null;
+  startTime?: string | null;
+  startTimeDayOfWeek?: string | null;
+  startTimeHourOfDay?: number | null;
+  endTime?: string | null;
+  canceled?: boolean | null;
+  deleted?: boolean | null;
+  cost?: string | null;
+  free?: boolean | null;
+  isHostedByOP?: boolean | null;
+  isAllDay?: boolean | null;
+  coverImageURL?: string | null;
+};
+
+export function buildEventEditFormValues(
+  eventData: EventEditSource
+): CreateEditEventFormValues {
+  return {
+    title: eventData.title ?? '',
+    description: eventData.description || '',
+    selectedTags: (eventData.Tags || []).map((tag) => tag.text),
+    selectedChannels: (eventData.EventChannels || []).map(
+      (ec) => ec.channelUniqueName ?? ''
+    ),
+    address: eventData.address || '',
+    locationName: eventData.locationName || '',
+    isInPrivateResidence: eventData.isInPrivateResidence || false,
+    virtualEventUrl: eventData.virtualEventUrl || '',
+    startTime: eventData.startTime ?? '',
+    startTimeDayOfWeek: eventData.startTimeDayOfWeek || '',
+    startTimeHourOfDay: eventData.startTimeHourOfDay || 0,
+    endTime: eventData.endTime ?? '',
+    canceled: eventData.canceled ?? false,
+    deleted: eventData.deleted || false,
+    cost: eventData.cost || '',
+    free: eventData.free || false,
+    isHostedByOP: eventData.isHostedByOP || false,
+    isAllDay: eventData.isAllDay || false,
+    coverImageURL: eventData.coverImageURL || '',
+    // Multi-date / recurring event fields
+    dateMode: 'single',
+    occurrences: [],
+    dateRangeGroups: [],
+    repeatPattern: undefined,
+  };
+}

--- a/utils/feedbackContextLink.spec.ts
+++ b/utils/feedbackContextLink.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { buildFeedbackContextLink } from './feedbackContextLink';
+
+const DISCUSSION_ROUTE = 'forums-forumId-discussions-feedback-discussionId';
+const PERMALINK_ROUTE =
+  'forums-forumId-discussions-feedback-discussionId-feedbackPermalink-feedbackId';
+
+describe('buildFeedbackContextLink', () => {
+  it('returns empty while the discussion has not loaded', () => {
+    expect(
+      buildFeedbackContextLink({
+        routeName: DISCUSSION_ROUTE,
+        discussionId: 'd1',
+        forumId: 'cats',
+        hasDiscussion: false,
+      })
+    ).toBe('');
+  });
+
+  it('links back to the discussion on the discussion feedback route', () => {
+    expect(
+      buildFeedbackContextLink({
+        routeName: DISCUSSION_ROUTE,
+        discussionId: 'd1',
+        forumId: 'cats',
+        hasDiscussion: true,
+      })
+    ).toEqual({
+      name: 'forums-forumId-discussions-discussionId',
+      params: { discussionId: 'd1', forumId: 'cats' },
+    });
+  });
+
+  it('links to the feedback comment permalink on the permalink route', () => {
+    expect(
+      buildFeedbackContextLink({
+        routeName: PERMALINK_ROUTE,
+        discussionId: 'd1',
+        forumId: 'cats',
+        hasDiscussion: true,
+        contextFeedbackId: 'fb9',
+      })
+    ).toEqual({
+      name: PERMALINK_ROUTE,
+      params: { discussionId: 'd1', forumId: 'cats', feedbackId: 'fb9' },
+    });
+  });
+
+  it('returns empty on the permalink route without a context feedback id', () => {
+    expect(
+      buildFeedbackContextLink({
+        routeName: PERMALINK_ROUTE,
+        discussionId: 'd1',
+        forumId: 'cats',
+        hasDiscussion: true,
+        contextFeedbackId: null,
+      })
+    ).toBe('');
+  });
+
+  it('returns empty for an unrelated route', () => {
+    expect(
+      buildFeedbackContextLink({
+        routeName: 'forums-forumId-discussions',
+        discussionId: 'd1',
+        forumId: 'cats',
+        hasDiscussion: true,
+      })
+    ).toBe('');
+  });
+});

--- a/utils/feedbackContextLink.ts
+++ b/utils/feedbackContextLink.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure builder for the "back to context" link on the discussion feedback page.
+ * Where the link points depends on the active route: feedback collected on a
+ * discussion links back to the discussion; feedback collected on a feedback
+ * comment links back to that comment's permalink. Extracted from
+ * discussions/feedback/[discussionId].vue so the routing logic is testable.
+ */
+
+export type FeedbackContextLink =
+  | { name: string; params: Record<string, unknown> }
+  | '';
+
+export type BuildFeedbackContextLinkParams = {
+  routeName: string | null | undefined;
+  discussionId: unknown;
+  forumId: unknown;
+  /** Whether the discussion has loaded (no link until it has). */
+  hasDiscussion: boolean;
+  /** Id of the comment the feedback is about, when on a feedback-permalink route. */
+  contextFeedbackId?: string | null;
+};
+
+export function buildFeedbackContextLink(
+  params: BuildFeedbackContextLinkParams
+): FeedbackContextLink {
+  const { routeName, discussionId, forumId, hasDiscussion, contextFeedbackId } =
+    params;
+
+  if (!hasDiscussion) return '';
+
+  // Feedback on a discussion -> back to the discussion page.
+  if (routeName === 'forums-forumId-discussions-feedback-discussionId') {
+    return {
+      name: 'forums-forumId-discussions-discussionId',
+      params: { discussionId, forumId },
+    };
+  }
+
+  // Feedback on a feedback comment -> back to that comment's permalink.
+  if (
+    routeName ===
+    'forums-forumId-discussions-feedback-discussionId-feedbackPermalink-feedbackId'
+  ) {
+    if (!contextFeedbackId) return '';
+    return {
+      name: 'forums-forumId-discussions-feedback-discussionId-feedbackPermalink-feedbackId',
+      params: { discussionId, forumId, feedbackId: contextFeedbackId },
+    };
+  }
+
+  return '';
+}

--- a/utils/forumListChannels.spec.ts
+++ b/utils/forumListChannels.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildChannelCountMap,
+  mergeChannelCounts,
+  toggleSelectedTag,
+} from './forumListChannels';
+
+describe('buildChannelCountMap', () => {
+  it('maps each channel name to its aggregate count', () => {
+    const map = buildChannelCountMap([
+      { uniqueName: 'cats', DiscussionChannelsAggregate: { count: 3 } },
+      { uniqueName: 'dogs', DiscussionChannelsAggregate: { count: 5 } },
+    ]);
+    expect(map.get('dogs')).toBe(5);
+  });
+
+  it('defaults a missing aggregate to zero', () => {
+    const map = buildChannelCountMap([{ uniqueName: 'cats' }]);
+    expect(map.get('cats')).toBe(0);
+  });
+
+  it('skips channels without a unique name', () => {
+    const map = buildChannelCountMap([
+      { DiscussionChannelsAggregate: { count: 1 } },
+    ]);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('mergeChannelCounts', () => {
+  const baseChannels = [
+    { uniqueName: 'cats', DiscussionChannelsAggregate: { count: 0 } },
+  ];
+
+  it('injects the corrected discussion count from the map', () => {
+    const merged = mergeChannelCounts({
+      baseChannels,
+      discussionCountMap: new Map([['cats', 7]]),
+      downloadCountMap: new Map(),
+    });
+    expect(merged[0].DiscussionChannelsAggregate.count).toBe(7);
+  });
+
+  it('injects the download count from the map', () => {
+    const merged = mergeChannelCounts({
+      baseChannels,
+      discussionCountMap: new Map(),
+      downloadCountMap: new Map([['cats', 4]]),
+    });
+    expect(merged[0].downloadCount).toBe(4);
+  });
+
+  it('defaults both counts to zero when the channel is absent from the maps', () => {
+    const merged = mergeChannelCounts({
+      baseChannels,
+      discussionCountMap: new Map(),
+      downloadCountMap: new Map(),
+    });
+    expect([
+      merged[0].DiscussionChannelsAggregate.count,
+      merged[0].downloadCount,
+    ]).toEqual([0, 0]);
+  });
+
+  it('returns an empty array for no base channels', () => {
+    expect(
+      mergeChannelCounts({
+        baseChannels: null,
+        discussionCountMap: new Map(),
+        downloadCountMap: new Map(),
+      })
+    ).toEqual([]);
+  });
+});
+
+describe('toggleSelectedTag', () => {
+  it('adds a tag that is not selected', () => {
+    expect(toggleSelectedTag(['a'], 'b')).toEqual(['a', 'b']);
+  });
+
+  it('removes a tag that is already selected', () => {
+    expect(toggleSelectedTag(['a', 'b'], 'a')).toEqual(['b']);
+  });
+});

--- a/utils/forumListChannels.ts
+++ b/utils/forumListChannels.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure helpers for the forum list page: building per-channel count maps from a
+ * query result and merging the discussion/download counts onto the base channel
+ * list. Extracted from forums/index.vue so the merge logic is unit-testable.
+ */
+
+type ChannelCountLike = {
+  uniqueName?: string | null;
+  DiscussionChannelsAggregate?: { count?: number | null } | null;
+};
+
+/**
+ * Map of channel uniqueName -> aggregate count, read from a channels list (the
+ * same `DiscussionChannelsAggregate.count` field is reused for download counts
+ * in the downloads query).
+ */
+export function buildChannelCountMap(
+  channels: ChannelCountLike[] | null | undefined
+): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const channel of channels || []) {
+    if (channel.uniqueName) {
+      map.set(channel.uniqueName, channel.DiscussionChannelsAggregate?.count || 0);
+    }
+  }
+  return map;
+}
+
+export type MergeChannelCountsParams<T extends ChannelCountLike> = {
+  baseChannels: T[] | null | undefined;
+  discussionCountMap: Map<string, number>;
+  downloadCountMap: Map<string, number>;
+};
+
+/**
+ * Inject the discussion count (corrected from the dedicated query) and the
+ * download count onto each base channel.
+ */
+export function mergeChannelCounts<T extends ChannelCountLike>(
+  params: MergeChannelCountsParams<T>
+): Array<T & { downloadCount: number }> {
+  const { baseChannels, discussionCountMap, downloadCountMap } = params;
+  return (baseChannels || []).map((channel) => {
+    const key = channel.uniqueName ?? '';
+    return {
+      ...channel,
+      DiscussionChannelsAggregate: {
+        ...channel.DiscussionChannelsAggregate,
+        count: discussionCountMap.get(key) || 0,
+      },
+      downloadCount: downloadCountMap.get(key) || 0,
+    };
+  });
+}
+
+/** Toggle a tag in the selected-tags list (pure: returns a new array). */
+export function toggleSelectedTag(tags: string[], tag: string): string[] {
+  return tags.includes(tag) ? tags.filter((t) => t !== tag) : [...tags, tag];
+}

--- a/utils/forumShellVisibility.spec.ts
+++ b/utils/forumShellVisibility.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { getForumShellVisibility } from './forumShellVisibility';
+
+describe('getForumShellVisibility', () => {
+  it('shows the discussion title on a discussion detail route', () => {
+    const v = getForumShellVisibility(
+      'forums-forumId-discussions-discussionId'
+    );
+    expect(v.showDiscussionTitle).toBe(true);
+  });
+
+  it('shows the issue sidebar on an issue detail route', () => {
+    const v = getForumShellVisibility(
+      'forums-forumId-issues-issueNumber'
+    );
+    expect(v.showChannelSidebarOnIssueDetail).toBe(true);
+  });
+
+  it('shows the discussion list panel only on the discussions list route', () => {
+    expect(
+      getForumShellVisibility('forums-forumId-discussions')
+        .showChannelDiscussionPanel
+    ).toBe(true);
+  });
+
+  it('shows channel tabs on the plain forum route', () => {
+    expect(getForumShellVisibility('forums-forumId').showChannelTabs).toBe(true);
+  });
+
+  it('keeps channel tabs visible on forum settings pages', () => {
+    expect(
+      getForumShellVisibility('forums-forumId-edit-basic').showChannelTabs
+    ).toBe(true);
+  });
+
+  it('hides channel tabs while editing content', () => {
+    expect(
+      getForumShellVisibility('forums-forumId-discussions-edit-discussionId')
+        .showChannelTabs
+    ).toBe(false);
+  });
+
+  it('hides channel tabs on create pages', () => {
+    expect(
+      getForumShellVisibility('forums-forumId-discussions-create')
+        .showChannelTabs
+    ).toBe(false);
+  });
+
+  it('hides channel tabs on a detail route', () => {
+    expect(
+      getForumShellVisibility('forums-forumId-discussions-discussionId')
+        .showChannelTabs
+    ).toBe(false);
+  });
+
+  it('enables split scroll on the events list route', () => {
+    expect(
+      getForumShellVisibility('forums-forumId-events').enableEventSplitScroll
+    ).toBe(true);
+  });
+
+  it('defaults everything off for a missing route name', () => {
+    const v = getForumShellVisibility(null);
+    expect([v.showDiscussionTitle, v.showChannelDiscussionPanel]).toEqual([
+      false,
+      false,
+    ]);
+  });
+
+  it('still shows channel tabs for an unknown plain route', () => {
+    expect(getForumShellVisibility(null).showChannelTabs).toBe(true);
+  });
+});

--- a/utils/forumShellVisibility.ts
+++ b/utils/forumShellVisibility.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure route-name -> panel-visibility logic for the forum shell page
+ * (forums/[forumId].vue). Which title bar, content panel, sidebar, and
+ * split-scroll behavior to show is entirely a function of the active route
+ * name, so it's extracted here to be unit-tested without mounting the shell.
+ */
+
+export type ForumShellVisibility = {
+  showDiscussionTitle: boolean;
+  showDownloadTitle: boolean;
+  showEventTitle: boolean;
+  showIssueTitle: boolean;
+  showChannelTabs: boolean;
+  showChannelDiscussionPanel: boolean;
+  showChannelEventPanel: boolean;
+  enableDiscussionSplitScroll: boolean;
+  enableEventSplitScroll: boolean;
+  showChannelSidebarOnDetail: boolean;
+  showChannelSidebarOnIssueDetail: boolean;
+  enableIssueSplitScroll: boolean;
+  showChannelIssuePanel: boolean;
+};
+
+// Forum settings routes (edit/*) that should still show the channel tabs.
+const FORUM_SETTINGS_ROUTE =
+  /^forums-forumId-edit-(basic|rules|mods|owners|roles|suspended-users|suspended-mods|events|downloads|images|emoji|feedback|wiki-settings|pipelines|plugins(-pluginId)?)$/;
+
+export function getForumShellVisibility(
+  routeName: string | null | undefined
+): ForumShellVisibility {
+  const name = routeName ? String(routeName) : '';
+
+  const showDiscussionTitle = name.includes(
+    'forums-forumId-discussions-discussionId'
+  );
+  const showDownloadTitle = name.includes(
+    'forums-forumId-downloads-discussionId'
+  );
+  const showEventTitle = name.includes('forums-forumId-events-eventId');
+  const showIssueTitle = name.includes('forums-forumId-issues-issueNumber');
+
+  const isCreatePage = name.includes('create');
+  const isForumSettingsPage =
+    name.startsWith('forums-forumId-edit') &&
+    (name === 'forums-forumId-edit' || !!name.match(FORUM_SETTINGS_ROUTE));
+  // Hide tabs for content editing (discussions, events, etc), not forum settings.
+  const isContentEditPage = name.includes('edit') && !isForumSettingsPage;
+
+  const showChannelTabs =
+    !showDiscussionTitle &&
+    !showDownloadTitle &&
+    !showEventTitle &&
+    !showIssueTitle &&
+    !isCreatePage &&
+    !isContentEditPage;
+
+  return {
+    showDiscussionTitle,
+    showDownloadTitle,
+    showEventTitle,
+    showIssueTitle,
+    showChannelTabs,
+    showChannelDiscussionPanel: name === 'forums-forumId-discussions',
+    showChannelEventPanel: name === 'forums-forumId-events',
+    enableDiscussionSplitScroll: name === 'forums-forumId-discussions',
+    enableEventSplitScroll: name === 'forums-forumId-events',
+    showChannelSidebarOnDetail: showDiscussionTitle || showEventTitle,
+    showChannelSidebarOnIssueDetail: showIssueTitle,
+    enableIssueSplitScroll: name === 'forums-forumId-issues',
+    showChannelIssuePanel: name === 'forums-forumId-issues',
+  };
+}

--- a/utils/revisionHistory.spec.ts
+++ b/utils/revisionHistory.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getRevisionAuthorName,
+  getVersionAuthorName,
+  getRevisionContent,
+  buildSequentialRevisionPairs,
+} from './revisionHistory';
+
+describe('getRevisionAuthorName', () => {
+  it('returns a non-empty string author as-is', () => {
+    expect(getRevisionAuthorName('alice')).toBe('alice');
+  });
+
+  it('returns [Deleted] for an empty string', () => {
+    expect(getRevisionAuthorName('')).toBe('[Deleted]');
+  });
+
+  it('returns [Deleted] for a null author', () => {
+    expect(getRevisionAuthorName(null)).toBe('[Deleted]');
+  });
+
+  it('prefers username', () => {
+    expect(
+      getRevisionAuthorName({ username: 'alice', displayName: 'Alice' })
+    ).toBe('alice');
+  });
+
+  it('falls back to displayName', () => {
+    expect(getRevisionAuthorName({ displayName: 'Alice' })).toBe('Alice');
+  });
+
+  it('falls back to the nested User username', () => {
+    expect(getRevisionAuthorName({ User: { username: 'bob' } })).toBe('bob');
+  });
+
+  it('returns [Deleted] when nothing identifies the author', () => {
+    expect(getRevisionAuthorName({})).toBe('[Deleted]');
+  });
+});
+
+describe('getVersionAuthorName', () => {
+  it('reads the author from a version', () => {
+    expect(
+      getVersionAuthorName({
+        id: 'v1',
+        createdAt: 't',
+        Author: { username: 'alice' },
+      })
+    ).toBe('alice');
+  });
+});
+
+describe('getRevisionContent', () => {
+  it('prefers the body', () => {
+    expect(
+      getRevisionContent({ id: 'v', createdAt: 't', body: 'B', title: 'T' })
+    ).toBe('B');
+  });
+
+  it('falls back to the title then empty string', () => {
+    expect(getRevisionContent({ id: 'v', createdAt: 't', title: 'T' })).toBe(
+      'T'
+    );
+  });
+});
+
+describe('buildSequentialRevisionPairs', () => {
+  const current = {
+    id: 'current',
+    body: 'v3',
+    createdAt: '2024-03-01',
+    Author: { username: 'carol' },
+  };
+
+  it('returns an empty list when there are no past versions', () => {
+    expect(
+      buildSequentialRevisionPairs({ pastVersions: [], currentVersion: current })
+    ).toEqual([]);
+  });
+
+  it('pairs the current version against the most recent past version', () => {
+    const pairs = buildSequentialRevisionPairs({
+      pastVersions: [{ id: 'p1', body: 'v2', createdAt: '2024-02-01' }],
+      currentVersion: current,
+    });
+    expect(pairs[0]).toMatchObject({ id: 'most-recent-edit', isCurrent: true });
+  });
+
+  it('uses currentAuthor for the most-recent pair when provided', () => {
+    const pairs = buildSequentialRevisionPairs({
+      pastVersions: [{ id: 'p1', body: 'v2', createdAt: '2024-02-01' }],
+      currentVersion: current,
+      currentAuthor: { username: 'dave' },
+    });
+    expect(pairs[0].author).toBe('dave');
+  });
+
+  it('skips the most-recent pair when unchanged and skipUnchangedCurrent is set', () => {
+    const pairs = buildSequentialRevisionPairs({
+      pastVersions: [{ id: 'p1', body: 'v3', createdAt: '2024-02-01' }],
+      currentVersion: current,
+      skipUnchangedCurrent: true,
+    });
+    expect(pairs).toEqual([]);
+  });
+
+  it('builds one sequential pair per older version step', () => {
+    const pairs = buildSequentialRevisionPairs({
+      pastVersions: [
+        { id: 'p1', body: 'v2', createdAt: '2024-02-01' },
+        { id: 'p2', body: 'v1', createdAt: '2024-01-01' },
+      ],
+      currentVersion: current,
+    });
+    // most-recent-edit + one historical pair (p2 vs p1)
+    expect(pairs.map((p) => p.id)).toEqual(['most-recent-edit', 'p2']);
+  });
+
+  it('resolves historical pair authors via getHistoricalPairAuthor', () => {
+    const pairs = buildSequentialRevisionPairs({
+      pastVersions: [
+        { id: 'p1', body: 'v2', createdAt: '2024-02-01' },
+        {
+          id: 'p2',
+          body: 'v1',
+          createdAt: '2024-01-01',
+          Author: { username: 'eve' },
+        },
+      ],
+      currentVersion: current,
+      getHistoricalPairAuthor: ({ oldVersion }) => oldVersion.Author,
+    });
+    expect(pairs[1].author).toBe('eve');
+  });
+});

--- a/utils/wikiSeo.spec.ts
+++ b/utils/wikiSeo.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { buildWikiPageHead } from './wikiSeo';
+
+const BASE = {
+  forumId: 'cats',
+  slug: 'getting-started',
+  serverDisplayName: 'Topical',
+  baseUrl: 'https://example.test',
+};
+
+describe('buildWikiPageHead', () => {
+  it('returns null while the query has not resolved', () => {
+    expect(buildWikiPageHead({ ...BASE, wikiPages: undefined })).toBeNull();
+  });
+
+  it('returns a noindex not-found head for an empty result', () => {
+    const head = buildWikiPageHead({ ...BASE, wikiPages: [] });
+    expect(head?.meta).toContainEqual({ name: 'robots', content: 'noindex' });
+  });
+
+  it('names the forum in the not-found title', () => {
+    const head = buildWikiPageHead({ ...BASE, wikiPages: [] });
+    expect(head?.title).toBe('Wiki Page Not Found | cats');
+  });
+
+  it('formats the loaded title with forum and server name', () => {
+    const head = buildWikiPageHead({
+      ...BASE,
+      wikiPages: [{ title: 'Getting Started', body: 'Hello' }],
+    });
+    expect(head?.title).toBe('Getting Started | cats Wiki | Topical');
+  });
+
+  it('truncates a long body for the description', () => {
+    const head = buildWikiPageHead({
+      ...BASE,
+      wikiPages: [{ title: 'T', body: 'x'.repeat(200) }],
+    });
+    const desc = head?.meta.find((m) => m.name === 'description');
+    expect(desc?.content).toBe(`${'x'.repeat(160)}...`);
+  });
+
+  it('falls back to a server description when the body is empty', () => {
+    const head = buildWikiPageHead({
+      ...BASE,
+      wikiPages: [{ title: 'T', body: '' }],
+    });
+    const desc = head?.meta.find((m) => m.name === 'description');
+    expect(desc?.content).toBe('View this wiki page on Topical');
+  });
+
+  it('emits an Article JSON-LD script', () => {
+    const head = buildWikiPageHead({
+      ...BASE,
+      wikiPages: [{ title: 'T', body: 'b' }],
+    });
+    expect(head?.script?.[0].type).toBe('application/ld+json');
+  });
+
+  it('falls back to Anonymous when the version author has no name', () => {
+    const head = buildWikiPageHead({
+      ...BASE,
+      wikiPages: [{ title: 'T', body: 'b', VersionAuthor: null }],
+    });
+    const data = JSON.parse(head!.script![0].children);
+    expect(data.author.name).toBe('Anonymous');
+  });
+});

--- a/utils/wikiSeo.spec.ts
+++ b/utils/wikiSeo.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildWikiPageHead } from './wikiSeo';
+import { buildWikiPageHead, buildWikiHomeHead } from './wikiSeo';
 
 const BASE = {
   forumId: 'cats',
@@ -64,5 +64,57 @@ describe('buildWikiPageHead', () => {
     });
     const data = JSON.parse(head!.script![0].children);
     expect(data.author.name).toBe('Anonymous');
+  });
+});
+
+describe('buildWikiHomeHead', () => {
+  const HOME = {
+    forumId: 'cats',
+    serverDisplayName: 'Topical',
+    baseUrl: 'https://example.test',
+  };
+
+  it('returns null while the query has not resolved', () => {
+    expect(buildWikiHomeHead({ ...HOME, channels: undefined })).toBeNull();
+  });
+
+  it('returns a not-found head for an empty channel result', () => {
+    const head = buildWikiHomeHead({ ...HOME, channels: [] });
+    expect(head?.title).toBe('Wiki Not Found | cats');
+  });
+
+  it('returns a noindex disabled head when the wiki is off', () => {
+    const head = buildWikiHomeHead({
+      ...HOME,
+      channels: [{ wikiEnabled: false }],
+    });
+    expect(head?.title).toBe('Wiki Disabled | cats | Topical');
+  });
+
+  it('marks the disabled head noindex', () => {
+    const head = buildWikiHomeHead({
+      ...HOME,
+      channels: [{ wikiEnabled: false }],
+    });
+    expect(head?.meta).toContainEqual({ name: 'robots', content: 'noindex' });
+  });
+
+  it('returns a WebSite landing head when there is no home page', () => {
+    const head = buildWikiHomeHead({
+      ...HOME,
+      channels: [{ wikiEnabled: true, WikiHomePage: null }],
+    });
+    const data = JSON.parse(head!.script![0].children);
+    expect(data['@type']).toBe('WebSite');
+  });
+
+  it('returns an Article head built from the home page', () => {
+    const head = buildWikiHomeHead({
+      ...HOME,
+      channels: [
+        { wikiEnabled: true, WikiHomePage: { title: 'Home', body: 'Hi' } },
+      ],
+    });
+    expect(head?.title).toBe('Home | cats Wiki | Topical');
   });
 });

--- a/utils/wikiSeo.ts
+++ b/utils/wikiSeo.ts
@@ -1,0 +1,117 @@
+import { truncateDescription } from '@/utils/discussionSeo';
+
+/**
+ * Pure builder for the wiki page's SEO/social metadata and schema.org Article
+ * structured data, extracted from the page's useHead callback so the title
+ * formatting, description truncation, and not-found handling can be unit-tested.
+ */
+
+export type WikiSeoSource = {
+  title?: string | null;
+  body?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  VersionAuthor?: { username?: string | null; displayName?: string | null } | null;
+};
+
+export type BuildWikiPageHeadParams = {
+  /** The `wikiPages` array from the query (undefined while loading). */
+  wikiPages: WikiSeoSource[] | null | undefined;
+  forumId: string;
+  slug: string;
+  serverDisplayName: string;
+  baseUrl: string;
+};
+
+type HeadMeta = { name?: string; property?: string; content: string };
+type HeadObject = {
+  title: string;
+  meta: HeadMeta[];
+  script?: { type: string; children: string }[];
+};
+
+/**
+ * Build the `useHead` object for a wiki page. Returns null while the query has
+ * not resolved (so the caller skips the head update), a noindex "not found"
+ * head for an empty result, and the full article head once loaded.
+ */
+export function buildWikiPageHead(
+  params: BuildWikiPageHeadParams
+): HeadObject | null {
+  const { wikiPages, forumId, slug, serverDisplayName, baseUrl } = params;
+
+  if (!wikiPages) return null;
+
+  if (wikiPages.length === 0) {
+    return {
+      title: `Wiki Page Not Found${forumId ? ` | ${forumId}` : ''}`,
+      meta: [
+        {
+          name: 'description',
+          content: 'The requested wiki page could not be found.',
+        },
+        { name: 'robots', content: 'noindex' },
+      ],
+    };
+  }
+
+  const wikiPage = wikiPages[0];
+  const title = wikiPage?.title || 'Wiki Page';
+  const description = wikiPage?.body
+    ? truncateDescription(wikiPage.body)
+    : `View this wiki page on ${serverDisplayName}`;
+  const pageUrl = `${baseUrl}/forums/${forumId}/wiki/${slug}`;
+
+  return {
+    title: `${title} | ${forumId} Wiki | ${serverDisplayName}`,
+    meta: [
+      { name: 'description', content: description },
+
+      // OpenGraph tags
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { property: 'og:type', content: 'article' },
+      { property: 'og:url', content: pageUrl },
+      { property: 'og:site_name', content: serverDisplayName },
+
+      // Twitter Card tags
+      { name: 'twitter:card', content: 'summary' },
+      { name: 'twitter:title', content: title },
+      { name: 'twitter:description', content: description },
+
+      // Additional meta tags for wiki pages
+      { name: 'article:section', content: 'Wiki' },
+      { name: 'article:tag', content: 'wiki' },
+    ],
+    script: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: title,
+          description,
+          author: {
+            '@type': 'Person',
+            name:
+              wikiPage?.VersionAuthor?.displayName ||
+              wikiPage?.VersionAuthor?.username ||
+              'Anonymous',
+          },
+          datePublished: wikiPage?.createdAt,
+          dateModified: wikiPage?.updatedAt || wikiPage?.createdAt,
+          publisher: {
+            '@type': 'Organization',
+            name: serverDisplayName,
+          },
+          mainEntityOfPage: {
+            '@type': 'WebPage',
+            '@id': pageUrl,
+          },
+          articleSection: 'Wiki',
+          keywords: ['wiki', forumId, title],
+        }),
+      },
+    ],
+  };
+}

--- a/utils/wikiSeo.ts
+++ b/utils/wikiSeo.ts
@@ -115,3 +115,142 @@ export function buildWikiPageHead(
     ],
   };
 }
+
+export type WikiHomeChannel = {
+  wikiEnabled?: boolean | null;
+  WikiHomePage?: WikiSeoSource | null;
+};
+
+export type BuildWikiHomeHeadParams = {
+  /** The `channels` array from the query (undefined while loading). */
+  channels: WikiHomeChannel[] | null | undefined;
+  forumId: string;
+  serverDisplayName: string;
+  baseUrl: string;
+};
+
+/**
+ * Build the `useHead` object for a forum's wiki home page. Returns null while
+ * loading, then handles four states: channel not found, wiki disabled, no home
+ * page yet (a WebSite landing), and an existing home page (an Article).
+ */
+export function buildWikiHomeHead(
+  params: BuildWikiHomeHeadParams
+): HeadObject | null {
+  const { channels, forumId, serverDisplayName, baseUrl } = params;
+
+  if (!channels) return null;
+
+  if (channels.length === 0) {
+    return {
+      title: `Wiki Not Found${forumId ? ` | ${forumId}` : ''}`,
+      meta: [
+        {
+          name: 'description',
+          content: 'The requested wiki could not be found.',
+        },
+        { name: 'robots', content: 'noindex' },
+      ],
+    };
+  }
+
+  const channel = channels[0];
+  const pageUrl = `${baseUrl}/forums/${forumId}/wiki`;
+
+  if (!channel?.wikiEnabled) {
+    return {
+      title: `Wiki Disabled | ${forumId} | ${serverDisplayName}`,
+      meta: [
+        {
+          name: 'description',
+          content: `The wiki feature is not enabled for ${forumId}.`,
+        },
+        { name: 'robots', content: 'noindex' },
+      ],
+    };
+  }
+
+  const wikiHomePage = channel.WikiHomePage;
+
+  if (!wikiHomePage) {
+    const title = `${forumId} Wiki`;
+    const description = `Create and explore wiki pages for ${forumId} on ${serverDisplayName}`;
+    return {
+      title: `${title} | ${serverDisplayName}`,
+      meta: [
+        { name: 'description', content: description },
+        { property: 'og:title', content: title },
+        { property: 'og:description', content: description },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:url', content: pageUrl },
+        { property: 'og:site_name', content: serverDisplayName },
+        { name: 'twitter:card', content: 'summary' },
+        { name: 'twitter:title', content: title },
+        { name: 'twitter:description', content: description },
+        { name: 'article:section', content: 'Wiki' },
+        { name: 'article:tag', content: 'wiki' },
+      ],
+      script: [
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebSite',
+            name: title,
+            description,
+            url: pageUrl,
+            publisher: { '@type': 'Organization', name: serverDisplayName },
+            mainEntityOfPage: { '@type': 'WebPage', '@id': pageUrl },
+            keywords: ['wiki', forumId],
+          }),
+        },
+      ],
+    };
+  }
+
+  const title = wikiHomePage.title || `${forumId} Wiki`;
+  const description = wikiHomePage.body
+    ? truncateDescription(wikiHomePage.body)
+    : `Explore the wiki for ${forumId} on ${serverDisplayName}`;
+
+  return {
+    title: `${title} | ${forumId} Wiki | ${serverDisplayName}`,
+    meta: [
+      { name: 'description', content: description },
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { property: 'og:type', content: 'article' },
+      { property: 'og:url', content: pageUrl },
+      { property: 'og:site_name', content: serverDisplayName },
+      { name: 'twitter:card', content: 'summary' },
+      { name: 'twitter:title', content: title },
+      { name: 'twitter:description', content: description },
+      { name: 'article:section', content: 'Wiki' },
+      { name: 'article:tag', content: 'wiki' },
+    ],
+    script: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: title,
+          description,
+          author: {
+            '@type': 'Person',
+            name:
+              wikiHomePage.VersionAuthor?.displayName ||
+              wikiHomePage.VersionAuthor?.username ||
+              'Anonymous',
+          },
+          datePublished: wikiHomePage.createdAt,
+          dateModified: wikiHomePage.updatedAt || wikiHomePage.createdAt,
+          publisher: { '@type': 'Organization', name: serverDisplayName },
+          mainEntityOfPage: { '@type': 'WebPage', '@id': pageUrl },
+          articleSection: 'Wiki',
+          keywords: ['wiki', forumId, title],
+        }),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
Adds unit coverage for **10 of the heaviest previously-untested pages**, using the established pattern: pull each page's pure logic into a focused, unit-tested utility, then add a page render/branch test. A nice side effect — several previously-untested **shared** utils now have specs, protecting their other call sites too.

All independent off `main` (no cross-PR dependencies). `tsc` clean, ESLint clean, full unit suite green (**4,454 tests**).

## Pages covered & utils extracted

| Page | Util | What's tested |
|---|---|---|
| `forums/index` | `forumListChannels` (new) | channel count-maps, discussion/download count merge, tag toggle |
| `forums/[forumId]/wiki/[slug]` | `wikiSeo.buildWikiPageHead` (new) | SEO/Article head — loading / not-found(noindex) / loaded, 160-char truncation |
| `forums/[forumId]/wiki/index` | `wikiSeo.buildWikiHomeHead` (new) | 4-branch home head — not-found / disabled / no-home-page(WebSite) / home(Article) |
| `forums/[forumId]` (shell) | `forumShellVisibility` (new) | route-name → 13 panel/title/sidebar/split-scroll flags incl. the channel-tabs rule |
| `u/[username]/images/[imageId]` | `albumImageOrder` (spec added) | image ordering + unmatched-id drop, reorder helpers; page deduped onto it |
| `forums/[forumId]/wiki/revisions/diff/[slug]/[revisionId]` | `revisionHistory` (spec added) | author resolution, content fallback, sequential pair building |
| `forums/[forumId]/discussions/edit/[discussionId]` | `discussionEditForm` (new) | event/discussion→form mapping + validImageOrder cross-check |
| `forums/[forumId]/events/edit/[eventId]` | `eventEditForm` (new) | event→form mapping + optional-field defaults |
| `forums/[forumId]/downloads/edit/[discussionId]` | `downloadEditForm` (new) | label grouping + downloadable-file mapping; reuses `discussionEditForm` base |
| `forums/[forumId]/discussions/feedback/[discussionId]` | `feedbackContextLink` (new) | route-driven "back to context" link |

## Summary
- **7 new tested utils** + **specs added for 2 previously-untested shared utils** (`albumImageOrder`, `revisionHistory`)
- **19 new spec files**, ~90 new tests
- 36 files changed (+2,148 / −573) — the extractions also shrink the pages (e.g. the download/discussion/event edit pages now share builders instead of duplicating them)

## Verification
`tsc` clean, ESLint clean, full unit suite green at **4,454 tests**. (Note: one full-suite run earlier flaked with timeouts under transient machine resource-starvation; re-running with a generous timeout / on a healthy machine passes cleanly — these are environmental, not logic failures.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)