### PR TITLE
test: unit coverage for 10 more pure utility modules (batch 3)

### DIFF
--- a/utils/albumImages.spec.ts
+++ b/utils/albumImages.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { mapAlbumImagesToForm, getInitialImageOrder } from './albumImages';
+
+describe('mapAlbumImagesToForm', () => {
+  it('returns an empty array for nullish input', () => {
+    expect(mapAlbumImagesToForm(null)).toEqual([]);
+  });
+
+  it('maps stored images into the form shape with defaults', () => {
+    expect(
+      mapAlbumImagesToForm([{ id: 'i1', url: 'u', alt: 'a' }])[0]
+    ).toEqual({
+      id: 'i1',
+      url: 'u',
+      alt: 'a',
+      caption: '',
+      isCoverImage: false,
+      hasSensitiveContent: false,
+      hasSpoiler: false,
+      copyright: '',
+    });
+  });
+});
+
+describe('getInitialImageOrder', () => {
+  it('uses the stored order when present', () => {
+    expect(
+      getInitialImageOrder({
+        albumImageOrder: ['i2', 'i1'],
+        images: [],
+      })
+    ).toEqual(['i2', 'i1']);
+  });
+
+  it('filters out non-string ids from the stored order', () => {
+    expect(
+      getInitialImageOrder({
+        albumImageOrder: ['i1', null, undefined],
+        images: [],
+      })
+    ).toEqual(['i1']);
+  });
+
+  it('derives the order from image ids when no stored order exists', () => {
+    expect(
+      getInitialImageOrder({
+        albumImageOrder: [],
+        images: [
+          { id: 'i1' },
+          { id: '' },
+          { id: 'i2' },
+        ] as Parameters<typeof getInitialImageOrder>[0]['images'],
+      })
+    ).toEqual(['i1', 'i2']);
+  });
+});

--- a/utils/channelSelection.spec.ts
+++ b/utils/channelSelection.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  areAllChannelsSelected,
+  getChannelsToToggle,
+  filterChannelsBySearch,
+} from './channelSelection';
+
+describe('areAllChannelsSelected', () => {
+  it('is true when every channel is selected', () => {
+    expect(
+      areAllChannelsSelected({
+        channelNames: ['a', 'b'],
+        selectedChannels: ['a', 'b'],
+      })
+    ).toBe(true);
+  });
+
+  it('is false when some channel is unselected', () => {
+    expect(
+      areAllChannelsSelected({ channelNames: ['a', 'b'], selectedChannels: ['a'] })
+    ).toBe(false);
+  });
+
+  it('is false when there are no channels', () => {
+    expect(
+      areAllChannelsSelected({ channelNames: [], selectedChannels: [] })
+    ).toBe(false);
+  });
+});
+
+describe('getChannelsToToggle', () => {
+  it('returns the unselected channels when not all are selected', () => {
+    expect(
+      getChannelsToToggle({ channelNames: ['a', 'b', 'c'], selectedChannels: ['a'] })
+    ).toEqual(['b', 'c']);
+  });
+
+  it('returns all selected channels when everything is selected (to deselect)', () => {
+    expect(
+      getChannelsToToggle({ channelNames: ['a', 'b'], selectedChannels: ['a', 'b'] })
+    ).toEqual(['a', 'b']);
+  });
+});
+
+describe('filterChannelsBySearch', () => {
+  const channels = [
+    { uniqueName: 'cats', displayName: 'Cats' },
+    { uniqueName: 'dogs', displayName: 'Doggos' },
+  ];
+
+  it('returns all channels for an empty search term', () => {
+    expect(filterChannelsBySearch({ channels, searchTerm: '' })).toBe(channels);
+  });
+
+  it('matches on display name case-insensitively', () => {
+    expect(
+      filterChannelsBySearch({ channels, searchTerm: 'dog' }).map((c) => c.uniqueName)
+    ).toEqual(['dogs']);
+  });
+});

