### PR TITLE
test(e2e): cover the moderation issue-detail flow

### DIFF
--- a/components/admin/plugins/PluginSettingsSection.spec.ts
+++ b/components/admin/plugins/PluginSettingsSection.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import type { PluginFormSection } from '@/types/pluginForms';
+import PluginSettingsSection from './PluginSettingsSection.vue';
+
+const sections = [{ title: 'S', fields: [] }] as unknown as PluginFormSection[];
+
+const mountSection = (props: Record<string, unknown> = {}) =>
+  mount(PluginSettingsSection, {
+    props: {
+      sections,
+      modelValue: {},
+      errors: {},
+      secretStatuses: [],
+      saving: false,
+      ...props,
+    },
+    global: {
+      stubs: {
+        FormRow: { template: '<div><slot name="content" /></div>' },
+        PluginSettingsForm: {
+          template: '<div class="form" @click="$emit(\'update:model-value\', { a: 1 })" />',
+        },
+      },
+    },
+  });
+
+describe('PluginSettingsSection', () => {
+  it('renders nothing when there are no sections', () => {
+    expect(mountSection({ sections: [] }).text()).toBe('');
+  });
+
+  it('renders the settings form when there are sections', () => {
+    expect(mountSection().find('.form').exists()).toBe(true);
+  });
+
+  it('emits save when the save button is clicked', async () => {
+    const wrapper = mountSection();
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('save')).toBeTruthy();
+  });
+
+  it('disables the save button while saving', () => {
+    const wrapper = mountSection({ saving: true });
+    expect((wrapper.find('button').element as HTMLButtonElement).disabled).toBe(
+      true
+    );
+  });
+
+  it('forwards model-value updates from the form', async () => {
+    const wrapper = mountSection();
+    await wrapper.find('.form').trigger('click');
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([{ a: 1 }]);
+  });
+});

--- a/components/album/AlbumThumbnailGrid.spec.ts
+++ b/components/album/AlbumThumbnailGrid.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AlbumThumbnailGrid from './AlbumThumbnailGrid.vue';
+
+const img = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  url: `${id}.png`,
+  Uploader: { username: 'alice' },
+  ...extra,
+});
+
+const mountGrid = (props: Record<string, unknown>) =>
+  mount(AlbumThumbnailGrid, {
+    props,
+    global: { stubs: { NuxtLink: { template: '<a><slot /></a>' } } },
+  });
+
+describe('AlbumThumbnailGrid', () => {
+  it('shows the empty message when there are no images', () => {
+    expect(mountGrid({ images: [] }).text()).toContain(
+      'No images in this album.'
+    );
+  });
+
+  it('renders a tile per image', () => {
+    expect(
+      mountGrid({ images: [img('a'), img('b')] }).findAll('img')
+    ).toHaveLength(2);
+  });
+
+  it('caps the number of tiles at maxImages', () => {
+    expect(
+      mountGrid({ images: [img('a'), img('b'), img('c')], maxImages: 2 }).findAll(
+        'img'
+      )
+    ).toHaveLength(2);
+  });
+
+  it('renders the caption when captions are enabled', () => {
+    expect(
+      mountGrid({ images: [img('a', { caption: 'Sunset' })] }).text()
+    ).toContain('Sunset');
+  });
+
+  it('hides captions when showCaptions is false', () => {
+    expect(
+      mountGrid({
+        images: [img('a', { caption: 'Sunset' })],
+        showCaptions: false,
+      }).text()
+    ).not.toContain('Sunset');
+  });
+});

--- a/components/channel/ChannelHeaderMobile.spec.ts
+++ b/components/channel/ChannelHeaderMobile.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import ChannelHeaderMobile from './ChannelHeaderMobile.vue';
+
+const mockIsAuthenticated = ref(false);
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => mockIsAuthenticated,
+}));
+
+const mountHeader = (channel: Record<string, unknown>) =>
+  mount(ChannelHeaderMobile, {
+    props: { channelId: 'cats', channel },
+    global: {
+      stubs: {
+        AvatarComponent: true,
+        ClientOnly: { template: '<div><slot /></div>' },
+        AddToChannelFavorites: { template: '<div class="fav" />' },
+      },
+    },
+  });
+
+describe('ChannelHeaderMobile', () => {
+  it('renders the display name and unique name', () => {
+    const wrapper = mountHeader({ displayName: 'Cats', uniqueName: 'cats' });
+    expect(wrapper.text()).toContain('Cats');
+  });
+
+  it('falls back to the channel id when there is no display name', () => {
+    expect(mountHeader({}).text()).toContain('cats');
+  });
+
+  it('shows the favorite button when authenticated', () => {
+    mockIsAuthenticated.value = true;
+    expect(
+      mountHeader({ displayName: 'Cats', uniqueName: 'cats' }).find('.fav').exists()
+    ).toBe(true);
+  });
+
+  it('hides the favorite button when not authenticated', () => {
+    mockIsAuthenticated.value = false;
+    expect(
+      mountHeader({ displayName: 'Cats', uniqueName: 'cats' }).find('.fav').exists()
+    ).toBe(false);
+  });
+});

