### PR TITLE
fix(branding): server display name everywhere; no more "undefined"/"Multiforum"

### DIFF
--- a/components/event/detail/EventDetail.vue
+++ b/components/event/detail/EventDetail.vue
@@ -341,7 +341,7 @@ const handleClickEditEventDescription = () => {
 watchEffect(() => {
   const forumName =
     activeEventChannel.value?.Channel?.displayName || channelId.value || '';
-  const serverDisplayName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
+  const serverDisplayName = config.serverDisplayName;
 
   useHead(
     buildEventSeoMeta({

--- a/components/nav/TopNav.spec.ts
+++ b/components/nav/TopNav.spec.ts
@@ -18,6 +18,7 @@ vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => h.username,
   useNotificationCount: () => h.notificationCount,
 }));
+vi.mock('@/config', () => ({ config: { serverDisplayName: 'Test Server' } }));
 
 const mountNav = () =>
   mount(TopNav, {
@@ -45,10 +46,10 @@ beforeEach(() => {
 });
 
 describe('TopNav branding', () => {
-  it('shows the logo', () => {
+  it('shows the server display name as the logo', () => {
     const wrapper = mountNav();
 
-    expect(wrapper.text()).toContain('Topical');
+    expect(wrapper.text()).toContain('Test Server');
   });
 
   it('shows the channel name and favorites when on a forum route', () => {

--- a/components/nav/TopNav.vue
+++ b/components/nav/TopNav.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { config } from '@/config';
 import { useDisplay } from 'vuetify';
 import HamburgerMenuButton from '@/components/nav/HamburgerMenuButton.vue';
 import UserProfileDropdownMenu from '@/components/nav/UserProfileDropdownMenu.vue';
@@ -91,7 +92,7 @@ const isOnMapPage = computed(() => {
             <h1
               class="logo-font text-lg font-bold text-gray-900 dark:text-white"
             >
-              Topical
+              {{ config.serverDisplayName }}
             </h1>
           </nuxt-link>
 

--- a/config.ts
+++ b/config.ts
@@ -25,7 +25,14 @@ const config: ConfigType = {
   openCageApiKey: import.meta.env.VITE_OPEN_CAGE_API_KEY,
   openGraphApiKey: import.meta.env.VITE_OPEN_GRAPH_API_KEY,
   serverName: import.meta.env.VITE_SERVER_NAME,
-  serverDisplayName: import.meta.env.VITE_SERVER_DISPLAY_NAME,
+  // Human-facing site name used in page titles / SEO. Falls back to the server
+  // identifier and finally the product name so a missing VITE_SERVER_DISPLAY_NAME
+  // never renders as "undefined". Set VITE_SERVER_DISPLAY_NAME in the deploy for
+  // the desired branding.
+  serverDisplayName:
+    import.meta.env.VITE_SERVER_DISPLAY_NAME ||
+    import.meta.env.VITE_SERVER_NAME ||
+    'Multiforum',
   enableLanguagePicker: import.meta.env.VITE_ENABLE_LANGUAGE_PICKER === 'true',
 };
 export { config };

--- a/config.ts
+++ b/config.ts
@@ -25,14 +25,14 @@ const config: ConfigType = {
   openCageApiKey: import.meta.env.VITE_OPEN_CAGE_API_KEY,
   openGraphApiKey: import.meta.env.VITE_OPEN_GRAPH_API_KEY,
   serverName: import.meta.env.VITE_SERVER_NAME,
-  // Human-facing site name used in page titles / SEO. Falls back to the server
-  // identifier and finally the product name so a missing VITE_SERVER_DISPLAY_NAME
-  // never renders as "undefined". Set VITE_SERVER_DISPLAY_NAME in the deploy for
-  // the desired branding.
+  // Human-facing site name used in the nav, page titles and SEO. Falls back to
+  // the server identifier and finally 'Untitled' so a missing
+  // VITE_SERVER_DISPLAY_NAME never renders as "undefined". Set
+  // VITE_SERVER_DISPLAY_NAME in the deploy for the desired branding.
   serverDisplayName:
     import.meta.env.VITE_SERVER_DISPLAY_NAME ||
     import.meta.env.VITE_SERVER_NAME ||
-    'Multiforum',
+    'Untitled',
   enableLanguagePicker: import.meta.env.VITE_ENABLE_LANGUAGE_PICKER === 'true',
 };
 export { config };

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,7 +10,7 @@ export default defineNuxtConfig({
   srcDir: '.',
   app: {
     head: {
-      title: config.serverDisplayName || 'Multiforum',
+      title: config.serverDisplayName,
       meta: [
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },

--- a/pages/comments/search.vue
+++ b/pages/comments/search.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { config } from '@/config';
 import { ref, computed, watch } from 'vue';
 import { useRoute, useRouter, useHead } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
@@ -54,7 +55,7 @@ const channelLabel = computed(() =>
 );
 
 const pageTitle = computed(() => {
-  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
+  const serverName = config.serverDisplayName;
   return `Comment search | ${serverName}`;
 });
 

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -196,7 +196,7 @@ onGetChannelResult((result) => {
 // registered during setup (not inside the async onResult callback, which
 // runs outside the Nuxt instance context during SSR).
 const metaData = computed(() => {
-  const serverName = config.serverDisplayName || 'Multiforum';
+  const serverName = config.serverDisplayName;
   const baseUrl = import.meta.env.VITE_BASE_URL;
   const loadedChannel = channel.value;
 

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { config } from '@/config';
 import ChannelTabs from '@/components/channel/ChannelTabs.vue';
 import ChannelHeaderMobile from '@/components/channel/ChannelHeaderMobile.vue';
 import ChannelHeaderDesktop from '@/components/channel/ChannelHeaderDesktop.vue';
@@ -195,7 +196,7 @@ onGetChannelResult((result) => {
 // registered during setup (not inside the async onResult callback, which
 // runs outside the Nuxt instance context during SSR).
 const metaData = computed(() => {
-  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME || 'Multiforum';
+  const serverName = config.serverDisplayName || 'Multiforum';
   const baseUrl = import.meta.env.VITE_BASE_URL;
   const loadedChannel = channel.value;
 

--- a/pages/forums/[forumId]/discussions/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/[discussionId].vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { config } from '@/config';
 import { ref, watchEffect, computed } from 'vue';
 import DiscussionDetailContent from '@/components/discussion/detail/DiscussionDetailContent.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
@@ -46,7 +47,7 @@ const metaData = computed(() => {
       discussions: discussionResult.value?.discussions,
       channelId: channelId.value,
       discussionId: discussionId.value,
-      serverDisplayName: import.meta.env.VITE_SERVER_DISPLAY_NAME,
+      serverDisplayName: config.serverDisplayName,
       baseUrl: import.meta.env.VITE_BASE_URL,
     });
   } catch (error) {
@@ -56,7 +57,7 @@ const metaData = computed(() => {
       meta: [
         {
           name: 'description',
-          content: `View this discussion on ${import.meta.env.VITE_SERVER_DISPLAY_NAME}`,
+          content: `View this discussion on ${config.serverDisplayName}`,
         },
       ],
     };

--- a/pages/forums/[forumId]/discussions/edit/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/edit/[discussionId].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { config } from '@/config';
 import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
 import { UPDATE_DISCUSSION_WITH_CHANNEL_CONNECTIONS } from '@/graphQLData/discussion/mutations';
 import { computed, ref } from 'vue';
@@ -146,7 +147,7 @@ onGetDiscussionResult((value) => {
   const discussion = value.data.discussions[0];
 
   // Set page title and meta tags
-  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
+  const serverName = config.serverDisplayName;
   useHead({
     title: `Edit Discussion | ${channelId.value} | ${serverName}`,
     meta: [

--- a/pages/forums/[forumId]/discussions/index.vue
+++ b/pages/forums/[forumId]/discussions/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { config } from '@/config';
 import { computed } from 'vue';
 import { useRoute, useHead } from 'nuxt/app';
 import SearchDiscussions from '@/components/discussion/list/SearchDiscussions.vue';
@@ -10,7 +11,7 @@ const channelId = computed(() => {
 });
 
 const pageTitle = computed(() => {
-  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
+  const serverName = config.serverDisplayName;
   return `Discussions | ${channelId.value} | ${serverName}`;
 });
 

--- a/pages/forums/[forumId]/downloads/[discussionId].vue
+++ b/pages/forums/[forumId]/downloads/[discussionId].vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { config } from '@/config';
 import { ref, computed } from 'vue';
 import DiscussionDetailContent from '@/components/discussion/detail/DiscussionDetailContent.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
@@ -51,9 +52,9 @@ onGetDownloadResult((result) => {
       const description = download.body
         ? download.body.substring(0, 160) +
           (download.body.length > 160 ? '...' : '')
-        : `View this download on ${import.meta.env.VITE_SERVER_DISPLAY_NAME}`;
+        : `View this download on ${config.serverDisplayName}`;
       const baseUrl = import.meta.env.VITE_BASE_URL;
-      const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
+      const serverName = config.serverDisplayName;
       const imageUrl = download.coverImageURL || '';
 
       // Set all meta tags using useHead
@@ -120,7 +121,7 @@ onGetDownloadResult((result) => {
       meta: [
         {
           name: 'description',
-          content: `View this download on ${import.meta.env.VITE_SERVER_DISPLAY_NAME}`,
+          content: `View this download on ${config.serverDisplayName}`,
         },
       ],
     });

--- a/pages/forums/[forumId]/downloads/edit/[discussionId].vue
+++ b/pages/forums/[forumId]/downloads/edit/[discussionId].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { config } from '@/config';
 import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
 import { GET_CHANNEL } from '@/graphQLData/channel/queries';
 import {
@@ -210,7 +211,7 @@ onGetDiscussionResult((value) => {
   const discussion = value.data.discussions[0];
 
   // Set page title and meta tags
-  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME;
+  const serverName = config.serverDisplayName;
   useHead({
     title: `Edit Download | ${channelId.value} | ${serverName}`,
     meta: [

--- a/pages/forums/[forumId]/wiki/[slug].vue
+++ b/pages/forums/[forumId]/wiki/[slug].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { config } from '@/config';
 import { computed } from 'vue';
 import { useRoute, useRouter, useHead } from 'nuxt/app';
 import { GET_CHANNEL, GET_WIKI_PAGE } from '@/graphQLData/channel/queries';
@@ -73,7 +74,7 @@ onGetWikiPageResult((result) => {
       wikiPages: result?.data?.wikiPages,
       forumId,
       slug,
-      serverDisplayName: import.meta.env.VITE_SERVER_DISPLAY_NAME,
+      serverDisplayName: config.serverDisplayName,
       baseUrl: import.meta.env.VITE_BASE_URL,
     });
     if (head) useHead(head);

--- a/pages/forums/[forumId]/wiki/index.vue
+++ b/pages/forums/[forumId]/wiki/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { config } from '@/config';
 import { computed } from 'vue';
 import { useRoute, useRouter, useHead } from 'nuxt/app';
 import { GET_CHANNEL } from '@/graphQLData/channel/queries';
@@ -94,7 +95,7 @@ onGetChannelResult((result) => {
     const head = buildWikiHomeHead({
       channels: result?.data?.channels,
       forumId,
-      serverDisplayName: import.meta.env.VITE_SERVER_DISPLAY_NAME,
+      serverDisplayName: config.serverDisplayName,
       baseUrl: import.meta.env.VITE_BASE_URL,
     });
     if (head) useHead(head);

--- a/pages/mod/[modId].vue
+++ b/pages/mod/[modId].vue
@@ -37,7 +37,7 @@ const mod = computed(() => {
 
 // Set page title for mod profile
 watchEffect(() => {
-  const serverName = config.serverDisplayName || 'Multiforum';
+  const serverName = config.serverDisplayName;
   const displayName = mod.value?.displayName || modProfileName.value;
 
   useHead({

--- a/pages/mod/[modId].vue
+++ b/pages/mod/[modId].vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { config } from '@/config';
 import { computed, watchEffect } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_MOD } from '@/graphQLData/mod/queries';
@@ -36,7 +37,7 @@ const mod = computed(() => {
 
 // Set page title for mod profile
 watchEffect(() => {
-  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME || 'Multiforum';
+  const serverName = config.serverDisplayName || 'Multiforum';
   const displayName = mod.value?.displayName || modProfileName.value;
 
   useHead({

--- a/pages/u/[username].vue
+++ b/pages/u/[username].vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { config } from '@/config';
 import { computed, watchEffect } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_USER } from '@/graphQLData/user/queries';
@@ -103,7 +104,7 @@ watchEffect(() => {
 
   const userName = user.value.displayName || user.value.username;
   const baseUrl = import.meta.env.VITE_BASE_URL;
-  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME || 'Multiforum';
+  const serverName = config.serverDisplayName || 'Multiforum';
   const profilePic = user.value.profilePicURL || '';
   const userBio = user.value.bio || `${userName}'s profile`;
 

--- a/pages/u/[username].vue
+++ b/pages/u/[username].vue
@@ -104,7 +104,7 @@ watchEffect(() => {
 
   const userName = user.value.displayName || user.value.username;
   const baseUrl = import.meta.env.VITE_BASE_URL;
-  const serverName = config.serverDisplayName || 'Multiforum';
+  const serverName = config.serverDisplayName;
   const profilePic = user.value.profilePicURL || '';
   const userBio = user.value.bio || `${userName}'s profile`;
 

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { config } from '@/config';
 import { computed, watchEffect, ref, onMounted, onUnmounted } from 'vue';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 import { useRoute, useHead } from 'nuxt/app';
@@ -224,7 +225,7 @@ watchEffect(() => {
 
   const imageCaption = image.value.caption || image.value.alt || 'Image';
   const uploaderName = uploader.value.displayName || uploader.value.username;
-  const serverName = import.meta.env.VITE_SERVER_DISPLAY_NAME || 'Multiforum';
+  const serverName = config.serverDisplayName || 'Multiforum';
 
   const description = `Image uploaded by ${uploaderName}: ${imageCaption}${image.value.longDescription ? '. ' + image.value.longDescription : ''}`;
 

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -225,7 +225,7 @@ watchEffect(() => {
 
   const imageCaption = image.value.caption || image.value.alt || 'Image';
   const uploaderName = uploader.value.displayName || uploader.value.username;
-  const serverName = config.serverDisplayName || 'Multiforum';
+  const serverName = config.serverDisplayName;
 
   const description = `Image uploaded by ${uploaderName}: ${imageCaption}${image.value.longDescription ? '. ' + image.value.longDescription : ''}`;
 

--- a/pages/wiki/search.vue
+++ b/pages/wiki/search.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { config } from '@/config';
 import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter, useHead } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
@@ -39,7 +40,7 @@ const channelLabel = computed(() =>
 
 const pageTitle = computed(() => {
   const serverName =
-    import.meta.env.VITE_SERVER_DISPLAY_NAME ||
+    config.serverDisplayName ||
     import.meta.env.VITE_SERVER_NAME ||
     'Multiforum';
   return `Wiki search | ${serverName}`;

--- a/pages/wiki/search.vue
+++ b/pages/wiki/search.vue
@@ -39,11 +39,7 @@ const channelLabel = computed(() =>
 );
 
 const pageTitle = computed(() => {
-  const serverName =
-    config.serverDisplayName ||
-    import.meta.env.VITE_SERVER_NAME ||
-    'Multiforum';
-  return `Wiki search | ${serverName}`;
+  return `Wiki search | ${config.serverDisplayName}`;
 });
 
 useHead({


### PR DESCRIPTION
Two related commits fixing the site-name display.

## 1. No more "undefined" in titles
Page titles/SEO read `VITE_SERVER_DISPLAY_NAME` directly; unset on the deploy, so titles rendered `… | cats | undefined` and some pages fell back to "Multiforum".
- `config.ts`: `serverDisplayName` falls back `VITE_SERVER_DISPLAY_NAME → VITE_SERVER_NAME → 'Untitled'` — never `undefined`.
- All 14 scattered title/SEO reads now go through `config.serverDisplayName` (single source of truth).

## 2. Nav uses the server name; 'Untitled' fallback; drop "Multiforum"
- **`TopNav`** now renders `{{ config.serverDisplayName }}` instead of a hardcoded brand string, so each instance shows its own name (with the env var set, that's "Topical").
- Final fallback is **'Untitled'**, not the product name. Removed the lingering `|| 'Multiforum'` fallbacks at the call sites. **'Multiforum' is no longer used as any instance's name** — the only remaining reference is product-documentation prose in `pages/admin/settings/plugins/docs.vue`.

Env vars for the deploy have been set (`VITE_SERVER_DISPLAY_NAME`), so the nav + titles will show the configured name.

## Testing
- `TopNav.spec` updated to mock `config` and assert the name renders from it; SEO/head specs pass (59 tests across the touched specs).
- eslint clean. (Also pruned a stale in-repo `.claude/worktrees/` git worktree that was polluting local vitest runs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)