### PR TITLE
feat(super-upvotes): fix active state, add Kudos notifications + e2e tests

### DIFF
--- a/components/comments/VoteButtons.vue
+++ b/components/comments/VoteButtons.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useMutation } from '@vue/apollo-composable';
+import type { Reference, StoreObject } from '@apollo/client/core';
 import ErrorBanner from '../ErrorBanner.vue';
 import {
   UPVOTE_COMMENT,
@@ -152,14 +153,27 @@ const {
   loading: undoSuperUpvoteLoading,
 } = useMutation(UNDO_SUPER_UPVOTE, {
   update: (cache, { data }) => {
-    if (data?.undoSuperUpvote?.success) {
-      cache.modify({
-        id: cache.identify({ __typename: 'Comment', id: props.commentData.id }),
-        fields: {
-          SuperUpvotedByUsers: () => data.undoSuperUpvote.superUpvotedByUsers || [],
-        },
-      });
-    }
+    if (!data?.undoSuperUpvote?.success) return;
+    const cacheId = cache.identify({
+      __typename: 'Comment',
+      id: props.commentData.id,
+    });
+    if (!cacheId) return;
+    const me = usernameVar.value;
+    // Authoritatively drop the actor from the list rather than trusting the
+    // server's returned list, which can lag behind the just-committed delete.
+    cache.modify({
+      id: cacheId,
+      fields: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        SuperUpvotedByUsers: (existing: any = [], { readField }) =>
+          me
+            ? (existing as ReadonlyArray<Reference | StoreObject>).filter(
+                (user) => readField('username', user) !== me
+              )
+            : existing,
+      },
+    });
   },
 });
 

--- a/components/discussion/vote/DiscussionVotes.vue
+++ b/components/discussion/vote/DiscussionVotes.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue';
 import { useRoute, useRouter } from 'nuxt/app';
 import { useMutation } from '@vue/apollo-composable';
+import type { Reference, StoreObject } from '@apollo/client/core';
 import type { User } from '@/__generated__/graphql';
 import {
   UPVOTE_DISCUSSION_CHANNEL,
@@ -93,14 +94,27 @@ const {
   loading: undoSuperUpvoteLoading,
 } = useMutation(UNDO_SUPER_UPVOTE, {
   update: (cache, { data }) => {
-    if (data?.undoSuperUpvote?.success) {
-      cache.modify({
-        id: cache.identify({ __typename: 'DiscussionChannel', id: discussionChannelId.value }),
-        fields: {
-          SuperUpvotedByUsers: () => data.undoSuperUpvote.superUpvotedByUsers || [],
-        },
-      });
-    }
+    if (!data?.undoSuperUpvote?.success) return;
+    const cacheId = cache.identify({
+      __typename: 'DiscussionChannel',
+      id: discussionChannelId.value,
+    });
+    if (!cacheId) return;
+    const me = usernameVar.value;
+    // Authoritatively drop the actor from the list rather than trusting the
+    // server's returned list, which can lag behind the just-committed delete.
+    cache.modify({
+      id: cacheId,
+      fields: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        SuperUpvotedByUsers: (existing: any = [], { readField }) =>
+          me
+            ? (existing as ReadonlyArray<Reference | StoreObject>).filter(
+                (user) => readField('username', user) !== me
+              )
+            : existing,
+      },
+    });
   },
 });
 

--- a/components/notifications/NotificationTabs.vue
+++ b/components/notifications/NotificationTabs.vue
@@ -1,15 +1,26 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 import { useUsername } from '@/composables/useAuthState';
 import { timeAgo } from '@/utils';
 import type { Notification } from '@/__generated__/graphql';
 import MarkdownRenderer from '../MarkdownRenderer.vue';
-import { MARK_NOTIFICATIONS_AS_READ } from '@/graphQLData/user/mutations';
+import {
+  MARK_NOTIFICATIONS_AS_READ,
+  MARK_NOTIFICATION_AS_READ,
+} from '@/graphQLData/user/mutations';
+import { UPDATE_SCRATCHPAD_ENTRY_VISIBILITY } from '@/graphQLData/scratchpad/mutations';
 import {
   GET_FEEDBACK_NOTIFICATIONS,
   GET_GENERAL_NOTIFICATIONS,
 } from '@/graphQLData/notification/queries';
+
+// The generated Notification type doesn't yet carry the ScratchpadEntry link
+// (super upvote notifications), so augment it locally.
+type ScratchpadEntryRef = { id: string; isPublic: boolean };
+type NotificationWithEntry = Notification & {
+  ScratchpadEntry?: ScratchpadEntryRef | null;
+};
 
 const NOTIFICATION_PAGE_LIMIT = 15;
 
@@ -84,12 +95,71 @@ markAsReadDone(() => {
   }
 });
 