--- a/components/discussion/detail/CarouselThumbnail.spec.ts
+++ b/components/discussion/detail/CarouselThumbnail.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CarouselThumbnail from './CarouselThumbnail.vue';
+
+const mountThumb = (props: Record<string, unknown>) =>
+  mount(CarouselThumbnail, {
+    props,
+    global: {
+      stubs: {
+        ClientOnly: { template: '<div><slot /></div>' },
+        ModelViewer: { template: '<div class="model" />' },
+        StlViewer: { template: '<div class="stl" />' },
+      },
+    },
+  });
+
+describe('CarouselThumbnail', () => {
+  it('renders a plain image for a regular url', () => {
+    expect(
+      mountThumb({ image: { url: 'a.png' } }).find('img').exists()
+    ).toBe(true);
+  });
+
+  it('renders the model viewer for a glb url', () => {
+    expect(
+      mountThumb({ image: { url: 'm.glb' } }).find('.model').exists()
+    ).toBe(true);
+  });
+
+  it('emits click when the thumbnail is clicked', async () => {
+    const wrapper = mountThumb({ image: { url: 'a.png' } });
+    await wrapper.find('div').trigger('click');
+    expect(wrapper.emitted('click')).toBeTruthy();
+  });
+
+  it('applies the active border class when active', () => {
+    expect(
+      mountThumb({ image: { url: 'a.png' }, isActive: true }).classes()
+    ).toContain('border-orange-500');
+  });
+
+  it('sizes the thumbnail from the size prop', () => {
+    const wrapper = mountThumb({ image: { url: 'a.png' }, size: 120 });
+    expect(wrapper.attributes('style')).toContain('120px');
+  });
+});

--- a/components/discussion/detail/CrosspostList.spec.ts
+++ b/components/discussion/detail/CrosspostList.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CrosspostList from './CrosspostList.vue';
+
+const mountList = (props: Record<string, unknown>) =>
+  mount(CrosspostList, {
+    props: { discussionId: 'd1', ...props },
+    global: {
+      stubs: {
+        'nuxt-link': { template: '<a><slot /></a>' },
+        Tag: { template: '<span class="tag" />' },
+      },
+    },
+  });
+
+describe('CrosspostList', () => {
+  it('renders the heading', () => {
+    expect(mountList({}).text()).toContain('Crossposted To Channels');
+  });
+
+  it('renders a row per channel link', () => {
+    const wrapper = mountList({
+      channelLinks: [{ uniqueName: 'cats' }, { uniqueName: 'dogs' }],
+    });
+    expect(wrapper.findAll('li')).toHaveLength(2);
+  });
+
+  it('uses the getCommentCount callback for the count label', () => {
+    const wrapper = mountList({
+      channelLinks: [{ uniqueName: 'cats' }],
+      getCommentCount: () => 7,
+    });
+    expect(wrapper.text()).toContain('7 comments');
+  });
+});

