### PR TITLE
test: unit coverage batch + fix unreachable PageNotFound on comment feedback page

### DIFF
--- a/pages/forums/[forumId]/contributors.spec.ts
+++ b/pages/forums/[forumId]/contributors.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import ChannelContributionChart from '@/components/charts/ChannelContributionChart.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' } }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (contributors: unknown[]) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ getChannelContributions: contributors }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./contributors.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('contributors page', () => {
+  it('shows the empty state when there are no contributors', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.text()).toContain('No results in the selected time period');
+  });
+
+  it('renders a contribution chart per contributor', async () => {
+    const wrapper = await mountWith([
+      { username: 'alice', dayData: [] },
+      { username: 'bob', dayData: [] },
+    ]);
+    expect(wrapper.findAllComponents(ChannelContributionChart)).toHaveLength(2);
+  });
+});

--- a/pages/forums/[forumId]/contributors.vue
+++ b/pages/forums/[forumId]/contributors.vue
@@ -7,11 +7,11 @@ import ChannelContributionChart from '@/components/charts/ChannelContributionCha
 import IconButtonDropdown from '@/components/IconButtonDropdown.vue';
 import type { MenuItemType } from '@/components/IconButtonDropdown.vue';
 import { DateTime } from 'luxon';
-import type {
-  Activity,
-  DayData,
-  UserContributionData,
-} from '@/__generated__/graphql';
+import type { UserContributionData } from '@/__generated__/graphql';
+import {
+  getMaxDayCount,
+  buildContributorStats,
+} from '@/utils/contributorStats';
 
 const route = useRoute();
 const forumId = computed(() => route.params.forumId as string);
@@ -89,41 +89,12 @@ const contributors = computed<UserContributionData[]>(() => {
 });
 
 // Calculate max Y-axis value across all contributors
-const maxYValue = computed(() => {
-  if (!contributors.value.length) return 0;
-
-  let max = 0;
-  contributors.value.forEach((contributor: UserContributionData) => {
-    contributor.dayData.forEach((day: DayData) => {
-      if (day.count > max) {
-        max = day.count;
-      }
-    });
-  });
-
-  return max;
-});
+const maxYValue = computed(() => getMaxDayCount(contributors.value));
 
 // Calculate discussion and comment counts for each contributor
-const contributorStats = computed(() => {
-  return contributors.value.map((contributor) => {
-    let discussionCount = 0;
-    let commentCount = 0;
-
-    contributor.dayData.forEach((day: DayData) => {
-      day.activities.forEach((activity: Activity) => {
-        discussionCount += (activity.Discussions || []).length;
-        commentCount += (activity.Comments || []).length;
-      });
-    });
-
-    return {
-      username: contributor.username,
-      discussionCount,
-      commentCount,
-    };
-  });
-});
+const contributorStats = computed(() =>
+  buildContributorStats(contributors.value)
+);
 </script>
 
 <template>

--- a/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].spec.ts
+++ b/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].spec.ts
@@ -3,6 +3,7 @@ import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import CommentHeader from '@/components/comments/CommentHeader.vue';
+import PageNotFound from '@/components/PageNotFound.vue';
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({
@@ -51,8 +52,8 @@ describe('comment feedback page', () => {
     expect(wrapper.findComponent(CommentHeader).exists()).toBe(true);
   });
 
-  it('does not render the comment header when the comment is missing', async () => {
+  it('shows the not-found page when the comment is missing', async () => {
     const wrapper = await mountWith(null);
-    expect(wrapper.findComponent(CommentHeader).exists()).toBe(false);
+    expect(wrapper.findComponent(PageNotFound).exists()).toBe(true);
   });
 });

--- a/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].vue
+++ b/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].vue
@@ -291,9 +291,6 @@ onAddFeedbackCommentToCommentDone(() => {
           >
             Feedback
           </h1>
-          <PageNotFound
-            v-if="!getCommentLoading && !getCommentError && !originalComment"
-          />
           <p class="mb-4 px-2 dark:text-white">
             This page collects feedback on this comment:
           </p>
@@ -314,6 +311,7 @@ onAddFeedbackCommentToCommentDone(() => {
             View original context
           </nuxt-link>
         </div>
+        <PageNotFound v-else-if="!getCommentLoading" />
         <FeedbackSection
           :add-feedback-comment-to-comment-error="
             addFeedbackCommentToCommentError?.message || ''

--- a/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId]/feedbackPermalink/[feedbackId].spec.ts
+++ b/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId]/feedbackPermalink/[feedbackId].spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import PermalinkedFeedbackComment from '@/components/comments/PermalinkedFeedbackComment.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { commentId: 'c1' } }),
+}));
+
+describe('comment feedback permalink page', () => {
+  it('passes the route comment id to the permalinked feedback comment', async () => {
+    const Page = (await import('./[feedbackId].vue')).default;
+    const wrapper = shallowMount(Page);
+    expect(
+      wrapper.findComponent(PermalinkedFeedbackComment).attributes('comment-id')
+    ).toBe('c1');
+  });
+});

