### PR TITLE
test(admin): suspended-pages + membership editor remove/error coverage

### DIFF
--- a/components/admin/ServerMembershipEditor.spec.ts
+++ b/components/admin/ServerMembershipEditor.spec.ts
@@ -10,6 +10,10 @@ const inviteServerMod = vi.fn();
 const cancelInviteServerMod = vi.fn();
 const removeServerModerator = vi.fn();
 const onUpdated = vi.fn();
+// Injectable error refs: the admin column's error banner reflects any admin
+// mutation error; the mod column's reflects any mod mutation error.
+const mockAdminError = ref<{ message: string } | null>(null);
+const mockModError = ref<{ message: string } | null>(null);
 
 // config.serverName comes from import.meta.env (unset under vitest), so mock it
 // to a stable value — the component passes config.serverName to the mutations.
@@ -21,15 +25,25 @@ vi.mock('@vue/apollo-composable', () => ({
   useMutation: (fn: any) => {
     const source = fn?.loc?.source?.body || '';
     let mutateFn = inviteServerAdmin;
+    let errorRef = mockAdminError;
     if (source.includes('CancelInviteServerAdmin')) mutateFn = cancelInviteServerAdmin;
     if (source.includes('RemoveServerAdmin')) mutateFn = removeServerAdmin;
-    if (source.includes('InviteServerMod')) mutateFn = inviteServerMod;
-    if (source.includes('CancelInviteServerMod')) mutateFn = cancelInviteServerMod;
-    if (source.includes('RemoveServerModerator')) mutateFn = removeServerModerator;
+    if (source.includes('InviteServerMod')) {
+      mutateFn = inviteServerMod;
+      errorRef = mockModError;
+    }
+    if (source.includes('CancelInviteServerMod')) {
+      mutateFn = cancelInviteServerMod;
+      errorRef = mockModError;
+    }
+    if (source.includes('RemoveServerModerator')) {
+      mutateFn = removeServerModerator;
+      errorRef = mockModError;
+    }
     return {
       mutate: mutateFn,
       loading: ref(false),
-      error: ref(null),
+      error: errorRef,
     };
   },
 }));
@@ -43,6 +57,8 @@ describe('ServerMembershipEditor', () => {
     cancelInviteServerMod.mockReset().mockResolvedValue({});
     removeServerModerator.mockReset().mockResolvedValue({});
     onUpdated.mockReset();
+    mockAdminError.value = null;
+    mockModError.value = null;
   });
 
   const serverConfig = {
@@ -122,5 +138,113 @@ describe('ServerMembershipEditor', () => {
       inviteeUsername: 'bob',
     });
     expect(onUpdated).toHaveBeenCalled();
+  });
+
+  const stubs = ['AvatarComponent', 'UsernameWithTooltip'];
+
+  const mountEditor = (cfg: unknown) =>
+    mount(ServerMembershipEditor, {
+      props: { serverConfig: cfg, onUpdated },
+      global: { stubs },
+    });
+
+  // --- Remove existing members ---
+
+  it('removes a server admin', async () => {
+    const wrapper = mountEditor(serverConfig);
+
+    const removeButtons = wrapper
+      .findAll('button')
+      .filter((b) => b.text() === 'Remove');
+    // First Remove belongs to the Server Admins column ("alice").
+    await removeButtons[0].trigger('click');
+
+    expect(removeServerAdmin).toHaveBeenCalledWith({
+      serverName: 'TestServer',
+      username: 'alice',
+    });
+    expect(onUpdated).toHaveBeenCalled();
+  });
+
+  it('removes a server moderator by mod profile name', async () => {
+    const wrapper = mountEditor(serverConfig);
+
+    const removeButtons = wrapper
+      .findAll('button')
+      .filter((b) => b.text() === 'Remove');
+    // Second Remove belongs to the Server Moderators column ("Mod Alice").
+    await removeButtons[1].trigger('click');
+
+    expect(removeServerModerator).toHaveBeenCalledWith({
+      serverName: 'TestServer',
+      displayName: 'Mod Alice',
+    });
+    expect(onUpdated).toHaveBeenCalled();
+  });
+
+  // --- Pending invites: display + cancel ---
+
+  const serverConfigWithPending = {
+    ...serverConfig,
+    PendingAdminInvites: [{ username: 'bob', displayName: 'Bob', profilePicURL: '' }],
+    PendingModInvites: [{ username: 'carol', displayName: 'Carol', profilePicURL: '' }],
+  };
+
+  it('marks pending invites with a (pending) badge', () => {
+    const wrapper = mountEditor(serverConfigWithPending);
+
+    expect(wrapper.text()).toContain('(pending)');
+  });
+
+  it('cancels a pending admin invite', async () => {
+    const wrapper = mountEditor(serverConfigWithPending);
+
+    const cancelButtons = wrapper
+      .findAll('button')
+      .filter((b) => b.text() === 'Cancel');
+    await cancelButtons[0].trigger('click');
+
+    expect(cancelInviteServerAdmin).toHaveBeenCalledWith({
+      serverName: 'TestServer',
+      inviteeUsername: 'bob',
+    });
+  });
+
+  it('cancels a pending mod invite', async () => {
+    const wrapper = mountEditor(serverConfigWithPending);
+
+    const cancelButtons = wrapper
+      .findAll('button')
+      .filter((b) => b.text() === 'Cancel');
+    await cancelButtons[1].trigger('click');
+
+    expect(cancelInviteServerMod).toHaveBeenCalledWith({
+      serverName: 'TestServer',
+      inviteeUsername: 'carol',
+    });
+  });
+
+  // --- Error display ---
+
+  it('shows an admin error message when an admin mutation fails', () => {
+    mockAdminError.value = { message: 'That user does not exist' };
+    const wrapper = mountEditor(serverConfig);
+
+    expect(wrapper.text()).toContain('That user does not exist');
+  });
+
+  it('shows a mod error message when a mod mutation fails', () => {
+    mockModError.value = { message: 'That mod does not exist' };
+    const wrapper = mountEditor(serverConfig);
+
+    expect(wrapper.text()).toContain('That mod does not exist');
+  });
+
+  // --- Empty states ---
+
+  it('shows an empty state when there are no admins or invites', () => {
+    const wrapper = mountEditor({ Admins: [], Moderators: [] });
+
+    expect(wrapper.text()).toContain('No server admins configured');
   });
 });

