### PR TITLE
test: unit coverage for 7 genuinely-untested components

### DIFF
--- a/components/AvatarComponent.spec.ts
+++ b/components/AvatarComponent.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AvatarComponent from './AvatarComponent.vue';
+
+describe('AvatarComponent', () => {
+  it('renders the provided src when given', () => {
+    const wrapper = mount(AvatarComponent, {
+      props: { text: 'alice', src: 'https://img.test/a.png' },
+    });
+    expect(wrapper.find('img').attributes('src')).toBe('https://img.test/a.png');
+  });
+
+  it('generates an identicon data URI when no src is provided', () => {
+    const wrapper = mount(AvatarComponent, { props: { text: 'alice' } });
+    expect(wrapper.find('img').attributes('src')).toContain(
+      'data:image/svg+xml;base64,'
+    );
+  });
+
+  it('uses the text as the alt by default', () => {
+    const wrapper = mount(AvatarComponent, { props: { text: 'alice' } });
+    expect(wrapper.find('img').attributes('alt')).toBe('alice');
+  });
+
+  it('hides a decorative avatar from assistive tech', () => {
+    const wrapper = mount(AvatarComponent, {
+      props: { text: 'alice', isDecorative: true },
+    });
+    expect([
+      wrapper.find('img').attributes('alt'),
+      wrapper.find('img').attributes('aria-hidden'),
+    ]).toEqual(['', 'true']);
+  });
+
+  it('applies the large size class when isLarge is set', () => {
+    const wrapper = mount(AvatarComponent, {
+      props: { text: 'alice', isLarge: true },
+    });
+    expect(wrapper.find('img').classes()).toContain('h-48');
+  });
+});

--- a/components/SortDropdown.spec.ts
+++ b/components/SortDropdown.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import SortDropdown from './SortDropdown.vue';
+
+describe('SortDropdown', () => {
+  it('hides the menu initially', () => {
+    const wrapper = mount(SortDropdown);
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+  });
+
+  it('opens the menu when the button is clicked', async () => {
+    const wrapper = mount(SortDropdown);
+    await wrapper.find('#menu-button').trigger('click');
+    expect(wrapper.find('[role="menu"]').exists()).toBe(true);
+  });
+
+  it('renders the sort options when open', async () => {
+    const wrapper = mount(SortDropdown);
+    await wrapper.find('#menu-button').trigger('click');
+    expect(wrapper.findAll('[role="menuitem"]')).toHaveLength(3);
+  });
+
+  it('closes the menu when the button is clicked again', async () => {
+    const wrapper = mount(SortDropdown);
+    await wrapper.find('#menu-button').trigger('click');
+    await wrapper.find('#menu-button').trigger('click');
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+  });
+});

--- a/components/admin/BrokenRuleListItem.spec.ts
+++ b/components/admin/BrokenRuleListItem.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import BrokenRuleListItem from './BrokenRuleListItem.vue';
+
+const rule = { summary: 'No spam', detail: 'Do not post spam.' };
+
+const mountItem = (selected: string[] = []) =>
+  mount(BrokenRuleListItem, {
+    props: { rule, selected },
+    global: {
+      stubs: { MarkdownRenderer: { template: '<div class="md"><slot /></div>' } },
+    },
+  });
+
+describe('BrokenRuleListItem', () => {
+  it('renders the rule summary', () => {
+    expect(mountItem().text()).toContain('No spam');
+  });
+
+  it('checks the box when the rule is selected', () => {
+    expect(
+      (mountItem(['No spam']).find('input').element as HTMLInputElement).checked
+    ).toBe(true);
+  });
+
+  it('emits toggleSelection with the rule summary on change', async () => {
+    const wrapper = mountItem();
+    await wrapper.find('input').trigger('change');
+    expect(wrapper.emitted('toggleSelection')?.[0]).toEqual(['No spam']);
+  });
+
+  it('hides the detail until "See More" is clicked', () => {
+    expect(mountItem().find('.md').exists()).toBe(false);
+  });
+
+  it('reveals the detail when "See More" is clicked', async () => {
+    const wrapper = mountItem();
+    await wrapper.get('[data-testid="forum-picker-Do not post spam."]').trigger('click');
+    expect(wrapper.find('.md').exists()).toBe(true);
+  });
+});

--- a/components/collection/PublicCollectionListItem.spec.ts
+++ b/components/collection/PublicCollectionListItem.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import type { Collection } from '@/__generated__/graphql';
+import PublicCollectionListItem from './PublicCollectionListItem.vue';
+
+const mountItem = (collection: Partial<Collection>) =>
+  mount(PublicCollectionListItem, {
+    props: { collection },
+    global: {
+      stubs: {
+        NuxtLink: { template: '<a><slot /></a>' },
+        CollectionDownloadListItem: { template: '<li class="dl" />' },
+      },
+    },
+  });
+
+describe('PublicCollectionListItem', () => {
+  it('renders the collection name', () => {
+    expect(mountItem({ id: 'c1', name: 'My Models' }).text()).toContain(
+      'My Models'
+    );
+  });
+
+  it('shows the creator display name with username', () => {
+    const wrapper = mountItem({
+      id: 'c1',
+      name: 'X',
+      CreatedBy: { username: 'alice', displayName: 'Alice' },
+    } as unknown as Partial<Collection>);
+    expect(wrapper.text()).toContain('Alice (alice)');
+  });
+
+  it('falls back to "Unknown user" with no creator', () => {
+    expect(mountItem({ id: 'c1', name: 'X' }).text()).toContain('Unknown user');
+  });
+
+  it('shows the empty-downloads message when there are none', () => {
+    expect(mountItem({ id: 'c1', name: 'X' }).text()).toContain(
+      'No downloads in this collection yet.'
+    );
+  });
+
+  it('renders at most five download previews', () => {
+    const downloads = Array.from({ length: 7 }, (_, i) => ({ id: `d${i}` }));
+    const wrapper = mountItem({
+      id: 'c1',
+      name: 'X',
+      Downloads: downloads,
+    } as unknown as Partial<Collection>);
+    expect(wrapper.findAll('.dl')).toHaveLength(5);
+  });
+});