--- a/pages/forums/[forumId]/downloads/index.spec.ts
+++ b/pages/forums/[forumId]/downloads/index.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' } }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (opts: {
+  channelDownloadsEnabled?: boolean;
+  serverDownloadsEnabled?: boolean;
+}) => {
+  const channel = { downloadsEnabled: opts.channelDownloadsEnabled ?? true };
+  const serverConfig = { enableDownloads: opts.serverDownloadsEnabled ?? true };
+  mockedUseQuery
+    .mockReturnValueOnce({
+      result: ref({ channels: [channel] }),
+      loading: ref(false),
+      error: ref(null),
+    })
+    .mockReturnValueOnce({
+      result: ref({ serverConfigs: [serverConfig] }),
+      loading: ref(false),
+      error: ref(null),
+    });
+  const Page = (await import('./index.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('downloads index page', () => {
+  it('shows the not-available message when downloads are disabled for the forum', async () => {
+    const wrapper = await mountWith({ channelDownloadsEnabled: false });
+    expect(wrapper.text()).toContain('Downloads Not Available');
+  });
+
+  it('hides the not-available message when downloads are enabled', async () => {
+    const wrapper = await mountWith({});
+    expect(wrapper.text()).not.toContain('Downloads Not Available');
+  });
+});

--- a/pages/forums/[forumId]/downloads/index.vue
+++ b/pages/forums/[forumId]/downloads/index.vue
@@ -10,6 +10,7 @@ import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
 import type { FilterGroup } from '@/__generated__/graphql';
 import { config } from '@/config';
 import { DateTime } from 'luxon';
+import { evaluateForumFeatureGate } from '@/utils/forumFeatureGate';
 
 const route = useRoute();
 
@@ -71,30 +72,25 @@ const anyError = computed(() => {
   return channelError.value || serverConfigError.value;
 });
 
-const shouldShowDownloads = computed(() => {
-  return (
-    !bothLoading.value &&
-    !anyError.value &&
-    serverDownloadsEnabled.value &&
-    channelDownloadsEnabled.value
-  );
-});
+const downloadsGate = computed(() =>
+  evaluateForumFeatureGate({
+    loading: bothLoading.value,
+    hasError: Boolean(anyError.value),
+    serverEnabled: serverDownloadsEnabled.value,
+    channelEnabled: channelDownloadsEnabled.value,
+    messages: {
+      error: 'Unable to load forum or server configuration.',
+      serverDisabled:
+        'Cannot show downloads because they are disabled at the server level.',
+      channelDisabled:
+        'Cannot show downloads because they are not enabled for this forum.',
+    },
+  })
+);
 
-const errorMessage = computed(() => {
-  if (anyError.value) {
-    return 'Unable to load forum or server configuration.';
-  }
+const shouldShowDownloads = computed(() => downloadsGate.value.shouldShow);
 
-  if (!serverDownloadsEnabled.value) {
-    return 'Cannot show downloads because they are disabled at the server level.';
-  }
-
-  if (!channelDownloadsEnabled.value) {
-    return 'Cannot show downloads because they are not enabled for this forum.';
-  }
-
-  return '';
-});
+const errorMessage = computed(() => downloadsGate.value.errorMessage);
 
 const filterGroups = computed<FilterGroup[]>(() => {
   return channel.value?.FilterGroups || [];

--- a/pages/forums/[forumId]/events/feedback/[eventId].spec.ts
+++ b/pages/forums/[forumId]/events/feedback/[eventId].spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import PageNotFound from '@/components/PageNotFound.vue';
+import EventHeader from '@/components/event/detail/EventHeader.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats', eventId: 'e1' } }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (event: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ events: event ? [event] : [] }),
+    error: ref(null),
+    loading: ref(false),
+    fetchMore: vi.fn(),
+  });
+  const Page = (await import('./[eventId].vue')).default;
+  return shallowMount(Page);
+};
+
+describe('event feedback page', () => {
+  it('shows the not-found page when the event is missing', async () => {
+    const wrapper = await mountWith(null);
+    expect(wrapper.findComponent(PageNotFound).exists()).toBe(true);
+  });
+
+  it('renders the event header when the event loads', async () => {
+    const wrapper = await mountWith({
+      id: 'e1',
+      title: 'Cat Meetup',
+      FeedbackComments: [],
+      FeedbackCommentsAggregate: { count: 0 },
+    });
+    expect(wrapper.findComponent(EventHeader).exists()).toBe(true);
+  });
+});

