### PR TITLE
test(e2e): cover the collections detail flow

### DIFF
--- a/tests/playwright/mocked/collections/collectionDetail.spec.ts
+++ b/tests/playwright/mocked/collections/collectionDetail.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '../../helpers/testFixture';
+import { buildBasicUser, buildServerConfig } from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+
+const TEST_USER = 'alice';
+const COLLECTION_ID = 'collection-1';
+
+const buildPublicCollection = (overrides = {}) => ({
+  id: COLLECTION_ID,
+  name: 'My Favorite Models',
+  description: 'A public collection of 3D models.',
+  visibility: 'PUBLIC',
+  collectionType: 'DOWNLOADS',
+  itemCount: 1,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  CreatedBy: {
+    username: 'bob',
+    displayName: 'Bob',
+    profilePicURL: '',
+  },
+  DownloadsAggregate: { count: 1 },
+  Downloads: [
+    {
+      id: 'download-1',
+      title: 'Cool Widget',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      hasSensitiveContent: false,
+      Album: { id: 'album-1', imageOrder: [], Images: [] },
+      DiscussionChannels: [
+        { id: 'dc-1', channelUniqueName: 'cats' },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+const getBaseMocks = (username: string) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username, displayName: username })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: { serverConfigs: [buildServerConfig({ serverName: 'Listical' })] },
+  }),
+  GetPublicCollectionById: () => ({
+    data: { collections: [buildPublicCollection()] },
+  }),
+});
+
+test.describe('Public collection detail', () => {
+  test('renders a public collection and its items', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, getBaseMocks(TEST_USER));
+
+    try {
+      await page.goto(`/collections/${COLLECTION_ID}`);
+
+      await expect(page.getByText('My Favorite Models')).toBeVisible();
+      await expect(
+        page.getByText('A public collection of 3D models.')
+      ).toBeVisible();
+      await expect(page.getByText('Cool Widget')).toBeVisible();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'GetPublicCollectionById'
+      );
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});

--- a/tests/playwright/mocked/collections/libraryCollection.spec.ts
+++ b/tests/playwright/mocked/collections/libraryCollection.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '../../helpers/testFixture';
+import { buildBasicUser, buildServerConfig } from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+
+const TEST_USER = 'alice';
+const COLLECTION_ID = 'collection-1';
+
+const buildCollectionItems = (overrides = {}) => ({
+  id: COLLECTION_ID,
+  name: 'My Test Collection',
+  description: 'A collection owned by the current user.',
+  collectionType: 'DISCUSSIONS',
+  visibility: 'PRIVATE',
+  itemCount: 0,
+  itemOrder: [],
+  Discussions: [],
+  Comments: [],
+  Images: [],
+  Channels: [],
+  Downloads: [],
+  ...overrides,
+});
+
+const getBaseMocks = (username: string) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username, displayName: username })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: { serverConfigs: [buildServerConfig({ serverName: 'Listical' })] },
+  }),
+  // library.vue parent shell counts
+  GetAllUserCollections: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  getUserFavoriteCounts: () => ({ data: { users: [{ username }] } }),
+  getUserFavoriteDownloadsCount: () => ({ data: { users: [{ username }] } }),
+  getUserOwnedDownloadsCount: () => ({ data: { users: [{ username }] } }),
+  // the collection detail
+  GetCollectionItems: () => ({
+    data: { collections: [buildCollectionItems()] },
+  }),
+});
+
+test.describe('Library collection detail', () => {
+  test('renders an owned collection by name', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, getBaseMocks(TEST_USER));
+
+    try {
+      await page.goto(`/library/${COLLECTION_ID}`);
+
+      await expect(page.getByText('My Test Collection').first()).toBeVisible();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'GetCollectionItems'
+      );
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Third E2E flow from the coverage strategy: the **collections** detail pages, covering both the public and the owned/library views.

## What it covers
- **Public collection** (`/collections/[collectionId]`) — renders the collection name, description, and a download item via `GetPublicCollectionById`. Standalone page, single query.
- **Library / owned collection** (`/library/[collectionId]`) — renders the owned collection by name via `GetCollectionItems`, exercising the page **and** its `library.vue` parent shell (the four favorite/owned-count queries + collection sidebar).

Both driven through mocked GraphQL (`installGraphqlMocks`) + `installMockAuth`, matching the existing mocked-suite pattern.

## Verification
- Both cases pass locally against the mocked dev server (stable across repeated runs).
- `npm run tsc` — clean
- `eslint` on both specs — clean

## Note
The `e2e` Codecov flag is carryforward + uploaded by the opt-in "Combined Coverage" workflow, so this flow's contribution shows up after that workflow next runs on `main`. Follows #160 (mod issue-detail) and #162 (plugin-detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)