### PR TITLE
test(e2e): cover the user album-detail page

### DIFF
--- a/tests/playwright/mocked/user/albumDetail.spec.ts
+++ b/tests/playwright/mocked/user/albumDetail.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from '../../helpers/testFixture';
+import { buildBasicUser, buildServerConfig } from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+
+const TEST_USER = 'alice';
+const ALBUM_ID = 'album-1';
+
+const buildAlbum = (overrides = {}) => ({
+  id: ALBUM_ID,
+  imageOrder: ['img-1'],
+  Owner: { username: TEST_USER, displayName: 'Alice' },
+  Images: [
+    {
+      id: 'img-1',
+      url: 'https://img.test/sunset.png',
+      alt: 'A sunset',
+      caption: 'Sunset over the hills',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      Uploader: { username: TEST_USER, displayName: 'Alice' },
+    },
+  ],
+  Discussions: [],
+  ...overrides,
+});
+
+const getBaseMocks = (username: string) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username, displayName: 'Alice' })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: { serverConfigs: [buildServerConfig({ serverName: 'Listical' })] },
+  }),
+  GetAlbumDetails: () => ({ data: { albums: [buildAlbum()] } }),
+});
+
+test.describe('User album detail', () => {
+  test('renders an album with its owner and images', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, getBaseMocks(TEST_USER));
+
+    try {
+      await page.goto(`/u/${TEST_USER}/albums/${ALBUM_ID}`);
+
+      await expect(
+        page.getByRole('heading', { name: /Album by Alice/ })
+      ).toBeVisible();
+      await expect(page.getByText('Sunset over the hills')).toBeVisible();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'GetAlbumDetails'
+      );
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('shows the not-found state for a missing album', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      GetAlbumDetails: () => ({ data: { albums: [] } }),
+    });
+
+    try {
+      await page.goto(`/u/${TEST_USER}/albums/${ALBUM_ID}`);
+
+      await expect(
+        page.getByRole('heading', { name: 'Album Not Found' })
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

E2E flow for the album-detail page (`/u/[username]/albums/[albumId]`), a permission-agnostic content page (~232 lines).

## What it covers
- **Album view** — renders the "Album by {owner}" heading plus an image (caption) via `GetAlbumDetails` (and `AlbumThumbnailGrid`).
- **Not found** — shows the "Album Not Found" state for a missing album.

Driven through mocked GraphQL + `installMockAuth`. Heading-scoped locators avoid the SEO-title duplicate.

## Why this target (context)
The originally-planned **channel-scoped plugin-settings** flow was dropped: it's permission-gated (forum-admin), and the frontend permission model — including the mock shape that makes a user an admin — is about to change to match a backend rewrite. Writing permission-gated E2E now would be throwaway work, so this picks a permission-agnostic page instead.

## Verification
- Both cases pass locally against the mocked dev server (stable across repeated runs).
- `npm run tsc` — clean
- `eslint` on the spec — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)