--- a/pages/forums/[forumId]/events/feedback/[eventId]/feedbackPermalink/[feedbackId].spec.ts
+++ b/pages/forums/[forumId]/events/feedback/[eventId]/feedbackPermalink/[feedbackId].spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import PermalinkedFeedbackComment from '@/components/comments/PermalinkedFeedbackComment.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { commentId: 'fc1' } }),
+}));
+
+describe('event feedback permalink page', () => {
+  it('passes the route comment id to the permalinked feedback comment', async () => {
+    const Page = (await import('./[feedbackId].vue')).default;
+    const wrapper = shallowMount(Page);
+    expect(
+      wrapper.findComponent(PermalinkedFeedbackComment).attributes('comment-id')
+    ).toBe('fc1');
+  });
+});

--- a/pages/forums/[forumId]/events/index.spec.ts
+++ b/pages/forums/[forumId]/events/index.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' } }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (opts: {
+  channelEventsEnabled?: boolean;
+  serverEventsEnabled?: boolean;
+}) => {
+  const channel = { eventsEnabled: opts.channelEventsEnabled ?? true };
+  const serverConfig = { enableEvents: opts.serverEventsEnabled ?? true };
+  mockedUseQuery
+    .mockReturnValueOnce({
+      result: ref({ channels: [channel] }),
+      loading: ref(false),
+      error: ref(null),
+    })
+    .mockReturnValueOnce({
+      result: ref({ serverConfigs: [serverConfig] }),
+      loading: ref(false),
+      error: ref(null),
+    });
+  const Page = (await import('./index.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('events index page', () => {
+  it('shows the not-available message when events are disabled server-wide', async () => {
+    const wrapper = await mountWith({ serverEventsEnabled: false });
+    expect(wrapper.text()).toContain('Calendar Not Available');
+  });
+
+  it('hides the not-available message when events are enabled', async () => {
+    const wrapper = await mountWith({});
+    expect(wrapper.text()).not.toContain('Calendar Not Available');
+  });
+});

--- a/pages/forums/[forumId]/events/index.vue
+++ b/pages/forums/[forumId]/events/index.vue
@@ -7,6 +7,7 @@ import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
 import { useRoute } from 'nuxt/app';
 import { config } from '@/config';
 import { DateTime } from 'luxon';
+import { evaluateForumFeatureGate } from '@/utils/forumFeatureGate';
 
 const route = useRoute();
 
@@ -70,30 +71,25 @@ const anyError = computed(() => {
   return channelError.value || serverConfigError.value;
 });
 
-const shouldShowEvents = computed(() => {
-  return (
-    !bothLoading.value &&
-    !anyError.value &&
-    serverEventsEnabled.value &&
-    channelEventsEnabled.value
-  );
-});
+const eventsGate = computed(() =>
+  evaluateForumFeatureGate({
+    loading: bothLoading.value,
+    hasError: Boolean(anyError.value),
+    serverEnabled: serverEventsEnabled.value,
+    channelEnabled: channelEventsEnabled.value,
+    messages: {
+      error: 'Unable to load forum or server configuration.',
+      serverDisabled:
+        'Cannot show the calendar because events are disabled at the server level.',
+      channelDisabled:
+        'Cannot show the calendar because it is not enabled for this forum.',
+    },
+  })
+);
 
-const errorMessage = computed(() => {
-  if (anyError.value) {
-    return 'Unable to load forum or server configuration.';
-  }
+const shouldShowEvents = computed(() => eventsGate.value.shouldShow);
 
-  if (!serverEventsEnabled.value) {
-    return 'Cannot show the calendar because events are disabled at the server level.';
-  }
-
-  if (!channelEventsEnabled.value) {
-    return 'Cannot show the calendar because it is not enabled for this forum.';
-  }
-
-  return '';
-});
+const errorMessage = computed(() => eventsGate.value.errorMessage);
 </script>
 <template>
   <div>

--- a/pages/forums/[forumId]/wiki/revisions/[slug].spec.ts
+++ b/pages/forums/[forumId]/wiki/revisions/[slug].spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats', slug: 'home' } }),
+  useRouter: () => ({ push: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (wikiPage: unknown) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(wikiPage ? { wikiPages: [wikiPage] } : { wikiPages: [] }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./[slug].vue')).default;
+  return shallowMount(Page);
+};
+
+describe('wiki revisions page', () => {
+  it('shows the not-found message when the wiki page is missing', async () => {
+    const wrapper = await mountWith(null);
+    expect(wrapper.text()).toContain("This wiki page doesn't exist.");
+  });
+
+  it('shows the no-edits message for a never-edited page', async () => {
+    const wrapper = await mountWith({
+      title: 'Home',
+      body: 'hello',
+      createdAt: '2024-01-01T00:00:00Z',
+      PastVersions: [],
+      VersionAuthor: { username: 'alice' },
+    });
+    expect(wrapper.text()).toContain('This page has not been edited yet.');
+  });
+
+  it('lists one row per edit when the page has past versions', async () => {
+    const wrapper = await mountWith({
+      title: 'Home',
+      body: 'hello v2',
+      updatedAt: '2024-02-01T00:00:00Z',
+      createdAt: '2024-01-01T00:00:00Z',
+      PastVersions: [
+        {
+          id: 'v1',
+          body: 'hello v1',
+          createdAt: '2024-01-15T00:00:00Z',
+          Author: { username: 'bob' },
+        },
+      ],
+      VersionAuthor: { username: 'alice' },
+    });
+    expect(wrapper.text()).toContain('Most recent edit');
+  });
+});

--- a/pages/library/favorite-channels.spec.ts
+++ b/pages/library/favorite-channels.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent, h, ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useHead: vi.fn(),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const RequireAuthStub = defineComponent({
+  name: 'RequireAuth',
+  setup(_, { slots }) {
+    return () => h('div', slots['has-auth']?.());
+  },
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (channels: unknown[]) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ users: [{ FavoriteChannels: channels }] }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./favorite-channels.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { RequireAuth: RequireAuthStub } },
+  });
+};
+
+describe('favorite-channels page', () => {
+  it('shows the empty state when there are no favorite forums', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.text()).toContain('No favorite forums yet');
+  });
+
+  it('renders a card for each favorite forum', async () => {
+    const wrapper = await mountWith([
+      { uniqueName: 'cats', displayName: 'Cats' },
+      { uniqueName: 'dogs', displayName: 'Dogs' },
+    ]);
+    expect(wrapper.findAllComponents({ name: 'AddToChannelFavorites' })).toHaveLength(
+      2
+    );
+  });
+});

