### PR TITLE
test: unit coverage for composables + the util tail

### DIFF
--- a/composables/useAuthState.spec.ts
+++ b/composables/useAuthState.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  useIsAuthenticated,
+  useUsername,
+  useNotificationCount,
+  setIsAuthenticated,
+  setUsername,
+  setNotificationCount,
+} from './useAuthState';
+
+const mockStateStore = new Map<string, { value: unknown }>();
+
+vi.mock('nuxt/app', () => ({
+  useState: (key: string, init: () => unknown) => {
+    if (!mockStateStore.has(key)) {
+      mockStateStore.set(key, { value: init() });
+    }
+    return mockStateStore.get(key);
+  },
+}));
+
+beforeEach(() => mockStateStore.clear());
+
+describe('useAuthState defaults', () => {
+  it('defaults isAuthenticated to false', () => {
+    expect(useIsAuthenticated().value).toBe(false);
+  });
+
+  it('defaults username to an empty string', () => {
+    expect(useUsername().value).toBe('');
+  });
+
+  it('defaults the notification count to 0', () => {
+    expect(useNotificationCount().value).toBe(0);
+  });
+});
+
+describe('useAuthState setters', () => {
+  it('setIsAuthenticated updates the state the getter reads', () => {
+    setIsAuthenticated(true);
+    expect(useIsAuthenticated().value).toBe(true);
+  });
+
+  it('setUsername updates the username state', () => {
+    setUsername('alice');
+    expect(useUsername().value).toBe('alice');
+  });
+
+  it('setNotificationCount updates the count state', () => {
+    setNotificationCount(7);
+    expect(useNotificationCount().value).toBe(7);
+  });
+});

--- a/composables/useMarkdownHeadings.spec.ts
+++ b/composables/useMarkdownHeadings.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+import { useMarkdownHeadings } from './useMarkdownHeadings';
+
+describe('useMarkdownHeadings', () => {
+  it('returns an empty list for empty content', () => {
+    expect(useMarkdownHeadings(ref('')).headings.value).toEqual([]);
+  });
+
+  it('parses heading levels from the markdown', () => {
+    const { headings } = useMarkdownHeadings(ref('# Title\n## Subtitle'));
+    expect(headings.value.map((h) => h.level)).toEqual([1, 2]);
+  });
+
+  it('builds a url-friendly anchor from the heading text', () => {
+    const { headings } = useMarkdownHeadings(ref('# Hello, World!'));
+    expect(headings.value[0]?.anchor).toBe('hello-world');
+  });
+
+  it('falls back to a heading id anchor when the text has no word chars', () => {
+    const { headings } = useMarkdownHeadings(ref('# !!!'));
+    expect(headings.value[0]?.anchor).toBe('heading-0');
+  });
+
+  it('reacts to content changes', () => {
+    const content = ref('# One');
+    const { headings } = useMarkdownHeadings(content);
+    content.value = '# One\n# Two';
+    expect(headings.value).toHaveLength(2);
+  });
+
+  it('scrolls to a heading element when present', () => {
+    const el = document.createElement('div');
+    el.id = 'target';
+    el.scrollIntoView = vi.fn();
+    document.body.appendChild(el);
+    useMarkdownHeadings(ref('')).scrollToHeading('target');
+    expect(el.scrollIntoView).toHaveBeenCalled();
+  });
+});

--- a/composables/useMarkdownRenderer.spec.ts
+++ b/composables/useMarkdownRenderer.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { useMarkdownRenderer } from './useMarkdownRenderer';
+
+const { renderMarkdown } = useMarkdownRenderer();
+
+describe('renderMarkdown', () => {
+  it('renders basic markdown emphasis', () => {
+    expect(renderMarkdown('**bold**')).toContain('<strong>bold</strong>');
+  });
+
+  it('opens external links in a new tab', () => {
+    expect(renderMarkdown('[x](https://example.com)')).toContain(
+      'target="_blank"'
+    );
+  });
+
+  it('does not mark a relative link as external', () => {
+    expect(renderMarkdown('[x](/forums/cats)')).not.toContain('target="_blank"');
+  });
+
+  it('linkifies a u/ user mention', () => {
+    expect(renderMarkdown('hi u/alice')).toContain('href="/u/alice"');
+  });
+
+  it('converts spoiler markup to a spoiler span', () => {
+    expect(renderMarkdown('>!secret!<')).toContain('class="spoiler-text"');
+  });
+
+  it('adds an anchor id to headings', () => {
+    expect(renderMarkdown('# My Heading')).toContain('id="my-heading"');
+  });
+
+  it('strips images when allowImages is false', () => {
+    expect(
+      renderMarkdown('![alt](https://img.test/a.png)', { allowImages: false })
+    ).not.toContain('<img');
+  });
+
+  it('sanitizes script tags out of the output', () => {
+    expect(renderMarkdown('<script>alert(1)</script>')).not.toContain(
+      '<script>'
+    );
+  });
+});

