### PR TITLE
chore(coverage): exclude icon components from the E2E lcov

### DIFF
--- a/tests/playwright/coverage/report.mjs
+++ b/tests/playwright/coverage/report.mjs
@@ -18,6 +18,11 @@ const CWD = process.cwd();
 
 // App-source scope, matching the unit-coverage include (skip Vue <style>/CSS).
 const APP_RE = /(^|\/)(components|pages|composables|utils)\//;
+// Presentational-only: icon components are pure <svg> markup with no logic.
+// Excluded from the unit coverage report (vitest.config.ts) and ignored by
+// Codecov (codecov.yml); drop them from the E2E lcov too so both flags agree
+// and icons never enter the coverage denominator.
+const ICONS_RE = /(^|\/)components\/icons\//;
 const layerOf = (p) => {
   const m = String(p).match(/(?:^|\/)(components|pages|composables|utils)\//);
   return m ? m[1] : null;
@@ -30,6 +35,7 @@ const mcr = new CoverageReport({
   entryFilter: (entry) => !!entry.url && /\/_nuxt\/.*\.js$/.test(entry.url),
   sourceFilter: (sourcePath) =>
     APP_RE.test(sourcePath) &&
+    !ICONS_RE.test(sourcePath) &&
     !sourcePath.includes('type=style') &&
     !/\.css(\?|$)/.test(sourcePath),
   // Relative paths so this lcov lines up with the unit lcov for Codecov.


### PR DESCRIPTION
## Summary

Completes the icon-coverage exclusion by dropping `components/icons/**` from the **E2E** coverage report too.

Icons were already excluded from the unit report (`vitest.config.ts`) and ignored by Codecov (`codecov.yml`, #151), but the E2E monocart report's `sourceFilter` only scoped to app code (`components|pages|composables|utils`) and still emitted icon components. Because the `e2e` flag is `carryforward: true`, that stale e2e report kept surfacing icons (~65%) in the combined Codecov sunburst even after the exclude was merged.

This adds an `ICONS_RE` guard to the E2E `sourceFilter` so both flags agree and icons never enter the denominator regardless of which report is viewed.

## Effect
- Next E2E/Combined Coverage upload will no longer contain icon files.
- No source or test changes; coverage tooling only.

## Note
The Codecov `ignore` (#151) only filters reports processed *after* it merged and is not retroactive, so the live badge won't drop icons until a fresh `e2e` report is uploaded. Re-running the "Combined Coverage" workflow on main after this merges will refresh it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)