--- a/pages/u/[username]/comments.spec.ts
+++ b/pages/u/[username]/comments.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import Comment from '@/components/comments/Comment.vue';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { username: 'alice' }, query: {} }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
+  useSelectedChannelsFromQuery: () => ({
+    selectedChannels: ref([]),
+    hasSelectedChannels: ref(false),
+  }),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (comments: unknown[]) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({
+      users: [{ Comments: comments, CommentsAggregate: { count: comments.length } }],
+    }),
+    loading: ref(false),
+    error: ref(null),
+    fetchMore: vi.fn(),
+  });
+  const Page = (await import('./comments.vue')).default;
+  return shallowMount(Page);
+};
+
+describe('user comments page', () => {
+  it('shows the empty message when the user has no comments', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.text()).toContain('No comments yet');
+  });
+
+  it('renders a Comment for each non-archived comment', async () => {
+    const wrapper = await mountWith([
+      { id: 'c1', archived: false, ParentComment: null, Event: {}, DiscussionChannel: {} },
+      { id: 'c2', archived: false, ParentComment: null, Event: {}, DiscussionChannel: {} },
+    ]);
+    expect(wrapper.findAllComponents(Comment)).toHaveLength(2);
+  });
+});

--- a/pages/wiki/search.spec.ts
+++ b/pages/wiki/search.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ query: {}, params: {} }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/components/discussion/list/getDiscussionFilterValuesFromParams', () => ({
+  getFilterValuesFromParams: () => ({ searchInput: '', channels: [] }),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const mountWith = async (wikiPages: unknown[]) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({
+      getSiteWideWikiList: {
+        wikiPages,
+        aggregateWikiPageCount: wikiPages.length,
+      },
+    }),
+    loading: ref(false),
+    error: ref(null),
+  });
+  const Page = (await import('./search.vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { NuxtLayout: { template: '<div><slot /></div>' } } },
+  });
+};
+
+describe('wiki search page', () => {
+  it('shows the empty message when no wiki pages match', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.text()).toContain('No wiki pages match your search.');
+  });
+
+  it('renders a result row per matching wiki page', async () => {
+    const wrapper = await mountWith([
+      { id: 'w1', title: 'Cats', slug: 'cats', channelUniqueName: 'cats', body: 'hi' },
+      { id: 'w2', title: 'Dogs', slug: 'dogs', channelUniqueName: 'dogs', body: 'hi' },
+    ]);
+    expect(wrapper.findAll('[data-testid="wiki-search-results"] > li')).toHaveLength(
+      2
+    );
+  });
+});