--- a/utils/collectionFilters.spec.ts
+++ b/utils/collectionFilters.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { isItemFavorited, filterCollectionsBySearch } from './collectionFilters';
+
+describe('isItemFavorited', () => {
+  it('short-circuits to true when already known to be favorited', () => {
+    expect(
+      isItemFavorited({ itemType: 'channel', itemId: 'cats', isAlreadyFavorite: true })
+    ).toBe(true);
+  });
+
+  it('matches channels on uniqueName', () => {
+    expect(
+      isItemFavorited({
+        itemType: 'channel',
+        itemId: 'cats',
+        favoriteItems: [{ uniqueName: 'cats' }],
+      })
+    ).toBe(true);
+  });
+
+  it('matches non-channel items on id', () => {
+    expect(
+      isItemFavorited({
+        itemType: 'discussion',
+        itemId: 'd1',
+        favoriteItems: [{ id: 'd1' }],
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when the item is not in favorites', () => {
+    expect(
+      isItemFavorited({ itemType: 'discussion', itemId: 'd2', favoriteItems: [{ id: 'd1' }] })
+    ).toBe(false);
+  });
+});
+
+describe('filterCollectionsBySearch', () => {
+  const collections = [{ name: 'Favorites' }, { name: 'Wishlist' }];
+
+  it('returns all collections for an empty term', () => {
+    expect(filterCollectionsBySearch({ collections, searchTerm: '' })).toBe(
+      collections
+    );
+  });
+
+  it('filters by a case-insensitive name match', () => {
+    expect(
+      filterCollectionsBySearch({ collections, searchTerm: 'wish' })
+    ).toEqual([{ name: 'Wishlist' }]);
+  });
+});

--- a/utils/discussionFormValidation.spec.ts
+++ b/utils/discussionFormValidation.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  discussionFormNeedsChanges,
+  getDiscussionFormValidationMessage,
+  type DiscussionFormValidationInput,
+} from './discussionFormValidation';
+
+const valid: DiscussionFormValidationInput = {
+  selectedChannelsCount: 1,
+  title: 'My Discussion',
+  body: 'body',
+};
+
+describe('discussionFormNeedsChanges', () => {
+  it('is false for a valid form', () => {
+    expect(discussionFormNeedsChanges(valid)).toBe(false);
+  });
+
+  it('is true with no title', () => {
+    expect(discussionFormNeedsChanges({ ...valid, title: '' })).toBe(true);
+  });
+
+  it('is true with no channel selected', () => {
+    expect(discussionFormNeedsChanges({ ...valid, selectedChannelsCount: 0 })).toBe(
+      true
+    );
+  });
+});
+
+describe('getDiscussionFormValidationMessage', () => {
+  it('asks for a title first when missing', () => {
+    expect(getDiscussionFormValidationMessage({ ...valid, title: '' })).toBe(
+      'A title is required.'
+    );
+  });
+
+  it('asks for a forum when none is selected', () => {
+    expect(
+      getDiscussionFormValidationMessage({ ...valid, selectedChannelsCount: 0 })
+    ).toBe('Must select at least one forum.');
+  });
+
+  it('returns an empty string for a valid form', () => {
+    expect(getDiscussionFormValidationMessage(valid)).toBe('');
+  });
+});

--- a/utils/downloadFileValidation.spec.ts
+++ b/utils/downloadFileValidation.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateDownloadFileType,
+  validateDownloadFileSize,
+  MAX_DOWNLOAD_FILE_SIZE_BYTES,
+} from './downloadFileValidation';
+
+describe('validateDownloadFileType', () => {
+  const base = {
+    fileName: 'model.stl',
+    fileType: 'application/octet-stream',
+    allowedFileTypes: ['stl'],
+    downloadsDisabled: false,
+  };
+
+  it('rejects when downloads are disabled', () => {
+    expect(
+      validateDownloadFileType({ ...base, downloadsDisabled: true }).message
+    ).toBe('Downloads are disabled in this channel.');
+  });
+
+  it('allows any type when there is no restriction', () => {
+    expect(
+      validateDownloadFileType({ ...base, allowedFileTypes: [] }).valid
+    ).toBe(true);
+  });
+
+  it('allows a file whose extension is in the allow-list', () => {
+    expect(validateDownloadFileType(base).valid).toBe(true);
+  });
+
+  it('rejects a file whose extension is not allowed', () => {
+    expect(
+      validateDownloadFileType({ ...base, fileName: 'doc.pdf', allowedFileTypes: ['stl'] })
+        .valid
+    ).toBe(false);
+  });
+});
+
+describe('validateDownloadFileSize', () => {
+  it('accepts a file under the limit', () => {
+    expect(validateDownloadFileSize(1024).valid).toBe(true);
+  });
+
+  it('rejects a file over the limit', () => {
+    expect(
+      validateDownloadFileSize(MAX_DOWNLOAD_FILE_SIZE_BYTES + 1).valid
+    ).toBe(false);
+  });
+});

--- a/utils/eventFormValidation.spec.ts
+++ b/utils/eventFormValidation.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  eventFormNeedsChanges,
+  getEventFormValidationMessage,
+  type EventFormValidationInput,
+} from './eventFormValidation';
+
+const valid: EventFormValidationInput = {
+  selectedChannelsCount: 1,
+  title: 'My Event',
+  description: 'desc',
+  virtualEventUrl: null,
+  urlIsValid: true,
+  startBeforeEnd: true,
+};
+
+describe('eventFormNeedsChanges', () => {
+  it('is false for a fully valid form', () => {
+    expect(eventFormNeedsChanges(valid)).toBe(false);
+  });
+
+  it('is true when no channel is selected', () => {
+    expect(eventFormNeedsChanges({ ...valid, selectedChannelsCount: 0 })).toBe(true);
+  });
+
+  it('is true when the start is not before the end', () => {
+    expect(eventFormNeedsChanges({ ...valid, startBeforeEnd: false })).toBe(true);
+  });
+
+  it('is true when a virtual URL is present but invalid', () => {
+    expect(
+      eventFormNeedsChanges({
+        ...valid,
+        virtualEventUrl: 'bad',
+        urlIsValid: false,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('getEventFormValidationMessage', () => {
+  it('asks for a channel when none is selected', () => {
+    expect(
+      getEventFormValidationMessage({ ...valid, selectedChannelsCount: 0 })
+    ).toBe('At least one channel must be selected.');
+  });
+
+  it('asks for a title when missing', () => {
+    expect(getEventFormValidationMessage({ ...valid, title: '' })).toBe(
+      'A title is required.'
+    );
+  });
+
+  it('rejects an invalid virtual URL', () => {
+    expect(
+      getEventFormValidationMessage({
+        ...valid,
+        virtualEventUrl: 'bad',
+        urlIsValid: false,
+      })
+    ).toBe('Virtual event URL must be valid.');
+  });
+
+  it('returns an empty string for a valid form', () => {
+    expect(getEventFormValidationMessage(valid)).toBe('');
+  });
+});

--- a/utils/eventTiming.spec.ts
+++ b/utils/eventTiming.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { DateTime } from 'luxon';
+import { isEventInThePast, hasEventStarted } from './eventTiming';
+
+const NOW = DateTime.fromISO('2024-06-15T12:00:00.000Z', { zone: 'utc' });
+
+describe('isEventInThePast', () => {
+  it('is true when the end time is before now', () => {
+    expect(
+      isEventInThePast({ endTime: '2024-06-15T11:00:00.000Z' }, NOW)
+    ).toBe(true);
+  });
+
+  it('is false when the end time is in the future', () => {
+    expect(
+      isEventInThePast({ endTime: '2024-06-15T13:00:00.000Z' }, NOW)
+    ).toBe(false);
+  });
+
+  it('is false when there is no end time', () => {
+    expect(isEventInThePast({}, NOW)).toBe(false);
+  });
+});
+
+describe('hasEventStarted', () => {
+  it('is true for an in-progress event', () => {
+    expect(
+      hasEventStarted(
+        { startTime: '2024-06-15T11:00:00.000Z', endTime: '2024-06-15T13:00:00.000Z' },
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('is false for an event that already ended', () => {
+    expect(
+      hasEventStarted(
+        { startTime: '2024-06-15T08:00:00.000Z', endTime: '2024-06-15T09:00:00.000Z' },
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it('is false for an event that has not started', () => {
+    expect(
+      hasEventStarted({ startTime: '2024-06-15T13:00:00.000Z' }, NOW)
+    ).toBe(false);
+  });
+});

--- a/utils/fileTypeUtils.spec.ts
+++ b/utils/fileTypeUtils.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasGlbExtension,
+  hasStlExtension,
+  is3DModelFile,
+  isImageFile,
+} from './fileTypeUtils';
+
+describe('hasGlbExtension', () => {
+  it('detects a .glb url case-insensitively', () => {
+    expect(hasGlbExtension('https://x.test/model.GLB')).toBe(true);
+  });
+
+  it('returns false for nullish input', () => {
+    expect(hasGlbExtension(null)).toBe(false);
+  });
+});
+
+describe('hasStlExtension', () => {
+  it('detects a .stl url', () => {
+    expect(hasStlExtension('model.stl')).toBe(true);
+  });
+});
+
+describe('is3DModelFile', () => {
+  it('is true for a supported 3D format', () => {
+    expect(is3DModelFile('a.glb')).toBe(true);
+  });
+
+  it('is false for an image', () => {
+    expect(is3DModelFile('a.png')).toBe(false);
+  });
+});
+
+describe('isImageFile', () => {
+  it.each(['a.jpg', 'a.jpeg', 'a.png', 'a.gif', 'a.webp', 'a.svg', 'a.bmp'])(
+    'recognizes %s as an image',
+    (url) => {
+      expect(isImageFile(url)).toBe(true);
+    }
+  );
+
+  it('returns false for a 3D model', () => {
+    expect(isImageFile('a.stl')).toBe(false);
+  });
+
+  it('returns false for nullish input', () => {
+    expect(isImageFile(undefined)).toBe(false);
+  });
+});

--- a/utils/pluginSettingsUtils.spec.ts
+++ b/utils/pluginSettingsUtils.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import type { PluginFormSection } from '@/types/pluginForms';
+import {
+  extractSecretKeys,
+  filterOutSecrets,
+  getSecretsToSave,
+} from './pluginSettingsUtils';
+
+const sections = [
+  {
+    title: 'S',
+    fields: [
+      { key: 'apiKey', type: 'secret' },
+      { key: 'name', type: 'text' },
+    ],
+  },
+] as unknown as PluginFormSection[];
+
+describe('extractSecretKeys', () => {
+  it('collects the keys of secret fields', () => {
+    expect([...extractSecretKeys(sections)]).toEqual(['apiKey']);
+  });
+});
+
+describe('filterOutSecrets', () => {
+  it('drops secret keys from the settings object', () => {
+    expect(
+      filterOutSecrets({ apiKey: 'x', name: 'bot' }, new Set(['apiKey']))
+    ).toEqual({ name: 'bot' });
+  });
+});
+
+describe('getSecretsToSave', () => {
+  it('returns non-empty string secrets as key/value pairs', () => {
+    expect(
+      getSecretsToSave({ apiKey: 'secret', name: 'bot' }, new Set(['apiKey']))
+    ).toEqual([{ key: 'apiKey', value: 'secret' }]);
+  });
+
+  it('skips blank secret values', () => {
+    expect(
+      getSecretsToSave({ apiKey: '   ' }, new Set(['apiKey']))
+    ).toEqual([]);
+  });
+});

--- a/utils/usernameValidation.spec.ts
+++ b/utils/usernameValidation.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidUsername,
+  getUsernameValidationMessage,
+  calculateAge,
+  getBirthdayValidationMessage,
+} from './usernameValidation';
+
+describe('isValidUsername', () => {
+  it('accepts letters, numbers, and underscores', () => {
+    expect(isValidUsername('alice_99')).toBe(true);
+  });
+
+  it('rejects names with other characters', () => {
+    expect(isValidUsername('alice-99')).toBe(false);
+  });
+});
+
+describe('getUsernameValidationMessage', () => {
+  it('flags an empty username', () => {
+    expect(
+      getUsernameValidationMessage({ username: '', isEmpty: true, isTaken: false })
+    ).toBe('Username cannot be empty.');
+  });
+
+  it('flags a taken username', () => {
+    expect(
+      getUsernameValidationMessage({ username: 'alice', isEmpty: false, isTaken: true })
+    ).toBe('The username is already taken.');
+  });
+
+  it('flags invalid characters', () => {
+    expect(
+      getUsernameValidationMessage({ username: 'a-b', isEmpty: false, isTaken: false })
+    ).toContain('letters, numbers, and underscores');
+  });
+
+  it('returns an empty string for a valid username', () => {
+    expect(
+      getUsernameValidationMessage({ username: 'alice', isEmpty: false, isTaken: false })
+    ).toBe('');
+  });
+});
+
+describe('calculateAge', () => {
+  it('returns 0 for an empty birth date', () => {
+    expect(calculateAge('', new Date('2024-06-15'))).toBe(0);
+  });
+
+  it('computes age, accounting for a birthday later in the year', () => {
+    expect(calculateAge('2010-12-31', new Date('2024-06-15'))).toBe(13);
+  });
+});
+
+describe('getBirthdayValidationMessage', () => {
+  it('requires a birthday', () => {
+    expect(getBirthdayValidationMessage({ birthday: '' })).toBe(
+      'Birthday is required.'
+    );
+  });
+
+  it('rejects under-13 signups', () => {
+    expect(
+      getBirthdayValidationMessage({
+        birthday: '2015-01-01',
+        now: new Date('2024-06-15'),
+      })
+    ).toContain('at least 13 years old');
+  });
+
+  it('accepts a birthday meeting the minimum age', () => {
+    expect(
+      getBirthdayValidationMessage({
+        birthday: '2000-01-01',
+        now: new Date('2024-06-15'),
+      })
+    ).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Batch 3 of the pure-util coverage sweep — direct unit tests for **10 more previously-untested pure utility modules**. Additive only: no source changes, no component mounting.

| Util | Coverage |
|---|---|
| `usernameValidation` | username rules/messages, age math, birthday gating |
| `eventFormValidation` | submittable predicate + first-error message |
| `discussionFormValidation` | submittable predicate + first-error message |
| `channelSelection` | select-all state, toggle set, search filter |
| `collectionFilters` | favorite membership, collection search |
| `fileTypeUtils` | glb/stl/3D/image extension detection |
| `downloadFileValidation` | allowed-type and size validation |
| `pluginSettingsUtils` | secret-key extraction/filtering/collection |
| `eventTiming` | past/started predicates (injectable `now`) |
| `albumImages` | stored-image→form mapping, initial image order |

## Verification
- `npm run tsc` — clean
- `eslint` on all 10 new specs — clean
- All new specs pass (208 tests green in the run)

Follows #152 (batch 1) and #153 (batch 2). After this, the large pure-util gap is essentially closed — only a handful of tiny single-export utils remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)