### PR TITLE
test: unit coverage for 10 more pure utility modules (batch 2)

### DIFF
--- a/utils/albumUpdateInput.spec.ts
+++ b/utils/albumUpdateInput.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { buildAlbumUpdateInput } from './albumUpdateInput';
+
+describe('buildAlbumUpdateInput', () => {
+  it('returns an empty object when there is no album data', () => {
+    expect(buildAlbumUpdateInput({ albumData: null })).toEqual({});
+  });
+
+  it('creates a new album connecting existing images when none exists yet', () => {
+    const result = buildAlbumUpdateInput({
+      albumData: { images: [{ id: 'i1' }], imageOrder: ['i1'] },
+    });
+    expect(result.Album?.create?.node?.Images?.connect).toEqual([
+      { where: { node: { id: 'i1' } } },
+    ]);
+  });
+
+  it('returns an empty object when creating with no valid image ids', () => {
+    expect(
+      buildAlbumUpdateInput({ albumData: { images: [{ url: 'x' }] } })
+    ).toEqual({});
+  });
+
+  it('connects images that are new to an existing album', () => {
+    const result = buildAlbumUpdateInput({
+      albumData: { images: [{ id: 'i2' }] },
+      existingAlbumId: 'a1',
+      existingImages: [{ id: 'i1' }],
+    });
+    expect(result.Album?.update?.node?.Images).toContainEqual({
+      connect: [{ where: { node: { id: 'i2' } } }],
+    });
+  });
+
+  it('disconnects images removed from an existing album', () => {
+    const result = buildAlbumUpdateInput({
+      albumData: { images: [], imageOrder: ['x'] },
+      existingAlbumId: 'a1',
+      existingImages: [{ id: 'i1' }],
+    });
+    expect(result.Album?.update?.node?.Images).toContainEqual({
+      disconnect: [{ where: { node: { id: 'i1' } } }],
+    });
+  });
+});