--- a/pages/wiki/search.vue
+++ b/pages/wiki/search.vue
@@ -12,15 +12,7 @@ import { updateFilters } from '@/utils/routerUtils';
 import { getChannelLabel, relativeTime } from '@/utils';
 import { getFilterValuesFromParams } from '@/components/discussion/list/getDiscussionFilterValuesFromParams';
 import { GET_SITE_WIDE_WIKI_LIST } from '@/graphQLData/wiki/queries';
-
-const formatWordCount = (body: string | null | undefined): string => {
-  if (!body) return '0 words';
-  const words = body.trim().split(/\s+/).filter(Boolean).length;
-  if (words >= 1000) {
-    return `${(words / 1000).toFixed(1).replace(/\.0$/, '')}k words`;
-  }
-  return `${words} ${words === 1 ? 'word' : 'words'}`;
-};
+import { formatWordCount } from '@/utils/wikiSearchDisplay';
 
 const WIKI_PAGE_LIMIT = 25;
 

--- a/utils/contributorStats.spec.ts
+++ b/utils/contributorStats.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import type { UserContributionData } from '@/__generated__/graphql';
+import { getMaxDayCount, buildContributorStats } from './contributorStats';
+
+const makeContributor = (
+  username: string,
+  days: { count: number; discussions?: number; comments?: number }[]
+): UserContributionData =>
+  ({
+    username,
+    dayData: days.map((d) => ({
+      count: d.count,
+      activities: [
+        {
+          Discussions: Array.from({ length: d.discussions ?? 0 }, (_, i) => ({
+            id: `d${i}`,
+          })),
+          Comments: Array.from({ length: d.comments ?? 0 }, (_, i) => ({
+            id: `c${i}`,
+          })),
+        },
+      ],
+    })),
+  }) as unknown as UserContributionData;
+
+describe('getMaxDayCount', () => {
+  it('returns 0 for no contributors', () => {
+    expect(getMaxDayCount([])).toBe(0);
+  });
+
+  it('returns the highest single-day count across all contributors', () => {
+    const contributors = [
+      makeContributor('alice', [{ count: 2 }, { count: 5 }]),
+      makeContributor('bob', [{ count: 9 }, { count: 1 }]),
+    ];
+    expect(getMaxDayCount(contributors)).toBe(9);
+  });
+});
+
+describe('buildContributorStats', () => {
+  it('sums discussions and comments across a contributor\'s days', () => {
+    const stats = buildContributorStats([
+      makeContributor('alice', [
+        { count: 3, discussions: 2, comments: 1 },
+        { count: 1, discussions: 0, comments: 4 },
+      ]),
+    ]);
+    expect(stats[0]).toEqual({
+      username: 'alice',
+      discussionCount: 2,
+      commentCount: 5,
+    });
+  });
+
+  it('returns a stat entry per contributor', () => {
+    const stats = buildContributorStats([
+      makeContributor('alice', [{ count: 1 }]),
+      makeContributor('bob', [{ count: 1 }]),
+    ]);
+    expect(stats.map((s) => s.username)).toEqual(['alice', 'bob']);
+  });
+});