--- a/components/discussion/form/AlbumImageItem.spec.ts
+++ b/components/discussion/form/AlbumImageItem.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AlbumImageItem from './AlbumImageItem.vue';
+
+vi.mock('vuetify', () => ({ useDisplay: () => ({ mdAndDown: false }) }));
+
+const image = { url: 'https://img.test/a.png', alt: 'A', caption: 'C', copyright: '' };
+
+const mountItem = (props: Record<string, unknown> = {}) =>
+  mount(AlbumImageItem, {
+    props: {
+      image,
+      index: 0,
+      isFirst: false,
+      isLast: false,
+      isLoading: false,
+      ...props,
+    },
+    global: {
+      stubs: {
+        XmarkIcon: true,
+        LoadingSpinner: true,
+        ExpandableImage: true,
+        ModelViewer: true,
+        StlViewer: true,
+        ClientOnly: { template: '<div><slot /></div>' },
+        FormRow: { template: '<div><slot name="content" /></div>' },
+        TextInput: {
+          props: ['value'],
+          template: '<input class="ti" @input="$emit(\'update\', \'changed\')" >',
+        },
+      },
+    },
+  });
+
+describe('AlbumImageItem', () => {
+  it('labels the image with its 1-based index', () => {
+    expect(mountItem({ index: 2 }).text()).toContain('Image 3');
+  });
+
+  it('disables the move-up button for the first image', () => {
+    const upButton = mountItem({ isFirst: true }).findAll('button')[0];
+    expect((upButton.element as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('emits delete when the delete button is clicked', async () => {
+    const wrapper = mountItem();
+    await wrapper.findAll('button').at(-1)?.trigger('click');
+    expect(wrapper.emitted('delete')).toBeTruthy();
+  });
+
+  it('emits move-down when the down button is clicked', async () => {
+    const wrapper = mountItem();
+    await wrapper.findAll('button')[1].trigger('click');
+    expect(wrapper.emitted('move-down')).toBeTruthy();
+  });
+
+  it('emits update-field with the field key when a text input changes', async () => {
+    const wrapper = mountItem();
+    await wrapper.findAll('.ti')[0].trigger('input');
+    expect(wrapper.emitted('update-field')?.[0]).toEqual(['url', 'changed']);
+  });
+});

--- a/components/event/detail/EventBody.spec.ts
+++ b/components/event/detail/EventBody.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import EventBody from './EventBody.vue';
+
+const mockUsername = ref('');
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => mockUsername,
+}));
+
+const mountBody = (props: Record<string, unknown>) =>
+  mount(EventBody, {
+    props,
+    global: {
+      stubs: {
+        MarkdownPreview: { template: '<div class="md" />' },
+        EventDescriptionEditForm: { template: '<form class="edit-form" />' },
+      },
+    },
+  });
+
+const event = { description: 'Come hang out', Poster: { username: 'alice' } };
+
+describe('EventBody', () => {
+  it('renders the description preview', () => {
+    mockUsername.value = '';
+    expect(mountBody({ event }).find('.md').exists()).toBe(true);
+  });
+
+  it('shows the Edit button to the event poster', () => {
+    mockUsername.value = 'alice';
+    expect(mountBody({ event }).text()).toContain('Edit');
+  });
+
+  it('hides the Edit button from other users', () => {
+    mockUsername.value = 'bob';
+    expect(mountBody({ event }).text()).not.toContain('Edit');
+  });
+
+  it('emits the edit event when the poster clicks Edit', async () => {
+    mockUsername.value = 'alice';
+    const wrapper = mountBody({ event });
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('handleClickEditEventDescription')).toBeTruthy();
+  });
+
+  it('renders the edit form in edit mode', () => {
+    mockUsername.value = 'alice';
+    expect(
+      mountBody({ event, eventDescriptionEditMode: true }).find('.edit-form').exists()
+    ).toBe(true);
+  });
+});

--- a/components/event/detail/EventChannelLink.spec.ts
+++ b/components/event/detail/EventChannelLink.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EventChannelLink from './EventChannelLink.vue';
+
+const mountLink = (props: Record<string, unknown> = {}) =>
+  mount(EventChannelLink, {
+    props: {
+      eventId: 'e1',
+      channelId: 'cats',
+      channelIcon: '',
+      channelDisplayName: '',
+      commentCount: 0,
+      ...props,
+    },
+    global: {
+      stubs: {
+        'nuxt-link': { template: '<a><slot /></a>' },
+        AvatarComponent: true,
+      },
+    },
+  });
+
+describe('EventChannelLink', () => {
+  it('renders the channel unique name', () => {
+    expect(mountLink().text()).toContain('cats');
+  });
+
+  it('renders the channel display name when provided', () => {
+    expect(mountLink({ channelDisplayName: 'Cats Forum' }).text()).toContain(
+      'Cats Forum'
+    );
+  });
+
+  it('renders the channel avatar', () => {
+    expect(
+      mountLink().findComponent({ name: 'AvatarComponent' }).exists()
+    ).toBe(true);
+  });
+});

--- a/components/event/detail/EventChannelLinks.spec.ts
+++ b/components/event/detail/EventChannelLinks.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import type { EventChannel } from '@/__generated__/graphql';
+import EventChannelLinks from './EventChannelLinks.vue';
+
+const channel = (name: string): EventChannel =>
+  ({
+    id: `ec-${name}`,
+    channelUniqueName: name,
+    eventId: 'e1',
+    Channel: { displayName: name },
+    CommentsAggregate: { count: 0 },
+  }) as unknown as EventChannel;
+
+const mountLinks = (props: Record<string, unknown>) =>
+  mount(EventChannelLinks, {
+    props,
+    global: { stubs: { EventChannelLink: { template: '<li class="link" />' } } },
+  });
+
+describe('EventChannelLinks', () => {
+  it('renders a link per channel when no active channel is set', () => {
+    expect(
+      mountLinks({ eventChannels: [channel('cats'), channel('dogs')] }).findAll(
+        '.link'
+      )
+    ).toHaveLength(2);
+  });
+
+  it('excludes the active channel from the other-forums list', () => {
+    expect(
+      mountLinks({
+        channelId: 'cats',
+        eventChannels: [channel('cats'), channel('dogs')],
+      }).findAll('.link')
+    ).toHaveLength(1);
+  });
+
+  it('shows the submitted-to heading when no active channel', () => {
+    expect(mountLinks({ eventChannels: [channel('cats')] }).text()).toContain(
+      'submitted to the following forums'
+    );
+  });
+});

