### PR TITLE
chore: remove Cypress entirely (Playwright-only project)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,7 @@ GOOGLE_CREDENTIALS_BASE64=placeholder
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/placeholder/placeholder/placeholder
 AUTH0_DOMAIN=gennit.us.auth0.com
 AUTH0_CLIENT_ID=placeholder
-SERVER_CONFIG_NAME="Cypress Test Server"
+SERVER_CONFIG_NAME="Playwright Test Server"
 # SERVER_CONFIG_NAME="Listical"
 
 VITE_ENABLE_LANGUAGE_PICKER=true

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ cloud_functions
 .env.*
 !.env.example
 
+# Cypress env file (contains secrets; must never be committed)
+cypress.env.json
+
 # config for docker compose
 config
 

--- a/composables/useTestAuthHelpers.ts
+++ b/composables/useTestAuthHelpers.ts
@@ -10,9 +10,7 @@ import { config } from '@/config';
 export function useTestAuthHelpers() {
   const isAuthenticatedVar = useIsAuthenticated();
   const isDevRuntime = import.meta.env.DEV;
-  const isTestEnv =
-    config.environment === 'test' ||
-    (typeof window !== 'undefined' && window.Cypress);
+  const isTestEnv = config.environment === 'test';
   const shouldExpose = isDevRuntime || isTestEnv;
 
   if (!shouldExpose) return;
@@ -44,7 +42,7 @@ export function useTestAuthHelpers() {
     }
   };
 
-  // Expose immediately on the client so Cypress can set auth state before
+  // Expose immediately on the client so test code can set auth state before
   // page-specific components finish mounting.
   exposeToWindow();
 

--- a/docs/MODERATION_PLAN.md
+++ b/docs/MODERATION_PLAN.md
@@ -1520,7 +1520,7 @@ Expected outcome:
 
 ---
 
-## Cypress Test Backlog
+## E2E Test Backlog
 
 These items should eventually have automated E2E coverage but can be manually verified using the instructions above.
 

--- a/docs/moderation-architecture.md
+++ b/docs/moderation-architecture.md
@@ -279,8 +279,10 @@ When testing moderator behavior:
 
 Suspension end-to-end coverage lives in:
 
-- `tests/cypress/e2e/suspensions/suspendedUserPermissions.spec.cy.ts`
-- `tests/cypress/e2e/suspensions/serverLevelSuspension.spec.cy.ts`
+- `tests/playwright/mocked/suspensions/suspendedUserNotices.spec.ts`
+- `tests/playwright/mocked/suspensions/suspendedModNotices.spec.ts`
+- `tests/playwright/mocked/suspensions/botSuspension.spec.ts`
+- `tests/playwright/mocked/discussions/archiveAndSuspend.spec.ts`
 
 ## Design Direction
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -32,9 +32,7 @@ const closeUserProfileDropdown = () => (showUserProfileDropdown.value = false);
 
 // Test helpers (only in dev/test environments)
 const shouldExposeTestHelpers =
-  isDevRuntime ||
-  config.environment === 'test' ||
-  (typeof window !== 'undefined' && window.Cypress);
+  isDevRuntime || config.environment === 'test';
 
 if (shouldExposeTestHelpers) {
   useTestAuthHelpers();

--- a/plugins/test-auth.client.ts
+++ b/plugins/test-auth.client.ts
@@ -20,7 +20,7 @@ export default defineNuxtPlugin(() => {
   const modProfileNameVar = useModProfileName();
 
   // Always check for mock auth data in localStorage - this is safe because
-  // mock auth data is only set by test code (Playwright, Cypress)
+  // mock auth data is only set by test code (Playwright)
   const syncMockAuthFromStorage = () => {
     const mockUsername = window.localStorage.getItem('mock_username');
     const mockModProfileName = window.localStorage.getItem(
@@ -46,7 +46,6 @@ export default defineNuxtPlugin(() => {
     import.meta.env.DEV ||
     config.environment === 'test' ||
     import.meta.env.VITE_E2E_MOCK_MODE === 'true' ||
-    (typeof window !== 'undefined' && window.Cypress) ||
     hasMockAuth;
 
   const setAuthStateDirect = (authState: {

--- a/types/window.d.ts
+++ b/types/window.d.ts
@@ -24,8 +24,6 @@ interface Window {
   __SET_AUTH_STATE_DIRECT__?: (userData?: AuthUserData) => void;
   // Debug function to monitor auth state
   __DEBUG_AUTH_STATE__?: () => AuthUserData | null;
-  // Cypress test framework
-  Cypress?: unknown;
 }
 
 interface Navigator {


### PR DESCRIPTION
Related issue: https://github.com/gennit-project/multiforum-nuxt/issues/156

## What

The project no longer uses Cypress (it migrated to Playwright). This PR removes the leftover Cypress remnants and adds a guard so the secrets-bearing Cypress env file can't come back.

> The original `cypress.env.json` (which contained live-looking secrets) has already been **scrubbed from all branch history** with `git-filter-repo`, and `main` was force-pushed with the cleaned history. This PR is the remaining source cleanup.

## Changes

- **`.gitignore`** — ignore `cypress.env.json` so it can never be re-committed.
- **Dead `window.Cypress` branches removed** — `composables/useTestAuthHelpers.ts`, `layouts/default.vue`, `plugins/test-auth.client.ts` no longer check `window.Cypress` (nothing sets it anymore), and `types/window.d.ts` drops the `Cypress?` declaration. Cypress-mentioning comments updated to reference Playwright.
- **`.env.example`** — sample `SERVER_CONFIG_NAME` renamed from `"Cypress Test Server"` → `"Playwright Test Server"`.
- **Docs** — `MODERATION_PLAN.md` heading "Cypress Test Backlog" → "E2E Test Backlog"; `moderation-architecture.md` dead `tests/cypress/*` suspension paths repointed to the real Playwright suspension specs.

## Intentionally left untouched (would break things / not owned here)

- **`__generated__/graphql.ts`** — auto-generated from the **backend** GraphQL schema. `dropDataForCypressTests` / `seedDataForCypressTests` are backend mutation names; they can only be removed via a backend rename + codegen, not by editing the generated file.
- **`playwright.config.ts` `CYPRESS_ADMIN_TEST_*` env keys** — these are read by the spawned **gennit-backend** process during stateful E2E runs. Renaming them here without a coordinated backend change would silently break those runs.
- **`docs/playwright-migration-context.md`** — a historical doc *about* the Cypress→Playwright migration; its Cypress mentions are intentional context.

## Verification

- `npm run tsc` — clean (exit 0)
- `npm run test:unit:run` — 589 files / 4986 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)