--- a/utils/contributorStats.ts
+++ b/utils/contributorStats.ts
@@ -1,0 +1,55 @@
+import type {
+  Activity,
+  DayData,
+  UserContributionData,
+} from '@/__generated__/graphql';
+
+/**
+ * Pure aggregation helpers for the forum contributors page. Extracted so the
+ * per-contributor counting and chart-scaling logic can be unit-tested without
+ * mounting the page or its chart component.
+ */
+
+/** Highest single-day contribution count across all contributors (chart Y max). */
+export function getMaxDayCount(
+  contributors: UserContributionData[]
+): number {
+  let max = 0;
+  for (const contributor of contributors) {
+    for (const day of contributor.dayData as DayData[]) {
+      if (day.count > max) {
+        max = day.count;
+      }
+    }
+  }
+  return max;
+}
+
+export type ContributorStat = {
+  username: string;
+  discussionCount: number;
+  commentCount: number;
+};
+
+/** Total discussions and comments each contributor authored over the period. */
+export function buildContributorStats(
+  contributors: UserContributionData[]
+): ContributorStat[] {
+  return contributors.map((contributor) => {
+    let discussionCount = 0;
+    let commentCount = 0;
+
+    (contributor.dayData as DayData[]).forEach((day) => {
+      day.activities.forEach((activity: Activity) => {
+        discussionCount += (activity.Discussions || []).length;
+        commentCount += (activity.Comments || []).length;
+      });
+    });
+
+    return {
+      username: contributor.username,
+      discussionCount,
+      commentCount,
+    };
+  });
+}

--- a/utils/forumFeatureGate.spec.ts
+++ b/utils/forumFeatureGate.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateForumFeatureGate } from './forumFeatureGate';
+
+const messages = {
+  error: 'load error',
+  serverDisabled: 'server off',
+  channelDisabled: 'channel off',
+};
+
+const base = {
+  loading: false,
+  hasError: false,
+  serverEnabled: true,
+  channelEnabled: true,
+  messages,
+};
+
+describe('evaluateForumFeatureGate', () => {
+  it('shows the feature when enabled at both levels and idle', () => {
+    expect(evaluateForumFeatureGate(base).shouldShow).toBe(true);
+  });
+
+  it('has no error message when the feature is shown', () => {
+    expect(evaluateForumFeatureGate(base).errorMessage).toBe('');
+  });
+
+  it('hides the feature while loading', () => {
+    expect(
+      evaluateForumFeatureGate({ ...base, loading: true }).shouldShow
+    ).toBe(false);
+  });
+
+  it('hides the feature on error', () => {
+    expect(
+      evaluateForumFeatureGate({ ...base, hasError: true }).shouldShow
+    ).toBe(false);
+  });
+
+  it('prefers the error message over disablement reasons', () => {
+    expect(
+      evaluateForumFeatureGate({
+        ...base,
+        hasError: true,
+        serverEnabled: false,
+      }).errorMessage
+    ).toBe('load error');
+  });
+
+  it('reports server-level disablement before channel-level', () => {
+    expect(
+      evaluateForumFeatureGate({
+        ...base,
+        serverEnabled: false,
+        channelEnabled: false,
+      }).errorMessage
+    ).toBe('server off');
+  });
+
+  it('reports channel-level disablement when only the channel is off', () => {
+    expect(
+      evaluateForumFeatureGate({ ...base, channelEnabled: false }).errorMessage
+    ).toBe('channel off');
+  });
+});

--- a/utils/forumFeatureGate.ts
+++ b/utils/forumFeatureGate.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared gating logic for forum feature index pages (downloads, events, …).
+ * A feature is shown only when it is enabled at BOTH the server and channel
+ * level and nothing is loading or errored. When it is hidden, a single
+ * human-readable reason is derived in a fixed precedence: load error, then
+ * server-level disablement, then channel-level disablement.
+ *
+ * Extracted from the near-identical logic in the downloads and events index
+ * pages so it can be unit-tested without mounting either page.
+ */
+
+export type ForumFeatureGateMessages = {
+  /** Shown when the channel or server config failed to load. */
+  error: string;
+  /** Shown when the feature is disabled server-wide. */
+  serverDisabled: string;
+  /** Shown when the feature is disabled for this specific forum. */
+  channelDisabled: string;
+};
+
+export type ForumFeatureGateParams = {
+  loading: boolean;
+  hasError: boolean;
+  serverEnabled: boolean;
+  channelEnabled: boolean;
+  messages: ForumFeatureGateMessages;
+};
+
+export type ForumFeatureGateResult = {
+  shouldShow: boolean;
+  errorMessage: string;
+};
+
+export function evaluateForumFeatureGate(
+  params: ForumFeatureGateParams
+): ForumFeatureGateResult {
+  const { loading, hasError, serverEnabled, channelEnabled, messages } = params;
+
+  const shouldShow =
+    !loading && !hasError && serverEnabled && channelEnabled;
+
+  let errorMessage = '';
+  if (hasError) {
+    errorMessage = messages.error;
+  } else if (!serverEnabled) {
+    errorMessage = messages.serverDisabled;
+  } else if (!channelEnabled) {
+    errorMessage = messages.channelDisabled;
+  }
+
+  return { shouldShow, errorMessage };
+}