-const generalNotifications = computed<Notification[]>(() => {
+// Per-notification actions for super-upvote ("scratchpad") notifications:
+// "Show on profile" publishes the thank-you note and marks the notification
+// read; "Ignore" just marks it read.
+const { mutate: markNotificationAsRead } = useMutation(MARK_NOTIFICATION_AS_READ);
+const { mutate: showScratchpadEntry } = useMutation(
+  UPDATE_SCRATCHPAD_ENTRY_VISIBILITY
+);
+
+const pendingNotificationId = ref<string | null>(null);
+const actionError = ref('');
+
+const refetchActive = () =>
+  activeTab.value === 'general' ? refetchGeneral() : refetchFeedback();
+
+const canActOnScratchpadEntry = (notification: NotificationWithEntry) =>
+  notification.notificationType === 'scratchpad' &&
+  !!notification.ScratchpadEntry?.id &&
+  !notification.ScratchpadEntry.isPublic &&
+  !notification.read;
+
+const isPublishedScratchpadEntry = (notification: NotificationWithEntry) =>
+  notification.notificationType === 'scratchpad' &&
+  !!notification.ScratchpadEntry?.isPublic;
+
+const handleIgnore = async (notification: NotificationWithEntry) => {
+  pendingNotificationId.value = notification.id;
+  actionError.value = '';
+  try {
+    await markNotificationAsRead({
+      username: usernameVar.value,
+      notificationId: notification.id,
+    });
+    await refetchActive();
+  } catch (error) {
+    actionError.value = (error as Error).message;
+  } finally {
+    pendingNotificationId.value = null;
+  }
+};
+
+const handleShowOnProfile = async (notification: NotificationWithEntry) => {
+  const entryId = notification.ScratchpadEntry?.id;
+  if (!entryId) return;
+  pendingNotificationId.value = notification.id;
+  actionError.value = '';
+  try {
+    await showScratchpadEntry({ scratchpadEntryId: entryId, isPublic: true });
+    await markNotificationAsRead({
+      username: usernameVar.value,
+      notificationId: notification.id,
+    });
+    await refetchActive();
+  } catch (error) {
+    actionError.value = (error as Error).message;
+  } finally {
+    pendingNotificationId.value = null;
+  }
+};
+
+const generalNotifications = computed<NotificationWithEntry[]>(() => {
   if (!generalResult.value?.users?.[0]) return [];
   return generalResult.value.users[0].Notifications || [];
 });
 
-const feedbackNotifications = computed<Notification[]>(() => {
+const feedbackNotifications = computed<NotificationWithEntry[]>(() => {
   if (!feedbackResult.value?.users?.[0]) return [];
   return feedbackResult.value.users[0].Notifications || [];
 });
@@ -267,6 +337,7 @@ const reachedEnd = computed(() => {
           />
         </div>
         <ErrorBanner v-if="markAsReadError" :text="markAsReadError.message" />
+        <ErrorBanner v-if="actionError" :text="actionError" />
 
         <ul
           role="list"
@@ -287,6 +358,39 @@ const reachedEnd = computed(() => {
               :text="notification.text"
               class="w-full"
             />
+            <div
+              v-if="canActOnScratchpadEntry(notification)"
+              class="mt-3 flex flex-wrap items-center gap-2"
+              :data-testid="`scratchpad-notification-actions-${notification.id}`"
+            >
+              <button
+                type="button"
+                data-testid="notification-show-on-profile"
+                :disabled="pendingNotificationId === notification.id"
+                class="inline-flex items-center gap-1 rounded-full bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+                @click="handleShowOnProfile(notification)"
+              >
+                <i class="fa-solid fa-star" />
+                Show on profile
+              </button>
+              <button
+                type="button"
+                data-testid="notification-ignore"
+                :disabled="pendingNotificationId === notification.id"
+                class="inline-flex items-center gap-1 rounded-full border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                @click="handleIgnore(notification)"
+              >
+                Ignore
+              </button>
+            </div>
+            <p
+              v-else-if="isPublishedScratchpadEntry(notification)"
+              class="mt-2 text-sm text-green-600 dark:text-green-400"
+              data-testid="notification-showing-on-profile"
+            >
+              <i class="fa-solid fa-circle-check mr-1" />
+              Showing on your Kudos page
+            </p>
           </li>
         </ul>
 

--- a/components/scratchpad/ScratchpadEntry.spec.ts
+++ b/components/scratchpad/ScratchpadEntry.spec.ts
@@ -55,12 +55,23 @@ const mountEntry = (props: Record<string, unknown> = {}) =>
     props: { entry: entry(), isOwner: true, ...props },
     global: {
       stubs: {
-        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        NuxtLink: {
+          props: ['to'],
+          // Serialize `to` so tests can assert the resolved route/href.
+          template: '<a :data-to="JSON.stringify(to)"><slot /></a>',
+        },
         AvatarComponent: true,
         ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
       },
     },
   });
+
+const sourceLinkTo = (w: ReturnType<typeof mount>) => {
+  const raw = w
+    .get('[data-testid="scratchpad-source-link"]')
+    .attributes('data-to');
+  return JSON.parse(raw as string);
+};
 
 const buttonByText = (w: ReturnType<typeof mount>, text: string) =>
   w.findAll('button').find((b) => b.text() === text);
@@ -112,6 +123,53 @@ describe('ScratchpadEntry display', () => {
     const wrapper = mountEntry({ isOwner: false });
 
     expect(wrapper.findAll('button')).toHaveLength(0);
+  });
+});
+
+describe('ScratchpadEntry source link', () => {
+  it('links a discussion entry to the discussion using its discussionId', () => {
+    const wrapper = mountEntry({
+      entry: entry({
+        sourceType: 'discussion',
+        sourceId: 'discussion-channel-1',
+        discussionId: 'discussion-1',
+        sourceChannelUniqueName: 'cats',
+      }),
+    });
+
+    expect(sourceLinkTo(wrapper)).toEqual({
+      name: 'forums-forumId-discussions-discussionId',
+      params: { forumId: 'cats', discussionId: 'discussion-1' },
+    });
+  });
+
+  it('links a comment entry to the comment permalink (commentId is sourceId)', () => {
+    const wrapper = mountEntry({
+      entry: entry({
+        sourceType: 'comment',
+        sourceId: 'comment-1',
+        discussionId: 'discussion-1',
+        sourceChannelUniqueName: 'cats',
+      }),
+    });
+
+    expect(sourceLinkTo(wrapper)).toEqual({
+      name: 'forums-forumId-discussions-discussionId-comments-commentId',
+      params: { forumId: 'cats', discussionId: 'discussion-1', commentId: 'comment-1' },
+    });
+  });
+
+  it('falls back to the forum discussion list when discussionId is missing', () => {
+    const wrapper = mountEntry({
+      entry: entry({
+        sourceType: 'discussion',
+        sourceId: 'discussion-channel-1',
+        sourceChannelUniqueName: 'cats',
+        discussionId: undefined,
+      }),
+    });
+
+    expect(sourceLinkTo(wrapper)).toBe('/forums/cats/discussions');
   });
 });
 

--- a/components/scratchpad/ScratchpadEntry.vue
+++ b/components/scratchpad/ScratchpadEntry.vue
@@ -6,6 +6,10 @@ import {
   UPDATE_SCRATCHPAD_ENTRY_VISIBILITY,
   DELETE_SCRATCHPAD_ENTRY,
 } from '@/graphQLData/scratchpad/mutations';
+import {
+  getPermalinkToDiscussion,
+  getPermalinkToDiscussionComment,
+} from '@/utils/routerUtils';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 
 interface ScratchpadEntryData {
@@ -14,8 +18,12 @@ interface ScratchpadEntryData {
   text: string;
   isPublic: boolean;
   sourceType: string;
+  // DiscussionChannel id (discussion) or Comment id (comment).
   sourceId: string;
   sourceChannelUniqueName?: string;
+  // The Discussion id the upvoted content belongs to. Needed to build a working
+  // link, since the discussion route expects the Discussion id, not sourceId.
+  discussionId?: string;
   Author: {
     username: string;
     displayName?: string;
@@ -41,20 +49,32 @@ const authorDisplayName = computed(() => {
 });
 
 const sourceLink = computed(() => {
-  const { sourceType, sourceId, sourceChannelUniqueName } = props.entry;
-  if (sourceType === 'comment') {
-    // Link to the comment - this may need adjustment based on actual routing
-    if (sourceChannelUniqueName) {
-      return `/forums/${sourceChannelUniqueName}/discussions/${sourceId}`;
-    }
-    return '#';
-  } else if (sourceType === 'discussion') {
-    if (sourceChannelUniqueName) {
-      return `/forums/${sourceChannelUniqueName}/discussions/${sourceId}`;
-    }
-    return '#';
+  const { sourceType, sourceId, sourceChannelUniqueName, discussionId } =
+    props.entry;
+
+  // Without the channel we cannot build any forum link.
+  if (!sourceChannelUniqueName) return '#';
+
+  // Without the discussion id (e.g. older entries created before it was
+  // recorded) fall back to the forum's discussion list rather than a wrong link.
+  if (!discussionId) {
+    return `/forums/${sourceChannelUniqueName}/discussions`;
   }
-  return '#';
+
+  if (sourceType === 'comment') {
+    // sourceId is the Comment id; link straight to the comment permalink.
+    return getPermalinkToDiscussionComment({
+      forumId: sourceChannelUniqueName,
+      discussionId,
+      commentId: sourceId,
+    });
+  }
+
+  // discussion: sourceId is the DiscussionChannel id; link to the discussion.
+  return getPermalinkToDiscussion({
+    forumId: sourceChannelUniqueName,
+    discussionId,
+  });
 });
 
 const sourceTypeLabel = computed(() => {
@@ -151,6 +171,7 @@ const isLoading = computed(() => updateLoading.value || deleteLoading.value);
             super upvoted your
             <NuxtLink
               :to="sourceLink"
+              data-testid="scratchpad-source-link"
               class="text-indigo-600 hover:underline dark:text-indigo-400"
             >
               {{ sourceTypeLabel }}

--- a/components/scratchpad/ScratchpadSection.spec.ts
+++ b/components/scratchpad/ScratchpadSection.spec.ts
@@ -85,7 +85,7 @@ describe('ScratchpadSection states', () => {
     h.username = ref('bob');
     const wrapper = mountSection();
 
-    expect(wrapper.text()).toContain("hasn't received any public scratchpad entries");
+    expect(wrapper.text()).toContain("hasn't received any public kudos");
   });
 });
 

--- a/components/scratchpad/ScratchpadSection.vue
+++ b/components/scratchpad/ScratchpadSection.vue
@@ -99,14 +99,14 @@ const handleEntryDeleted = () => {
           />
         </div>
         <h3 class="text-lg font-medium text-gray-900 dark:text-white">
-          No scratchpad entries yet
+          No kudos yet
         </h3>
         <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
           <template v-if="isOwner">
             When someone super upvotes your content, their thank-you note will appear here.
           </template>
           <template v-else>
-            This user hasn't received any public scratchpad entries yet.
+            This user hasn't received any public kudos yet.
           </template>
         </p>
       </div>

--- a/components/superUpvote/SuperUpvoteModal.vue
+++ b/components/superUpvote/SuperUpvoteModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue';
 import { useMutation } from '@vue/apollo-composable';
+import type { Reference, StoreObject } from '@apollo/client/core';
 import {
   Dialog,
   DialogPanel,
@@ -10,6 +11,9 @@ import {
 } from '@headlessui/vue';
 import { CREATE_SCRATCHPAD_ENTRY } from '@/graphQLData/scratchpad/mutations';
 import ErrorBanner from '@/components/ErrorBanner.vue';
+import { useUsername } from '@/composables/useAuthState';
+
+const usernameVar = useUsername();
 
 const MAX_TEXT_LENGTH = 500;
 
@@ -76,15 +80,31 @@ const {
   onDone,
 } = useMutation(CREATE_SCRATCHPAD_ENTRY, {
   update: (cache, { data }) => {
-    if (data?.createScratchpadEntry?.superUpvotedByUsers) {
-      const typename = props.sourceType === 'comment' ? 'Comment' : 'DiscussionChannel';
-      cache.modify({
-        id: cache.identify({ __typename: typename, id: props.sourceId }),
-        fields: {
-          SuperUpvotedByUsers: () => data.createScratchpadEntry.superUpvotedByUsers,
+    if (!data?.createScratchpadEntry) return;
+    const typename = props.sourceType === 'comment' ? 'Comment' : 'DiscussionChannel';
+    const cacheId = cache.identify({ __typename: typename, id: props.sourceId });
+    if (!cacheId) return;
+    const me = usernameVar.value;
+    // Be authoritative about the actor instead of trusting the server's returned
+    // list: the logged-in user just super upvoted this content, so ensure they
+    // appear in SuperUpvotedByUsers. A server read-after-write lag can return a
+    // stale list that omits them, which would otherwise leave the button looking
+    // inactive (and un-undoable). See tests/playwright/mocked/superUpvote.
+    cache.modify({
+      id: cacheId,
+      fields: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        SuperUpvotedByUsers: (existing: any = [], { readField }) => {
+          if (!me) return existing;
+          const users = existing as ReadonlyArray<Reference | StoreObject>;
+          const alreadyPresent = users.some(
+            (user) => readField('username', user) === me
+          );
+          if (alreadyPresent) return existing;
+          return [...users, { __typename: 'User', username: me }];
         },
-      });
-    }
+      },
+    });
   },
 });
 
@@ -175,6 +195,7 @@ const handleSubmit = () => {
                       <textarea
                         ref="textareaRef"
                         v-model="text"
+                        data-testid="super-upvote-text-input"
                         :placeholder="placeholderText"
                         rows="4"
                         :maxlength="MAX_TEXT_LENGTH + 50"
@@ -207,6 +228,7 @@ const handleSubmit = () => {
                   </button>
                   <button
                     type="button"
+                    data-testid="super-upvote-submit"
                     :disabled="!isValid || loading"
                     class="flex-1 inline-flex justify-center items-center gap-2 rounded-full px-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500 disabled:cursor-not-allowed"
                     :class="{

--- a/components/user/UserProfileTabs.vue
+++ b/components/user/UserProfileTabs.vue
@@ -133,7 +133,7 @@ const tabs = computed(() => {
       count: props.user?.AlbumsAggregate?.count,
     },
     {
-      name: 'Scratchpad',
+      name: 'Kudos',
       path: `/u/${usernameInParams.value}/scratchpad`,
       to: getTabTo(`/u/${usernameInParams.value}/scratchpad`),
       current: false,

--- a/graphQLData/notification/queries.js
+++ b/graphQLData/notification/queries.js
@@ -11,6 +11,10 @@ export const GET_NOTIFICATIONS = gql`
         read
         text
         notificationType
+        ScratchpadEntry {
+          id
+          isPublic
+        }
       }
       NotificationsAggregate(where: { read: false }) {
         count
@@ -62,6 +66,10 @@ export const GET_GENERAL_NOTIFICATIONS = gql`
         read
         text
         notificationType
+        ScratchpadEntry {
+          id
+          isPublic
+        }
       }
       NotificationsAggregate(
         where: { read: false, NOT: { notificationType: "feedback" } }

--- a/graphQLData/scratchpad/mutations.js
+++ b/graphQLData/scratchpad/mutations.js
@@ -22,6 +22,7 @@ export const CREATE_SCRATCHPAD_ENTRY = gql`
       sourceType
       sourceId
       sourceChannelUniqueName
+      discussionId
       Author {
         username
         displayName
@@ -52,6 +53,7 @@ export const UPDATE_SCRATCHPAD_ENTRY_VISIBILITY = gql`
       sourceType
       sourceId
       sourceChannelUniqueName
+      discussionId
       createdAt
       Author {
         username

--- a/graphQLData/scratchpad/queries.js
+++ b/graphQLData/scratchpad/queries.js
@@ -14,6 +14,7 @@ export const GET_PUBLIC_SCRATCHPAD_ENTRIES = gql`
       sourceType
       sourceId
       sourceChannelUniqueName
+      discussionId
       Author {
         username
         displayName
@@ -40,6 +41,7 @@ export const GET_PENDING_SCRATCHPAD_ENTRIES = gql`
       sourceType
       sourceId
       sourceChannelUniqueName
+      discussionId
       Author {
         username
         displayName
@@ -66,6 +68,7 @@ export const GET_ALL_SCRATCHPAD_ENTRIES = gql`
       sourceType
       sourceId
       sourceChannelUniqueName
+      discussionId
       Author {
         username
         displayName

--- a/graphQLData/user/mutations.js
+++ b/graphQLData/user/mutations.js
@@ -46,6 +46,30 @@ export const MARK_NOTIFICATIONS_AS_READ = gql`
   }
 `;
 
+// Mark a single notification as read (e.g. when ignoring a super-upvote note).
+// Goes through updateUsers because direct updateNotifications is denied server-side.
+export const MARK_NOTIFICATION_AS_READ = gql`
+  mutation markNotificationAsRead($username: String!, $notificationId: ID!) {
+    updateUsers(
+      where: { username: $username }
+      update: {
+        Notifications: {
+          where: { node: { id: $notificationId } }
+          update: { node: { read: true } }
+        }
+      }
+    ) {
+      users {
+        username
+        Notifications(where: { id: $notificationId }) {
+          id
+          read
+        }
+      }
+    }
+  }
+`;
+
 export const ADD_FAVORITE_CHANNEL = gql`
   mutation addFavoriteChannel($channel: String!, $username: String!) {
     updateUsers(

--- a/tests/playwright/helpers/graphqlFixtures.ts
+++ b/tests/playwright/helpers/graphqlFixtures.ts
@@ -153,6 +153,7 @@ export type DiscussionChannelFixture = Pick<
   CommentsAggregate: CountAggregate;
   UpvotedByUsers: Array<Pick<User, 'username'>>;
   UpvotedByUsersAggregate: CountAggregate;
+  SuperUpvotedByUsers: Array<Pick<User, 'username'>>;
   SubscribedToNotifications: Array<Pick<User, 'username'>>;
 };
 
@@ -381,6 +382,7 @@ export const buildDiscussionChannel = ({
   CommentsAggregate: { count: commentsCount },
   UpvotedByUsers: [{ username: DEFAULT_USERNAME }],
   UpvotedByUsersAggregate: { count: 1 },
+  SuperUpvotedByUsers: [],
   SubscribedToNotifications: [],
   Answers: [],
   LabelOptions: [],

--- a/tests/playwright/helpers/mockedSuperUpvoteHandlers.ts
+++ b/tests/playwright/helpers/mockedSuperUpvoteHandlers.ts
@@ -1,0 +1,434 @@
+import {
+  buildDiscussion,
+  buildDiscussionChannel,
+  buildUser,
+  DEFAULT_USERNAME,
+  MOCK_DATE,
+} from './graphqlFixtures';
+import { createBaseHandlers, type BaseHandlerConfig } from './baseHandlers';
+import type { GraphQLHandler } from './mockGraphql';
+
+// Stateful mock backing for the super-upvote ("scratchpad") give/undo flow on a
+// discussion detail page. The discussion is authored by `authorUsername` (so the
+// logged-in `actorUsername` is allowed to super upvote it), and the upvote /
+// super-upvote relationships live in mutable arrays that the mutation handlers
+// edit and the query handlers read back — mirroring the real backend so the
+// frontend Apollo cache logic is exercised faithfully.
+export type SuperUpvoteState = {
+  channelId: string;
+  discussionId: string;
+  discussionChannelId: string;
+  authorUsername: string;
+  actorUsername: string;
+  title: string;
+  body: string;
+  upvoters: string[];
+  superUpvoters: string[];
+};
+
+export type SuperUpvoteConfig = {
+  channelId?: string;
+  discussionId?: string;
+  discussionChannelId?: string;
+  authorUsername?: string;
+  actorUsername?: string;
+  title?: string;
+  body?: string;
+  startUpvoted?: boolean;
+  startSuperUpvoted?: boolean;
+};
+
+export const createSuperUpvoteState = (
+  config: SuperUpvoteConfig = {}
+): SuperUpvoteState => {
+  const {
+    channelId = 'cats',
+    discussionId = 'discussion-1',
+    discussionChannelId = 'discussion-channel-1',
+    authorUsername = 'alice',
+    actorUsername = DEFAULT_USERNAME,
+    title = 'Alice has a great idea',
+    body = 'Here is the body of the discussion.',
+    startUpvoted = false,
+    startSuperUpvoted = false,
+  } = config;
+
+  return {
+    channelId,
+    discussionId,
+    discussionChannelId,
+    authorUsername,
+    actorUsername,
+    title,
+    body,
+    upvoters: startUpvoted ? [actorUsername] : [],
+    superUpvoters: startSuperUpvoted ? [actorUsername] : [],
+  };
+};
+
+const toUsernameList = (usernames: string[]) =>
+  usernames.map((username) => ({ __typename: 'User', username }));
+
+// The DiscussionChannel sub-object shared by the detail queries, reflecting the
+// current upvote / super-upvote state.
+const buildStatefulDiscussionChannel = (state: SuperUpvoteState) =>
+  buildDiscussionChannel({
+    id: state.discussionChannelId,
+    discussionId: state.discussionId,
+    channelUniqueName: state.channelId,
+    title: state.title,
+    overrides: {
+      weightedVotesCount: state.upvoters.length + state.superUpvoters.length,
+      UpvotedByUsers: toUsernameList(state.upvoters),
+      UpvotedByUsersAggregate: { count: state.upvoters.length },
+      SuperUpvotedByUsers: toUsernameList(state.superUpvoters),
+      Discussion: {
+        id: state.discussionId,
+        title: state.title,
+        Author: buildUser({ username: state.authorUsername }),
+      },
+    },
+  });
+
+// Shape returned by the upvote / undo-upvote mutations (matches the selection
+// set in graphQLData/discussion/mutations.js).
+const buildVoteMutationResult = (state: SuperUpvoteState) => ({
+  id: state.discussionChannelId,
+  weightedVotesCount: state.upvoters.length + state.superUpvoters.length,
+  UpvotedByUsers: toUsernameList(state.upvoters),
+  UpvotedByUsersAggregate: { count: state.upvoters.length },
+  SuperUpvotedByUsers: toUsernameList(state.superUpvoters),
+  __typename: 'DiscussionChannel',
+});
+
+export const createSuperUpvoteHandlers = (
+  state: SuperUpvoteState
+): Record<string, GraphQLHandler> => {
+  const baseConfig: BaseHandlerConfig = {
+    username: state.actorUsername,
+    channelId: state.channelId,
+    discussionId: state.discussionId,
+    discussionChannelId: state.discussionChannelId,
+    discussionTitle: state.title,
+    discussionsCount: 1,
+  };
+
+  return {
+    ...createBaseHandlers(baseConfig),
+
+    getDiscussion: () => ({
+      data: {
+        discussions: [
+          buildDiscussion({
+            id: state.discussionId,
+            discussionChannelId: state.discussionChannelId,
+            channelUniqueName: state.channelId,
+            title: state.title,
+            body: state.body,
+            overrides: {
+              Author: buildUser({ username: state.authorUsername }),
+              DiscussionChannels: [buildStatefulDiscussionChannel(state)],
+            },
+          }),
+        ],
+      },
+    }),
+
+    getCommentSection: () => ({
+      data: {
+        getCommentSection: {
+          DiscussionChannel: buildStatefulDiscussionChannel(state),
+          Comments: [],
+        },
+      },
+    }),
+
+    getDiscussionChannelRootCommentAggregate: () => ({
+      data: {
+        discussionChannels: [
+          {
+            id: state.discussionChannelId,
+            discussionId: state.discussionId,
+            channelUniqueName: state.channelId,
+            archived: false,
+            answered: false,
+            locked: false,
+            CommentsAggregate: { count: 0 },
+          },
+        ],
+      },
+    }),
+
+    getDiscussionCommentIssue: () => ({
+      data: {
+        discussionChannels: [
+          { id: state.discussionChannelId, Comments: [] },
+        ],
+      },
+    }),
+
+    isDiscussionAnswered: () => ({
+      data: {
+        discussionChannels: [
+          {
+            id: state.discussionChannelId,
+            discussionId: state.discussionId,
+            channelUniqueName: state.channelId,
+            weightedVotesCount: state.upvoters.length + state.superUpvoters.length,
+            archived: false,
+            answered: false,
+            locked: false,
+            Channel: { uniqueName: state.channelId },
+          },
+        ],
+      },
+    }),
+
+    upvoteDiscussionChannel: () => {
+      if (!state.upvoters.includes(state.actorUsername)) {
+        state.upvoters.push(state.actorUsername);
+      }
+      return { data: { upvoteDiscussionChannel: buildVoteMutationResult(state) } };
+    },
+
+    undoUpvoteDiscussionChannel: () => {
+      state.upvoters = state.upvoters.filter((u) => u !== state.actorUsername);
+      // Undoing an upvote also clears any super upvote on the backend.
+      state.superUpvoters = state.superUpvoters.filter(
+        (u) => u !== state.actorUsername
+      );
+      return {
+        data: { undoUpvoteDiscussionChannel: buildVoteMutationResult(state) },
+      };
+    },
+
+    createScratchpadEntry: ({ body }) => {
+      const variables = (body.variables ?? {}) as {
+        recipientUsername?: string;
+        text?: string;
+        sourceType?: string;
+        sourceId?: string;
+        sourceChannelUniqueName?: string;
+      };
+      if (!state.superUpvoters.includes(state.actorUsername)) {
+        state.superUpvoters.push(state.actorUsername);
+      }
+      return {
+        data: {
+          createScratchpadEntry: {
+            id: 'scratchpad-entry-1',
+            createdAt: MOCK_DATE,
+            text: variables.text ?? '',
+            isPublic: false,
+            sourceType: variables.sourceType ?? 'discussion',
+            sourceId: variables.sourceId ?? state.discussionChannelId,
+            sourceChannelUniqueName:
+              variables.sourceChannelUniqueName ?? state.channelId,
+            discussionId: state.discussionId,
+            Author: {
+              username: state.actorUsername,
+              displayName: state.actorUsername,
+              profilePicURL: '',
+            },
+            Recipient: { username: variables.recipientUsername ?? state.authorUsername },
+            superUpvotedByUsers: toUsernameList(state.superUpvoters),
+            __typename: 'ScratchpadEntry',
+          },
+        },
+      };
+    },
+
+    undoSuperUpvote: ({ body }) => {
+      const variables = (body.variables ?? {}) as {
+        sourceType?: string;
+        sourceId?: string;
+      };
+      state.superUpvoters = state.superUpvoters.filter(
+        (u) => u !== state.actorUsername
+      );
+      return {
+        data: {
+          undoSuperUpvote: {
+            success: true,
+            message: 'Super upvote removed successfully',
+            sourceId: variables.sourceId ?? state.discussionChannelId,
+            sourceType: variables.sourceType ?? 'discussion',
+            superUpvotedByUsers: toUsernameList(state.superUpvoters),
+            __typename: 'UndoSuperUpvoteResult',
+          },
+        },
+      };
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Receiving side: a recipient who got a super upvote sees a notification with
+// "Show on profile" / "Ignore" actions, and published notes appear in their
+// Kudos section. State is shared so mutations reflect into later queries.
+// ---------------------------------------------------------------------------
+
+export type ReceivedSuperUpvoteState = {
+  recipientUsername: string;
+  senderUsername: string;
+  channelId: string;
+  discussionId: string;
+  notificationId: string;
+  entryId: string;
+  noteText: string;
+  read: boolean;
+  isPublic: boolean;
+};
+
+export const createReceivedSuperUpvoteState = (
+  config: Partial<ReceivedSuperUpvoteState> = {}
+): ReceivedSuperUpvoteState => ({
+  recipientUsername: 'alice',
+  senderUsername: 'bob',
+  channelId: 'cats',
+  discussionId: 'discussion-1',
+  notificationId: 'notification-1',
+  entryId: 'scratchpad-entry-1',
+  noteText: 'Thanks for the thoughtful post!',
+  read: false,
+  isPublic: false,
+  ...config,
+});
+
+const buildScratchpadNotification = (state: ReceivedSuperUpvoteState) => {
+  const postUrl = `/forums/${state.channelId}/discussions/${state.discussionId}`;
+  const kudosUrl = `/u/${state.recipientUsername}/scratchpad`;
+  return {
+    __typename: 'Notification' as const,
+    id: state.notificationId,
+    createdAt: MOCK_DATE,
+    read: state.read,
+    notificationType: 'scratchpad',
+    text:
+      `[@${state.senderUsername}](/u/${state.senderUsername}) super upvoted your ` +
+      `[post](${postUrl}) with a thank-you note: "${state.noteText}" — ` +
+      `[View on your Kudos page](${kudosUrl})`,
+    ScratchpadEntry: {
+      __typename: 'ScratchpadEntry' as const,
+      id: state.entryId,
+      isPublic: state.isPublic,
+    },
+  };
+};
+
+const buildScratchpadEntry = (state: ReceivedSuperUpvoteState) => ({
+  __typename: 'ScratchpadEntry' as const,
+  id: state.entryId,
+  createdAt: MOCK_DATE,
+  text: state.noteText,
+  isPublic: state.isPublic,
+  sourceType: 'discussion',
+  sourceId: 'discussion-channel-1',
+  sourceChannelUniqueName: state.channelId,
+  discussionId: state.discussionId,
+  Author: {
+    __typename: 'User' as const,
+    username: state.senderUsername,
+    displayName: state.senderUsername,
+    profilePicURL: '',
+  },
+  Recipient: { __typename: 'User' as const, username: state.recipientUsername },
+});
+
+// Handlers for the /notifications page (general tab) carrying a super-upvote
+// notification, plus the mutations its action buttons fire.
+export const createReceivedNotificationHandlers = (
+  state: ReceivedSuperUpvoteState
+): Record<string, GraphQLHandler> => ({
+  ...createBaseHandlers({
+    username: state.recipientUsername,
+    channelId: state.channelId,
+  }),
+
+  getGeneralNotifications: () => ({
+    data: {
+      users: [
+        {
+          __typename: 'User',
+          username: state.recipientUsername,
+          Notifications: [buildScratchpadNotification(state)],
+          NotificationsAggregate: { count: state.read ? 0 : 1 },
+          totalNotificationsAggregate: { count: 1 },
+        },
+      ],
+    },
+  }),
+
+  getFeedbackNotifications: () => ({
+    data: {
+      users: [
+        {
+          __typename: 'User',
+          username: state.recipientUsername,
+          Notifications: [],
+          NotificationsAggregate: { count: 0 },
+          totalNotificationsAggregate: { count: 0 },
+        },
+      ],
+    },
+  }),
+
+  markNotificationAsRead: () => {
+    state.read = true;
+    return {
+      data: {
+        updateUsers: {
+          users: [
+            {
+              __typename: 'User',
+              username: state.recipientUsername,
+              Notifications: [
+                {
+                  __typename: 'Notification',
+                  id: state.notificationId,
+                  read: true,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+  },
+
+  updateScratchpadEntryVisibility: ({ body }) => {
+    const variables = (body.variables ?? {}) as { isPublic?: boolean };
+    state.isPublic = variables.isPublic ?? true;
+    return {
+      data: {
+        updateScratchpadEntryVisibility: buildScratchpadEntry(state),
+      },
+    };
+  },
+});
+
+// Handlers for the recipient's own Kudos page, reflecting whether the note has
+// been published. Reuse for asserting a published note shows up on the profile.
+export const createKudosPageHandlers = (
+  state: ReceivedSuperUpvoteState
+): Record<string, GraphQLHandler> => ({
+  ...createBaseHandlers({
+    username: state.recipientUsername,
+    channelId: state.channelId,
+  }),
+
+  getServerRules: () => ({ data: { serverConfigs: [{ rules: '[]' }] } }),
+  getUserContributions: () => ({ data: { getUserContributions: [] } }),
+
+  getPublicScratchpadEntries: () => ({
+    data: {
+      scratchpadEntries: state.isPublic ? [buildScratchpadEntry(state)] : [],
+    },
+  }),
+
+  getPendingScratchpadEntries: () => ({
+    data: {
+      scratchpadEntries: state.isPublic ? [] : [buildScratchpadEntry(state)],
+    },
+  }),
+});

--- a/tests/playwright/mocked/superUpvote/giveSuperUpvote.spec.ts
+++ b/tests/playwright/mocked/superUpvote/giveSuperUpvote.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '../../helpers/testFixture';
+import {
+  createSuperUpvoteState,
+  createSuperUpvoteHandlers,
+} from '../../helpers/mockedSuperUpvoteHandlers';
+
+const CHANNEL = 'cats';
+const DISCUSSION_ID = 'discussion-1';
+
+// Workflow under test (giving a super upvote):
+//  - upvote a discussion posted by another user (alice)
+//  - the super upvote button appears
+//  - clicking it opens the super upvote modal
+//  - filling + submitting the form records the super upvote
+//  - the super upvote button shows active styling ("Undo")
+//  - undoing the super upvote removes the active styling
+test('user can give and undo a super upvote on another user\'s discussion', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createSuperUpvoteState({
+    channelId: CHANNEL,
+    discussionId: DISCUSSION_ID,
+    authorUsername: 'alice',
+    actorUsername: 'cluse',
+  });
+
+  const { diagnostics } = await setupMockedPage({
+    username: 'cluse',
+    handlers: createSuperUpvoteHandlers(state),
+  });
+
+  await page.goto(`/forums/${CHANNEL}/discussions/${DISCUSSION_ID}`);
+
+  const upvoteButton = page.getByTestId('upvote-discussion-button').first();
+  const superUpvoteButton = page
+    .getByTestId('super-upvote-discussion-button')
+    .first();
+
+  // Before upvoting, the super upvote affordance is not available.
+  await expect(upvoteButton).toBeVisible();
+  await expect(superUpvoteButton).toHaveCount(0);
+
+  // Upvote alice's discussion.
+  await upvoteButton.click();
+  await page.waitForResponse(
+    (response) =>
+      response.url().includes('/graphql') && response.request().method() === 'POST'
+  );
+
+  // The super upvote button now appears, in its inactive state.
+  await expect(superUpvoteButton).toBeVisible();
+  await expect(superUpvoteButton).not.toContainText('Undo');
+
+  // Open the super upvote modal.
+  await superUpvoteButton.click();
+  const textInput = page.getByTestId('super-upvote-text-input');
+  await expect(textInput).toBeVisible();
+
+  // Fill out and submit the thank-you note.
+  await textInput.fill('Thanks for the thoughtful post, alice!');
+  await page.getByTestId('super-upvote-submit').click();
+
+  // The button shows active styling (renders the "Undo" affordance).
+  await expect(superUpvoteButton).toContainText('Undo');
+
+  // Undo the super upvote.
+  await superUpvoteButton.click();
+
+  // Active styling is gone.
+  await expect(superUpvoteButton).not.toContainText('Undo');
+  // ...but the regular upvote (and therefore the super upvote button) remains.
+  await expect(superUpvoteButton).toBeVisible();
+
+  expect(diagnostics.pageErrors).toEqual([]);
+});

--- a/tests/playwright/mocked/superUpvote/receiveSuperUpvote.spec.ts
+++ b/tests/playwright/mocked/superUpvote/receiveSuperUpvote.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '../../helpers/testFixture';
+import {
+  createReceivedSuperUpvoteState,
+  createReceivedNotificationHandlers,
+  createKudosPageHandlers,
+} from '../../helpers/mockedSuperUpvoteHandlers';
+
+const RECIPIENT = 'alice';
+
+// Workflow under test (receiving a super upvote):
+//  - the recipient sees a notification that their post was super upvoted, with a
+//    working link to the post
+//  - the notification offers "Show on profile" or "Ignore"
+//  - "Ignore" marks the notification read
+//  - "Show on profile" publishes the note (which then appears in the recipient's
+//    Kudos section)
+
+test('the recipient sees a super upvote notification with a working link to the post', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createReceivedSuperUpvoteState();
+  await setupMockedPage({
+    username: RECIPIENT,
+    handlers: createReceivedNotificationHandlers(state),
+  });
+
+  await page.goto('/notifications');
+  await expect(
+    page.getByRole('heading', { name: 'Notifications' })
+  ).toBeVisible({ timeout: 30000 });
+
+  // Notification body links directly to the upvoted post.
+  const postLink = page.locator(
+    `a[href*="/forums/${state.channelId}/discussions/${state.discussionId}"]`
+  );
+  await expect(postLink.first()).toBeVisible();
+
+  // The choice is offered inline.
+  await expect(page.getByTestId('notification-show-on-profile')).toBeVisible();
+  await expect(page.getByTestId('notification-ignore')).toBeVisible();
+});
+
+test('ignoring a super upvote notification marks it as read', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createReceivedSuperUpvoteState();
+  await setupMockedPage({
+    username: RECIPIENT,
+    handlers: createReceivedNotificationHandlers(state),
+  });
+
+  await page.goto('/notifications');
+  const ignoreButton = page.getByTestId('notification-ignore');
+  await expect(ignoreButton).toBeVisible({ timeout: 30000 });
+
+  await ignoreButton.click();
+
+  // The action buttons disappear and the notification reads as "Read".
+  await expect(page.getByTestId('notification-ignore')).toHaveCount(0);
+  await expect(page.getByTestId('notification-list')).toContainText('Read');
+});
+
+test('showing a super upvote on profile publishes it', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createReceivedSuperUpvoteState();
+  await setupMockedPage({
+    username: RECIPIENT,
+    handlers: createReceivedNotificationHandlers(state),
+  });
+
+  await page.goto('/notifications');
+  const showButton = page.getByTestId('notification-show-on-profile');
+  await expect(showButton).toBeVisible({ timeout: 30000 });
+
+  await showButton.click();
+
+  // The notification confirms the note is now public, and the action is gone.
+  await expect(page.getByTestId('notification-showing-on-profile')).toBeVisible();
+  await expect(page.getByTestId('notification-show-on-profile')).toHaveCount(0);
+});
+
+test('a published super upvote appears in the recipient\'s Kudos section', async ({
+  page,
+  setupMockedPage,
+}) => {
+  // Simulate the note already having been shown on the profile.
+  const state = createReceivedSuperUpvoteState({ isPublic: true });
+  const { diagnostics } = await setupMockedPage({
+    username: RECIPIENT,
+    handlers: createKudosPageHandlers(state),
+  });
+
+  await page.goto(`/u/${RECIPIENT}/scratchpad`);
+
+  // The thank-you note is rendered in the Kudos section.
+  await expect(page.getByText(state.noteText)).toBeVisible({ timeout: 30000 });
+  // It is shown as a public entry, not a pending one.
+  await expect(page.getByText('Pending')).toHaveCount(0);
+
+  expect(diagnostics.pageErrors).toEqual([]);
+});

--- a/tests/playwright/mocked/superUpvote/staleReturn.spec.ts
+++ b/tests/playwright/mocked/superUpvote/staleReturn.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '../../helpers/testFixture';
+import {
+  createSuperUpvoteState,
+  createSuperUpvoteHandlers,
+} from '../../helpers/mockedSuperUpvoteHandlers';
+
+const CHANNEL = 'cats';
+const DISCUSSION_ID = 'discussion-1';
+
+// Regression test for the original bug: after a super upvote the button looked
+// inactive (and could not be undone) because the frontend overwrote its cache
+// with the exact list the server returned. The server can return a stale list
+// (read-after-write lag) that omits the actor. The frontend is now authoritative
+// about the actor, so the button must go active regardless of the returned list.
+test('super upvote goes active even when the backend returns a stale list', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createSuperUpvoteState({
+    channelId: CHANNEL,
+    discussionId: DISCUSSION_ID,
+    authorUsername: 'alice',
+    actorUsername: 'cluse',
+    startUpvoted: true,
+  });
+
+  const handlers = createSuperUpvoteHandlers(state);
+  // Simulate the backend read-after-write gap: the create succeeds but the
+  // returned superUpvotedByUsers does NOT include the actor.
+  handlers.createScratchpadEntry = ({ body }) => {
+    const v = (body.variables ?? {}) as Record<string, string>;
+    return {
+      data: {
+        createScratchpadEntry: {
+          id: 'scratchpad-entry-1',
+          createdAt: '2023-12-31T00:00:00.000Z',
+          text: v.text ?? '',
+          isPublic: false,
+          sourceType: v.sourceType ?? 'discussion',
+          sourceId: v.sourceId ?? state.discussionChannelId,
+          sourceChannelUniqueName: v.sourceChannelUniqueName ?? state.channelId,
+          discussionId: state.discussionId,
+          Author: { username: 'cluse', displayName: 'cluse', profilePicURL: '' },
+          Recipient: { username: 'alice' },
+          superUpvotedByUsers: [],
+          __typename: 'ScratchpadEntry',
+        },
+      },
+    };
+  };
+
+  await setupMockedPage({ username: 'cluse', handlers });
+  await page.goto(`/forums/${CHANNEL}/discussions/${DISCUSSION_ID}`);
+
+  const superUpvoteButton = page
+    .getByTestId('super-upvote-discussion-button')
+    .first();
+  await expect(superUpvoteButton).toBeVisible();
+  await superUpvoteButton.click();
+  await page.getByTestId('super-upvote-text-input').fill('Thanks alice!');
+  await page.getByTestId('super-upvote-submit').click();
+  await expect(superUpvoteButton).toContainText('Undo');
+});


### PR DESCRIPTION
## Summary
Finishes the super-upvote feature and fixes its bugs (frontend half). Pairs with **gennit-project/multiforum-backend#feat/super-upvotes** (schema/resolver changes) — merge/deploy the backend alongside this.

### Giving a super upvote (bug fix)
- The super-upvote button looked inactive and couldn't be undone because the Apollo cache was overwritten with the server's returned `SuperUpvotedByUsers` list, which can lag behind the write (read-after-write). The cache is now **authoritative for the actor** on create/undo (`SuperUpvoteModal`, `DiscussionVotes`, `comments/VoteButtons`).
- Added test ids to the super-upvote modal.

### Receiving a super upvote (new)
- `NotificationTabs` renders inline **"Show on profile" / "Ignore"** actions on super-upvote notifications. Ignore marks the single notification read; Show on profile publishes the note (it then appears in the profile section).
- Notifications query the linked `ScratchpadEntry`; added `MARK_NOTIFICATION_AS_READ`.
- Renamed the profile **"Scratchpad" tab → "Kudos"** (route/code names unchanged).

### Kudos card link
- Uses the real `discussionId` (not the DiscussionChannel/Comment id) with the route helpers, so the "super upvoted your post/comment" link works; comments link to the comment permalink. Entries now query `discussionId`.

## Tests
- Playwright (`tests/playwright/mocked/superUpvote/`): give/undo flow, stale-return regression, and the four receiving-side steps.
- Unit: `ScratchpadEntry` link tests; "Kudos" copy updates.
- `tsc` + ESLint clean; 85 unit tests + 6 superUpvote Playwright + notifications regression all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)