### PR TITLE
feat(badges): show both Admin and Mod badges when applicable

### DIFF
--- a/components/UsernameWithTooltip.spec.ts
+++ b/components/UsernameWithTooltip.spec.ts
@@ -53,10 +53,11 @@ describe('UsernameWithTooltip badges', () => {
     expect(wrapper.text()).toContain('Mod');
   });
 
-  it('prefers the Admin badge over Mod', () => {
+  it('shows both Admin and Mod when the user is a server admin and a channel mod', () => {
     const wrapper = mountUsername({ isAdmin: true, isMod: true });
 
-    expect(wrapper.text()).not.toContain('Mod');
+    expect(wrapper.text()).toContain('Admin');
+    expect(wrapper.text()).toContain('Mod');
   });
 
   it('shows an OP badge', () => {

--- a/components/UsernameWithTooltip.vue
+++ b/components/UsernameWithTooltip.vue
@@ -98,7 +98,7 @@ const modBadgeClasses = computed(() => {
               >Admin</span
             >
             <span
-              v-else-if="isMod"
+              v-if="isMod"
               :class="modBadgeClasses"
             >
               Mod
@@ -159,7 +159,7 @@ const modBadgeClasses = computed(() => {
           >Admin</span
         >
         <span
-          v-else-if="isMod"
+          v-if="isMod"
           :class="modBadgeClasses"
         >
           Mod
@@ -194,7 +194,7 @@ const modBadgeClasses = computed(() => {
           >Admin</span
         >
         <span
-          v-else-if="isMod"
+          v-if="isMod"
           :class="modBadgeClasses"
         >
           Mod

--- a/components/discussion/detail/DiscussionHeader.vue
+++ b/components/discussion/detail/DiscussionHeader.vue
@@ -386,7 +386,7 @@ const warningModalBody = computed(() => {
               >Admin</span
             >
             <span
-              v-else-if="authorIsMod"
+              v-if="authorIsMod"
               class="rounded-md border border-orange-500 px-1 py-0 text-xs text-gray-500 dark:border-gray-300 dark:text-gray-300"
               >Mod</span
             >


### PR DESCRIPTION
## Summary

A user who is **both** a server-config admin **and** a channel moderator previously showed only the **Admin** badge — the **Mod** badge was rendered with `v-else-if`, so it was suppressed. This makes the two badges independent so both display.

- **`UsernameWithTooltip.vue`** — all three badge render spots (inline display, tooltip header, SSR fallback) now use an independent `v-if` for the Mod badge. Used by the channel discussion/download list items and `EventFooter`.
- **`DiscussionHeader.vue`** — same for the inline detail-view badges.
- Spec updated: both badges show when `isAdmin && isMod` (was "prefers Admin over Mod").

The Admin badge derives from `ServerConfig.Admins` membership; the Mod badge from `authorIsChannelModerator` (channel owner/moderator).

## Pairs with the backend fix

Depends on gennit-project/multiforum-backend#? which populates `authorIsChannelModerator` in the channel-list resolver — without it the Mod badge has no data in list views. Deploy the backend first (or together).

## Testing

- `UsernameWithTooltip.spec.ts` + `DiscussionHeader.spec.ts` pass (12 tests), incl. the new "shows both" assertion.
- eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)