--- a/components/discussion/detail/DiscussionChannelLink.spec.ts
+++ b/components/discussion/detail/DiscussionChannelLink.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import DiscussionChannelLink from './DiscussionChannelLink.vue';
+
+const mountLink = (props: Record<string, unknown>) =>
+  mount(DiscussionChannelLink, {
+    props: {
+      discussionId: 'd1',
+      channelId: 'cats',
+      commentCount: 3,
+      ...props,
+    },
+    global: {
+      stubs: {
+        'nuxt-link': { template: '<a><slot /></a>' },
+        AvatarComponent: true,
+      },
+    },
+  });
+
+describe('DiscussionChannelLink', () => {
+  it('renders the comment count', () => {
+    expect(mountLink({ commentCount: 3 }).text()).toContain('3 comments');
+  });
+
+  it('uses the singular noun for one upvote', () => {
+    expect(mountLink({ upvoteCount: 1 }).text()).toContain('1 upvote');
+  });
+
+  it('uses the plural noun for multiple upvotes', () => {
+    expect(mountLink({ upvoteCount: 2 }).text()).toContain('2 upvotes');
+  });
+
+  it('renders the channel display name when provided', () => {
+    expect(
+      mountLink({ channelDisplayName: 'Cats Forum' }).text()
+    ).toContain('Cats Forum');
+  });
+});

--- a/components/discussion/detail/DiscussionChannelLinks.spec.ts
+++ b/components/discussion/detail/DiscussionChannelLinks.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import type { DiscussionChannel } from '@/__generated__/graphql';
+import DiscussionChannelLinks from './DiscussionChannelLinks.vue';
+
+const channel = (name: string): DiscussionChannel =>
+  ({
+    id: `dc-${name}`,
+    channelUniqueName: name,
+    discussionId: 'd1',
+    Channel: { displayName: name },
+    CommentsAggregate: { count: 1 },
+    UpvotedByUsersAggregate: { count: 0 },
+  }) as unknown as DiscussionChannel;
+
+const mountLinks = (props: Record<string, unknown>) =>
+  mount(DiscussionChannelLinks, {
+    props,
+    global: { stubs: { DiscussionChannelLink: { template: '<li class="link" />' } } },
+  });
+
+describe('DiscussionChannelLinks', () => {
+  it('renders a link per channel when no active channel is set', () => {
+    const wrapper = mountLinks({
+      discussionChannels: [channel('cats'), channel('dogs')],
+    });
+    expect(wrapper.findAll('.link')).toHaveLength(2);
+  });
+
+  it('excludes the active channel from the "other forums" list', () => {
+    const wrapper = mountLinks({
+      channelId: 'cats',
+      discussionChannels: [channel('cats'), channel('dogs')],
+    });
+    expect(wrapper.findAll('.link')).toHaveLength(1);
+  });
+
+  it('shows the "Comments in Forums" heading when no active channel', () => {
+    const wrapper = mountLinks({ discussionChannels: [channel('cats')] });
+    expect(wrapper.text()).toContain('Comments in Forums');
+  });
+});

--- a/components/discussion/list/DiscussionDetailEmptyState.spec.ts
+++ b/components/discussion/list/DiscussionDetailEmptyState.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import DiscussionDetailEmptyState from './DiscussionDetailEmptyState.vue';
+
+describe('DiscussionDetailEmptyState', () => {
+  it('shows the default prompt message', () => {
+    expect(mount(DiscussionDetailEmptyState).text()).toContain(
+      'Select a discussion to view details.'
+    );
+  });
+
+  it('shows a custom message when provided', () => {
+    const wrapper = mount(DiscussionDetailEmptyState, {
+      props: { message: 'Nothing selected yet' },
+    });
+    expect(wrapper.text()).toContain('Nothing selected yet');
+  });
+});


### PR DESCRIPTION
## Summary

Colocated specs for **7 components that no existing spec imports**. Additive only — no source changes; all mount cleanly with light stubs.

| Component | Coverage |
|---|---|
| `AvatarComponent` | provided src vs generated identicon, sizing class, decorative a11y |
| `SortDropdown` | open/close toggle, menu items |
| `BrokenRuleListItem` | checked state, `toggleSelection` emit, see-more expand |
| `DiscussionChannelLink` | comment count, upvote pluralization, display name |
| `DiscussionDetailEmptyState` | default + custom message |
| `PublicCollectionListItem` | creator label, empty state, 5-item preview cap |
| `DiscussionChannelLinks` | per-channel links, active-channel exclusion |

## Note on the plugin-field cluster
This batch was originally scoped as the plugin form-field components (`PluginTextField`/`Number`/`Select`/`Boolean`/`Secret`). On inspection those are **already covered** by the aggregate specs `pluginFieldComponents.spec.ts` (mounts all five) and `pluginFields.spec.ts` (computed logic) — they were only flagged as "untested" by a colocated-filename census heuristic. Re-testing them would have been pure duplication with no coverage gain, so this PR instead targets components that genuinely have no test referencing them.

## Verification
- `npm run tsc` — clean
- `eslint` on all 7 new specs — clean
- All new specs pass (28 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)