--- a/utils/authUtils.spec.ts
+++ b/utils/authUtils.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { ApolloError } from '@apollo/client/errors';
+import {
+  shouldRestoreUsername,
+  persistUsername,
+  clearPersistedAuth,
+  handleAuthError,
+  USERNAME_STORAGE_KEY,
+  TOKEN_STORAGE_KEY,
+} from './authUtils';
+
+afterEach(() => {
+  window.localStorage.clear();
+  delete (window as unknown as { refreshAuthToken?: unknown }).refreshAuthToken;
+});
+
+describe('shouldRestoreUsername', () => {
+  it('restores only when both username and token are present', () => {
+    expect(shouldRestoreUsername('alice', 'tok')).toBe(true);
+  });
+
+  it('does not restore a username without a token (ghost login)', () => {
+    expect(shouldRestoreUsername('alice', null)).toBe(false);
+  });
+});
+
+describe('persistUsername', () => {
+  it('writes the username to localStorage', () => {
+    persistUsername('alice');
+    expect(window.localStorage.getItem(USERNAME_STORAGE_KEY)).toBe('alice');
+  });
+
+  it('is a no-op for an empty username', () => {
+    persistUsername('');
+    expect(window.localStorage.getItem(USERNAME_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('clearPersistedAuth', () => {
+  it('removes both the username and token', () => {
+    window.localStorage.setItem(USERNAME_STORAGE_KEY, 'alice');
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, 'tok');
+    clearPersistedAuth();
+    expect([
+      window.localStorage.getItem(USERNAME_STORAGE_KEY),
+      window.localStorage.getItem(TOKEN_STORAGE_KEY),
+    ]).toEqual([null, null]);
+  });
+});
+
+describe('handleAuthError', () => {
+  const authError = {
+    graphQLErrors: [{ message: 'session expired' }],
+  } as unknown as ApolloError;
+
+  it('refreshes the token and retries on an auth error', async () => {
+    (window as unknown as { refreshAuthToken: () => Promise<boolean> }).refreshAuthToken =
+      vi.fn().mockResolvedValue(true);
+    const retryFn = vi.fn().mockResolvedValue({ data: 'ok' });
+    const result = await handleAuthError(authError, retryFn);
+    expect(result).toEqual({ data: 'ok' });
+  });
+
+  it('rethrows the original error for a non-auth error', async () => {
+    const otherError = {
+      graphQLErrors: [{ message: 'bad input' }],
+    } as unknown as ApolloError;
+    await expect(handleAuthError(otherError, vi.fn())).rejects.toBe(otherError);
+  });
+});

--- a/utils/downloadFileHelpers.spec.ts
+++ b/utils/downloadFileHelpers.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getDownloadFileMimeType,
+  getDownloadFileKind,
+  buildDownloadAcceptAttribute,
+  buildDownloadableFilesUpdateInput,
+} from './downloadFileHelpers';
+
+describe('getDownloadFileMimeType', () => {
+  it('maps a known extension to its MIME type', () => {
+    expect(getDownloadFileMimeType('archive.zip')).toBe('application/zip');
+  });
+
+  it('returns octet-stream for an unknown extension', () => {
+    expect(getDownloadFileMimeType('file.xyz')).toBe('application/octet-stream');
+  });
+
+  it('returns null when there is no name', () => {
+    expect(getDownloadFileMimeType('')).toBeNull();
+  });
+});
+
+describe('getDownloadFileKind', () => {
+  it.each([
+    ['model.stl', 'STL'],
+    ['photo.JPG', 'JPG'],
+    ['art.png', 'PNG'],
+    ['pack.zip', 'ZIP'],
+    ['notes.txt', 'OTHER'],
+  ])('classifies %s as %s', (name, kind) => {
+    expect(getDownloadFileKind(name)).toBe(kind);
+  });
+});
+
+describe('buildDownloadAcceptAttribute', () => {
+  it('returns undefined when there is no restriction', () => {
+    expect(buildDownloadAcceptAttribute([])).toBeUndefined();
+  });
+
+  it('builds a dot-prefixed comma list', () => {
+    expect(buildDownloadAcceptAttribute(['zip', '.stl'])).toBe('.zip,.stl');
+  });
+});
+
+describe('buildDownloadableFilesUpdateInput', () => {
+  it('connects all current files when there were none before', () => {
+    const result = buildDownloadableFilesUpdateInput({
+      originalFiles: [],
+      currentFiles: [{ id: 'f1' }],
+    });
+    expect(result.DownloadableFiles).toEqual([
+      { connect: [{ where: { node: { id: 'f1' } } }] },
+    ]);
+  });
+
+  it('sets hasDownload false when there are no files', () => {
+    expect(
+      buildDownloadableFilesUpdateInput({ originalFiles: [], currentFiles: [] })
+        .hasDownload
+    ).toBe(false);
+  });
+
+  it('connects new files and disconnects removed ones for an existing set', () => {
+    const result = buildDownloadableFilesUpdateInput({
+      originalFiles: [{ id: 'f1' }],
+      currentFiles: [{ id: 'f2' }],
+    });
+    expect(result.DownloadableFiles).toEqual([
+      {
+        connect: [{ where: { node: { id: 'f2' } } }],
+        disconnect: [{ where: { node: { id: 'f1' } } }],
+      },
+    ]);
+  });
+});

--- a/utils/expandDateRangeGroups.spec.ts
+++ b/utils/expandDateRangeGroups.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import type { DateRangeGroup } from '@/types/Event';
+import {
+  expandDateRangeGroups,
+  validateDateRangeGroup,
+} from './expandDateRangeGroups';
+
+const group = (overrides: Partial<DateRangeGroup> = {}): DateRangeGroup =>
+  ({
+    startDate: '2024-12-12',
+    endDate: '2024-12-14',
+    startTimeOfDay: '09:00',
+    endTimeOfDay: '17:00',
+    ...overrides,
+  }) as DateRangeGroup;
+
+describe('expandDateRangeGroups', () => {
+  it('produces one occurrence per day in the range', () => {
+    expect(expandDateRangeGroups([group()])).toHaveLength(3);
+  });
+
+  it('skips groups with an invalid date', () => {
+    expect(
+      expandDateRangeGroups([group({ startDate: 'not-a-date' })])
+    ).toEqual([]);
+  });
+
+  it('orders occurrences by start time', () => {
+    const result = expandDateRangeGroups([group()]);
+    expect(result[0].startTime < result[1].startTime).toBe(true);
+  });
+});
+
+describe('validateDateRangeGroup', () => {
+  it('accepts a well-formed group', () => {
+    expect(validateDateRangeGroup(group()).valid).toBe(true);
+  });
+
+  it('rejects an end date before the start date', () => {
+    expect(
+      validateDateRangeGroup(group({ endDate: '2024-12-10' })).error
+    ).toBe('End date must be on or after start date');
+  });
+
+  it('rejects an end time that is not after the start time', () => {
+    expect(
+      validateDateRangeGroup(group({ startTimeOfDay: '17:00', endTimeOfDay: '09:00' }))
+        .error
+    ).toBe('End time must be after start time');
+  });
+
+  it('rejects a range longer than 31 days', () => {
+    expect(
+      validateDateRangeGroup(group({ startDate: '2024-01-01', endDate: '2024-03-01' }))
+        .error
+    ).toBe('Date range cannot exceed 31 days');
+  });
+});

--- a/utils/filterGroupYaml.spec.ts
+++ b/utils/filterGroupYaml.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  serializeFilterGroupsToYaml,
+  parseFilterGroupsYaml,
+  type PlainFilterGroup,
+} from './filterGroupYaml';
+
+const group: PlainFilterGroup = {
+  key: 'color',
+  displayName: 'Color',
+  mode: 'INCLUDE',
+  order: 0,
+  options: [{ value: 'red', displayName: 'Red', order: 0 }],
+};
+
+describe('serializeFilterGroupsToYaml', () => {
+  it('serializes a group to YAML containing its key', () => {
+    expect(serializeFilterGroupsToYaml([group])).toContain('key: color');
+  });
+
+  it('round-trips through parse back to the same group', () => {
+    const yaml = serializeFilterGroupsToYaml([group]);
+    expect(parseFilterGroupsYaml(yaml).groups).toEqual([group]);
+  });
+});
+
+describe('parseFilterGroupsYaml', () => {
+  it('fails when the YAML is not an array', () => {
+    expect(parseFilterGroupsYaml('key: value').success).toBe(false);
+  });
+
+  it('fails when a group is missing required fields', () => {
+    expect(parseFilterGroupsYaml('- displayName: X\n  mode: INCLUDE').error).toContain(
+      'missing required fields'
+    );
+  });
+
+  it('fails on an invalid mode', () => {
+    expect(
+      parseFilterGroupsYaml('- key: k\n  displayName: D\n  mode: MAYBE').error
+    ).toContain('invalid mode');
+  });
+
+  it('defaults order to the index when omitted', () => {
+    const result = parseFilterGroupsYaml('- key: k\n  displayName: D\n  mode: INCLUDE');
+    expect(result.groups?.[0].order).toBe(0);
+  });
+
+  it('returns an error string for malformed YAML', () => {
+    expect(parseFilterGroupsYaml(': : :').success).toBe(false);
+  });
+});

--- a/utils/index.spec.ts
+++ b/utils/index.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isFileSizeValid,
+  getUploadFileName,
+  encodeSpacesInURL,
+  getDuration,
+  getTagLabel,
+  getLinksInText,
+  getChannelLabel,
+} from './index';
+
+const fileOfSize = (bytes: number, name = 'f.zip'): File => {
+  const file = new File(['x'], name);
+  Object.defineProperty(file, 'size', { value: bytes });
+  return file;
+};
+
+describe('isFileSizeValid', () => {
+  it('accepts a file under the 5MB default limit', () => {
+    expect(isFileSizeValid({ file: fileOfSize(1024) }).valid).toBe(true);
+  });
+
+  it('rejects a file over the 5MB default limit', () => {
+    expect(isFileSizeValid({ file: fileOfSize(6 * 1024 * 1024) }).valid).toBe(false);
+  });
+
+  it('applies the stricter 1MB limit for profile pictures', () => {
+    expect(
+      isFileSizeValid({ file: fileOfSize(2 * 1024 * 1024), isProfilePic: true }).valid
+    ).toBe(false);
+  });
+});
+
+describe('getUploadFileName', () => {
+  it('replaces spaces in the file name with underscores', () => {
+    const name = getUploadFileName({
+      file: fileOfSize(10, 'my file.png'),
+      username: 'alice',
+      filename: 'my file.png',
+      fileType: 'image/png',
+    });
+    expect(name).not.toContain(' ');
+  });
+
+  it('includes the username', () => {
+    const name = getUploadFileName({
+      file: fileOfSize(10, 'a.png'),
+      username: 'alice',
+      filename: 'a.png',
+      fileType: 'image/png',
+    });
+    expect(name).toContain('alice');
+  });
+});
+
+describe('encodeSpacesInURL', () => {
+  it('encodes spaces as %20', () => {
+    expect(encodeSpacesInURL('a b c')).toBe('a%20b%20c');
+  });
+});
+
+describe('getDuration', () => {
+  it('formats a 90-minute span as "1h 30m"', () => {
+    expect(
+      getDuration('2024-01-01T10:00:00.000Z', '2024-01-01T11:30:00.000Z')
+    ).toBe('1h 30m');
+  });
+
+  it('returns an empty string when the end precedes the start', () => {
+    expect(
+      getDuration('2024-01-01T11:00:00.000Z', '2024-01-01T10:00:00.000Z')
+    ).toBe('');
+  });
+});
+
+describe('getTagLabel', () => {
+  it('returns the bare label with no tags', () => {
+    expect(getTagLabel([])).toBe('Tags');
+  });
+
+  it('includes the count when tags are selected', () => {
+    expect(getTagLabel(['a', 'b'])).toBe('Tags (2)');
+  });
+});
+
+describe('getLinksInText', () => {
+  it('extracts a non-image http link', () => {
+    expect(getLinksInText('see https://example.com/page now')).toEqual([
+      'https://example.com/page',
+    ]);
+  });
+
+  it('returns an empty array for text with no links', () => {
+    expect(getLinksInText('no links here')).toEqual([]);
+  });
+});
+
+describe('getChannelLabel', () => {
+  it('returns "All Forums" when none are selected', () => {
+    expect(getChannelLabel([])).toBe('All Forums');
+  });
+
+  it('includes the count when forums are selected', () => {
+    expect(getChannelLabel(['cats', 'dogs'])).toBe('Forums (2)');
+  });
+});

--- a/utils/originalPoster.spec.ts
+++ b/utils/originalPoster.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getOriginalPoster,
+  isCurrentUserOriginalPoster,
+  getIssueActionVisibility,
+} from './originalPoster';
+
+describe('getOriginalPoster', () => {
+  it('reads the discussion author', () => {
+    expect(
+      getOriginalPoster({ Discussion: { Author: { username: 'alice' } } })
+    ).toEqual({ username: 'alice', modProfileName: '' });
+  });
+
+  it('reads the event poster', () => {
+    expect(
+      getOriginalPoster({ Event: { Poster: { username: 'bob' } } }).username
+    ).toBe('bob');
+  });
+
+  it('reads a User comment author', () => {
+    expect(
+      getOriginalPoster({
+        Comment: { CommentAuthor: { __typename: 'User', username: 'carol' } },
+      }).username
+    ).toBe('carol');
+  });
+
+  it('reads a ModerationProfile comment author as a mod profile name', () => {
+    expect(
+      getOriginalPoster({
+        Comment: {
+          CommentAuthor: { __typename: 'ModerationProfile', displayName: 'Mod' },
+        },
+      })
+    ).toEqual({ username: '', modProfileName: 'Mod' });
+  });
+
+  it('returns empty values when there is no recognizable author', () => {
+    expect(getOriginalPoster({})).toEqual({ username: '', modProfileName: '' });
+  });
+});
+
+describe('isCurrentUserOriginalPoster', () => {
+  it('matches the user author', () => {
+    expect(
+      isCurrentUserOriginalPoster({
+        originalAuthorUsername: 'alice',
+        currentUsername: 'alice',
+      })
+    ).toBe(true);
+  });
+
+  it('matches the moderation-profile author', () => {
+    expect(
+      isCurrentUserOriginalPoster({
+        originalModProfileName: 'Mod',
+        currentModProfileName: 'Mod',
+      })
+    ).toBe(true);
+  });
+
+  it('does not match a different user', () => {
+    expect(
+      isCurrentUserOriginalPoster({
+        originalAuthorUsername: 'alice',
+        currentUsername: 'bob',
+      })
+    ).toBe(false);
+  });
+});
+
+describe('getIssueActionVisibility', () => {
+  it('hides all actions when there is no related content', () => {
+    expect(
+      getIssueActionVisibility({ hasRelatedContent: false, isOriginalPoster: true })
+    ).toMatchObject({ showOpActions: false, showModActions: false });
+  });
+
+  it('enables OP actions for the original poster', () => {
+    expect(
+      getIssueActionVisibility({ hasRelatedContent: true, isOriginalPoster: true })
+    ).toMatchObject({ opActionsEnabled: true, modActionsEnabled: false });
+  });
+
+  it('enables mod actions for a non-original poster', () => {
+    expect(
+      getIssueActionVisibility({ hasRelatedContent: true, isOriginalPoster: false })
+    ).toMatchObject({ opActionsEnabled: false, modActionsEnabled: true });
+  });
+});

--- a/utils/pluginVersionUtils.spec.ts
+++ b/utils/pluginVersionUtils.spec.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import type { PluginFormSection } from '@/types/pluginForms';
+import {
+  resolvePluginMetadata,
+  resolvePluginReadme,
+  canEnablePlugin,
+  sortVersionsDescending,
+  hasNewerVersions,
+  mapInstallErrorMessage,
+  validateRequiredSettings,
+} from './pluginVersionUtils';
+
+describe('resolvePluginMetadata', () => {
+  it('prefers the installed display name', () => {
+    expect(
+      resolvePluginMetadata({
+        installed: { displayName: 'Installed' },
+        registry: { displayName: 'Registry' },
+        pluginId: 'p1',
+      }).displayName
+    ).toBe('Installed');
+  });
+
+  it('falls back to the plugin id when nothing else is available', () => {
+    expect(
+      resolvePluginMetadata({ pluginId: 'p1' }).displayName
+    ).toBe('p1');
+  });
+
+  it('defaults tags to an empty array', () => {
+    expect(resolvePluginMetadata({ pluginId: 'p1' }).tags).toEqual([]);
+  });
+});
+
+describe('resolvePluginReadme', () => {
+  const versions = [
+    { version: '1.0.0', readmeMarkdown: 'one' },
+    { version: '2.0.0', readmeMarkdown: 'two' },
+  ];
+
+  it('prefers the installed README', () => {
+    expect(
+      resolvePluginReadme({
+        installedReadme: 'installed',
+        detailVersions: versions,
+      })
+    ).toBe('installed');
+  });
+
+  it('uses the selected version README', () => {
+    expect(
+      resolvePluginReadme({ selectedVersion: '2.0.0', detailVersions: versions })
+    ).toBe('two');
+  });
+
+  it('falls back to the first version with a README', () => {
+    expect(
+      resolvePluginReadme({ selectedVersion: '9.0.0', detailVersions: versions })
+    ).toBe('one');
+  });
+
+  it('returns null when no README exists anywhere', () => {
+    expect(resolvePluginReadme({ detailVersions: [] })).toBeNull();
+  });
+});
+
+describe('canEnablePlugin', () => {
+  it('returns false when the plugin is not installed', () => {
+    expect(canEnablePlugin({ isInstalled: false, secrets: [] })).toBe(false);
+  });
+
+  it('returns true when all secrets are valid or untested', () => {
+    expect(
+      canEnablePlugin({
+        isInstalled: true,
+        secrets: [{ status: 'VALID' }, { status: 'SET_UNTESTED' }],
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when any secret is invalid', () => {
+    expect(
+      canEnablePlugin({ isInstalled: true, secrets: [{ status: 'INVALID' }] })
+    ).toBe(false);
+  });
+});
+
+describe('sortVersionsDescending', () => {
+  it('orders versions newest-first', () => {
+    expect(
+      sortVersionsDescending([
+        { version: '1.0.0' },
+        { version: '2.1.0' },
+        { version: '2.0.0' },
+      ]).map((v) => v.version)
+    ).toEqual(['2.1.0', '2.0.0', '1.0.0']);
+  });
+});
+
+describe('hasNewerVersions', () => {
+  it('returns true when no version is installed', () => {
+    expect(hasNewerVersions(undefined, [{ version: '1.0.0' }])).toBe(true);
+  });
+
+  it('returns false when only the installed version is available', () => {
+    expect(hasNewerVersions('1.0.0', [{ version: '1.0.0' }])).toBe(false);
+  });
+});
+
+describe('mapInstallErrorMessage', () => {
+  it('maps a registry-not-found error', () => {
+    expect(mapInstallErrorMessage('PLUGIN_VERSION_NOT_FOUND')).toContain(
+      'not found in registry'
+    );
+  });
+
+  it('maps an integrity mismatch error', () => {
+    expect(mapInstallErrorMessage('SHA-256 mismatch')).toContain(
+      'integrity check failed'
+    );
+  });
+
+  it('falls back to a generic message including the original text', () => {
+    expect(mapInstallErrorMessage('boom')).toBe('Installation failed: boom');
+  });
+});
+
+describe('validateRequiredSettings', () => {
+  const sections = [
+    {
+      title: 'S',
+      fields: [
+        { key: 'name', label: 'Name', validation: { required: true } },
+        { key: 'opt', label: 'Opt' },
+      ],
+    },
+  ] as unknown as PluginFormSection[];
+
+  it('reports an error for an empty required field', () => {
+    expect(validateRequiredSettings(sections, {})).toEqual({
+      name: 'Name is required',
+    });
+  });
+
+  it('passes when the required field is provided', () => {
+    expect(validateRequiredSettings(sections, { name: 'x' })).toEqual({});
+  });
+});

--- a/utils/sidebarEventUtils.spec.ts
+++ b/utils/sidebarEventUtils.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { DateTime } from 'luxon';
+import type { Event } from '@/__generated__/graphql';
+import {
+  isEventHappeningNow,
+  isEventHappeningToday,
+  isEventHappeningTomorrow,
+  isEventAfterTomorrow,
+  getDateSectionFormat,
+  getSidebarLinkText,
+  categorizeEventsByTiming,
+  groupEventsByDateSection,
+} from './sidebarEventUtils';
+
+const NOW = DateTime.fromISO('2024-06-15T12:00:00.000Z', { zone: 'utc' });
+
+const ev = (startTime: string, endTime: string, extra: Partial<Event> = {}): Event =>
+  ({ startTime, endTime, title: 'E', ...extra } as Event);
+
+describe('isEventHappeningNow', () => {
+  it('is true when now falls between start and end', () => {
+    expect(
+      isEventHappeningNow(
+        ev('2024-06-15T11:00:00.000Z', '2024-06-15T13:00:00.000Z'),
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('is false for an event that already ended', () => {
+    expect(
+      isEventHappeningNow(
+        ev('2024-06-15T08:00:00.000Z', '2024-06-15T09:00:00.000Z'),
+        NOW
+      )
+    ).toBe(false);
+  });
+});
+
+describe('isEventHappeningToday', () => {
+  it('is true for an event starting on the same calendar day', () => {
+    expect(
+      isEventHappeningToday(ev('2024-06-15T20:00:00.000Z', '2024-06-15T21:00:00.000Z'), NOW)
+    ).toBe(true);
+  });
+});
+
+describe('isEventHappeningTomorrow', () => {
+  it('is true for an event starting the next day', () => {
+    expect(
+      isEventHappeningTomorrow(
+        ev('2024-06-16T10:00:00.000Z', '2024-06-16T11:00:00.000Z'),
+        NOW
+      )
+    ).toBe(true);
+  });
+});
+
+describe('isEventAfterTomorrow', () => {
+  it('is true for an event two or more days out', () => {
+    expect(
+      isEventAfterTomorrow(
+        ev('2024-06-18T10:00:00.000Z', '2024-06-18T11:00:00.000Z'),
+        NOW
+      )
+    ).toBe(true);
+  });
+});
+
+describe('getDateSectionFormat', () => {
+  it('formats an ISO date as a weekday-month-day header', () => {
+    expect(getDateSectionFormat('2024-06-15T12:00:00.000Z')).toMatch(/Jun 15/);
+  });
+});
+
+describe('getSidebarLinkText', () => {
+  it('prefixes all-day events with "All Day"', () => {
+    expect(
+      getSidebarLinkText(ev('2024-06-15T00:00:00.000Z', '2024-06-15T23:59:00.000Z', {
+        isAllDay: true,
+        title: 'Festival',
+      }))
+    ).toBe('All Day · Festival');
+  });
+});
+
+describe('categorizeEventsByTiming', () => {
+  it('buckets an in-progress event under happeningNow', () => {
+    const result = categorizeEventsByTiming(
+      [ev('2024-06-15T11:00:00.000Z', '2024-06-15T13:00:00.000Z')],
+      NOW
+    );
+    expect(result.happeningNow).toHaveLength(1);
+  });
+});
+
+describe('groupEventsByDateSection', () => {
+  it('groups events under their date-section header', () => {
+    const grouped = groupEventsByDateSection([
+      ev('2024-06-18T10:00:00.000Z', '2024-06-18T11:00:00.000Z'),
+      ev('2024-06-18T14:00:00.000Z', '2024-06-18T15:00:00.000Z'),
+    ]);
+    expect(Object.values(grouped)[0]).toHaveLength(2);
+  });
+});

--- a/utils/ssrSafetyUtils.spec.ts
+++ b/utils/ssrSafetyUtils.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  safeArrayFirst,
+  safeArrayLength,
+  ensureArray,
+  safeGet,
+  isClient,
+  clientOnly,
+  validateDiscussionData,
+  validateEventData,
+} from './ssrSafetyUtils';
+
+describe('safeArrayFirst', () => {
+  it('returns the first item of a non-empty array', () => {
+    expect(safeArrayFirst([1, 2, 3])).toBe(1);
+  });
+
+  it('returns the fallback for an empty array', () => {
+    expect(safeArrayFirst([], 'x')).toBe('x');
+  });
+
+  it('returns null for undefined input', () => {
+    expect(safeArrayFirst(undefined)).toBeNull();
+  });
+});
+
+describe('safeArrayLength', () => {
+  it('returns the length of an array', () => {
+    expect(safeArrayLength([1, 2])).toBe(2);
+  });
+
+  it('returns the fallback for non-array input', () => {
+    expect(safeArrayLength(null, 5)).toBe(5);
+  });
+});
+
+describe('ensureArray', () => {
+  it('passes an array through', () => {
+    expect(ensureArray([1])).toEqual([1]);
+  });
+
+  it('returns an empty array for nullish input', () => {
+    expect(ensureArray(null)).toEqual([]);
+  });
+});
+
+describe('safeGet', () => {
+  it('reads a nested path', () => {
+    expect(safeGet({ a: { b: { c: 5 } } }, 'a.b.c')).toBe(5);
+  });
+
+  it('returns the fallback for a missing path', () => {
+    expect(safeGet({ a: {} }, 'a.b.c', 'none')).toBe('none');
+  });
+});
+
+describe('isClient', () => {
+  it('returns true under the happy-dom test environment', () => {
+    expect(isClient()).toBe(true);
+  });
+});
+
+describe('clientOnly', () => {
+  it('runs the function on the client', () => {
+    expect(clientOnly(() => 42)).toBe(42);
+  });
+});
+
+describe('validateDiscussionData', () => {
+  it('returns null for nullish input', () => {
+    expect(validateDiscussionData(null)).toBeNull();
+  });
+
+  it('guarantees array properties exist', () => {
+    expect(validateDiscussionData({ id: 'd1' })).toMatchObject({
+      DownloadableFiles: [],
+      DiscussionChannels: [],
+    });
+  });
+});
+
+describe('validateEventData', () => {
+  it('guarantees EventChannels exists', () => {
+    expect(validateEventData({ id: 'e1' })?.EventChannels).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Batch 2 of the pure-util coverage sweep — direct unit tests for **10 more previously-untested pure utility modules**. Additive only: no source changes, no component mounting.

| Util | Coverage |
|---|---|
| `pluginVersionUtils` | metadata/README resolution, enable gating, version sort, install-error mapping, required-settings validation |
| `ssrSafetyUtils` | safe array/get helpers, client guards, GraphQL data shaping |
| `authUtils` | username-restore gating, persistence, auth-error refresh+retry |
| `originalPoster` | OP resolution, OP identity check, issue-action visibility |
| `filterGroupYaml` | YAML serialize/parse + validation round-trip |
| `albumUpdateInput` | album create vs connect/update/disconnect input builder |
| `sidebarEventUtils` | event-timing predicates, categorization, date grouping (deterministic `now`) |
| `downloadFileHelpers` | mime/kind/accept attribute, downloadable-files update input |
| `expandDateRangeGroups` | date-range→occurrence expansion, group validation |
| `index` | file-size validation, upload filename, duration, tag/forum/link labels |

## Verification
- `npm run tsc` — clean
- `eslint` on all 10 new specs — clean
- All new specs pass (355 tests green in the run)

Follows #152 (batch 1). With this, ~18 of the originally-untested utils now have tests; a batch 3 would clear most of the remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)