--- a/composables/useServerLogout.spec.ts
+++ b/composables/useServerLogout.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useServerLogout } from './useServerLogout';
+
+const setIsAuthenticated = vi.fn();
+const setUsername = vi.fn();
+const clearPersistedAuth = vi.fn();
+
+vi.mock('@/composables/useAuthState', () => ({
+  setIsAuthenticated: (v: boolean) => setIsAuthenticated(v),
+  setUsername: (v: string) => setUsername(v),
+}));
+
+vi.mock('@/utils/authUtils', () => ({
+  clearPersistedAuth: () => clearPersistedAuth(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe('useServerLogout', () => {
+  it('remembers the current path for post-logout redirect', () => {
+    useServerLogout().logout();
+    expect(window.localStorage.getItem('postLogoutRedirect')).not.toBeNull();
+  });
+
+  it('clears the authenticated flag', () => {
+    useServerLogout().logout();
+    expect(setIsAuthenticated).toHaveBeenCalledWith(false);
+  });
+
+  it('clears the persisted username', () => {
+    useServerLogout().logout();
+    expect(setUsername).toHaveBeenCalledWith('');
+  });
+
+  it('clears persisted auth before handing off to the server route', () => {
+    useServerLogout().logout();
+    expect(clearPersistedAuth).toHaveBeenCalled();
+  });
+});

--- a/composables/useToast.spec.ts
+++ b/composables/useToast.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useToast } from './useToast';
+
+const drain = () => {
+  const { toasts, removeToast } = useToast();
+  [...toasts.value].forEach((t) => removeToast(t.id));
+};
+
+beforeEach(drain);
+afterEach(() => vi.useRealTimers());
+
+describe('useToast', () => {
+  it('adds a toast with the given message', () => {
+    const { showToast, toasts } = useToast();
+    showToast('hello');
+    expect(toasts.value.at(-1)?.message).toBe('hello');
+  });
+
+  it('defaults the toast type to info', () => {
+    const { showToast, toasts } = useToast();
+    const id = showToast('hi');
+    expect(toasts.value.find((t) => t.id === id)?.type).toBe('info');
+  });
+
+  it('uses the success type for success()', () => {
+    const { success, toasts } = useToast();
+    const id = success('done');
+    expect(toasts.value.find((t) => t.id === id)?.type).toBe('success');
+  });
+
+  it('removes a toast by id', () => {
+    const { showToast, removeToast, toasts } = useToast();
+    const id = showToast('temp');
+    removeToast(id);
+    expect(toasts.value.find((t) => t.id === id)).toBeUndefined();
+  });
+
+  it('auto-removes a toast after its duration', () => {
+    vi.useFakeTimers();
+    const { showToast, toasts } = useToast();
+    const id = showToast('bye', 'info', 1000);
+    vi.advanceTimersByTime(1000);
+    expect(toasts.value.find((t) => t.id === id)).toBeUndefined();
+  });
+});

--- a/utils/defaultEventFormValues.spec.ts
+++ b/utils/defaultEventFormValues.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { DateTime } from 'luxon';
+import getDefaultEventFormValues from './defaultEventFormValues';
+
+describe('getDefaultEventFormValues', () => {
+  it('seeds selectedChannels with the given channel id', () => {
+    expect(getDefaultEventFormValues('cats').selectedChannels).toEqual(['cats']);
+  });
+
+  it('leaves selectedChannels empty when no channel id is given', () => {
+    expect(getDefaultEventFormValues('').selectedChannels).toEqual([]);
+  });
+
+  it('defaults the end time to two hours after the start time', () => {
+    const values = getDefaultEventFormValues('cats');
+    const diff = DateTime.fromISO(values.endTime)
+      .diff(DateTime.fromISO(values.startTime), 'hours')
+      .toObject();
+    expect(diff.hours).toBe(2);
+  });
+
+  it('defaults to a non-all-day single-date event', () => {
+    expect(getDefaultEventFormValues('cats').dateMode).toBe('single');
+  });
+});

--- a/utils/downloadFilters.spec.ts
+++ b/utils/downloadFilters.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import type { RouteLocationNormalizedLoaded } from 'vue-router';
+import { convertUrlParamsToLabelFilters } from './downloadFilters';
+
+const routeWithQuery = (query: Record<string, unknown>) =>
+  ({ query } as unknown as RouteLocationNormalizedLoaded);
+
+describe('convertUrlParamsToLabelFilters', () => {
+  it('converts a filter_ param into a label filter', () => {
+    expect(
+      convertUrlParamsToLabelFilters(
+        routeWithQuery({ filter_lot_type: 'residential' })
+      )
+    ).toEqual([{ groupKey: 'lot_type', values: ['residential'] }]);
+  });
+
+  it('splits a comma-separated value into multiple values', () => {
+    expect(
+      convertUrlParamsToLabelFilters(
+        routeWithQuery({ filter_style: 'modern,contemporary' })
+      )[0].values
+    ).toEqual(['modern', 'contemporary']);
+  });
+
+  it('ignores non-filter query params', () => {
+    expect(
+      convertUrlParamsToLabelFilters(routeWithQuery({ page: '2' }))
+    ).toEqual([]);
+  });
+
+  it('keeps only string values from array params', () => {
+    expect(
+      convertUrlParamsToLabelFilters(
+        routeWithQuery({ filter_tag: ['a', null, 'b'] })
+      )[0].values
+    ).toEqual(['a', 'b']);
+  });
+});

--- a/utils/downloadLabelUtils.spec.ts
+++ b/utils/downloadLabelUtils.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import type { FilterGroup } from '@/__generated__/graphql';
+import { resolveSelectedLabelOptionIds } from './downloadLabelUtils';
+
+const filterGroups = [
+  {
+    key: 'style',
+    options: [
+      { id: 'opt-modern', value: 'modern' },
+      { id: 'opt-classic', value: 'classic' },
+    ],
+  },
+] as unknown as FilterGroup[];
+
+describe('resolveSelectedLabelOptionIds', () => {
+  it('resolves selected label values to their option ids', () => {
+    expect(
+      resolveSelectedLabelOptionIds({
+        downloadLabels: { style: ['modern'] },
+        filterGroups,
+      })
+    ).toEqual(['opt-modern']);
+  });
+
+  it('skips values from unknown groups', () => {
+    expect(
+      resolveSelectedLabelOptionIds({
+        downloadLabels: { unknown: ['x'] },
+        filterGroups,
+      })
+    ).toEqual([]);
+  });
+
+  it('skips unknown values within a known group', () => {
+    expect(
+      resolveSelectedLabelOptionIds({
+        downloadLabels: { style: ['neon'] },
+        filterGroups,
+      })
+    ).toEqual([]);
+  });
+
+  it('returns an empty array when there are no labels', () => {
+    expect(
+      resolveSelectedLabelOptionIds({ downloadLabels: null, filterGroups })
+    ).toEqual([]);
+  });
+});

--- a/utils/eventDateFormat.spec.ts
+++ b/utils/eventDateFormat.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { formatEventDateString } from './eventDateFormat';
+
+describe('formatEventDateString', () => {
+  it('includes a time component for a timed event', () => {
+    expect(
+      formatEventDateString({ startTime: '2024-06-15T14:30:00.000Z' })
+    ).toMatch(/\d:\d{2}\s?(AM|PM)/i);
+  });
+
+  it('omits the time for a single all-day event', () => {
+    expect(
+      formatEventDateString({
+        startTime: '2024-06-15T00:00:00.000Z',
+        endTime: '2024-06-15T23:59:00.000Z',
+        isAllDay: true,
+      })
+    ).not.toMatch(/:/);
+  });
+
+  it('shows a date range for a multi-day all-day event', () => {
+    expect(
+      formatEventDateString({
+        startTime: '2024-06-15T00:00:00.000Z',
+        endTime: '2024-06-17T00:00:00.000Z',
+        isAllDay: true,
+      })
+    ).toContain(' - ');
+  });
+});

--- a/utils/forumRoleBadges.spec.ts
+++ b/utils/forumRoleBadges.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { getForumRoleBadge } from './forumRoleBadges';
+
+describe('getForumRoleBadge', () => {
+  it('returns forumAdmin when the username is a forum admin', () => {
+    expect(
+      getForumRoleBadge({ username: 'alice', adminUsernames: ['alice'] })
+    ).toBe('forumAdmin');
+  });
+
+  it('returns forumMod when the username is a forum mod', () => {
+    expect(
+      getForumRoleBadge({ username: 'bob', modUsernames: ['bob'] })
+    ).toBe('forumMod');
+  });
+
+  it('returns forumMod when the mod-profile name matches', () => {
+    expect(
+      getForumRoleBadge({ modProfileName: 'ModBob', modProfileNames: ['ModBob'] })
+    ).toBe('forumMod');
+  });
+
+  it('prefers admin over mod when both match', () => {
+    expect(
+      getForumRoleBadge({
+        username: 'alice',
+        adminUsernames: ['alice'],
+        modUsernames: ['alice'],
+      })
+    ).toBe('forumAdmin');
+  });
+
+  it('returns null when there is no matching role', () => {
+    expect(getForumRoleBadge({ username: 'carol' })).toBeNull();
+  });
+});

--- a/utils/markdown.spec.ts
+++ b/utils/markdown.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { generateHeadingId } from './markdown';
+
+describe('generateHeadingId', () => {
+  it('lowercases and hyphenates the text', () => {
+    expect(generateHeadingId('My Heading')).toBe('my-heading');
+  });
+
+  it('removes special characters', () => {
+    expect(generateHeadingId('Hello, World!')).toBe('hello-world');
+  });
+
+  it('collapses multiple spaces into a single hyphen', () => {
+    expect(generateHeadingId('a    b')).toBe('a-b');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    expect(generateHeadingId('!!!hi!!!')).toBe('hi');
+  });
+});

--- a/utils/searchUtils.spec.ts
+++ b/utils/searchUtils.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { escapeRegex, createCaseInsensitivePattern } from './searchUtils';
+
+describe('escapeRegex', () => {
+  it('escapes regex metacharacters', () => {
+    expect(escapeRegex('a.b*c')).toBe('a\\.b\\*c');
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeRegex('plain')).toBe('plain');
+  });
+});
+
+describe('createCaseInsensitivePattern', () => {
+  it('returns undefined for an empty search term', () => {
+    expect(createCaseInsensitivePattern('   ')).toBeUndefined();
+  });
+
+  it('wraps the escaped term in a case-insensitive contains pattern', () => {
+    expect(createCaseInsensitivePattern('a.b')).toBe('(?i).*a\\.b.*');
+  });
+});


### PR DESCRIPTION
## Summary

Next coverage batch per the roadmap: **5 composables** + the **7 small leftover utils**. Additive only — no source changes, high-ROI/low-flake (mostly pure logic, no component mounting).

### Composables (was 30/43 → 35/43)
| Composable | Coverage |
|---|---|
| `useToast` | add/remove/auto-dismiss + typed helpers |
| `useMarkdownHeadings` | heading parse, anchor slug, reactivity, scroll-to |
| `useMarkdownRenderer` | external-link handling, user mentions, spoilers, heading anchors, image stripping, XSS sanitization |
| `useServerLogout` | post-logout redirect + auth-state clearing (mocked) |
| `useAuthState` | request-scoped defaults + setters (`useState` mocked) |

### Utils (closes the util tail → utils essentially 100% of logic-bearing files)
`markdown`, `searchUtils`, `eventDateFormat`, `forumRoleBadges`, `downloadLabelUtils`, `downloadFilters`, `defaultEventFormValues`.

`constants.ts` is intentionally **not** tested — it's bare magic-number values with no logic (testing it would be a trivial assertion the project guidelines say to avoid).

## Notes
- Skipped `usePopoverPositioning` (needs component mount + lifecycle hooks — flake-prone; better suited to the component batch).
- `eventDateFormat` time assertion is timezone-robust (matches the presence of a time component, not a fixed local time).

## Verification
- `npm run tsc` — clean
- `eslint` on all 12 new specs — clean
- All new specs pass (153 tests green in the run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)