### PR TITLE
fix(library): expand inline images & fix permalink in favorite comments

### DIFF
--- a/pages/library/[collectionId].spec.ts
+++ b/pages/library/[collectionId].spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref, defineComponent, h } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
+import MarkdownPreview from '@/components/MarkdownPreview.vue';
 
 vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
 
@@ -61,5 +62,43 @@ describe('library collection detail page', () => {
       itemCount: 0,
     });
     expect(wrapper.text()).toContain('Cat GIFs');
+  });
+
+  const commentsCollection = {
+    id: 'col-2',
+    name: 'Saved comments',
+    collectionType: 'COMMENTS',
+    visibility: 'PRIVATE',
+    itemCount: 1,
+    Comments: [
+      {
+        id: 'c1',
+        text: 'Look at this ![cat](https://example.com/cat.png)',
+        createdAt: '2024-01-01T00:00:00Z',
+        CommentAuthor: { __typename: 'User', username: 'bob' },
+        DiscussionChannel: {
+          channelUniqueName: 'cats',
+          discussionId: 'd1',
+          Discussion: { id: 'd1', title: 'Cats' },
+        },
+      },
+    ],
+  };
+
+  // Regression: comment bodies in a COMMENTS collection must render via
+  // MarkdownPreview so inline images open the lightbox, not the bare
+  // MarkdownRenderer which cannot expand images.
+  it('renders comment bodies via MarkdownPreview', async () => {
+    const wrapper = await mountWith(commentsCollection);
+    expect(wrapper.findComponent(MarkdownPreview).props('text')).toBe(
+      commentsCollection.Comments[0].text
+    );
+  });
+
+  it('enables the image lightbox for comment bodies', async () => {
+    const wrapper = await mountWith(commentsCollection);
+    expect(wrapper.findComponent(MarkdownPreview).props('disableGallery')).toBe(
+      false
+    );
   });
 });

--- a/pages/library/[collectionId].vue
+++ b/pages/library/[collectionId].vue
@@ -15,7 +15,7 @@ import {
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import TagComponent from '@/components/TagComponent.vue';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
-import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
+import MarkdownPreview from '@/components/MarkdownPreview.vue';
 import AvatarComponent from '@/components/AvatarComponent.vue';
 import GenericModal from '@/components/GenericModal.vue';
 import WarningModal from '@/components/WarningModal.vue';
@@ -567,7 +567,7 @@ const handleDelete = async () => {
                   </div>
 
                   <div class="text-sm text-gray-600 dark:text-gray-300">
-                    <MarkdownRenderer :text="comment.text" font-size="small" />
+                    <MarkdownPreview :text="comment.text" :disable-gallery="false" />
                   </div>
                   <div
                     class="mt-4 flex items-center justify-between text-sm text-gray-500 dark:text-gray-400"

--- a/pages/library/favorite-comments.spec.ts
+++ b/pages/library/favorite-comments.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref, defineComponent, h } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
-import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
+import MarkdownPreview from '@/components/MarkdownPreview.vue';
 
 vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
 
@@ -38,22 +38,46 @@ const mountWith = async (comments: unknown[]) => {
   });
 };
 