--- a/components/event/form/EditScopeModal.spec.ts
+++ b/components/event/form/EditScopeModal.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EditScopeModal from './EditScopeModal.vue';
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(EditScopeModal, {
+    props: { isOpen: true, ...props },
+    global: { stubs: { Teleport: { template: '<div><slot /></div>' } } },
+  });
+
+describe('EditScopeModal', () => {
+  it('renders nothing when closed', () => {
+    expect(mountModal({ isOpen: false }).find('[role="dialog"]').exists()).toBe(
+      false
+    );
+  });
+
+  it('renders the three scope options when open', () => {
+    expect(mountModal().findAll('input[type="radio"]')).toHaveLength(3);
+  });
+
+  it('emits close when Cancel is clicked', async () => {
+    const wrapper = mountModal();
+    await wrapper.get('[data-testid="edit-scope-cancel"]').trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('confirms with the default THIS_ONLY scope', async () => {
+    const wrapper = mountModal();
+    await wrapper.get('[data-testid="edit-scope-confirm"]').trigger('click');
+    expect(wrapper.emitted('confirm')?.[0]).toEqual(['THIS_ONLY']);
+  });
+
+  it('confirms with the selected scope', async () => {
+    const wrapper = mountModal();
+    await wrapper.get('[data-testid="edit-scope-all-in-series"] input').setValue();
+    await wrapper.get('[data-testid="edit-scope-confirm"]').trigger('click');
+    expect(wrapper.emitted('confirm')?.[0]).toEqual(['ALL_IN_SERIES']);
+  });
+});

--- a/components/image/ImageListItem.spec.ts
+++ b/components/image/ImageListItem.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import type { Image } from '@/__generated__/graphql';
+import ImageListItem from './ImageListItem.vue';
+
+const mountItem = (image: Partial<Image>) =>
+  mount(ImageListItem, {
+    props: { image: image as Image, username: 'alice' },
+    global: {
+      stubs: {
+        NuxtLink: { template: '<a><slot /></a>' },
+        ClientOnly: { template: '<div><slot /></div>' },
+        ModelViewer: { template: '<div class="model" />' },
+        StlViewer: { template: '<div class="stl" />' },
+        AddToImageFavorites: { template: '<div class="fav" />' },
+      },
+    },
+  });
+
+describe('ImageListItem', () => {
+  it('renders a plain image for a regular url', () => {
+    const wrapper = mountItem({ id: 'i1', url: 'https://img.test/a.png' });
+    expect(wrapper.find('img').exists()).toBe(true);
+  });
+
+  it('uses alt, then caption, then a fallback for the image alt', () => {
+    const wrapper = mountItem({ id: 'i1', url: 'a.png', caption: 'A cat' });
+    expect(wrapper.find('img').attributes('alt')).toBe('A cat');
+  });
+
+  it('renders the 3D model viewer for a glb url', () => {
+    const wrapper = mountItem({ id: 'i1', url: 'https://img.test/m.glb' });
+    expect(wrapper.find('.model').exists()).toBe(true);
+  });
+
+  it('shows the sensitive-content overlay', () => {
+    const wrapper = mountItem({
+      id: 'i1',
+      url: 'a.png',
+      hasSensitiveContent: true,
+    });
+    expect(wrapper.text()).toContain('Sensitive');
+  });
+
+  it('hides the favorite button when showFavoriteButton is false', () => {
+    const wrapper = mount(ImageListItem, {
+      props: {
+        image: { id: 'i1', url: 'a.png' } as Image,
+        username: 'alice',
+        showFavoriteButton: false,
+      },
+      global: {
+        stubs: {
+          NuxtLink: { template: '<a><slot /></a>' },
+          ClientOnly: { template: '<div><slot /></div>' },
+          ModelViewer: true,
+          StlViewer: true,
+          AddToImageFavorites: { template: '<div class="fav" />' },
+        },
+      },
+    });
+    expect(wrapper.find('.fav').exists()).toBe(false);
+  });
+});

--- a/components/mod/IssueBodyEditor.spec.ts
+++ b/components/mod/IssueBodyEditor.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import IssueBodyEditor from './IssueBodyEditor.vue';
+
+const mountEditor = (props: Record<string, unknown> = {}) =>
+  mount(IssueBodyEditor, {
+    props: {
+      isIssueAuthor: true,
+      isLocked: false,
+      isEditingIssueBody: false,
+      editedIssueBody: '',
+      updateIssueBodyLoading: false,
+      issueBodyHasChanges: false,
+      ...props,
+    },
+    global: {
+      stubs: {
+        GenericButton: {
+          props: ['text'],
+          template: '<button @click="$emit(\'click\')">{{ text }}</button>',
+        },
+        SaveButton: {
+          props: ['label', 'disabled'],
+          template:
+            '<button class="save" :disabled="disabled" @click="$emit(\'click\')">{{ label }}</button>',
+        },
+        MarkdownPreview: { props: ['text'], template: '<div class="md">{{ text }}</div>' },
+        TextEditor: {
+          template: '<textarea class="te" @input="$emit(\'update\', \'new body\')" />',
+        },
+        ErrorBanner: { props: ['text'], template: '<div class="err">{{ text }}</div>' },
+      },
+    },
+  });
+
+describe('IssueBodyEditor', () => {
+  it('shows the Edit button to the author of an unlocked issue', () => {
+    expect(mountEditor().text()).toContain('Edit');
+  });
+
+  it('hides edit controls when the issue is locked', () => {
+    expect(mountEditor({ isLocked: true }).text()).not.toContain('Edit');
+  });
+
+  it('emits startEdit when Edit is clicked', async () => {
+    const wrapper = mountEditor();
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('startEdit')).toBeTruthy();
+  });
+
+  it('renders the markdown preview when not editing', () => {
+    expect(
+      mountEditor({ issueBody: 'Hello' }).find('.md').text()
+    ).toBe('Hello');
+  });
+
+  it('shows the editor and forwards body updates in edit mode', async () => {
+    const wrapper = mountEditor({ isEditingIssueBody: true });
+    await wrapper.find('.te').trigger('input');
+    expect(wrapper.emitted('update:editedIssueBody')?.[0]).toEqual(['new body']);
+  });
+
+  it('shows the error banner when there is an update error', () => {
+    expect(
+      mountEditor({ updateIssueBodyError: { message: 'Failed' } }).find('.err').text()
+    ).toBe('Failed');
+  });
+});

--- a/components/mod/IssueLockDialog.spec.ts
+++ b/components/mod/IssueLockDialog.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import IssueLockDialog from './IssueLockDialog.vue';
+
+const mountDialog = (props: Record<string, unknown> = {}) =>
+  mount(IssueLockDialog, {
+    props: { lockReasonInput: '', lockIssueLoading: false, ...props },
+    global: {
+      stubs: {
+        GenericButton: {
+          props: ['text'],
+          template: '<button @click="$emit(\'click\')">{{ text }}</button>',
+        },
+        SaveButton: {
+          props: ['label', 'disabled', 'loading'],
+          template:
+            '<button :disabled="disabled" @click="$emit(\'click\')">{{ label }}</button>',
+        },
+        ErrorBanner: { props: ['text'], template: '<div class="err">{{ text }}</div>' },
+      },
+    },
+  });
+
+describe('IssueLockDialog', () => {
+  it('emits update:lockReasonInput when the textarea changes', async () => {
+    const wrapper = mountDialog();
+    await wrapper.find('textarea').setValue('spam');
+    expect(wrapper.emitted('update:lockReasonInput')?.[0]).toEqual(['spam']);
+  });
+
+  it('emits close when Cancel is clicked', async () => {
+    const wrapper = mountDialog();
+    await wrapper.findAll('button')[0].trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('emits lock when the lock button is clicked', async () => {
+    const wrapper = mountDialog({ lockReasonInput: 'spam' });
+    await wrapper.findAll('button').at(-1)?.trigger('click');
+    expect(wrapper.emitted('lock')).toBeTruthy();
+  });
+
+  it('disables the lock button when the reason is blank', () => {
+    const wrapper = mountDialog({ lockReasonInput: '   ' });
+    expect(
+      (wrapper.findAll('button').at(-1)?.element as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
+  it('shows the error banner when there is a lock error', () => {
+    const wrapper = mountDialog({
+      lockIssueError: { message: 'Boom' } as never,
+    });
+    expect(wrapper.find('.err').text()).toBe('Boom');
+  });
+});

--- a/tests/playwright/helpers/graphqlFixtures.ts
+++ b/tests/playwright/helpers/graphqlFixtures.ts
@@ -603,3 +603,133 @@ export const buildEvent = ({
   }),
   ...overrides,
 });
+
+// ---------------------------------------------------------------------------
+// Moderation issues
+//
+// Shapes match GET_ISSUE / ISSUE_BASE_FIELDS (graphQLData/issue/queries.js) so
+// the mod issue-detail flow (and future mod flows) can build issue mocks
+// without re-declaring the query shape inline.
+// ---------------------------------------------------------------------------
+
+export type ModerationActionFixture = {
+  __typename: 'ModerationAction';
+  id: string;
+  actionDescription: string;
+  actionType: string;
+  createdAt: string;
+  ModerationProfile: { displayName: string } | null;
+  User: { username: string } | null;
+  Revision: null;
+  Comment: CommentFixture | null;
+};
+
+export const buildModerationAction = ({
+  id = 'mod-action-1',
+  actionType = 'report',
+  actionDescription = 'reported this issue',
+  moderatorDisplayName = 'mod-alice',
+  createdAt = MOCK_DATE,
+  comment = null,
+  overrides = {},
+}: {
+  id?: string;
+  actionType?: string;
+  actionDescription?: string;
+  moderatorDisplayName?: string | null;
+  createdAt?: string;
+  comment?: CommentFixture | null;
+  overrides?: Override<ModerationActionFixture>;
+} = {}): ModerationActionFixture => ({
+  __typename: 'ModerationAction',
+  id,
+  actionDescription,
+  actionType,
+  createdAt,
+  ModerationProfile: moderatorDisplayName
+    ? { displayName: moderatorDisplayName }
+    : null,
+  User: null,
+  Revision: null,
+  Comment: comment,
+  ...overrides,
+});
+
+export type IssueFixture = {
+  __typename: 'Issue';
+  id: string;
+  issueNumber: number;
+  title: string;
+  body: string;
+  isOpen: boolean;
+  createdAt: string;
+  updatedAt: string;
+  relatedCommentId: string | null;
+  relatedDiscussionId: string | null;
+  relatedEventId: string | null;
+  relatedImageId: string | null;
+  relatedWikiPageId: string | null;
+  relatedWikiRevisionId: string | null;
+  relatedChannelUniqueName: string | null;
+  channelUniqueName: string;
+  Author: { __typename: 'User'; username: string };
+  flaggedServerRuleViolation: boolean;
+  SubscribedToNotifications: Array<{ username: string }>;
+  locked: boolean;
+  lockedAt: string | null;
+  lockReason: string | null;
+  LockedBy: { displayName: string } | null;
+  ActivityFeed: ModerationActionFixture[];
+  ActivityFeedAggregate: { count: number };
+};
+
+export const buildIssue = ({
+  issueNumber = 1,
+  channelUniqueName = 'cats',
+  title = 'Reported discussion',
+  body = 'This discussion violates the rules.',
+  isOpen = true,
+  authorUsername = DEFAULT_USERNAME,
+  locked = false,
+  activityFeed = [buildModerationAction()],
+  overrides = {},
+}: {
+  issueNumber?: number;
+  channelUniqueName?: string;
+  title?: string;
+  body?: string;
+  isOpen?: boolean;
+  authorUsername?: string;
+  locked?: boolean;
+  activityFeed?: ModerationActionFixture[];
+  overrides?: Override<IssueFixture>;
+} = {}): IssueFixture => ({
+  __typename: 'Issue',
+  id: `issue-${issueNumber}`,
+  issueNumber,
+  title,
+  body,
+  isOpen,
+  createdAt: MOCK_DATE,
+  updatedAt: MOCK_DATE,
+  relatedCommentId: null,
+  relatedDiscussionId: null,
+  relatedEventId: null,
+  relatedImageId: null,
+  relatedWikiPageId: null,
+  relatedWikiRevisionId: null,
+  relatedChannelUniqueName: null,
+  channelUniqueName,
+  Author: { __typename: 'User', username: authorUsername },
+  flaggedServerRuleViolation: false,
+  SubscribedToNotifications: [],
+  locked,
+  lockedAt: locked ? MOCK_DATE : null,
+  lockReason: locked ? 'Locked for review' : null,
+  LockedBy: locked ? { displayName: 'mod-alice' } : null,
+  ActivityFeed: activityFeed,
+  ActivityFeedAggregate: {
+    count: activityFeed.filter((a) => a.actionType === 'report').length,
+  },
+  ...overrides,
+});

--- a/tests/playwright/mocked/mod/issueDetail.spec.ts
+++ b/tests/playwright/mocked/mod/issueDetail.spec.ts
@@ -99,7 +99,7 @@ const getBaseMocks = (username: string) => ({
 });
 
 test.describe('Moderation issue detail', () => {
-  test('renders an open issue with its activity feed', async ({
+  test('renders an open issue with a varied activity feed', async ({
     context,
     page,
   }, testInfo) => {
@@ -108,6 +108,7 @@ test.describe('Moderation issue detail', () => {
       email: 'alice@example.com',
     });
 
+    // Mixed action types exercise the activity-feed label branches.
     const issue = buildIssue({
       issueNumber: ISSUE_NUMBER,
       channelUniqueName: TEST_CHANNEL,
@@ -119,6 +120,19 @@ test.describe('Moderation issue detail', () => {
           id: 'action-report',
           actionType: 'report',
           actionDescription: 'reported this discussion',
+          moderatorDisplayName: 'mod-alice',
+        }),
+        buildModerationAction({
+          id: 'action-close',
+          actionType: 'close',
+          actionDescription: 'closed the issue',
+          moderatorDisplayName: 'mod-bob',
+        }),
+        buildModerationAction({
+          id: 'action-suspend',
+          actionType: 'suspension',
+          actionDescription: 'suspended the user',
+          moderatorDisplayName: 'mod-carol',
         }),
       ],
     });
@@ -131,15 +145,16 @@ test.describe('Moderation issue detail', () => {
     try {
       await page.goto(`/forums/${TEST_CHANNEL}/issues/${ISSUE_NUMBER}`);
 
-      // Issue body/title render once the issue query resolves.
       await expect(
         page.getByText('Reported discussion about spam')
       ).toBeVisible();
       await expect(
         page.getByText('This discussion violates the no-spam rule.')
       ).toBeVisible();
-      // The moderation activity feed renders the report action label.
-      await expect(page.getByText(/reported by/i).first()).toBeVisible();
+      // ActivityFeedListItem renders a distinct passive label per action type.
+      await expect(page.getByText(/was reported by/i).first()).toBeVisible();
+      await expect(page.getByText(/the issue was closed by/i)).toBeVisible();
+      await expect(page.getByText(/the user was suspended by/i)).toBeVisible();
 
       await waitForGraphqlOperation(diagnostics.completedOperations, 'getIssue');
     } finally {
@@ -176,6 +191,62 @@ test.describe('Moderation issue detail', () => {
       await page.goto(`/forums/${TEST_CHANNEL}/issues/${ISSUE_NUMBER}`);
 
       await expect(page.getByText('Locked for review')).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('renders the moderation wizard and opens the broken-rules modal', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    // An issue tied to a related discussion renders the ModerationWizard
+    // (mod actions) because the current user is a moderator, not the OP.
+    const issue = buildIssue({
+      issueNumber: ISSUE_NUMBER,
+      channelUniqueName: TEST_CHANNEL,
+      title: 'Reported discussion needing review',
+      isOpen: true,
+      overrides: { relatedDiscussionId: 'discussion-1' },
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      getIssue: () => ({ data: { issues: [issue] } }),
+      // Related content lookup — empty list keeps IssueRelatedContent inert
+      // while the wizard renders from the issue's relatedDiscussionId.
+      getDiscussion: () => ({ data: { discussions: [] } }),
+      // Drives the wizard's "is archived" check (false → Archive action shown).
+      getDiscussionChannelID: () => ({
+        data: { discussionChannels: [{ archived: false }] },
+      }),
+      // Author suspension check for the wizard.
+      getSuspension: () => ({ data: { isOriginalPosterSuspended: false } }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/issues/${ISSUE_NUMBER}`);
+
+      // ModerationWizard renders an Archive action for the related discussion.
+      const archiveButton = page
+        .getByRole('button', { name: /Archive Discussion/i })
+        .first();
+      await expect(archiveButton).toBeVisible();
+
+      // Opening it surfaces the BrokenRulesModal.
+      await archiveButton.click();
+      await expect(page.getByText('Archive Content')).toBeVisible();
+      await expect(
+        page.getByText('Please select at least one broken rule')
+      ).toBeVisible();
     } finally {
       await testInfo.attach('graphql-operations.json', {
         body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),

--- a/tests/playwright/mocked/mod/issueDetail.spec.ts
+++ b/tests/playwright/mocked/mod/issueDetail.spec.ts
@@ -12,10 +12,19 @@ import {
   installGraphqlMocks,
   waitForGraphqlOperation,
 } from '../../helpers/mockGraphql';
+import {
+  createRulesJSON,
+  DEFAULT_RULES_JSON,
+} from '../../helpers/moderationFixtures';
 
 const TEST_CHANNEL = 'cats';
 const TEST_USER = 'alice';
 const ISSUE_NUMBER = 1;
+
+// Channel-scoped rule (distinct from the server rule) so the modal shows both.
+const CHANNEL_RULES_JSON = createRulesJSON([
+  { summary: 'No spam', detail: 'Do not post spam.' },
+]);
 
 // Base operations the app shell + channel/issues layout fire on any
 // authenticated channel-issue page. The current user is a channel admin so the
@@ -95,6 +104,17 @@ const getBaseMocks = (username: string) => ({
   countClosedIssues: () => ({ data: { issuesAggregate: { count: 0 } } }),
   getEvents: () => ({
     data: { events: [], eventsAggregate: { count: 0 } },
+  }),
+  // Rules shown in the broken-rules modal: server-wide + channel-scoped.
+  getServerRules: () => ({
+    data: {
+      serverConfigs: [{ serverName: 'Listical', rules: DEFAULT_RULES_JSON }],
+    },
+  }),
+  getChannelRules: () => ({
+    data: {
+      channels: [{ uniqueName: TEST_CHANNEL, rules: CHANNEL_RULES_JSON }],
+    },
   }),
 });
 
@@ -247,6 +267,15 @@ test.describe('Moderation issue detail', () => {
       await expect(
         page.getByText('Please select at least one broken rule')
       ).toBeVisible();
+
+      // The modal is populated with the server config's rules...
+      await expect(page.getByText('Server Rules')).toBeVisible();
+      await expect(page.getByText('Be kind')).toBeVisible();
+
+      // ...and a rule is selectable.
+      const ruleCheckbox = page.locator('input[value="Be kind"]');
+      await ruleCheckbox.check();
+      await expect(ruleCheckbox).toBeChecked();
     } finally {
       await testInfo.attach('graphql-operations.json', {
         body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),

--- a/tests/playwright/mocked/mod/issueDetail.spec.ts
+++ b/tests/playwright/mocked/mod/issueDetail.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test } from '../../helpers/testFixture';
+import {
+  buildBasicUser,
+  buildChannel,
+  buildServerConfig,
+  buildUser,
+  buildIssue,
+  buildModerationAction,
+} from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+
+const TEST_CHANNEL = 'cats';
+const TEST_USER = 'alice';
+const ISSUE_NUMBER = 1;
+
+// Base operations the app shell + channel/issues layout fire on any
+// authenticated channel-issue page. The current user is a channel admin so the
+// moderation UI renders.
+const getBaseMocks = (username: string) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username, displayName: username })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: { serverConfigs: [buildServerConfig({ serverName: 'Listical' })] },
+  }),
+  getChannel: () => ({
+    data: {
+      channels: [
+        buildChannel({
+          uniqueName: TEST_CHANNEL,
+          overrides: { Admins: [buildUser({ username })] },
+        }),
+      ],
+    },
+  }),
+  getChannelDownloadCount: () => ({
+    data: {
+      channels: [
+        {
+          uniqueName: TEST_CHANNEL,
+          DiscussionChannelsAggregate: { count: 0 },
+        },
+      ],
+    },
+  }),
+  getModsByChannel: () => ({
+    data: {
+      channels: [
+        {
+          uniqueName: TEST_CHANNEL,
+          SuspendedModsAggregate: { count: 0 },
+          SuspendedMods: [],
+        },
+      ],
+    },
+  }),
+  userIsModInChannel: () => ({
+    data: {
+      channels: [
+        {
+          uniqueName: TEST_CHANNEL,
+          Admins: [{ username }],
+          SuspendedUsers: [],
+          Moderators: [],
+          SuspendedMods: [],
+        },
+      ],
+    },
+  }),
+  countOpenIssues: () => ({ data: { issuesAggregate: { count: 1 } } }),
+  countClosedIssues: () => ({ data: { issuesAggregate: { count: 0 } } }),
+  getEvents: () => ({
+    data: { events: [], eventsAggregate: { count: 0 } },
+  }),
+});
+
+test.describe('Moderation issue detail', () => {
+  test('renders an open issue with its activity feed', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const issue = buildIssue({
+      issueNumber: ISSUE_NUMBER,
+      channelUniqueName: TEST_CHANNEL,
+      title: 'Reported discussion about spam',
+      body: 'This discussion violates the no-spam rule.',
+      isOpen: true,
+      activityFeed: [
+        buildModerationAction({
+          id: 'action-report',
+          actionType: 'report',
+          actionDescription: 'reported this discussion',
+        }),
+      ],
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      getIssue: () => ({ data: { issues: [issue] } }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/issues/${ISSUE_NUMBER}`);
+
+      // Issue body/title render once the issue query resolves.
+      await expect(
+        page.getByText('Reported discussion about spam')
+      ).toBeVisible();
+      await expect(
+        page.getByText('This discussion violates the no-spam rule.')
+      ).toBeVisible();
+      // The moderation activity feed renders the report action label.
+      await expect(page.getByText(/reported by/i).first()).toBeVisible();
+
+      await waitForGraphqlOperation(diagnostics.completedOperations, 'getIssue');
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('shows the locked banner for a locked issue', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const issue = buildIssue({
+      issueNumber: ISSUE_NUMBER,
+      channelUniqueName: TEST_CHANNEL,
+      title: 'Locked issue',
+      isOpen: true,
+      locked: true,
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      getIssue: () => ({ data: { issues: [issue] } }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/issues/${ISSUE_NUMBER}`);
+
+      await expect(page.getByText('Locked for review')).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

First E2E flow from the coverage strategy: a mocked Playwright spec for the channel-scoped **mod issue-detail** page (`/forums/[forumId]/issues/[issueNumber]`).

Per the per-file measurement, this was the densest **no-E2E** cold cluster — `IssueDetail` (48% unit), `BrokenRulesModal` (36%), `ActivityFeedListItem` (56%) and the related-content/wizard children were exercised only by unit mounts, leaving the real Apollo/routing/render branches uncovered. One page load here lights up that whole tree against real component composition.

## What it covers
- **Open issue** — renders title, body, and the moderation activity-feed report label.
- **Locked issue** — renders the locked banner.

Driven entirely through mocked GraphQL (`installGraphqlMocks`) + `installMockAuth`, matching the existing mocked-suite pattern. The current user is a channel admin so the moderation UI renders.

## Reusable fixtures
Adds `buildIssue` / `buildModerationAction` to `graphqlFixtures.ts` (shapes match `GET_ISSUE` / `ISSUE_BASE_FIELDS`) so this and future mod flows don't re-declare the issue query shape inline.

## Verification
- Both cases pass locally against the mocked dev server (stable across repeated runs).
- `npm run tsc` — clean
- `eslint` on the spec + fixtures — clean

## Note on coverage mechanics
The `e2e` Codecov flag is carryforward + uploaded by the opt-in "Combined Coverage" workflow, so this flow's contribution shows up after that workflow next runs on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)