### PR TITLE
chore(codecov): ignore icon components in coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -47,3 +47,7 @@ ignore:
   - "node_modules/**"
   - "coverage/**"
   - "**/*.d.ts"
+  # Presentational-only: icons are pure <svg> markup with no logic. Also
+  # excluded from the vitest coverage report; ignored here so the combined
+  # (unit + e2e) report drops them regardless of which tool produced it.
+  - "components/icons/**"


### PR DESCRIPTION
## Summary

Exclude `components/icons/**` from Codecov coverage calculations.

Icon components are pure `<svg>` markup with no logic (87 files). They are already excluded from the vitest coverage report (`vitest.config.ts` line 76), but were still listed nowhere in `codecov.yml`'s `ignore` block — so the combined **unit + e2e** report could surface them and drag down the coverage denominator.

This adds `components/icons/**` to the `codecov.yml` ignore list so Codecov drops them regardless of which tool produced the upload.

## Effect
- Icons no longer count toward the project coverage %.
- No source or test changes; config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)