### PR TITLE
refactor: DRY cleanup — shared composables, fragment, and util dedupe

### DIFF
--- a/components/discussion/form/CreateDiscussion.vue
+++ b/components/discussion/form/CreateDiscussion.vue
@@ -159,7 +159,6 @@ const discussionCreateInput = computed<DiscussionCreateInput>(() => {
 });
 
 const channelConnections = computed(() => formValues.value.selectedChannels);
-const createDiscussionLoading = ref(false);
 const submitError = ref<string | null>(null);
 const submitAttempted = ref(false);
 
@@ -176,6 +175,7 @@ const showSuspensionNotice = computed(() => {
 
 const {
   mutate: createDiscussion,
+  loading: createDiscussionLoading,
   error: createDiscussionError,
   onDone,
 } = useMutation(CREATE_DISCUSSION_WITH_CHANNEL_CONNECTIONS, () => ({
@@ -253,7 +253,6 @@ onDone((response) => {
     response.data?.createDiscussionWithChannelConnections;
   const newDiscussion = newDiscussionArray?.[0]?.DiscussionChannels?.[0];
   const newDiscussionId = newDiscussion?.Discussion?.id;
-  createDiscussionLoading.value = false;
 
   if (!newDiscussionId) {
     submitError.value =
@@ -277,7 +276,6 @@ function submit() {
   }
   submitAttempted.value = true;
   submitError.value = null;
-  createDiscussionLoading.value = true;
   createDiscussion();
 }
 

--- a/components/discussion/form/DiscussionRootCommentFormWrapper.vue
+++ b/components/discussion/form/DiscussionRootCommentFormWrapper.vue
@@ -163,7 +163,6 @@ const createCommentInput = computed((): CommentCreateInput[] => {
   return [input];
 });
 
-const createCommentLoading = ref(false);
 const commentEditorOpen = ref(false);
 const showSavedNotice = ref(false);
 const submitAttempted = ref(false);
@@ -171,6 +170,7 @@ let savedNoticeTimeout: ReturnType<typeof setTimeout> | null = null;
 
 const {
   mutate: createComment,
+  loading: createCommentLoading,
   error: createCommentError,
   onDone,
 } = useMutation(CREATE_COMMENT, () => ({
@@ -305,7 +305,6 @@ const {
 }));
 
 onDone((result) => {
-  createCommentLoading.value = false;
   if (result?.errors?.length) {
     return;
   }
@@ -352,7 +351,6 @@ const handleCreateComment = async () => {
     return;
   }
   submitAttempted.value = true;
-  createCommentLoading.value = true;
   createComment();
 };
 

--- a/components/discussion/form/InlineCommentForm.vue
+++ b/components/discussion/form/InlineCommentForm.vue
@@ -141,7 +141,6 @@ const createCommentInput = computed((): CommentCreateInput[] => {
   return [input];
 });
 
-const createCommentLoading = ref(false);
 const showSavedNotice = ref(false);
 const submitAttempted = ref(false);
 let savedNoticeTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -150,6 +149,7 @@ const inlineTextarea = ref<HTMLTextAreaElement | null>(null);
 
 const {
   mutate: createComment,
+  loading: createCommentLoading,
   error: createCommentError,
   onDone,
 } = useMutation(CREATE_COMMENT, () => ({
@@ -278,7 +278,6 @@ const {
 }));
 
 onDone((result) => {
-  createCommentLoading.value = false;
   if (result?.errors?.length) {
     return;
   }
@@ -325,7 +324,6 @@ const handleCreateComment = async () => {
     return;
   }
   submitAttempted.value = true;
-  createCommentLoading.value = true;
   createComment();
 };
 

--- a/components/event/detail/EventRootCommentFormWrapper.vue
+++ b/components/event/detail/EventRootCommentFormWrapper.vue
@@ -118,7 +118,6 @@ const createCommentInput = computed(() => {
   return [baseInput];
 });
 
-const createCommentLoading = ref(false);
 const commentEditorOpen = ref(false);
 const createCommentPermissionError = ref('');
 const submitAttempted = ref(false);
@@ -126,6 +125,7 @@ const submitAttempted = ref(false);
 // Mutation for creating a comment
 const {
   mutate: createComment,
+  loading: createCommentLoading,
   error: createCommentError,
   onDone,
 } = useMutation(CREATE_COMMENT, {
@@ -150,12 +150,10 @@ onDone((result) => {
     console.error('Error creating comment:', result.errors);
     createCommentPermissionError.value =
       result.errors[0]?.message || 'Unknown error';
-    createCommentLoading.value = false;
     return;
   }
   submitAttempted.value = false;
   createFormValues.value = createCommentDefaultValues;
-  createCommentLoading.value = false;
   commentEditorOpen.value = false;
 });
 
@@ -187,7 +185,6 @@ function handleCreateComment() {
     return;
   }
   submitAttempted.value = true;
-  createCommentLoading.value = true;
   createComment({ createCommentInput: createCommentInput.value });
 }
 

--- a/components/event/form/CreateEvent.vue
+++ b/components/event/form/CreateEvent.vue
@@ -75,7 +75,6 @@ const eventCreateInput = computed<EventCreateInput>(() => {
 
 const channelConnections = computed(() => formValues.value.selectedChannels);
 
-const createEventLoading = ref(false);
 const submitError = ref<string | null>(null);
 const submitAttempted = ref(false);
 
@@ -124,6 +123,7 @@ const showSuspensionNotice = computed(() => {
 
 const {
   mutate: createEvent,
+  loading: createEventLoading,
   error: createEventError,
   onDone,
 } = useMutation(CREATE_EVENT_WITH_CHANNEL_CONNECTIONS, {
@@ -141,7 +141,6 @@ const {
   },
 });
 onDone((response) => {
-  createEventLoading.value = false;
   const newEventId = response.data?.createEventWithChannelConnections?.[0]?.id;
   const redirectChannelId = formValues.value.selectedChannels[0];
   if (!newEventId) {
@@ -175,7 +174,6 @@ function submit() {
     return;
   }
 
-  createEventLoading.value = true;
   createEvent({
     input: [
       {

--- a/components/favorites/AddImageToFavorites.vue
+++ b/components/favorites/AddImageToFavorites.vue
@@ -7,7 +7,7 @@ import {
   REMOVE_FAVORITE_IMAGE,
 } from '@/graphQLData/user/mutations';
 import { useUsername } from '@/composables/useAuthState';
-import { useToastStore } from '@/stores/toastStore';
+import { useFavoriteToggle } from '@/composables/useFavoriteToggle';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
 
 const usernameVar = useUsername();
@@ -40,8 +40,6 @@ const GET_USER_FAVORITE_IMAGE = gql`
 `;
 
 const isFavorited = ref(false);
-const isLoading = ref(false);
-const toastStore = useToastStore();
 
 const { result: favoritesResult, refetch: refetchFavorites } = useQuery(
   GET_USER_FAVORITE_IMAGE,
@@ -69,42 +67,21 @@ watch(
 const { mutate: addFavorite } = useMutation(ADD_FAVORITE_IMAGE);
 const { mutate: removeFavorite } = useMutation(REMOVE_FAVORITE_IMAGE);
 
-const handleToggleFavorite = async () => {
-  if (!usernameVar.value) return;
-
-  // Optimistic update - toggle immediately
-  isFavorited.value = !isFavorited.value;
-  isLoading.value = true;
-
-  try {
-    if (!isFavorited.value) {
-      // We're removing from favorites
-      await removeFavorite({
-        imageId: props.imageId,
-        username: usernameVar.value,
-      });
-      toastStore.showToast('Image removed from favorites.');
-    } else {
-      // We're adding to favorites
-      await addFavorite({
-        imageId: props.imageId,
-        username: usernameVar.value,
-      });
-      toastStore.showToast('Image added to favorites.');
-    }
+const { isLoading, handleToggleFavorite } = useFavoriteToggle({
+  isFavorited,
+  itemId: () => props.imageId,
+  entityType: () => 'image',
+  // This variant has no "Organize" affordance, so always show a plain toast.
+  allowAddToList: () => false,
+  addedMessage: () => 'Image added to favorites.',
+  removedMessage: () => 'Image removed from favorites.',
+  addFavorite,
+  removeFavorite,
+  mutationItemKey: 'imageId',
+  onAfterToggle: () => {
     refetchFavorites();
-  } catch (error) {
-    console.error('Error toggling favorite:', error);
-    // Revert optimistic update on error
-    isFavorited.value = !isFavorited.value;
-    toastStore.showToast(
-      'Error updating favorites. Please try again.',
-      'error'
-    );
-  } finally {
-    isLoading.value = false;
-  }
-};
+  },
+});
 
 const displayName = computed(() => {
   return props.imageTitle || 'image';

--- a/components/favorites/AddToChannelFavorites.spec.ts
+++ b/components/favorites/AddToChannelFavorites.spec.ts
@@ -170,11 +170,11 @@ describe('AddToChannelFavorites toasts', () => {
 });
 
 describe('AddToChannelFavorites mutation completion', () => {
-  it('clears loading and marks favorited when the add completes', async () => {
+  it('marks favorited after a successful add toggle', async () => {
     const wrapper = mountFav({ initialIsFavorited: false });
 
-    h.addDone?.();
-    await wrapper.vm.$nextTick();
+    await button(wrapper).vm.$emit('toggle');
+    await flushPromises();
 
     expect(button(wrapper).props('isFavorited')).toBe(true);
   });

--- a/components/favorites/AddToChannelFavorites.vue
+++ b/components/favorites/AddToChannelFavorites.vue
@@ -7,8 +7,7 @@ import {
   REMOVE_FAVORITE_CHANNEL,
 } from '@/graphQLData/user/mutations';
 import { useUsername } from '@/composables/useAuthState';
-import { useToastStore } from '@/stores/toastStore';
-import { useAddToListModalStore } from '@/stores/addToListModalStore';
+import { useFavoriteToggle } from '@/composables/useFavoriteToggle';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
 
 const usernameVar = useUsername();
@@ -50,9 +49,6 @@ const GET_USER_FAVORITES = gql`
 
 // Use initial value if provided, otherwise default to false
 const isFavorited = ref(props.initialIsFavorited ?? false);
-const isLoading = ref(false);
-const toastStore = useToastStore();
-const addToListModalStore = useAddToListModalStore();
 
 // Only fetch if initialIsFavorited was not provided
 const shouldFetchFavorite = computed(() =>
@@ -93,87 +89,30 @@ watch(
   { immediate: true }
 );
 
-const {
-  mutate: addFavorite,
-  onDone: onAddFavoriteDone,
-} = useMutation(ADD_FAVORITE_CHANNEL);
-const {
-  mutate: removeFavorite,
-  onDone: onRemoveFavoriteDone,
-} = useMutation(REMOVE_FAVORITE_CHANNEL);
-
-const showAddedToast = () => {
-  const message = 'Added to Favorites.';
-
-  if (!props.allowAddToList) {
-    toastStore.showToast(message);
-    return;
-  }
-
-  toastStore.showToast(message, 'success', {
-    label: 'Organize',
-    onClick: () =>
-      addToListModalStore.open({
-        itemId: props.channelUniqueName,
-        itemType: 'channel',
-        isAlreadyFavorite: true,
-      }),
-  });
-};
-
-onAddFavoriteDone(() => {
-  isFavorited.value = true;
-  isLoading.value = false;
-});
-
-onRemoveFavoriteDone(() => {
-  isFavorited.value = false;
-  isLoading.value = false;
-});
+const { mutate: addFavorite } = useMutation(ADD_FAVORITE_CHANNEL);
+const { mutate: removeFavorite } = useMutation(REMOVE_FAVORITE_CHANNEL);
 
 const handleFavoriteChange = (nextIsFavorited: boolean) => {
   isFavorited.value = nextIsFavorited;
 };
 
-const handleToggleFavorite = async () => {
-  if (!usernameVar.value) return;
-
-  // Optimistic update - toggle immediately
-  isFavorited.value = !isFavorited.value;
-  isLoading.value = true;
-
-  try {
-    if (!isFavorited.value) {
-      // We're removing from favorites
-      await removeFavorite({
-        channel: props.channelUniqueName,
-        username: usernameVar.value,
-      });
-      toastStore.showToast('Removed from favorites.');
-    } else {
-      // We're adding to favorites
-      await addFavorite({
-        channel: props.channelUniqueName,
-        username: usernameVar.value,
-      });
-      showAddedToast();
-    }
-    // Only refetch if we're managing our own query
+const { isLoading, handleToggleFavorite } = useFavoriteToggle({
+  isFavorited,
+  itemId: () => props.channelUniqueName,
+  entityType: () => 'channel',
+  allowAddToList: () => props.allowAddToList,
+  addedMessage: () => 'Added to Favorites.',
+  removedMessage: () => 'Removed from favorites.',
+  addFavorite,
+  removeFavorite,
+  mutationItemKey: 'channel',
+  // Only refetch if we're managing our own query
+  onAfterToggle: () => {
     if (shouldFetchFavorite.value) {
       refetchFavorites();
     }
-  } catch (error) {
-    console.error('Error toggling favorite:', error);
-    // Revert optimistic update on error
-    isFavorited.value = !isFavorited.value;
-    toastStore.showToast(
-      'Error updating favorites. Please try again.',
-      'error'
-    );
-  } finally {
-    isLoading.value = false;
-  }
-};
+  },
+});
 </script>
 
 <template>

--- a/components/favorites/AddToCommentFavorites.vue
+++ b/components/favorites/AddToCommentFavorites.vue
@@ -8,8 +8,7 @@ import {
   REMOVE_FAVORITE_COMMENT,
 } from '@/graphQLData/user/mutations';
 import { useUsername } from '@/composables/useAuthState';
-import { useToastStore } from '@/stores/toastStore';
-import { useAddToListModalStore } from '@/stores/addToListModalStore';
+import { useFavoriteToggle } from '@/composables/useFavoriteToggle';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
 
 const usernameVar = useUsername();
@@ -44,9 +43,6 @@ const GET_USER_FAVORITE_COMMENT = gql`
 `;
 
 const isFavorited = ref(props.isFavorited ?? false);
-const isLoading = ref(false);
-const toastStore = useToastStore();
-const addToListModalStore = useAddToListModalStore();
 const shouldLookupFavorite = computed(() => props.isFavorited === null);
 
 const { result: favoritesResult, refetch: refetchFavorites } = useQuery(
@@ -58,6 +54,26 @@ const { result: favoritesResult, refetch: refetchFavorites } = useQuery(
     enabled: shouldLookupFavorite.value && !!props.commentId && !!usernameVar.value,
   })
 );
+
+const { mutate: addFavorite } = useMutation(ADD_FAVORITE_COMMENT);
+const { mutate: removeFavorite } = useMutation(REMOVE_FAVORITE_COMMENT);
+
+const { isLoading, handleToggleFavorite } = useFavoriteToggle({
+  isFavorited,
+  itemId: () => props.commentId,
+  entityType: () => 'comment',
+  allowAddToList: () => props.allowAddToList,
+  addedMessage: () => `${props.entityName} added to Favorites.`,
+  removedMessage: () => `${props.entityName} removed from favorites.`,
+  addFavorite,
+  removeFavorite,
+  mutationItemKey: 'commentId',
+  onAfterToggle: () => {
+    if (shouldLookupFavorite.value) {
+      refetchFavorites();
+    }
+  },
+});
 
 watch(
   () => props.isFavorited,
@@ -78,67 +94,6 @@ watch(
   },
   { immediate: true }
 );
-
-const { mutate: addFavorite } = useMutation(ADD_FAVORITE_COMMENT);
-const { mutate: removeFavorite } = useMutation(REMOVE_FAVORITE_COMMENT);
-
-const showAddedToast = () => {
-  const message = `${props.entityName} added to Favorites.`;
-
-  if (!props.allowAddToList) {
-    toastStore.showToast(message);
-    return;
-  }
-
-  toastStore.showToast(message, 'success', {
-    label: 'Organize',
-    onClick: () =>
-      addToListModalStore.open({
-        itemId: props.commentId,
-        itemType: 'comment',
-        isAlreadyFavorite: true,
-      }),
-  });
-};
-
-const handleToggleFavorite = async () => {
-  if (!usernameVar.value) return;
-
-  // Optimistic update - toggle immediately
-  isFavorited.value = !isFavorited.value;
-  isLoading.value = true;
-
-  try {
-    if (!isFavorited.value) {
-      // We're removing from favorites
-      await removeFavorite({
-        commentId: props.commentId,
-        username: usernameVar.value,
-      });
-      toastStore.showToast(`${props.entityName} removed from favorites.`);
-    } else {
-      // We're adding to favorites
-      await addFavorite({
-        commentId: props.commentId,
-        username: usernameVar.value,
-      });
-      showAddedToast();
-    }
-    if (shouldLookupFavorite.value) {
-      refetchFavorites();
-    }
-  } catch (error) {
-    console.error('Error toggling favorite:', error);
-    // Revert optimistic update on error
-    isFavorited.value = !isFavorited.value;
-    toastStore.showToast(
-      'Error updating favorites. Please try again.',
-      'error'
-    );
-  } finally {
-    isLoading.value = false;
-  }
-};
 </script>
 
 <template>

--- a/components/favorites/AddToDiscussionFavorites.vue
+++ b/components/favorites/AddToDiscussionFavorites.vue
@@ -7,8 +7,7 @@ import {
   REMOVE_FAVORITE_DISCUSSION,
 } from '@/graphQLData/user/mutations';
 import { useUsername } from '@/composables/useAuthState';
-import { useToastStore } from '@/stores/toastStore';
-import { useAddToListModalStore, type AllowedItemType } from '@/stores/addToListModalStore';
+import { useFavoriteToggle } from '@/composables/useFavoriteToggle';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
 
 const usernameVar = useUsername();
@@ -64,9 +63,6 @@ const GET_USER_FAVORITE_DISCUSSION = gql`
 
 // Use initial value if provided, otherwise default to false
 const isFavorited = ref(props.initialIsFavorited ?? false);
-const isLoading = ref(false);
-const toastStore = useToastStore();
-const addToListModalStore = useAddToListModalStore();
 
 // Only fetch if initialIsFavorited was not provided
 const shouldFetchFavorite = computed(() =>
@@ -110,64 +106,23 @@ watch(
 const { mutate: addFavorite } = useMutation(ADD_FAVORITE_DISCUSSION);
 const { mutate: removeFavorite } = useMutation(REMOVE_FAVORITE_DISCUSSION);
 
-const showAddedToast = () => {
-  const message = `${props.entityName} added to Favorites.`;
-
-  if (!props.allowAddToList) {
-    toastStore.showToast(message);
-    return;
-  }
-
-  toastStore.showToast(message, 'success', {
-    label: 'Organize',
-    onClick: () =>
-      addToListModalStore.open({
-        itemId: props.discussionId,
-        itemType: props.entityType as AllowedItemType,
-        isAlreadyFavorite: true,
-      }),
-  });
-};
-
-const handleToggleFavorite = async () => {
-  if (!usernameVar.value) return;
-
-  // Optimistic update - toggle immediately
-  isFavorited.value = !isFavorited.value;
-  isLoading.value = true;
-
-  try {
-    if (!isFavorited.value) {
-      // We're removing from favorites
-      await removeFavorite({
-        discussionId: props.discussionId,
-        username: usernameVar.value,
-      });
-      toastStore.showToast(`${props.entityName} removed from favorites.`);
-    } else {
-      // We're adding to favorites
-      await addFavorite({
-        discussionId: props.discussionId,
-        username: usernameVar.value,
-      });
-      showAddedToast();
-    }
-    // Only refetch if we're managing our own query (parent didn't provide isFavorited)
+const { isLoading, handleToggleFavorite } = useFavoriteToggle({
+  isFavorited,
+  itemId: () => props.discussionId,
+  entityType: () => props.entityType,
+  allowAddToList: () => props.allowAddToList,
+  addedMessage: () => `${props.entityName} added to Favorites.`,
+  removedMessage: () => `${props.entityName} removed from favorites.`,
+  addFavorite,
+  removeFavorite,
+  mutationItemKey: 'discussionId',
+  // Only refetch if we're managing our own query (parent didn't provide isFavorited)
+  onAfterToggle: () => {
     if (shouldFetchFavorite.value) {
       refetchFavorites();
     }
-  } catch (error) {
-    console.error('Error toggling favorite:', error);
-    // Revert optimistic update on error
-    isFavorited.value = !isFavorited.value;
-    toastStore.showToast(
-      'Error updating favorites. Please try again.',
-      'error'
-    );
-  } finally {
-    isLoading.value = false;
-  }
-};
+  },
+});
 
 const displayName = computed(() => {
   return props.discussionTitle ? `"${props.discussionTitle}"` : 'discussion';

--- a/components/favorites/AddToImageFavorites.vue
+++ b/components/favorites/AddToImageFavorites.vue
@@ -7,8 +7,7 @@ import {
   REMOVE_FAVORITE_IMAGE,
 } from '@/graphQLData/user/mutations';
 import { useUsername } from '@/composables/useAuthState';
-import { useToastStore } from '@/stores/toastStore';
-import { useAddToListModalStore } from '@/stores/addToListModalStore';
+import { useFavoriteToggle } from '@/composables/useFavoriteToggle';
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
 
 const usernameVar = useUsername();
@@ -55,9 +54,6 @@ const GET_USER_FAVORITE_IMAGE = gql`
 
 // Use initial value if provided, otherwise default to false
 const isFavorited = ref(props.initialIsFavorited ?? false);
-const isLoading = ref(false);
-const toastStore = useToastStore();
-const addToListModalStore = useAddToListModalStore();
 
 // Only fetch if initialIsFavorited was not provided
 const shouldFetchFavorite = computed(() =>
@@ -101,64 +97,23 @@ watch(
 const { mutate: addFavorite } = useMutation(ADD_FAVORITE_IMAGE);
 const { mutate: removeFavorite } = useMutation(REMOVE_FAVORITE_IMAGE);
 
-const showAddedToast = () => {
-  const message = `${props.entityName} added to Favorites.`;
-
-  if (!props.allowAddToList) {
-    toastStore.showToast(message);
-    return;
-  }
-
-  toastStore.showToast(message, 'success', {
-    label: 'Organize',
-    onClick: () =>
-      addToListModalStore.open({
-        itemId: props.imageId,
-        itemType: 'image',
-        isAlreadyFavorite: true,
-      }),
-  });
-};
-
-const handleToggleFavorite = async () => {
-  if (!usernameVar.value) return;
-
-  // Optimistic update - toggle immediately
-  isFavorited.value = !isFavorited.value;
-  isLoading.value = true;
-
-  try {
-    if (!isFavorited.value) {
-      // We're removing from favorites
-      await removeFavorite({
-        imageId: props.imageId,
-        username: usernameVar.value,
-      });
-      toastStore.showToast(`${props.entityName} removed from favorites.`);
-    } else {
-      // We're adding to favorites
-      await addFavorite({
-        imageId: props.imageId,
-        username: usernameVar.value,
-      });
-      showAddedToast();
-    }
-    // Only refetch if we're managing our own query
+const { isLoading, handleToggleFavorite } = useFavoriteToggle({
+  isFavorited,
+  itemId: () => props.imageId,
+  entityType: () => 'image',
+  allowAddToList: () => props.allowAddToList,
+  addedMessage: () => `${props.entityName} added to Favorites.`,
+  removedMessage: () => `${props.entityName} removed from favorites.`,
+  addFavorite,
+  removeFavorite,
+  mutationItemKey: 'imageId',
+  // Only refetch if we're managing our own query
+  onAfterToggle: () => {
     if (shouldFetchFavorite.value) {
       refetchFavorites();
     }
-  } catch (error) {
-    console.error('Error toggling favorite:', error);
-    // Revert optimistic update on error
-    isFavorited.value = !isFavorited.value;
-    toastStore.showToast(
-      'Error updating favorites. Please try again.',
-      'error'
-    );
-  } finally {
-    isLoading.value = false;
-  }
-};
+  },
+});
 
 const displayName = computed(() => {
   return props.imageCaption ? `"${props.imageCaption}"` : 'image';

--- a/composables/useCopyCurrentUrl.ts
+++ b/composables/useCopyCurrentUrl.ts
@@ -1,0 +1,31 @@
+import { ref } from 'vue';
+import { useRoute, useRouter } from 'nuxt/app';
+
+/**
+ * Copies the current route's absolute URL to the clipboard and briefly flips a
+ * notification flag (auto-resets after 2s). Extracted from the image- and
+ * album-detail pages, which both hand-rolled the same SSR-safe origin logic.
+ */
+export function useCopyCurrentUrl() {
+  const route = useRoute();
+  const router = useRouter();
+  const showCopiedNotification = ref(false);
+
+  const copyCurrentUrl = async () => {
+    try {
+      const basePath = import.meta.client
+        ? window.location.origin
+        : process.env.BASE_URL || '';
+      const permalink = `${basePath}${router.resolve(route).href}`;
+      await navigator.clipboard.writeText(permalink);
+      showCopiedNotification.value = true;
+      setTimeout(() => {
+        showCopiedNotification.value = false;
+      }, 2000);
+    } catch (e) {
+      console.error('Failed to copy link:', e);
+    }
+  };
+
+  return { showCopiedNotification, copyCurrentUrl };
+}

--- a/composables/useFavoriteToggle.ts
+++ b/composables/useFavoriteToggle.ts
@@ -1,0 +1,105 @@
+import { ref, type Ref } from 'vue';
+import { useUsername } from '@/composables/useAuthState';
+import { useToastStore } from '@/stores/toastStore';
+import {
+  useAddToListModalStore,
+  type AllowedItemType,
+} from '@/stores/addToListModalStore';
+
+type MutateFn = (
+  variables: Record<string, unknown>
+) => Promise<unknown> | undefined;
+
+type UseFavoriteToggleParams = {
+  /** The optimistic favorited state, owned by the calling component. */
+  isFavorited: Ref<boolean>;
+  /** Identifier of the item being favorited (reactive getter). */
+  itemId: () => string;
+  /** Item type used for the "Organize" modal (reactive getter). */
+  entityType: () => string;
+  /** Whether to offer the "Organize" action on the added toast. */
+  allowAddToList: () => boolean;
+  /** Toast message shown when the item is added to favorites. */
+  addedMessage: () => string;
+  /** Toast message shown when the item is removed from favorites. */
+  removedMessage: () => string;
+  /** Apollo mutate function for adding the favorite. */
+  addFavorite: MutateFn;
+  /** Apollo mutate function for removing the favorite. */
+  removeFavorite: MutateFn;
+  /** Key used for the item id in the mutation variables (e.g. "discussionId"). */
+  mutationItemKey: string;
+  /** Optional hook run after a successful toggle (e.g. refetch the lookup query). */
+  onAfterToggle?: () => void;
+};
+
+/**
+ * Shared favorite-toggle behavior for the AddTo*Favorites button components.
+ *
+ * Owns the loading state and the optimistic add/remove flow (toggle eagerly,
+ * call the mutation, surface a toast, revert on error). Each component keeps its
+ * own query and `isFavorited` derivation since those differ per entity, and
+ * passes the entity-specific mutations, variable key, and messages in here.
+ */
+export function useFavoriteToggle(params: UseFavoriteToggleParams) {
+  const isLoading = ref(false);
+  const usernameVar = useUsername();
+  const toastStore = useToastStore();
+
+  const showAddedToast = () => {
+    const message = params.addedMessage();
+
+    if (!params.allowAddToList()) {
+      toastStore.showToast(message);
+      return;
+    }
+
+    toastStore.showToast(message, 'success', {
+      label: 'Organize',
+      // Resolve the modal store lazily so components that never offer the
+      // "Organize" action don't need it provided in their test environment.
+      onClick: () =>
+        useAddToListModalStore().open({
+          itemId: params.itemId(),
+          itemType: params.entityType() as AllowedItemType,
+          isAlreadyFavorite: true,
+        }),
+    });
+  };
+
+  const handleToggleFavorite = async () => {
+    if (!usernameVar.value) return;
+
+    // Optimistic update - toggle immediately
+    params.isFavorited.value = !params.isFavorited.value;
+    isLoading.value = true;
+
+    const variables = {
+      [params.mutationItemKey]: params.itemId(),
+      username: usernameVar.value,
+    };
+
+    try {
+      if (!params.isFavorited.value) {
+        await params.removeFavorite(variables);
+        toastStore.showToast(params.removedMessage());
+      } else {
+        await params.addFavorite(variables);
+        showAddedToast();
+      }
+      params.onAfterToggle?.();
+    } catch (error) {
+      console.error('Error toggling favorite:', error);
+      // Revert optimistic update on error
+      params.isFavorited.value = !params.isFavorited.value;
+      toastStore.showToast(
+        'Error updating favorites. Please try again.',
+        'error'
+      );
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  return { isLoading, handleToggleFavorite };
+}

--- a/graphQLData/comment/queries.js
+++ b/graphQLData/comment/queries.js
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client/core';
-import { AUTHOR_FIELDS } from '../discussion/queries';
+import { AUTHOR_FIELDS } from '../fragments';
 
 // Fragment for comment search results with context links
 export const SEARCH_COMMENT_FIELDS = gql`

--- a/graphQLData/discussion/queries.js
+++ b/graphQLData/discussion/queries.js
@@ -1,15 +1,9 @@
 import { gql } from '@apollo/client/core';
+import { AUTHOR_FIELDS } from '../fragments';
 
-export const AUTHOR_FIELDS = gql`
-  fragment AuthorFields on User {
-    username
-    displayName
-    profilePicURL
-    createdAt
-    discussionKarma
-    commentKarma
-  }
-`;
+// Re-exported for backward compatibility; the canonical definition now lives in
+// graphQLData/fragments.js.
+export { AUTHOR_FIELDS };
 
 const CROSSPOST_PREVIEW_FIELDS = gql`
   fragment CrosspostPreviewFields on Discussion {

--- a/graphQLData/event/queries.js
+++ b/graphQLData/event/queries.js
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client/core';
-import { AUTHOR_FIELDS } from '../discussion/queries';
+import { AUTHOR_FIELDS } from '../fragments';
 
 // Fragment for shared event fields
 export const EVENT_FIELDS = gql`

--- a/graphQLData/fragments.js
+++ b/graphQLData/fragments.js
@@ -1,0 +1,20 @@
+import { gql } from '@apollo/client/core';
+
+/**
+ * Canonical reusable GraphQL fragments shared across query/mutation files.
+ *
+ * AUTHOR_FIELDS is the standard selection for a user rendered as the author of
+ * content (discussions, comments, events, images). Spread it with
+ * `...AuthorFields` in a selection set and interpolate `${AUTHOR_FIELDS}` into
+ * the surrounding gql template so Apollo can resolve the fragment definition.
+ */
+export const AUTHOR_FIELDS = gql`
+  fragment AuthorFields on User {
+    username
+    displayName
+    profilePicURL
+    createdAt
+    discussionKarma
+    commentKarma
+  }
+`;

--- a/pages/u/[username]/albums/[albumId].vue
+++ b/pages/u/[username]/albums/[albumId].vue
@@ -1,12 +1,13 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
-import { useRoute, useHead, useRouter } from 'nuxt/app';
+import { useRoute, useHead } from 'nuxt/app';
 import { GET_ALBUM_DETAILS } from '@/graphQLData/image/queries';
 import type { Album, Image } from '@/__generated__/graphql';
 import AlbumThumbnailGrid from '@/components/album/AlbumThumbnailGrid.vue';
 import LinkIcon from '@/components/icons/LinkIcon.vue';
 import Notification from '@/components/NotificationComponent.vue';
+import { useCopyCurrentUrl } from '@/composables/useCopyCurrentUrl';
 
 // @ts-ignore - definePageMeta is auto-imported by Nuxt
 definePageMeta({
@@ -14,29 +15,12 @@ definePageMeta({
 });
 
 const route = useRoute();
-const router = useRouter();
 
 // Share functionality
-const showCopiedLinkNotification = ref(false);
-
-const copyAlbumLink = async () => {
-  try {
-    let basePath = '';
-    if (import.meta.client) {
-      basePath = window.location.origin;
-    } else {
-      basePath = process.env.BASE_URL || '';
-    }
-    const permalink = `${basePath}${router.resolve(route).href}`;
-    await navigator.clipboard.writeText(permalink);
-    showCopiedLinkNotification.value = true;
-    setTimeout(() => {
-      showCopiedLinkNotification.value = false;
-    }, 2000);
-  } catch (e) {
-    console.error('Failed to copy link:', e);
-  }
-};
+const {
+  showCopiedNotification: showCopiedLinkNotification,
+  copyCurrentUrl: copyAlbumLink,
+} = useCopyCurrentUrl();
 
 const username = computed(() => {
   return typeof route.params.username === 'string' ? route.params.username : '';

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -1,10 +1,11 @@
 <script lang="ts" setup>
 import { computed, watchEffect, ref, onMounted, onUnmounted } from 'vue';
 import { useQuery, useMutation } from '@vue/apollo-composable';
-import { useRoute, useHead, useRouter } from 'nuxt/app';
+import { useRoute, useHead } from 'nuxt/app';
 import { GET_IMAGE_DETAILS } from '@/graphQLData/image/queries';
 import { UPDATE_IMAGE } from '@/graphQLData/discussion/mutations';
 import type { Image } from '@/__generated__/graphql';
+import { useCopyCurrentUrl } from '@/composables/useCopyCurrentUrl';
 import ModelViewer from '@/components/ModelViewer.vue';
 import StlViewer from '@/components/download/StlViewer.vue';
 import MarkdownPreview from '@/components/MarkdownPreview.vue';
@@ -30,29 +31,12 @@ definePageMeta({
 });
 
 const route = useRoute();
-const router = useRouter();
 
 // Share functionality
-const showCopiedLinkNotification = ref(false);
-
-const copyImageLink = async () => {
-  try {
-    let basePath = '';
-    if (import.meta.client) {
-      basePath = window.location.origin;
-    } else {
-      basePath = process.env.BASE_URL || '';
-    }
-    const permalink = `${basePath}${router.resolve(route).href}`;
-    await navigator.clipboard.writeText(permalink);
-    showCopiedLinkNotification.value = true;
-    setTimeout(() => {
-      showCopiedLinkNotification.value = false;
-    }, 2000);
-  } catch (e) {
-    console.error('Failed to copy link:', e);
-  }
-};
+const {
+  showCopiedNotification: showCopiedLinkNotification,
+  copyCurrentUrl: copyImageLink,
+} = useCopyCurrentUrl();
 
 const username = computed(() => {
   return typeof route.params.username === 'string' ? route.params.username : '';

--- a/tests/unit/graphqlFragments.spec.ts
+++ b/tests/unit/graphqlFragments.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+
+// Guards every GraphQL document in graphQLData/: each fragment spread must
+// resolve to a definition present in the same document. Catches a
+// `...SomeFragment` spread whose `${SOME_FRAGMENT}` interpolation was forgotten,
+// which would otherwise only surface as an "Unknown fragment" error at runtime.
+const modules = import.meta.glob('../../graphQLData/**/*.{js,ts}', {
+  eager: true,
+}) as Record<string, Record<string, unknown>>;
+
+type AstNode = { kind?: string; name?: { value: string }; [k: string]: unknown };
+
+function collect(doc: AstNode) {
+  const spreads = new Set<string>();
+  const defs = new Set<string>();
+  const visit = (node: unknown) => {
+    if (!node || typeof node !== 'object') return;
+    const n = node as AstNode;
+    if (n.kind === 'FragmentSpread' && n.name) spreads.add(n.name.value);
+    if (n.kind === 'FragmentDefinition' && n.name) defs.add(n.name.value);
+    for (const val of Object.values(n)) {
+      if (Array.isArray(val)) val.forEach(visit);
+      else if (val && typeof val === 'object') visit(val);
+    }
+  };
+  visit(doc);
+  return { spreads, defs };
+}
+
+describe('graphQLData fragment resolution', () => {
+  const unresolved: string[] = [];
+  let checked = 0;
+
+  for (const [path, mod] of Object.entries(modules)) {
+    for (const [name, value] of Object.entries(mod)) {
+      const doc = value as AstNode;
+      if (!doc || doc.kind !== 'Document') continue;
+      checked++;
+      const { spreads, defs } = collect(doc);
+      for (const spread of spreads) {
+        if (!defs.has(spread)) {
+          unresolved.push(`${path} → ${name}: "${spread}"`);
+        }
+      }
+    }
+  }
+
+  it('resolves every fragment spread to a local definition', () => {
+    expect({ checked: checked > 0, unresolved }).toEqual({
+      checked: true,
+      unresolved: [],
+    });
+  });
+});

--- a/tests/unit/utils/eventSeo.spec.ts
+++ b/tests/unit/utils/eventSeo.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import {
-  truncateDescription,
   buildEventSeoMeta,
   buildEventStructuredData,
   type EventSeoData,
@@ -15,18 +14,6 @@ const baseEvent: EventSeoData = {
   coverImageURL: 'https://img/x.png',
   Poster: { username: 'alice', displayName: 'Alice' },
 };
-
-describe('truncateDescription', () => {
-  it('leaves short text unchanged', () => {
-    expect(truncateDescription('short', 160)).toBe('short');
-  });
-
-  it('truncates long text and appends an ellipsis', () => {
-    expect(truncateDescription('a'.repeat(200), 160)).toBe(
-      `${'a'.repeat(160)}...`
-    );
-  });
-});
 
 describe('buildEventSeoMeta', () => {
   it('returns not-found meta when there is no event', () => {

--- a/tests/unit/utils/index.spec.ts
+++ b/tests/unit/utils/index.spec.ts
@@ -5,7 +5,6 @@ import {
   encodeSpacesInURL,
   getDuration,
   getTagLabel,
-  getLinksInText,
   getChannelLabel,
   checkUrl,
   isAlphaNumeric,
@@ -180,68 +179,6 @@ describe('getTagLabel', () => {
 
   it('returns count of 1 for single tag', () => {
     expect(getTagLabel(['single'])).toBe('Tags (1)');
-  });
-});
-
-describe('getLinksInText', () => {
-  it('extracts http links from text', () => {
-    const text = 'Check out http://example.com for more info';
-
-    const result = getLinksInText(text);
-
-    expect(result).toContain('http://example.com');
-  });
-
-  it('extracts https links from text', () => {
-    const text = 'Visit https://secure.example.com/page';
-
-    const result = getLinksInText(text);
-
-    expect(result).toContain('https://secure.example.com/page');
-  });
-
-  it('extracts multiple links', () => {
-    const text = 'Check https://one.com and https://two.com';
-
-    const result = getLinksInText(text);
-
-    expect(result).toHaveLength(2);
-  });
-
-  it('excludes image URLs', () => {
-    const text = 'Image: https://example.com/photo.jpg';
-
-    const result = getLinksInText(text);
-
-    expect(result).toHaveLength(0);
-  });
-
-  it('excludes png image URLs', () => {
-    const text = 'Image: https://example.com/photo.png';
-
-    const result = getLinksInText(text);
-
-    expect(result).toHaveLength(0);
-  });
-
-  it('excludes gif image URLs', () => {
-    const text = 'Animation: https://example.com/anim.gif';
-
-    const result = getLinksInText(text);
-
-    expect(result).toHaveLength(0);
-  });
-
-  it('returns empty array for text without links', () => {
-    expect(getLinksInText('No links here')).toEqual([]);
-  });
-
-  it('returns empty array for empty string', () => {
-    expect(getLinksInText('')).toEqual([]);
-  });
-
-  it('returns empty array for falsy input', () => {
-    expect(getLinksInText(null as unknown as string)).toEqual([]);
   });
 });
 

--- a/utils/arrayHelpers.ts
+++ b/utils/arrayHelpers.ts
@@ -1,0 +1,17 @@
+/**
+ * Small, generic array helpers shared across the codebase. Several modules
+ * previously each defined their own "toggle membership" helper
+ * (toggleArrayItem, toggleSelectedTag, toggleInArray) with identical logic;
+ * this is the single canonical implementation they now re-export.
+ */
+
+/**
+ * Return a new array with `value` removed if present, or appended if absent.
+ */
+export function toggleInArray<T>(array: T[], value: T): T[] {
+  const index = array.indexOf(value);
+  if (index === -1) {
+    return [...array, value];
+  }
+  return array.filter((_, i) => i !== index);
+}

--- a/utils/eventMap.ts
+++ b/utils/eventMap.ts
@@ -4,11 +4,7 @@
  */
 
 /** Toggle an item in an array: remove it if present, otherwise append it. */
-export function toggleArrayItem(items: string[], item: string): string[] {
-  return items.includes(item)
-    ? items.filter((existing) => existing !== item)
-    : [...items, item];
-}
+export { toggleInArray as toggleArrayItem } from '@/utils/arrayHelpers';
 
 /** Drop falsy values from a params object, returning string-valued entries. */
 export function cleanQueryParams(

--- a/utils/eventSeo.spec.ts
+++ b/utils/eventSeo.spec.ts
@@ -1,20 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
-  truncateDescription,
   buildEventSeoMeta,
   buildEventStructuredData,
   type EventSeoData,
 } from './eventSeo';
-
-describe('truncateDescription', () => {
-  it('leaves a short description unchanged', () => {
-    expect(truncateDescription('short', 160)).toBe('short');
-  });
-
-  it('truncates and appends an ellipsis past the limit', () => {
-    expect(truncateDescription('abcdef', 3)).toBe('abc...');
-  });
-});
 
 describe('buildEventSeoMeta', () => {
   const params = {

--- a/utils/eventSeo.ts
+++ b/utils/eventSeo.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import { truncateDescription } from '@/utils/discussionSeo';
 
 /**
  * Pure builders for EventDetail's SEO metadata and schema.org structured data,
@@ -19,17 +20,8 @@ export type EventSeoData = {
   Poster?: { username?: string | null; displayName?: string | null } | null;
 };
 
-export const DESCRIPTION_MAX_LENGTH = 160;
-
 export function formatEventDate(iso: string): string {
   return DateTime.fromISO(iso).toLocaleString(DateTime.DATE_FULL);
-}
-
-export function truncateDescription(
-  text: string,
-  max: number = DESCRIPTION_MAX_LENGTH
-): string {
-  return text.length > max ? `${text.substring(0, max)}...` : text;
 }
 
 const eventTitle = (event: EventSeoData): string => event.title || 'Event';

--- a/utils/forumListChannels.ts
+++ b/utils/forumListChannels.ts
@@ -54,6 +54,4 @@ export function mergeChannelCounts<T extends ChannelCountLike>(
 }
 
 /** Toggle a tag in the selected-tags list (pure: returns a new array). */
-export function toggleSelectedTag(tags: string[], tag: string): string[] {
-  return tags.includes(tag) ? tags.filter((t) => t !== tag) : [...tags, tag];
-}
+export { toggleInArray as toggleSelectedTag } from '@/utils/arrayHelpers';

--- a/utils/forumRoleBadges.ts
+++ b/utils/forumRoleBadges.ts
@@ -1,38 +1,14 @@
+import { resolveRoleBadge, type RoleBadgeParams } from '@/utils/roleBadges';
+
 export type ForumRoleBadge = 'forumAdmin' | 'forumMod' | null;
 
-type GetForumRoleBadgeParams = {
-  username?: string | null;
-  modProfileName?: string | null;
-  adminUsernames?: string[];
-  modUsernames?: string[];
-  modProfileNames?: string[];
-};
-
-const hasMatch = (value: string | null | undefined, candidates: string[]) => {
-  if (!value) {
-    return false;
-  }
-
-  return candidates.includes(value);
-};
-
-export const getForumRoleBadge = ({
-  username,
-  modProfileName,
-  adminUsernames = [],
-  modUsernames = [],
-  modProfileNames = [],
-}: GetForumRoleBadgeParams): ForumRoleBadge => {
-  if (hasMatch(username, adminUsernames)) {
+export const getForumRoleBadge = (params: RoleBadgeParams): ForumRoleBadge => {
+  const kind = resolveRoleBadge(params);
+  if (kind === 'admin') {
     return 'forumAdmin';
   }
-
-  if (
-    hasMatch(username, modUsernames) ||
-    hasMatch(modProfileName, modProfileNames)
-  ) {
+  if (kind === 'mod') {
     return 'forumMod';
   }
-
   return null;
 };

--- a/utils/index.spec.ts
+++ b/utils/index.spec.ts
@@ -5,7 +5,6 @@ import {
   encodeSpacesInURL,
   getDuration,
   getTagLabel,
-  getLinksInText,
   getChannelLabel,
 } from './index';
 
@@ -80,18 +79,6 @@ describe('getTagLabel', () => {
 
   it('includes the count when tags are selected', () => {
     expect(getTagLabel(['a', 'b'])).toBe('Tags (2)');
-  });
-});
-
-describe('getLinksInText', () => {
-  it('extracts a non-image http link', () => {
-    expect(getLinksInText('see https://example.com/page now')).toEqual([
-      'https://example.com/page',
-    ]);
-  });
-
-  it('returns an empty array for text with no links', () => {
-    expect(getLinksInText('no links here')).toEqual([]);
   });
 });
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -381,19 +381,6 @@ export const getTagLabel = (selectedTags: Array<string>) => {
   return `Tags (${selectedTags.length})`;
 };
 
-export const getLinksInText = (text: string) => {
-  if (!text) {
-    return [];
-  }
-  const matches = text.match(
-    /https?:\/\/(?!(?:.*\.(?:jpe?g|gif|png)))[^\s]+/g
-  ) as string[];
-  if (matches) {
-    return matches;
-  }
-  return [];
-};
-
 export const getChannelLabel = (selectedChannels: Array<string>) => {
   if (selectedChannels.length === 0) {
     return 'All Forums';

--- a/utils/roleBadges.ts
+++ b/utils/roleBadges.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared role-badge resolution used by both the forum-scoped and server-scoped
+ * badge helpers. The matching logic is identical across scopes; only the
+ * returned label literals differ, so the scope-specific wrappers in
+ * forumRoleBadges.ts / serverRoleBadges.ts map this generic result onto their
+ * own string union.
+ */
+
+export type RoleBadgeParams = {
+  username?: string | null;
+  modProfileName?: string | null;
+  adminUsernames?: string[];
+  modUsernames?: string[];
+  modProfileNames?: string[];
+};
+
+/** Generic badge kind, scope-agnostic. */
+export type RoleBadgeKind = 'admin' | 'mod' | null;
+
+const hasMatch = (value: string | null | undefined, candidates: string[]) => {
+  if (!value) {
+    return false;
+  }
+
+  return candidates.includes(value);
+};
+
+export const resolveRoleBadge = ({
+  username,
+  modProfileName,
+  adminUsernames = [],
+  modUsernames = [],
+  modProfileNames = [],
+}: RoleBadgeParams): RoleBadgeKind => {
+  if (hasMatch(username, adminUsernames)) {
+    return 'admin';
+  }
+
+  if (
+    hasMatch(username, modUsernames) ||
+    hasMatch(modProfileName, modProfileNames)
+  ) {
+    return 'mod';
+  }
+
+  return null;
+};

--- a/utils/searchQueryBuilder.ts
+++ b/utils/searchQueryBuilder.ts
@@ -65,16 +65,7 @@ export function buildSearchQuery(
   };
 }
 
-/**
- * Return a new array with `value` removed if present, or appended if absent.
- */
-export function toggleInArray<T>(array: T[], value: T): T[] {
-  const index = array.indexOf(value);
-  if (index === -1) {
-    return [...array, value];
-  }
-  return array.filter((_, i) => i !== index);
-}
+export { toggleInArray } from '@/utils/arrayHelpers';
 
 /**
  * Two recent searches are considered the same when query, type, modified

--- a/utils/serverRoleBadges.ts
+++ b/utils/serverRoleBadges.ts
@@ -1,35 +1,14 @@
+import { resolveRoleBadge, type RoleBadgeParams } from '@/utils/roleBadges';
+
 export type ServerRoleBadge = 'serverAdmin' | 'serverMod' | null;
 
-type GetServerRoleBadgeParams = {
-  username?: string | null;
-  modProfileName?: string | null;
-  adminUsernames?: string[];
-  modUsernames?: string[];
-  modProfileNames?: string[];
-};
-
-const hasMatch = (value: string | null | undefined, candidates: string[]) => {
-  if (!value) {
-    return false;
-  }
-
-  return candidates.includes(value);
-};
-
-export const getServerRoleBadge = ({
-  username,
-  modProfileName,
-  adminUsernames = [],
-  modUsernames = [],
-  modProfileNames = [],
-}: GetServerRoleBadgeParams): ServerRoleBadge => {
-  if (hasMatch(username, adminUsernames)) {
+export const getServerRoleBadge = (params: RoleBadgeParams): ServerRoleBadge => {
+  const kind = resolveRoleBadge(params);
+  if (kind === 'admin') {
     return 'serverAdmin';
   }
-
-  if (hasMatch(username, modUsernames) || hasMatch(modProfileName, modProfileNames)) {
+  if (kind === 'mod') {
     return 'serverMod';
   }
-
   return null;
 };


### PR DESCRIPTION
## Summary

Code-quality / DRY cleanup surfaced by an analysis of the codebase. Five focused, behavior-preserving refactors. **Net −175 lines** (400 insertions, 575 deletions across 33 files).

Each commit is independently reviewable:

| Commit | What |
|---|---|
| Dead code + duplicate utils | Delete unused `getLinksInText`; collapse three identical array-toggle helpers into `utils/arrayHelpers.ts`; dedupe `truncateDescription` (eventSeo now imports the canonical copy from discussionSeo); extract shared `resolveRoleBadge` so the forum/server badge helpers only map its result onto their scoped string unions |
| Centralize `AuthorFields` fragment | Move the canonical `AUTHOR_FIELDS` definition to `graphQLData/fragments.js`, repoint the discussion/comment/event importers, and add a unit test guarding that every GraphQL document's fragment spreads resolve to a local definition |
| `useMutation` built-in loading | Remove hand-rolled `loading = ref(false)` toggles across the comment + create forms and bind UI to `useMutation`'s own `loading` ref (per `CLAUDE.md`); the built-in ref also clears correctly on error paths |
| `useFavoriteToggle` composable | The six `AddTo*Favorites` components each duplicated the same optimistic add/remove flow + `showAddedToast`. Extract into `composables/useFavoriteToggle`, parameterized by the entity-specific mutations, variable key, and messages. Each component keeps its own query / `isFavorited` derivation. (−219 net lines across those components) |
| `useCopyCurrentUrl` composable | Extract the byte-identical SSR-safe copy-link + 2s-notification logic from the image- and album-detail pages |

## Notes / deliberately out of scope

- **Full `AuthorFields` standardization** — several query files still inline author/karma selections with *drifted* field sets (some omit `createdAt`). Converting those changes query payloads, so it's left as a separate follow-up rather than smuggled into a dedupe commit.
- **`useForumId`** — ~36 pages extract `route.params.forumId as string` (non-reactive). A correct composable returns a `ComputedRef<string>`, which means updating every usage site; that broad sweep deserves its own focused PR.

## Verification

- `npm run tsc` — 0 errors
- `npx vitest run` — **4972 tests pass** (590 files), including all 6 favorites specs and the new fragment-resolution guard
- Playwright mocked flows for comment creation and discussion create/edit/delete pass
- `eslint` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