--- a/components/admin/ServerSuspendedModList.spec.ts
+++ b/components/admin/ServerSuspendedModList.spec.ts
@@ -34,8 +34,8 @@ const mountList = () =>
       stubs: {
         AvatarComponent: true,
         ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
-        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
-        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+        NuxtLink: { name: 'NuxtLink', props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { name: 'NuxtLink', props: ['to'], template: '<a><slot /></a>' },
       },
     },
   });
@@ -102,5 +102,22 @@ describe('ServerSuspendedModList content', () => {
     const wrapper = mountList();
 
     expect(wrapper.text()).toContain('Related Issue');
+  });
+
+  it('points the related-issue link at the correct issue route', () => {
+    h.result = ref(withMods([suspension({ RelatedIssue: { issueNumber: 9 } })]));
+    const wrapper = mountList();
+
+    const issueLink = wrapper
+      .findAllComponents({ name: 'NuxtLink' })
+      .find(
+        (link) =>
+          (link.props('to') as { name?: string })?.name ===
+          'admin-issues-issueNumber'
+      );
+    expect(issueLink?.props('to')).toEqual({
+      name: 'admin-issues-issueNumber',
+      params: { issueNumber: 9 },
+    });
   });
 });

--- a/components/admin/ServerSuspendedUserList.spec.ts
+++ b/components/admin/ServerSuspendedUserList.spec.ts
@@ -35,8 +35,8 @@ const mountList = () =>
         AvatarComponent: true,
         ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
         UsernameWithTooltip: { name: 'UsernameWithTooltip', props: ['username'], template: '<span>{{ username }}</span>' },
-        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
-        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+        NuxtLink: { name: 'NuxtLink', props: ['to'], template: '<a><slot /></a>' },
+        'nuxt-link': { name: 'NuxtLink', props: ['to'], template: '<a><slot /></a>' },
       },
     },
   });
