### PR TITLE
Test wiki revision pages and fix missing current-version badge

### DIFF
--- a/components/comments/CommentEditsDropdown.spec.ts
+++ b/components/comments/CommentEditsDropdown.spec.ts
@@ -152,3 +152,33 @@ describe('CommentEditsDropdown diff modal', () => {
     ).toBe(false);
   });
 });
+
+describe('CommentEditsDropdown current-version flag', () => {
+  // Regression: the modal's isMostRecent must come from the pair's isCurrent
+  // flag so the "Current version" badge renders for the most-recent edit.
+  it('flags the most recent edit as current', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob', 'carol']));
+    await open(wrapper);
+
+    await wrapper.findAll('li')[0].trigger('click');
+
+    expect(
+      wrapper
+        .findComponent({ name: 'CommentRevisionDiffModal' })
+        .props('isMostRecent')
+    ).toBe(true);
+  });
+
+  it('does not flag an older edit as current', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob', 'carol']));
+    await open(wrapper);
+
+    await wrapper.findAll('li')[1].trigger('click');
+
+    expect(
+      wrapper
+        .findComponent({ name: 'CommentRevisionDiffModal' })
+        .props('isMostRecent')
+    ).toBe(false);
+  });
+});

--- a/components/comments/CommentEditsDropdown.vue
+++ b/components/comments/CommentEditsDropdown.vue
@@ -223,7 +223,7 @@ onUnmounted(() => {
       :open="!!activeRevision"
       :old-version="activeRevision.oldVersionData || {}"
       :new-version="activeRevision.newVersionData || {}"
-      :is-most-recent="activeRevision === allEdits[0]"
+      :is-most-recent="!!activeRevision?.isCurrent"
       @close="closeRevisionDiff"
       @deleted="handleRevisionDeleted"
     />

--- a/components/revision/RevisionDiffContent.spec.ts
+++ b/components/revision/RevisionDiffContent.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import RevisionDiffContent from './RevisionDiffContent.vue';
+
+// The three revision modals (discussion body / comment / wiki) and the wiki
+// revision detail page all delegate their rendering to this single component,
+// so its behavior is what "all three modals render consistently" actually means.
+
+const baseProps = {
+  oldVersion: {
+    id: 'past-1',
+    body: 'old content',
+    createdAt: '2024-01-01T12:00:00.000Z',
+    Author: { username: 'alice' },
+  },
+  newVersion: {
+    id: 'current',
+    body: 'new content',
+    createdAt: '2024-01-02T12:00:00.000Z',
+    Author: { username: 'bob' },
+  },
+};
+
+describe('RevisionDiffContent', () => {
+  it('renders from/to author metadata for both versions', () => {
+    const wrapper = mount(RevisionDiffContent, { props: baseProps });
+
+    const text = wrapper.text();
+    expect(text).toContain('From version by alice');
+    expect(text).toContain('To version by bob');
+  });
+
+  it('falls back to [Deleted] when a version has no author', () => {
+    const wrapper = mount(RevisionDiffContent, {
+      props: {
+        ...baseProps,
+        oldVersion: { ...baseProps.oldVersion, Author: null },
+      },
+    });
+
+    expect(wrapper.text()).toContain('From version by [Deleted]');
+  });
+
+  it('shows the current-version badge only when isMostRecent is set', () => {
+    const withBadge = mount(RevisionDiffContent, {
+      props: { ...baseProps, isMostRecent: true },
+    });
+    expect(withBadge.text()).toContain('Current version');
+
+    const withoutBadge = mount(RevisionDiffContent, {
+      props: { ...baseProps, isMostRecent: false },
+    });
+    expect(withoutBadge.text()).not.toContain('Current version');
+  });
+
+  it('renders a side-by-side diff with previous and current content', () => {
+    const wrapper = mount(RevisionDiffContent, { props: baseProps });
+    const text = wrapper.text();
+
+    // Both panes are present...
+    expect(text).toContain('Previous Version');
+    expect(text).toContain('Current Version');
+    // ...and each shows its respective content.
+    expect(text).toContain('old content');
+    expect(text).toContain('new content');
+
+    // The removed/added line cells carry the diff color classes.
+    expect(wrapper.html()).toContain('bg-red-500/20');
+    expect(wrapper.html()).toContain('bg-green-500/20');
+  });
+
+  it('displays the edit reason when present and hides it otherwise', () => {
+    const withReason = mount(RevisionDiffContent, {
+      props: {
+        ...baseProps,
+        newVersion: { ...baseProps.newVersion, editReason: 'Fixed a typo' },
+      },
+    });
+    expect(withReason.text()).toContain('Edit reason:');
+    expect(withReason.text()).toContain('Fixed a typo');
+
+    const withoutReason = mount(RevisionDiffContent, { props: baseProps });
+    expect(withoutReason.text()).not.toContain('Edit reason:');
+  });
+
+  it('collapses unchanged lines and reveals them when the toggle is clicked', async () => {
+    const base = Array.from({ length: 12 }, (_, i) => `line ${i + 1}`).join(
+      '\n'
+    );
+    const wrapper = mount(RevisionDiffContent, {
+      props: {
+        oldVersion: { ...baseProps.oldVersion, body: base },
+        newVersion: {
+          ...baseProps.newVersion,
+          body: base.replace('line 6', 'line 6 EDITED'),
+        },
+      },
+    });
+
+    // Unchanged runs outside the 3-line context window start collapsed behind a
+    // toggle, so leading lines are hidden until the user expands them.
+    const showButtons = wrapper
+      .findAll('button')
+      .filter((b) => b.text() === 'Show 2 unchanged lines');
+    expect(showButtons.length).toBeGreaterThan(0);
+    expect(wrapper.text()).not.toContain('line 1');
+
+    await showButtons[0].trigger('click');
+
+    // Expanding reveals the previously hidden lines and removes that toggle.
+    expect(wrapper.text()).toContain('line 1');
+    expect(
+      wrapper.findAll('button').filter((b) => b.text() === 'Show 2 unchanged lines')
+    ).toHaveLength(0);
+  });
+});

--- a/components/wiki/WikiEditsDropdown.spec.ts
+++ b/components/wiki/WikiEditsDropdown.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { ref } from 'vue';
+import { ref, nextTick } from 'vue';
 import WikiEditsDropdown from './WikiEditsDropdown.vue';
 
 vi.mock('@/composables/usePopoverPositioning', () => ({
@@ -65,23 +65,6 @@ describe('WikiEditsDropdown', () => {
     expect(wrapper.text()).toContain('Edits');
   });
 
-  it('builds sequential revision pairs correctly', () => {
-    const wrapper = mount(WikiEditsDropdown, {
-      props: {
-        wikiPage: mockWikiPage,
-      },
-      global: {
-        stubs: {
-          WikiRevisionDiffModal: { template: '<div />' },
-        },
-      },
-    });
-
-    // The component should have computed the edits
-    // We can verify by checking that it renders without errors
-    expect(wrapper.exists()).toBe(true);
-  });
-
   it('hides dropdown when no edits exist', () => {
     const wikiPageNoEdits = {
       ...mockWikiPage,
@@ -117,5 +100,100 @@ describe('WikiEditsDropdown', () => {
 
     // Should render trigger button when edits exist
     expect(wrapper.find('button').exists()).toBe(true);
+  });
+});
+
+describe('WikiEditsDropdown revision pairing', () => {
+  // PastVersions sorted newest-first, as the GraphQL query returns them.
+  const orderedWikiPage = {
+    id: 'wiki-1',
+    title: 'Test Wiki Page',
+    body: 'Current content',
+    editReason: 'Latest reason',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-15T00:00:00Z',
+    VersionAuthor: { username: 'editor' },
+    PastVersions: [
+      {
+        id: 'v2',
+        body: 'Second version',
+        editReason: 'Fixed typos',
+        createdAt: '2024-01-10T00:00:00Z',
+        Author: { username: 'bob' },
+      },
+      {
+        id: 'v1',
+        body: 'First version',
+        createdAt: '2024-01-01T00:00:00Z',
+        Author: { username: 'alice' },
+      },
+    ],
+  };
+
+  // Records the versions the dropdown hands to the modal when an edit is opened.
+  const ModalStub = {
+    name: 'WikiRevisionDiffModal',
+    props: ['open', 'oldVersion', 'newVersion', 'isMostRecent'],
+    template: '<div class="modal-stub" />',
+  };
+
+  const mountOpened = async () => {
+    const wrapper = mount(WikiEditsDropdown, {
+      props: { wikiPage: orderedWikiPage },
+      global: {
+        stubs: {
+          Teleport: { template: '<div><slot /></div>' },
+          WikiRevisionDiffModal: ModalStub,
+        },
+      },
+    });
+    await wrapper.get('button').trigger('click');
+    await nextTick();
+    return wrapper;
+  };
+
+  it('summarizes the edit count and lists one row per pair', async () => {
+    const wrapper = await mountOpened();
+
+    expect(wrapper.text()).toContain('Edited 2 times');
+    expect(wrapper.findAll('li')).toHaveLength(2);
+  });
+
+  it('flags the top row as the current revision', async () => {
+    const wrapper = await mountOpened();
+    expect(wrapper.findAll('li')[0].text()).toContain('(Current)');
+  });
+
+  it('compares the current content against the most recent past version', async () => {
+    const wrapper = await mountOpened();
+
+    await wrapper.findAll('li')[0].trigger('click');
+    await nextTick();
+
+    const modal = wrapper.findComponent(ModalStub);
+    expect(modal.props('oldVersion').id).toBe('v2');
+    expect(modal.props('newVersion').id).toBe('current');
+    // Regression: the most-recent edit must flag the modal as current so the
+    // "Current version" badge renders (previously broken object-identity check).
+    expect(modal.props('isMostRecent')).toBe(true);
+  });
+
+  it('compares adjacent past versions for older edits', async () => {
+    const wrapper = await mountOpened();
+
+    await wrapper.findAll('li')[1].trigger('click');
+    await nextTick();
+
+    const modal = wrapper.findComponent(ModalStub);
+    expect(modal.props('oldVersion').id).toBe('v1');
+    expect(modal.props('newVersion').id).toBe('v2');
+    expect(modal.props('isMostRecent')).toBe(false);
+  });
+
+  it('shows the edit reason for a revision', async () => {
+    const wrapper = await mountOpened();
+
+    expect(wrapper.text()).toContain('Edit reason:');
+    expect(wrapper.text()).toContain('Fixed typos');
   });
 });

--- a/components/wiki/WikiEditsDropdown.vue
+++ b/components/wiki/WikiEditsDropdown.vue
@@ -226,7 +226,7 @@ onUnmounted(() => {
       :open="!!activeRevision"
       :old-version="activeRevision.oldVersionData || {}"
       :new-version="activeRevision.newVersionData || {}"
-      :is-most-recent="activeRevision === allEdits[0]"
+      :is-most-recent="!!activeRevision?.isCurrent"
       @close="closeRevisionDiff"
       @deleted="handleRevisionDeleted"
     />

--- a/tests/playwright/mocked/wiki/wikiRevisions.spec.ts
+++ b/tests/playwright/mocked/wiki/wikiRevisions.spec.ts
@@ -1,0 +1,310 @@
+import { expect, test } from '../../helpers/testFixture';
+import {
+  buildBasicUser,
+  buildChannel,
+  buildServerConfig,
+} from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+
+const TEST_CHANNEL = 'cats';
+const TEST_USER = 'alice';
+const SLUG = 'cat-care';
+const WIKI_PAGE_ID = 'wiki-page-1';
+
+const getBaseMocks = (username: string) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username, displayName: username })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: {
+      serverConfigs: [
+        buildServerConfig({ serverName: 'Listical', enableEvents: true }),
+      ],
+    },
+  }),
+  getChannel: () => ({
+    data: {
+      channels: [
+        buildChannel({
+          uniqueName: TEST_CHANNEL,
+          overrides: { eventsEnabled: true, wikiEnabled: true },
+        }),
+      ],
+    },
+  }),
+  getChannelTags: () => ({
+    data: { channels: [{ uniqueName: TEST_CHANNEL, Tags: [] }] },
+  }),
+  getTags: () => ({ data: { tags: [] } }),
+  userIsModInChannel: () => ({
+    data: {
+      channels: [
+        {
+          uniqueName: TEST_CHANNEL,
+          Admins: [],
+          SuspendedUsers: [],
+          Moderators: [],
+          SuspendedMods: [],
+        },
+      ],
+    },
+  }),
+});
+
+// A wiki page whose current body differs from every past version, with two
+// past versions sorted newest-first (as the GraphQL query returns them).
+const buildWikiPage = (overrides = {}) => ({
+  __typename: 'WikiPage',
+  id: WIKI_PAGE_ID,
+  title: 'Cat Care Guide',
+  slug: SLUG,
+  body: 'Current version of the page.',
+  editReason: 'Latest tweak',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-15T00:00:00Z',
+  VersionAuthor: { username: 'carol' },
+  ChildPages: [],
+  PastVersions: [
+    {
+      id: 'rev-2',
+      body: 'Second version of the page.',
+      editReason: 'Clarified wording',
+      createdAt: '2024-01-10T00:00:00Z',
+      Author: { username: 'bob' },
+    },
+    {
+      id: 'rev-1',
+      body: 'Original version of the page.',
+      editReason: null,
+      createdAt: '2024-01-05T00:00:00Z',
+      Author: { username: 'alice' },
+    },
+  ],
+  Channel: { uniqueName: TEST_CHANNEL },
+  ...overrides,
+});
+
+test.describe('Wiki revision history pages', () => {
+  test('lists revisions newest-first and shows edit reasons', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      getWikiPage: () => ({ data: { wikiPages: [buildWikiPage()] } }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/wiki/revisions/${SLUG}`);
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'getWikiPage'
+      );
+
+      await expect(
+        page.getByRole('heading', { name: 'Revision History For Wiki Page' })
+      ).toBeVisible();
+      await expect(page.getByText('has been edited 2 times')).toBeVisible();
+
+      // Revisions are listed newest-first: the current/most-recent edit (by the
+      // version author) on top, then the older edit.
+      const authors = page.locator('div.font-medium.text-gray-900');
+      await expect(authors.nth(0)).toHaveText('carol');
+      await expect(authors.nth(1)).toHaveText('alice');
+      await expect(
+        page.getByText('Most recent edit', { exact: true })
+      ).toBeVisible();
+
+      // Edit reasons surface in the list.
+      await expect(page.getByText('Clarified wording')).toBeVisible();
+      await expect(page.getByText('Latest tweak')).toBeVisible();
+
+      expect(diagnostics.pageErrors).toEqual([]);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('opens a revision detail page rendered through the shared diff', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      getWikiPage: () => ({ data: { wikiPages: [buildWikiPage()] } }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/wiki/revisions/${SLUG}`);
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'getWikiPage'
+      );
+
+      // Click the top (most-recent) revision to open its detail page. Clicking
+      // the badge bubbles to the row's click handler.
+      await page.getByText('Most recent edit', { exact: true }).click();
+      await expect(page).toHaveURL(
+        new RegExp(`/wiki/revisions/diff/${SLUG}/most-recent-edit$`)
+      );
+
+      // Breadcrumbs + heading.
+      const breadcrumb = page.locator(
+        'nav[aria-label="Wiki revision detail breadcrumb"]'
+      );
+      await expect(breadcrumb).toContainText('Cat Care Guide');
+      await expect(breadcrumb).toContainText('Revision History');
+      await expect(breadcrumb).toContainText('Revision Detail');
+      await expect(
+        page.getByRole('heading', { name: 'Revision Detail' })
+      ).toBeVisible();
+      await expect(
+        page.getByText('Most recent edit', { exact: true })
+      ).toBeVisible();
+
+      // Rendered through the shared RevisionDiffContent: side-by-side panes,
+      // from/to metadata, the diffed content, and the legend.
+      await expect(
+        page.getByRole('heading', { name: 'Previous Version', exact: true })
+      ).toBeVisible();
+      await expect(
+        page.getByRole('heading', { name: 'Current Version', exact: true })
+      ).toBeVisible();
+      await expect(page.getByText('From version by bob')).toBeVisible();
+      await expect(page.getByText('To version by carol')).toBeVisible();
+      await expect(
+        page.getByText('Second version of the page.', { exact: true })
+      ).toBeVisible();
+      await expect(
+        page.getByText('Current version of the page.', { exact: true })
+      ).toBeVisible();
+      await expect(page.getByText('Removed content')).toBeVisible();
+      await expect(page.getByText('Added content')).toBeVisible();
+
+      // The old v-code-diff view-mode toggle is gone.
+      await expect(page.locator('.v-code-diff')).toHaveCount(0);
+      await expect(
+        page.getByRole('button', { name: /split|unified|line by line|side by side/i })
+      ).toHaveCount(0);
+
+      // The redact action is present (foundation work leaves delete intact).
+      await expect(
+        page.getByRole('button', { name: 'Redact Revision' })
+      ).toBeVisible();
+
+      // The compare-revision dropdown ordering matches the list ordering
+      // (most-recent first, then the older edit).
+      const optionLabels = await page
+        .locator('#wiki-revision-select option')
+        .allTextContents();
+      expect(optionLabels).toHaveLength(2);
+      expect(optionLabels[0]).toContain('Most recent edit by carol');
+      expect(optionLabels[1]).toContain('Edit by alice');
+
+      expect(diagnostics.pageErrors).toEqual([]);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('redacting a revision routes back to the revision list', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      getWikiPage: () => ({ data: { wikiPages: [buildWikiPage()] } }),
+      deleteWikiRevision: () => ({
+        data: {
+          deleteWikiRevision: {
+            id: 'rev-2',
+            body: 'Second version of the page.',
+            editReason: 'Clarified wording',
+            createdAt: '2024-01-10T00:00:00Z',
+            updatedAt: '2024-01-10T00:00:00Z',
+            Author: { username: 'bob' },
+          },
+        },
+      }),
+    });
+
+    // The redact button asks for confirmation via window.confirm.
+    page.on('dialog', (dialog) => dialog.accept());
+
+    try {
+      await page.goto(
+        `/forums/${TEST_CHANNEL}/wiki/revisions/diff/${SLUG}/most-recent-edit`
+      );
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'getWikiPage'
+      );
+
+      await page.getByRole('button', { name: 'Redact Revision' }).click();
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'deleteWikiRevision'
+      );
+
+      // onDone navigates back to the revision history list.
+      await expect(page).toHaveURL(
+        new RegExp(`/wiki/revisions/${SLUG}$`)
+      );
+      await expect(
+        page.getByRole('heading', { name: 'Revision History For Wiki Page' })
+      ).toBeVisible();
+
+      expect(diagnostics.pageErrors).toEqual([]);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for the recently completed wiki revision-history refactor, and fixes a bug surfaced while writing those tests.

### Tests
- **`components/revision/RevisionDiffContent.spec.ts`** (new) — unit spec for the shared diff component every revision modal + the wiki detail page delegate to: from/to author metadata, `[Deleted]` fallback, current-version badge (only when `isMostRecent`), side-by-side removed/added diff, collapse→expand of unchanged lines, and edit-reason display.
- **`components/wiki/WikiEditsDropdown.spec.ts`** — replaced a no-op test with real pairing coverage: edit count, current-vs-most-recent-past pairing, and adjacent-past pairing.
- **`tests/playwright/mocked/wiki/wikiRevisions.spec.ts`** (new) — e2e for the wiki revision **list** and **detail** pages: newest-first ordering, edit reasons, breadcrumbs, shared-diff rendering, **no `v-code-diff` toggle**, redact action, and redact routing back to the list. Compare-`<select>` ordering matches the list ordering.

### Fix
The Wiki and Comment "Edits" dropdowns computed the diff modal's `isMostRecent` via object identity against a recomputed `computed` array (`activeRevision === allEdits[0]`), which resolved to `false` even for the most-recent edit — so `RevisionDiffContent`'s green **"Current version"** badge never rendered when opening the top edit from a dropdown.

- `components/wiki/WikiEditsDropdown.vue` and `components/comments/CommentEditsDropdown.vue` now bind to the pair's reliable `isCurrent` flag: `:is-most-recent="!!activeRevision?.isCurrent"`.
- Regression assertions added to both dropdown specs (verified to fail on the old binding, pass on the fix).

## Test plan
- `npx vitest run components/revision/RevisionDiffContent.spec.ts components/wiki/WikiEditsDropdown.spec.ts components/comments/CommentEditsDropdown.spec.ts` → all green.
- `npx playwright test tests/playwright/mocked/wiki/wikiRevisions.spec.ts` → 3 passed (run within the warm mocked suite; the dev server compiles routes on demand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)