### PR TITLE
test(e2e): cover the user image-detail page

### DIFF
--- a/tests/playwright/mocked/user/imageDetail.spec.ts
+++ b/tests/playwright/mocked/user/imageDetail.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '../../helpers/testFixture';
+import { buildBasicUser, buildServerConfig } from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+
+const TEST_USER = 'alice';
+const IMAGE_ID = 'image-1';
+
+const buildImage = (overrides = {}) => ({
+  id: IMAGE_ID,
+  url: 'https://img.test/photo.png',
+  alt: 'A scenic photo',
+  caption: 'Sunset over the hills',
+  copyright: '',
+  longDescription: '',
+  hasSensitiveContent: false,
+  hasSpoiler: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  scanCheckedAt: '2024-01-01T00:00:00.000Z',
+  Uploader: {
+    username: TEST_USER,
+    displayName: 'Alice',
+    profilePicURL: '',
+  },
+  Album: null,
+  ...overrides,
+});
+
+const getBaseMocks = (username: string) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username, displayName: username })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: { serverConfigs: [buildServerConfig({ serverName: 'Listical' })] },
+  }),
+  GetImageDetails: () => ({ data: { images: [buildImage()] } }),
+});
+
+test.describe('User image detail', () => {
+  test('renders an image with its uploader and caption', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, getBaseMocks(TEST_USER));
+
+    try {
+      await page.goto(`/u/${TEST_USER}/images/${IMAGE_ID}`);
+
+      await expect(page.getByText('Image uploaded by Alice')).toBeVisible();
+      await expect(
+        page.getByText('Sunset over the hills', { exact: true })
+      ).toBeVisible();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'GetImageDetails'
+      );
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('warns when the route user is not the uploader', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      GetImageDetails: () => ({
+        data: {
+          images: [
+            buildImage({
+              Uploader: {
+                username: 'bob',
+                displayName: 'Bob',
+                profilePicURL: '',
+              },
+            }),
+          ],
+        },
+      }),
+    });
+
+    try {
+      // Route says /u/alice but the image was uploaded by bob.
+      await page.goto(`/u/${TEST_USER}/images/${IMAGE_ID}`);
+
+      await expect(
+        page.getByText(/uploaded by bob, not/i)
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fourth E2E flow from the coverage strategy: the user image-detail page (`/u/[username]/images/[imageId]`), a cold no-E2E page (~53% before, 741 lines).

## What it covers
- **Normal view** — renders the image with its uploader ("Image uploaded by Alice"), caption, and metadata via `GetImageDetails`.
- **Mismatch warning** — when the route user doesn't match the image's actual uploader, the page shows the "uploaded by X, not Y" notice (a distinct branch).

Driven through mocked GraphQL (`GetImageDetails`) + `installMockAuth`.

## Verification
- Both cases pass locally against the mocked dev server (stable across repeated runs).
- `npm run tsc` — clean
- `eslint` on the spec — clean

## Note
The `e2e` Codecov flag is carryforward + uploaded by the opt-in "Combined Coverage" workflow, so this flow's contribution shows up after that workflow next runs on `main`. Follows #160 (mod issue-detail), #162 (plugin-detail), #163 (collections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)