@@ -117,5 +117,22 @@ describe('ServerSuspendedUserList content', () => {
     const wrapper = mountList();
 
     expect(wrapper.text()).toContain('Related Issue');
+  });
+
+  it('points the related-issue link at the correct issue route', () => {
+    h.result = ref(withUsers([suspension({ RelatedIssue: { issueNumber: 9 } })]));
+    const wrapper = mountList();
+
+    const issueLink = wrapper
+      .findAllComponents({ name: 'NuxtLink' })
+      .find(
+        (link) =>
+          (link.props('to') as { name?: string })?.name ===
+          'admin-issues-issueNumber'
+      );
+    expect(issueLink?.props('to')).toEqual({
+      name: 'admin-issues-issueNumber',
+      params: { issueNumber: 9 },
+    });
   });
 });

--- a/tests/playwright/mocked/admin/suspendedAdminPages.spec.ts
+++ b/tests/playwright/mocked/admin/suspendedAdminPages.spec.ts
@@ -1,0 +1,224 @@
+import { expect, test } from '../../helpers/testFixture';
+import { buildBasicUser, buildServerConfig } from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import { installGraphqlMocks } from '../../helpers/mockGraphql';
+
+// Workflow: "Review Server Suspended Users / Mods Page". Drives the full
+// page -> query -> render chain for /admin/suspended-users and
+// /admin/suspended-mods (the component unit tests mock the query result; this
+// exercises the real Apollo query against a mocked GraphQL payload).
+
+const TEST_USER = 'alice';
+
+const getBaseMocks = (username: string) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username, displayName: username })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username, Collections: [] }] },
+  }),
+  // The /admin wrapper renders its NuxtPage only once getServerConfig resolves.
+  getServerConfig: () => ({
+    data: {
+      serverConfigs: [
+        buildServerConfig({
+          serverName: 'Listical',
+          Admins: [{ username }],
+        }),
+      ],
+    },
+  }),
+  getChannelDownloadCount: () => ({
+    data: {
+      channels: [{ uniqueName: 'cats', DiscussionChannelsAggregate: { count: 0 } }],
+    },
+  }),
+});
+
+const userSuspension = (overrides: Record<string, unknown> = {}) => ({
+  id: 'sus-1',
+  username: 'baduser',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  suspendedUntil: null,
+  suspendedIndefinitely: true,
+  SuspendedUser: {
+    username: 'baduser',
+    displayName: 'Bad User',
+    profilePicURL: '',
+    commentKarma: 0,
+    discussionKarma: 0,
+    createdAt: '2023-01-01T00:00:00.000Z',
+    isBot: false,
+  },
+  RelatedIssue: { id: 'issue-1', issueNumber: 7 },
+  ...overrides,
+});
+
+const modSuspension = (overrides: Record<string, unknown> = {}) => ({
+  id: 'msus-1',
+  modProfileName: 'BadMod',
+  username: 'badmoduser',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  suspendedUntil: null,
+  suspendedIndefinitely: true,
+  SuspendedMod: { displayName: 'BadMod' },
+  RelatedIssue: { id: 'issue-2', issueNumber: 8 },
+  ...overrides,
+});
+
+test('renders server-suspended users (temporary + indefinite) with issue links', async ({
+  context,
+  page,
+}) => {
+  await installMockAuth(context, page, {
+    username: TEST_USER,
+    email: 'alice@example.com',
+  });
+
+  await installGraphqlMocks(page, {
+    ...getBaseMocks(TEST_USER),
+    getServerSuspendedUsers: () => ({
+      data: {
+        serverConfigs: [
+          {
+            serverName: 'Listical',
+            SuspendedUsersAggregate: { count: 2 },
+            SuspendedUsers: [
+              userSuspension(),
+              userSuspension({
+                id: 'sus-2',
+                username: 'tempuser',
+                suspendedUntil: '2999-01-01T00:00:00.000Z',
+                suspendedIndefinitely: false,
+                SuspendedUser: {
+                  username: 'tempuser',
+                  displayName: 'Temp User',
+                  profilePicURL: '',
+                  commentKarma: 0,
+                  discussionKarma: 0,
+                  createdAt: '2023-01-01T00:00:00.000Z',
+                  isBot: false,
+                },
+                RelatedIssue: { id: 'issue-3', issueNumber: 12 },
+              }),
+            ],
+          },
+        ],
+      },
+    }),
+  });
+
+  await page.goto('/admin/suspended-users', { waitUntil: 'domcontentloaded' });
+
+  await expect(page.getByText('baduser').first()).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText('tempuser').first()).toBeVisible();
+  // Indefinite vs temporary rendering.
+  await expect(page.getByText(/Suspended indefinitely/i).first()).toBeVisible();
+  await expect(page.getByText(/Suspended until/i).first()).toBeVisible();
+  // Related-issue link(s).
+  await expect(page.getByRole('link', { name: /Related Issue/i }).first()).toBeVisible();
+});
+
+test('shows the empty state when there are no server-suspended users', async ({
+  context,
+  page,
+}) => {
+  await installMockAuth(context, page, {
+    username: TEST_USER,
+    email: 'alice@example.com',
+  });
+
+  await installGraphqlMocks(page, {
+    ...getBaseMocks(TEST_USER),
+    getServerSuspendedUsers: () => ({
+      data: {
+        serverConfigs: [
+          { serverName: 'Listical', SuspendedUsersAggregate: { count: 0 }, SuspendedUsers: [] },
+        ],
+      },
+    }),
+  });
+
+  await page.goto('/admin/suspended-users', { waitUntil: 'domcontentloaded' });
+
+  await expect(
+    page.getByText(/no active server-scoped user suspensions/i)
+  ).toBeVisible({ timeout: 60_000 });
+});
+
+test('renders server-suspended mods with the mod name and issue link', async ({
+  context,
+  page,
+}) => {
+  await installMockAuth(context, page, {
+    username: TEST_USER,
+    email: 'alice@example.com',
+  });
+
+  await installGraphqlMocks(page, {
+    ...getBaseMocks(TEST_USER),
+    getServerSuspendedMods: () => ({
+      data: {
+        serverConfigs: [
+          {
+            serverName: 'Listical',
+            SuspendedModsAggregate: { count: 1 },
+            SuspendedMods: [modSuspension()],
+          },
+        ],
+      },
+    }),
+  });
+
+  await page.goto('/admin/suspended-mods', { waitUntil: 'domcontentloaded' });
+
+  await expect(page.getByText('BadMod').first()).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText(/Suspended indefinitely/i).first()).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: /Related Issue/i }).first()
+  ).toBeVisible();
+});
+
+test('shows the empty state when there are no server-suspended mods', async ({
+  context,
+  page,
+}) => {
+  await installMockAuth(context, page, {
+    username: TEST_USER,
+    email: 'alice@example.com',
+  });
+
+  await installGraphqlMocks(page, {
+    ...getBaseMocks(TEST_USER),
+    getServerSuspendedMods: () => ({
+      data: {
+        serverConfigs: [
+          { serverName: 'Listical', SuspendedModsAggregate: { count: 0 }, SuspendedMods: [] },
+        ],
+      },
+    }),
+  });
+
+  await page.goto('/admin/suspended-mods', { waitUntil: 'domcontentloaded' });
+
+  await expect(
+    page.getByText(/no active server-scoped mod suspensions/i)
+  ).toBeVisible({ timeout: 60_000 });
+});


