### PR TITLE
test(e2e): cover the plugin-registries and support pages

### DIFF
--- a/tests/playwright/mocked/admin/pluginRegistries.spec.ts
+++ b/tests/playwright/mocked/admin/pluginRegistries.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '../../helpers/testFixture';
+import { buildBasicUser, buildServerConfig } from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+
+const TEST_USER = 'alice';
+const REGISTRY_URL = 'https://registry.test/plugins';
+
+const getBaseMocks = (username: string) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username, displayName: username })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: {
+      serverConfigs: [
+        buildServerConfig({
+          serverName: 'Listical',
+          pluginRegistries: [REGISTRY_URL],
+        }),
+      ],
+    },
+  }),
+});
+
+test.describe('Server plugin registries', () => {
+  test('lists the configured plugin registries', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, getBaseMocks(TEST_USER));
+
+    try {
+      await page.goto('/admin/settings/plugins/registries');
+
+      await expect(page.getByText('Current Registries (1)')).toBeVisible();
+      await expect(page.getByText(REGISTRY_URL)).toBeVisible();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'getServerConfig'
+      );
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});

--- a/tests/playwright/mocked/support.spec.ts
+++ b/tests/playwright/mocked/support.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '../helpers/testFixture';
+import { buildBasicUser, buildServerConfig } from '../helpers/graphqlFixtures';
+import { installMockAuth } from '../helpers/mockAuth';
+import { installGraphqlMocks } from '../helpers/mockGraphql';
+
+const TEST_USER = 'alice';
+
+const getBaseMocks = (username: string) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username, displayName: username })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: { serverConfigs: [buildServerConfig({ serverName: 'Listical' })] },
+  }),
+});
+
+test.describe('Support page', () => {
+  test('renders the support / contact form', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, getBaseMocks(TEST_USER));
+
+    try {
+      await page.goto('/support');
+
+      await expect(page.getByText('Contact Email')).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two permission-agnostic, standalone pages:

- **`/admin/settings/plugins/registries`** — lists the configured plugin registries from the server config (`getServerConfig.pluginRegistries`), asserting the count and the registry URL render.
- **`/support`** — renders the support/contact form.

Driven through mocked GraphQL + `installMockAuth`. Both stable across repeated runs.

## What was dropped and why
The **user images-list** page (`/u/[username]/images`) was attempted but removed: it renders inside the heavy user-profile shell (contribution chart + tabs), and the lazy-loaded image grid on that tall page is flaky under the mocked `nuxt dev` harness (intermittent across repeated runs, even warm). Its render path is already covered by the `ImageListItem` unit test, so the loss is minimal. The profile route is the same kind of cold-compile/flaky heavy route as the channel-scoped pages — not a reliable E2E target.

## Verification
- Both specs pass locally (2 passed × 3 consecutive runs).
- `npm run tsc` — clean
- `eslint` — clean

Continues the permission-agnostic E2E work (the channel-scoped plugin-settings flow was dropped earlier because it's permission-gated and the admin model is changing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)