--- a/utils/wikiSearchDisplay.spec.ts
+++ b/utils/wikiSearchDisplay.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { formatWordCount } from './wikiSearchDisplay';
+
+describe('formatWordCount', () => {
+  it('returns "0 words" for an empty body', () => {
+    expect(formatWordCount('')).toBe('0 words');
+  });
+
+  it('returns "0 words" for null', () => {
+    expect(formatWordCount(null)).toBe('0 words');
+  });
+
+  it('returns "0 words" for whitespace only', () => {
+    expect(formatWordCount('   ')).toBe('0 words');
+  });
+
+  it('uses the singular noun for a single word', () => {
+    expect(formatWordCount('hello')).toBe('1 word');
+  });
+
+  it('counts multiple words separated by arbitrary whitespace', () => {
+    expect(formatWordCount('one  two\nthree')).toBe('3 words');
+  });
+
+  it('uses a compact k-suffix at 1000 words', () => {
+    expect(formatWordCount(Array(1000).fill('w').join(' '))).toBe('1k words');
+  });
+
+  it('keeps one decimal place for non-round thousands', () => {
+    expect(formatWordCount(Array(1200).fill('w').join(' '))).toBe('1.2k words');
+  });
+});

--- a/utils/wikiSearchDisplay.ts
+++ b/utils/wikiSearchDisplay.ts
@@ -1,0 +1,19 @@
+/**
+ * Display helpers for the site-wide wiki search results. Extracted from the
+ * page so the word-count formatting can be unit-tested without mounting it.
+ */
+
+/**
+ * Human-readable word count for a wiki page body: "0 words" for empty,
+ * singular "1 word", and a compact "1.2k words" form once the count reaches
+ * 1000 (trailing ".0" trimmed, e.g. "2k words").
+ */
+export function formatWordCount(body: string | null | undefined): string {
+  if (!body) return '0 words';
+  const words = body.trim().split(/\s+/).filter(Boolean).length;
+  if (words === 0) return '0 words';
+  if (words >= 1000) {
+    return `${(words / 1000).toFixed(1).replace(/\.0$/, '')}k words`;
+  }
+  return `${words} ${words === 1 ? 'word' : 'words'}`;
+}


### PR DESCRIPTION
## Summary

Two related pieces of work on a fresh branch off `main`:

### 1. Bug fix — unreachable PageNotFound on the comment feedback page
`pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].vue` had a `<PageNotFound>` nested inside `v-if="originalComment"` while also requiring `!originalComment` — so it could never render. Moved it to a sibling `v-else-if="!getCommentLoading"` so a missing comment now correctly shows the not-found page.

### 2. Unit coverage batch — 10 pages + 3 extracted utils
Render tests for 10 previously-untested pages, with pure logic extracted into tested utility modules following the established pattern.

**New tested utils (with the pages refactored to use them):**
- `utils/forumFeatureGate.ts` — shared server/channel feature-gating logic, now used by both the downloads and events index pages (previously duplicated inline)
- `utils/wikiSearchDisplay.ts` — `formatWordCount`, extracted from `pages/wiki/search.vue`
- `utils/contributorStats.ts` — `getMaxDayCount` / `buildContributorStats`, extracted from `pages/forums/[forumId]/contributors.vue`

**Pages now covered with render tests:**
- `library/favorite-channels`
- `forums/[forumId]/wiki/revisions/[slug]`
- `forums/[forumId]/downloads/index`
- `forums/[forumId]/events/index`
- `u/[username]/comments`
- `forums/[forumId]/events/feedback/[eventId]`
- `wiki/search`
- `forums/[forumId]/contributors`
- both `feedbackPermalink/[feedbackId]` wrappers (comment + event)

## Verification
- `npm run tsc` — clean
- `eslint` on all changed files — clean
- All new specs pass (37 tests across 13 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)