### PR DESCRIPTION
## Summary

Fills the admin-pages test gaps identified for the suspended-users / suspended-mods / roles workflows (frontend half; the backend server-scoped suspension coverage is in multiforum-backend #89).

### ServerMembershipEditor (`/admin/roles`)
- **Remove admin / Remove mod** — `removeServerAdmin` / `removeServerModerator` called with the correct vars + `onUpdated` (was untested).
- **Error banners** — admin/mod error refs render their message.
- **Pending invites** — `(pending)` badge + Cancel → `cancelInviteServerAdmin/Mod`.
- **Empty state**.

### Suspended lists (`ServerSuspendedUserList` / `ServerSuspendedModList`)
- Strengthen the related-issue assertion to verify the link resolves to `admin-issues-issueNumber` with the right `issueNumber` (the existing tests only checked the "Related Issue" text).

### Playwright (new `admin/suspendedAdminPages.spec.ts`)
- Drives `/admin/suspended-users` and `/admin/suspended-mods` through the real Apollo query (not just a mocked result ref): temporary vs indefinite rows, related-issue links, and the empty states for each page.

## Notes (spec vs. implementation)
Three behaviors the manual-test spec expects are **not implemented**, so they're feature work rather than test gaps and are intentionally not covered here:
- inline **unsuspend** action on the suspended pages (today you unsuspend via the linked issue),
- **pagination** for large lists,
- **confirmation** on Remove/Cancel.

## Verification
30 affected unit tests pass; the 4 new Playwright tests pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)