### PR TITLE
test(super-upvotes): comment-side e2e + fix unrelated admin specs

### DIFF
--- a/components/admin/ServerMembershipEditor.spec.ts
+++ b/components/admin/ServerMembershipEditor.spec.ts
@@ -11,6 +11,12 @@ const cancelInviteServerMod = vi.fn();
 const removeServerModerator = vi.fn();
 const onUpdated = vi.fn();
 
+// config.serverName comes from import.meta.env (unset under vitest), so mock it
+// to a stable value — the component passes config.serverName to the mutations.
+vi.mock('@/config', () => ({
+  config: { serverName: 'TestServer' },
+}));
+
 vi.mock('@vue/apollo-composable', () => ({
   useMutation: (fn: any) => {
     const source = fn?.loc?.source?.body || '';

--- a/tests/playwright/helpers/graphqlFixtures.ts
+++ b/tests/playwright/helpers/graphqlFixtures.ts
@@ -210,6 +210,7 @@ export type CommentFixture = Pick<
   Channel: Pick<Channel, '__typename' | 'uniqueName'>;
   UpvotedByUsers: Array<Pick<User, 'username'>>;
   UpvotedByUsersAggregate: CountAggregate;
+  SuperUpvotedByUsers: Array<Pick<User, 'username'>>;
 };
 
 export const buildUser = (
@@ -494,6 +495,7 @@ export const buildComment = ({
   },
   UpvotedByUsers: [{ username: DEFAULT_USERNAME }],
   UpvotedByUsersAggregate: { count: 1 },
+  SuperUpvotedByUsers: [],
 });
 
 export type EventFixture = {

--- a/tests/playwright/helpers/mockedSuperUpvoteHandlers.ts
+++ b/tests/playwright/helpers/mockedSuperUpvoteHandlers.ts
@@ -1,4 +1,5 @@
 import {
+  buildComment,
   buildDiscussion,
   buildDiscussionChannel,
   buildUser,
@@ -432,3 +433,221 @@ export const createKudosPageHandlers = (
     },
   }),
 });
+
+// ---------------------------------------------------------------------------
+// Giving a super upvote on a COMMENT (rendered inside a discussion detail page).
+// The comment is authored by `commentAuthor`; the logged-in `actorUsername`
+// upvotes it, then super upvotes it. State tracks the comment's vote arrays.
+// ---------------------------------------------------------------------------
+
+export type CommentSuperUpvoteState = {
+  channelId: string;
+  discussionId: string;
+  discussionChannelId: string;
+  commentId: string;
+  commentAuthor: string;
+  actorUsername: string;
+  upvoters: string[];
+  superUpvoters: string[];
+};
+
+export const createCommentSuperUpvoteState = (
+  config: Partial<CommentSuperUpvoteState> = {}
+): CommentSuperUpvoteState => ({
+  channelId: 'cats',
+  discussionId: 'discussion-1',
+  discussionChannelId: 'discussion-channel-1',
+  commentId: 'comment-1',
+  commentAuthor: 'alice',
+  actorUsername: DEFAULT_USERNAME,
+  upvoters: [],
+  superUpvoters: [],
+  ...config,
+});
+
+const buildStatefulComment = (state: CommentSuperUpvoteState) => ({
+  ...buildComment({
+    comment: { id: state.commentId, text: 'A genuinely helpful comment', parentCommentId: null },
+    comments: [{ id: state.commentId, text: 'A genuinely helpful comment', parentCommentId: null }],
+    channelUniqueName: state.channelId,
+    discussionId: state.discussionId,
+    discussionChannelId: state.discussionChannelId,
+  }),
+  CommentAuthor: buildUser({ username: state.commentAuthor }),
+  UpvotedByUsers: toUsernameList(state.upvoters),
+  UpvotedByUsersAggregate: { count: state.upvoters.length },
+  SuperUpvotedByUsers: toUsernameList(state.superUpvoters),
+});
+
+// Shape returned by upvoteComment / undoUpvoteComment.
+const buildCommentVoteResult = (state: CommentSuperUpvoteState) => ({
+  __typename: 'Comment',
+  id: state.commentId,
+  weightedVotesCount: state.upvoters.length + state.superUpvoters.length,
+  UpvotedByUsers: toUsernameList(state.upvoters),
+  UpvotedByUsersAggregate: { count: state.upvoters.length },
+  SuperUpvotedByUsers: toUsernameList(state.superUpvoters),
+});
+
+export const createCommentSuperUpvoteHandlers = (
+  state: CommentSuperUpvoteState
+): Record<string, GraphQLHandler> => {
+  // The discussion itself is authored by the actor (so its own super-upvote
+  // button never appears), keeping the comment the only super-upvotable target.
+  const discussionChannel = buildDiscussionChannel({
+    id: state.discussionChannelId,
+    discussionId: state.discussionId,
+    channelUniqueName: state.channelId,
+    title: 'Discussion with a comment',
+    overrides: {
+      UpvotedByUsers: [],
+      UpvotedByUsersAggregate: { count: 0 },
+      SuperUpvotedByUsers: [],
+      Discussion: {
+        id: state.discussionId,
+        title: 'Discussion with a comment',
+        Author: buildUser({ username: state.actorUsername }),
+      },
+    },
+  });
+
+  return {
+    ...createBaseHandlers({
+      username: state.actorUsername,
+      channelId: state.channelId,
+      discussionId: state.discussionId,
+      discussionChannelId: state.discussionChannelId,
+      discussionsCount: 1,
+    }),
+
+    getDiscussion: () => ({
+      data: {
+        discussions: [
+          buildDiscussion({
+            id: state.discussionId,
+            discussionChannelId: state.discussionChannelId,
+            channelUniqueName: state.channelId,
+            title: 'Discussion with a comment',
+            overrides: {
+              Author: buildUser({ username: state.actorUsername }),
+              DiscussionChannels: [discussionChannel],
+            },
+          }),
+        ],
+      },
+    }),
+
+    getCommentSection: () => ({
+      data: {
+        getCommentSection: {
+          DiscussionChannel: discussionChannel,
+          Comments: [buildStatefulComment(state)],
+        },
+      },
+    }),
+
+    getDiscussionChannelRootCommentAggregate: () => ({
+      data: {
+        discussionChannels: [
+          {
+            id: state.discussionChannelId,
+            discussionId: state.discussionId,
+            channelUniqueName: state.channelId,
+            archived: false,
+            answered: false,
+            locked: false,
+            CommentsAggregate: { count: 1 },
+          },
+        ],
+      },
+    }),
+
+    getDiscussionCommentIssue: () => ({
+      data: {
+        discussionChannels: [{ id: state.discussionChannelId, Comments: [] }],
+      },
+    }),
+
+    isDiscussionAnswered: () => ({
+      data: {
+        discussionChannels: [
+          {
+            id: state.discussionChannelId,
+            discussionId: state.discussionId,
+            channelUniqueName: state.channelId,
+            weightedVotesCount: 0,
+            archived: false,
+            answered: false,
+            locked: false,
+            Channel: { uniqueName: state.channelId },
+          },
+        ],
+      },
+    }),
+
+    upvoteComment: () => {
+      if (!state.upvoters.includes(state.actorUsername)) {
+        state.upvoters.push(state.actorUsername);
+      }
+      return { data: { upvoteComment: buildCommentVoteResult(state) } };
+    },
+
+    undoUpvoteComment: () => {
+      state.upvoters = state.upvoters.filter((u) => u !== state.actorUsername);
+      state.superUpvoters = state.superUpvoters.filter(
+        (u) => u !== state.actorUsername
+      );
+      return { data: { undoUpvoteComment: buildCommentVoteResult(state) } };
+    },
+
+    createScratchpadEntry: ({ body }) => {
+      const variables = (body.variables ?? {}) as {
+        recipientUsername?: string;
+        text?: string;
+      };
+      if (!state.superUpvoters.includes(state.actorUsername)) {
+        state.superUpvoters.push(state.actorUsername);
+      }
+      return {
+        data: {
+          createScratchpadEntry: {
+            id: 'scratchpad-entry-1',
+            createdAt: MOCK_DATE,
+            text: variables.text ?? '',
+            isPublic: false,
+            sourceType: 'comment',
+            sourceId: state.commentId,
+            sourceChannelUniqueName: state.channelId,
+            discussionId: state.discussionId,
+            Author: {
+              username: state.actorUsername,
+              displayName: state.actorUsername,
+              profilePicURL: '',
+            },
+            Recipient: { username: variables.recipientUsername ?? state.commentAuthor },
+            superUpvotedByUsers: toUsernameList(state.superUpvoters),
+            __typename: 'ScratchpadEntry',
+          },
+        },
+      };
+    },
+
+    undoSuperUpvote: () => {
+      state.superUpvoters = state.superUpvoters.filter(
+        (u) => u !== state.actorUsername
+      );
+      return {
+        data: {
+          undoSuperUpvote: {
+            success: true,
+            message: 'Super upvote removed successfully',
+            sourceId: state.commentId,
+            sourceType: 'comment',
+            superUpvotedByUsers: toUsernameList(state.superUpvoters),
+            __typename: 'UndoSuperUpvoteResult',
+          },
+        },
+      };
+    },
+  };
+};

--- a/tests/playwright/mocked/superUpvote/giveCommentSuperUpvote.spec.ts
+++ b/tests/playwright/mocked/superUpvote/giveCommentSuperUpvote.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '../../helpers/testFixture';
+import {
+  createCommentSuperUpvoteState,
+  createCommentSuperUpvoteHandlers,
+} from '../../helpers/mockedSuperUpvoteHandlers';
+
+const CHANNEL = 'cats';
+const DISCUSSION_ID = 'discussion-1';
+
+// Same give/undo workflow as the discussion test, but for a COMMENT authored by
+// another user (alice), exercising the comment vote container + the shared
+// authoritative-cache fix.
+test('user can give and undo a super upvote on another user\'s comment', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createCommentSuperUpvoteState({
+    channelId: CHANNEL,
+    discussionId: DISCUSSION_ID,
+    commentAuthor: 'alice',
+    actorUsername: 'cluse',
+  });
+
+  const { diagnostics } = await setupMockedPage({
+    username: 'cluse',
+    handlers: createCommentSuperUpvoteHandlers(state),
+  });
+
+  await page.goto(`/forums/${CHANNEL}/discussions/${DISCUSSION_ID}`);
+  await page.waitForLoadState('networkidle');
+
+  const upvoteButton = page.getByTestId('upvote-comment-button').first();
+  const superUpvoteButton = page
+    .getByTestId('super-upvote-comment-button')
+    .first();
+
+  // Before upvoting the comment, the super upvote affordance is not available.
+  await expect(upvoteButton).toBeVisible();
+  await expect(superUpvoteButton).toHaveCount(0);
+
+  // Upvote alice's comment.
+  await upvoteButton.click();
+  await page.waitForResponse(
+    (response) =>
+      response.url().includes('/graphql') && response.request().method() === 'POST'
+  );
+
+  // The super upvote button appears, inactive.
+  await expect(superUpvoteButton).toBeVisible();
+  await expect(superUpvoteButton).not.toContainText('Undo');
+
+  // Open the modal, fill, and submit.
+  await superUpvoteButton.click();
+  const textInput = page.getByTestId('super-upvote-text-input');
+  await expect(textInput).toBeVisible();
+  await textInput.fill('Thanks for the helpful comment, alice!');
+  await page.getByTestId('super-upvote-submit').click();
+
+  // Active styling appears...
+  await expect(superUpvoteButton).toContainText('Undo');
+
+  // ...and undo removes it (the comment upvote, and the button, remain).
+  await superUpvoteButton.click();
+  await expect(superUpvoteButton).not.toContainText('Undo');
+  await expect(superUpvoteButton).toBeVisible();
+
+  expect(diagnostics.pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Follow-ups to the merged super-upvote feature (frontend half). Pairs with **gennit-project/multiforum-backend#83** (karma / atomicity / suspension / comment deep-links) — deploy together.

## Changes
- **Comment-side e2e**: adds a Playwright test for giving/undoing a super upvote on a *comment* authored by another user (upvote → super upvote via modal → active state → undo). Both content types are now covered end-to-end (the discussion flow already was). Adds stateful comment handlers and `SuperUpvotedByUsers` to the comment fixture.
- **Fix unrelated failing unit tests**: `ServerMembershipEditor` invite specs failed because `config.serverName` is read from `import.meta.env` (unset under vitest), so the component passed `serverName: undefined`. Mock `@/config` so it's a stable string.

## Notes
- The `NotificationWithEntry` local type augmentation in `NotificationTabs.vue` is **kept**: regenerating frontend codegen does not yet surface `Notification.ScratchpadEntry` / `ScratchpadEntry.discussionId` because the backend schema (multiforum-backend#83) isn't deployed to the codegen endpoint. Remove the augmentation once the backend is deployed and codegen is re-run.
- The suspension guarantee is covered backend-side; a full e2e shield test hit a `node:test`/testcontainers flake, so it's covered by a deterministic permission-decision unit test there instead.

## Verification
- 7/7 superUpvote Playwright specs pass; full unit suite green (4974 tests); `tsc` + lint clean (final commit ran the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)