+const sampleComment = {
+  id: 'c1',
+  text: 'A memorable comment ![cat](https://example.com/cat.png)',
+  createdAt: '2024-01-01T00:00:00Z',
+  CommentAuthor: { __typename: 'User', username: 'bob' },
+  DiscussionChannel: {
+    channelUniqueName: 'cats',
+    discussionId: 'd1',
+    Discussion: { id: 'd1', title: 'Cats', hasDownload: false },
+  },
+};
+
 describe('favorite comments page', () => {
   it('shows the empty state when there are no favorites', async () => {
     expect((await mountWith([])).text()).toContain('No favorite comments yet');
   });
 
-  it('renders a favorited comment via the markdown renderer', async () => {
-    const wrapper = await mountWith([
-      {
-        id: 'c1',
-        text: 'A memorable comment',
-        createdAt: '2024-01-01T00:00:00Z',
-        CommentAuthor: { __typename: 'User', username: 'bob' },
-      },
-    ]);
-    expect(wrapper.findComponent(MarkdownRenderer).props('text')).toBe(
-      'A memorable comment'
+  // Regression: the comment body must render via MarkdownPreview (which wires up
+  // the inline-image lightbox), not the bare MarkdownRenderer which cannot
+  // expand images.
+  it('renders the comment body via MarkdownPreview', async () => {
+    const wrapper = await mountWith([sampleComment]);
+    expect(wrapper.findComponent(MarkdownPreview).props('text')).toBe(
+      sampleComment.text
     );
+  });
+
+  // Regression: the gallery/lightbox must be enabled so inline images expand.
+  it('enables the image lightbox on the comment body', async () => {
+    const wrapper = await mountWith([sampleComment]);
+    expect(wrapper.findComponent(MarkdownPreview).props('disableGallery')).toBe(
+      false
+    );
+  });
+
+  // Regression: the comment body is no longer wrapped in a permalink link
+  // (which nested anchors and blocked the lightbox); a dedicated permalink link
+  // is rendered instead.
+  it('renders a View Comment permalink link', async () => {
+    const wrapper = await mountWith([sampleComment]);
+    expect(wrapper.text()).toContain('View Comment');
   });
 });

--- a/pages/library/favorite-comments.vue
+++ b/pages/library/favorite-comments.vue
@@ -7,7 +7,7 @@ import { useUsername } from '@/composables/useAuthState';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import AddToCommentFavorites from '@/components/favorites/AddToCommentFavorites.vue';
-import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
+import MarkdownPreview from '@/components/MarkdownPreview.vue';
 import { relativeTime } from '@/utils';
 import {
   getCommentPermalink,
@@ -202,16 +202,18 @@ const getFavoriteCommentAuthorInfo = (
                   </div>
                 </div>
 
-                <!-- Comment content -->
+                <!-- Comment content. Not wrapped in a permalink link: that
+                  nests interactive markdown links/images inside an anchor
+                  (invalid HTML that can swallow navigation) and blocks the
+                  inline-image lightbox. Use the "View Comment" link below to
+                  reach the permalink. -->
                 <div class="mb-4">
-                  <NuxtLink :to="getCommentPermalink(comment)" class="block">
-                    <div class="prose prose-sm max-w-none dark:prose-invert">
-                      <MarkdownRenderer
-                        :text="comment.text"
-                        font-size="small"
-                      />
-                    </div>
-                  </NuxtLink>
+                  <div class="prose prose-sm max-w-none dark:prose-invert">
+                    <MarkdownPreview
+                      :text="comment.text"
+                      :disable-gallery="false"
+                    />
+                  </div>
                 </div>
 
                 <!-- Meta information -->


### PR DESCRIPTION
## Problem
In the library favorite-comment views, two issues:
1. **Inline images didn't expand.** Comment bodies rendered with the bare `MarkdownRenderer`, which has no image lightbox — clicking an inline image did nothing.
2. **Permalink/navigation issue on the favorite-comments page.** The whole comment body was wrapped in a permalink `<NuxtLink>`, nesting interactive markdown links/images inside an anchor (invalid HTML that can swallow navigation) and blocking any lightbox.

## Fix
- Render comment bodies with `MarkdownPreview` (`:disable-gallery="false"`) so inline images open the `vue-easy-lightbox` viewer. Applied to both the COMMENTS collection page (`[collectionId].vue`) and the favorite-comments page.
- Remove the body-wrapping `NuxtLink` on the favorite-comments page; the explicit "View Comment" permalink link remains for navigation.

## Verification
Verified in the browser: clicking an inline image now opens the lightbox on both views, and the permalink links navigate to the highlighted comment. Added regression tests (10 passing) asserting both views render via `MarkdownPreview` with the lightbox enabled, plus the "View Comment" permalink link; `vue-tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)