### PR TITLE
Wiki moderation test coverage (forms, report, profile, chart)

### DIFF
--- a/components/charts/GithubContributionChart.spec.ts
+++ b/components/charts/GithubContributionChart.spec.ts
@@ -7,7 +7,14 @@ import {
   emptyContributionData,
   consecutiveDaysContributionData,
   allTypesContributionData,
+  wikiEditsContributionData,
 } from './fixtures/contributionData';
+
+const NuxtLinkStub = {
+  name: 'NuxtLink',
+  props: ['to'],
+  template: '<a><slot /></a>',
+};
 
 // Mock the child components to simplify testing
 vi.mock('@/components/comments/Comment.vue', () => ({
@@ -262,6 +269,36 @@ describe('GithubContributionChart', () => {
     expect(detailsSection.text()).toContain('comment');
     expect(detailsSection.text()).toContain('discussion');
     expect(detailsSection.text()).toContain('event');
+  });
+
+  // Wiki edits in the selected-day details
+  it('shows wiki edits in the selected day details with page and revision links', async () => {
+    const wrapper = mount(GithubContributionChart, {
+      props: {
+        contributionData: wikiEditsContributionData,
+        year: 2023,
+      },
+      global: { stubs: { NuxtLink: NuxtLinkStub } },
+    });
+
+    await flushPromises();
+
+    await wrapper.find('rect[data-count="2"]').trigger('click');
+
+    const detailsSection = wrapper.find('.mt-4.p-4.rounded-lg.border');
+    expect(detailsSection.exists()).toBe(true);
+    expect(detailsSection.text()).toContain('Wiki Edits');
+    expect(detailsSection.text()).toContain('Cat Care');
+    expect(detailsSection.text()).toContain('Fixed a typo');
+    expect(detailsSection.text()).toContain('wiki edit');
+
+    const targets = wrapper
+      .findAllComponents(NuxtLinkStub)
+      .map((l) => l.props('to'));
+    expect(targets).toContain('/forums/cats/wiki/cat-care');
+    expect(targets).toContain(
+      '/forums/cats/wiki/revisions/diff/cat-care/we1'
+    );
   });
 
   // Test deselecting a day

--- a/components/charts/fixtures/contributionData.ts
+++ b/components/charts/fixtures/contributionData.ts
@@ -1,6 +1,8 @@
 // Contribution data fixture for testing GithubContributionChart component
-import type { DayData } from '@/types/contribution';
+import type { DayData, Activity } from '@/types/contribution';
 import type { User, Comment, Discussion, Event } from '@/__generated__/graphql';
+
+type WikiEditFixture = NonNullable<Activity['WikiEdits']>[number];
 
 // Create a stable date for testing that won't change with the current date
 const TEST_YEAR = 2023;
@@ -140,6 +142,48 @@ export const contributionDataFixture: DayData[] = [
     date: createDateString(TEST_YEAR, 6, 14),
     count: 0,
     activities: [],
+  },
+];
+
+// Helper to create minimal test wiki-edit data
+const createTestWikiEdit = (
+  id: string,
+  title: string,
+  slug: string,
+  channelUniqueName: string,
+  editReason?: string
+): WikiEditFixture =>
+  ({
+    id,
+    body: 'Wiki edit body',
+    editReason,
+    createdAt: new Date().toISOString(),
+    Author: createTestUser('testuser'),
+    WikiPage: { id: `wp-${id}`, title, slug, channelUniqueName },
+  }) as unknown as WikiEditFixture;
+
+// Data with a day of wiki edits
+export const wikiEditsContributionData: DayData[] = [
+  {
+    date: createDateString(TEST_YEAR, 7, 8),
+    count: 2,
+    activities: [
+      {
+        id: 'activity-wiki',
+        type: 'WikiEdit',
+        description: 'Wiki edits',
+        WikiEdits: [
+          createTestWikiEdit(
+            'we1',
+            'Cat Care',
+            'cat-care',
+            'cats',
+            'Fixed a typo'
+          ),
+          createTestWikiEdit('we2', 'Dog Care', 'dog-care', 'dogs'),
+        ],
+      },
+    ],
   },
 ];
 

--- a/components/mod/BrokenRulesModal.spec.ts
+++ b/components/mod/BrokenRulesModal.spec.ts
@@ -191,6 +191,17 @@ describe('BrokenRulesModal Component', () => {
     expect((wrapper.vm as any).modalTitle).toBe('Archive Event');
   });
 
+  it('renders the correct title for reporting a wiki edit', async () => {
+    const wrapper = await mountComponent({
+      wikiPageId: 'wiki-1',
+      wikiRevisionId: 'rev-1',
+      discussionId: '',
+      archiveAfterReporting: false,
+    });
+
+    expect((wrapper.vm as any).modalTitle).toBe('Report Wiki Edit');
+  });
+
   it('toggles forum rule selection correctly', async () => {
     const wrapper = await mountComponent();
 

--- a/pages/forums/[forumId]/wiki/create-child.spec.ts
+++ b/pages/forums/[forumId]/wiki/create-child.spec.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import PrimaryButton from '@/components/PrimaryButton.vue';
+import SuspensionNotice from '@/components/SuspensionNotice.vue';
+import TextInput from '@/components/TextInput.vue';
+
+const suspension = vi.hoisted(() => ({
+  active: null as unknown,
+  issueNumber: null as number | null,
+}));
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { forumId: 'cats' }, query: {} }),
@@ -10,7 +17,10 @@ vi.mock('nuxt/app', () => ({
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: () => ({
-    result: ref({ channels: [{ wikiEnabled: true }] }),
+    // create-child only renders the form when a wiki home page exists.
+    result: ref({
+      channels: [{ wikiEnabled: true, WikiHomePage: { id: 'home-1' } }],
+    }),
     loading: ref(false),
     error: ref(null),
   }),
@@ -29,18 +39,41 @@ vi.mock('@/composables/useAuthState', () => ({
 
 vi.mock('@/composables/useSuspensionNotice', () => ({
   useChannelSuspensionNotice: () => ({
-    activeSuspension: ref(null),
-    issueNumber: ref(null),
+    activeSuspension: ref(suspension.active),
+    issueNumber: ref(suspension.issueNumber),
     suspendedUntil: ref(null),
     suspendedIndefinitely: ref(false),
     channelId: ref('cats'),
   }),
 }));
 
+const mountPage = async () => {
+  const Page = (await import('./create-child.vue')).default;
+  return shallowMount(Page);
+};
+
 describe('wiki create-child page', () => {
-  it('renders the create form actions when the wiki is enabled', async () => {
-    const Page = (await import('./create-child.vue')).default;
-    const wrapper = shallowMount(Page);
+  beforeEach(() => {
+    suspension.active = null;
+    suspension.issueNumber = null;
+  });
+
+  it('renders the create form with an edit-reason field when wiki is enabled', async () => {
+    const wrapper = await mountPage();
     expect(wrapper.findComponent(PrimaryButton).exists()).toBe(true);
+    expect(
+      wrapper
+        .findAllComponents(TextInput)
+        .some((c) => c.props('testId') === 'edit-reason-input')
+    ).toBe(true);
+  });
+
+  it('hides the form and shows a notice for a suspended user', async () => {
+    suspension.active = { suspendedIndefinitely: true };
+    suspension.issueNumber = 9;
+    const wrapper = await mountPage();
+
+    expect(wrapper.findComponent(PrimaryButton).exists()).toBe(false);
+    expect(wrapper.findComponent(SuspensionNotice).exists()).toBe(true);
   });
 });

--- a/pages/forums/[forumId]/wiki/create.spec.ts
+++ b/pages/forums/[forumId]/wiki/create.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import PrimaryButton from '@/components/PrimaryButton.vue';
+import SuspensionNotice from '@/components/SuspensionNotice.vue';
+import TextInput from '@/components/TextInput.vue';
+import TextEditor from '@/components/TextEditor.vue';
+
+const suspension = vi.hoisted(() => ({
+  active: null as unknown,
+  issueNumber: null as number | null,
+}));
+const createMutate = vi.hoisted(() => vi.fn());
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' }, query: {} }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@vue/apollo-composable', async () => {
+  const { ref } = await import('vue');
+  return {
+    useMutation: () => ({
+      mutate: createMutate,
+      loading: ref(false),
+      error: ref(null),
+      onDone: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/composables/useAuthState', async () => {
+  const { ref } = await import('vue');
+  return { useUsername: () => ref('alice') };
+});
+
+vi.mock('@/composables/useSuspensionNotice', async () => {
+  const { ref } = await import('vue');
+  return {
+    useChannelSuspensionNotice: () => ({
+      activeSuspension: ref(suspension.active),
+      issueNumber: ref(suspension.issueNumber),
+      suspendedUntil: ref(null),
+      suspendedIndefinitely: ref(false),
+      channelId: ref('cats'),
+    }),
+  };
+});
+
+const mountPage = async () => {
+  const Page = (await import('./create.vue')).default;
+  return shallowMount(Page);
+};
+
+const editReasonInput = (wrapper: Awaited<ReturnType<typeof mountPage>>) =>
+  wrapper
+    .findAllComponents(TextInput)
+    .find((c) => c.props('testId') === 'edit-reason-input');
+
+describe('wiki create page', () => {
+  beforeEach(() => {
+    suspension.active = null;
+    suspension.issueNumber = null;
+    createMutate.mockReset();
+  });
+
+  it('shows the form with an edit-reason field for an unsuspended user', async () => {
+    const wrapper = await mountPage();
+
+    expect(wrapper.find('form').exists()).toBe(true);
+    expect(wrapper.findComponent(PrimaryButton).exists()).toBe(true);
+    expect(editReasonInput(wrapper)).toBeTruthy();
+    expect(wrapper.findComponent(SuspensionNotice).exists()).toBe(false);
+  });
+
+  it('hides the form and shows a notice for a suspended user', async () => {
+    suspension.active = { suspendedIndefinitely: true };
+    suspension.issueNumber = 7;
+    const wrapper = await mountPage();
+
+    expect(wrapper.find('form').exists()).toBe(false);
+    expect(wrapper.findComponent(SuspensionNotice).exists()).toBe(true);
+  });
+
+  it('submits the entered edit reason with the create mutation', async () => {
+    const wrapper = await mountPage();
+
+    const titleInput = wrapper
+      .findAllComponents(TextInput)
+      .find((c) => c.props('testId') === 'title-input');
+    await titleInput?.vm.$emit('update', 'My Title');
+    await wrapper.findComponent(TextEditor).vm.$emit('update', 'Body content');
+    await editReasonInput(wrapper)?.vm.$emit('update', 'Fixed wording');
+
+    await wrapper.find('form').trigger('submit');
+
+    expect(createMutate).toHaveBeenCalledTimes(1);
+    const node =
+      createMutate.mock.calls[0][0].update.WikiHomePage.create.node;
+    expect(node.title).toBe('My Title');
+    expect(node.body).toBe('Body content');
+    expect(node.editReason).toBe('Fixed wording');
+  });
+});

--- a/pages/forums/[forumId]/wiki/edit/[slug].spec.ts
+++ b/pages/forums/[forumId]/wiki/edit/[slug].spec.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import TextInput from '@/components/TextInput.vue';
+import PrimaryButton from '@/components/PrimaryButton.vue';
+import SuspensionNotice from '@/components/SuspensionNotice.vue';
+
+const suspension = vi.hoisted(() => ({
+  active: null as unknown,
+  issueNumber: null as number | null,
+}));
 
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => ref('alice'),
@@ -9,8 +16,8 @@ vi.mock('@/composables/useAuthState', () => ({
 
 vi.mock('@/composables/useSuspensionNotice', () => ({
   useChannelSuspensionNotice: () => ({
-    activeSuspension: ref(null),
-    issueNumber: ref(null),
+    activeSuspension: ref(suspension.active),
+    issueNumber: ref(suspension.issueNumber),
     suspendedUntil: ref(null),
     suspendedIndefinitely: ref(false),
     channelId: ref('cats'),
@@ -45,10 +52,33 @@ vi.mock('@vue/apollo-composable', () => ({
   }),
 }));
 
+const mountPage = async () => {
+  const Page = (await import('./[slug].vue')).default;
+  return shallowMount(Page);
+};
+
 describe('wiki edit page', () => {
-  it('renders the wiki title input when the page loads', async () => {
-    const Page = (await import('./[slug].vue')).default;
-    const wrapper = shallowMount(Page);
+  beforeEach(() => {
+    suspension.active = null;
+    suspension.issueNumber = null;
+  });
+
+  it('renders the title and edit-reason inputs when the page loads', async () => {
+    const wrapper = await mountPage();
     expect(wrapper.findComponent(TextInput).exists()).toBe(true);
+    expect(
+      wrapper
+        .findAllComponents(TextInput)
+        .some((c) => c.props('testId') === 'edit-reason-input')
+    ).toBe(true);
+  });
+
+  it('hides the form and shows a notice for a suspended user', async () => {
+    suspension.active = { suspendedIndefinitely: true };
+    suspension.issueNumber = 11;
+    const wrapper = await mountPage();
+
+    expect(wrapper.findComponent(PrimaryButton).exists()).toBe(false);
+    expect(wrapper.findComponent(SuspensionNotice).exists()).toBe(true);
   });
 });

--- a/pages/forums/[forumId]/wiki/index.spec.ts
+++ b/pages/forums/[forumId]/wiki/index.spec.ts
@@ -4,6 +4,13 @@ import { ref } from 'vue';
 import { setActivePinia, createPinia } from 'pinia';
 import { useQuery } from '@vue/apollo-composable';
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
+import GenericButton from '@/components/GenericButton.vue';
+import SuspensionNotice from '@/components/SuspensionNotice.vue';
+
+const suspension = vi.hoisted(() => ({
+  active: null as unknown,
+  issueNumber: null as number | null,
+}));
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { forumId: 'cats' } }),
@@ -19,8 +26,8 @@ vi.mock('@/composables/useAuthState', () => ({
 
 vi.mock('@/composables/useSuspensionNotice', () => ({
   useChannelSuspensionNotice: () => ({
-    activeSuspension: ref(null),
-    issueNumber: ref(null),
+    activeSuspension: ref(suspension.active),
+    issueNumber: ref(suspension.issueNumber),
     suspendedUntil: ref(null),
     suspendedIndefinitely: ref(false),
     channelId: ref('cats'),
@@ -29,7 +36,7 @@ vi.mock('@/composables/useSuspensionNotice', () => ({
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
-const mountWith = async (channel: unknown) => {
+const mountWith = async (channel: unknown, stubs: Record<string, unknown> = {}) => {
   mockedUseQuery
     .mockReturnValueOnce({
       result: ref({ channels: [channel] }),
@@ -38,11 +45,16 @@ const mountWith = async (channel: unknown) => {
     })
     .mockReturnValueOnce({ onResult: vi.fn() });
   const Page = (await import('./index.vue')).default;
-  return shallowMount(Page);
+  return shallowMount(Page, { global: { stubs } });
 };
 
 describe('wiki home page', () => {
-  beforeEach(() => setActivePinia(createPinia()));
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    suspension.active = null;
+    suspension.issueNumber = null;
+    mockedUseQuery.mockReset();
+  });
 
   it('renders the wiki home page body when one exists', async () => {
     const wrapper = await mountWith({
@@ -57,5 +69,20 @@ describe('wiki home page', () => {
   it('shows a create prompt when there is no home page', async () => {
     const wrapper = await mountWith({ wikiEnabled: true, WikiHomePage: null });
     expect(wrapper.findComponent(MarkdownRenderer).exists()).toBe(false);
+  });
+
+  it('disables wiki edit buttons and shows a notice for a suspended user', async () => {
+    suspension.active = { suspendedIndefinitely: true };
+    suspension.issueNumber = 5;
+    const wrapper = await mountWith(
+      { wikiEnabled: true, WikiHomePage: { title: 'Home', body: 'Welcome' } },
+      // Render RequireAuth's has-auth slot so the gated buttons mount.
+      { RequireAuth: { template: '<div><slot name="has-auth" /></div>' } }
+    );
+
+    expect(wrapper.findComponent(SuspensionNotice).exists()).toBe(true);
+    const buttons = wrapper.findAllComponents(GenericButton);
+    expect(buttons.length).toBeGreaterThan(0);
+    expect(buttons.every((b) => b.props('disabled') === true)).toBe(true);
   });
 });

--- a/pages/u/[username]/wiki-edits.spec.ts
+++ b/pages/u/[username]/wiki-edits.spec.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
+
+const channelFilter = vi.hoisted(() => ({
+  selected: [] as string[],
+  hasSelected: false,
+}));
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { username: 'alice' }, query: {} }),
@@ -13,12 +18,18 @@ vi.mock('@vue/apollo-composable', () => ({
 
 vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
   useSelectedChannelsFromQuery: () => ({
-    selectedChannels: ref([]),
-    hasSelectedChannels: ref(false),
+    selectedChannels: ref(channelFilter.selected),
+    hasSelectedChannels: ref(channelFilter.hasSelected),
   }),
 }));
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+
+const NuxtLinkStub = {
+  name: 'NuxtLink',
+  props: ['to'],
+  template: '<a><slot /></a>',
+};
 
 const mountWith = async (wikiPages: unknown[]) => {
   mockedUseQuery.mockReturnValue({
@@ -27,12 +38,28 @@ const mountWith = async (wikiPages: unknown[]) => {
     error: ref(null),
   });
   const Page = (await import('./wiki-edits.vue')).default;
-  return shallowMount(Page, {
-    global: { stubs: { NuxtLink: { template: '<a><slot /></a>' } } },
-  });
+  return shallowMount(Page, { global: { stubs: { NuxtLink: NuxtLinkStub } } });
 };
 
+const SAMPLE = [
+  {
+    id: 'w1',
+    title: 'Cat Care',
+    slug: 'cat-care',
+    channelUniqueName: 'cats',
+    PastVersions: [
+      { id: 'v1', createdAt: '2024-02-01T00:00:00Z', editReason: 'Tidied up' },
+    ],
+  },
+];
+
 describe('user wiki edits page', () => {
+  beforeEach(() => {
+    channelFilter.selected = [];
+    channelFilter.hasSelected = false;
+    mockedUseQuery.mockReset();
+  });
+
   it('shows the empty-state message when there are no edits', async () => {
     expect((await mountWith([])).text()).toContain('No wiki edits yet');
   });
@@ -72,5 +99,37 @@ describe('user wiki edits page', () => {
     ]);
     const text = wrapper.text();
     expect(text.indexOf('NEWER')).toBeLessThan(text.indexOf('OLDER'));
+  });
+
+  it('shows the page title, channel, and edit reason', async () => {
+    const wrapper = await mountWith(SAMPLE);
+    const text = wrapper.text();
+    expect(text).toContain('Cat Care');
+    expect(text).toContain('in cats');
+    expect(text).toContain('Tidied up');
+  });
+
+  it('links to the wiki page and the revision diff', async () => {
+    const wrapper = await mountWith(SAMPLE);
+    const targets = wrapper
+      .findAllComponents(NuxtLinkStub)
+      .map((l) => l.props('to'));
+    expect(targets).toContain('/forums/cats/wiki/cat-care');
+    expect(targets).toContain(
+      '/forums/cats/wiki/revisions/diff/cat-care/v1'
+    );
+  });
+
+  it('narrows the query to the selected channels when filtering', async () => {
+    channelFilter.selected = ['cats'];
+    channelFilter.hasSelected = true;
+    await mountWith(SAMPLE);
+
+    // The page passes a reactive variables getter to useQuery.
+    const variablesGetter = mockedUseQuery.mock.calls[0][1] as () => {
+      where: { AND?: Array<{ channelUniqueName_IN?: string[] }> };
+    };
+    const where = variablesGetter().where;
+    expect(where.AND?.[1]?.channelUniqueName_IN).toEqual(['cats']);
   });
 });

--- a/tests/playwright/mocked/wiki/reportWikiEdit.spec.ts
+++ b/tests/playwright/mocked/wiki/reportWikiEdit.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '../../helpers/testFixture';
+import { buildChannel } from '../../helpers/graphqlFixtures';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import {
+  DEFAULT_MOD_ROLE,
+  DEFAULT_RULES_JSON,
+} from '../../helpers/moderationFixtures';
+
+const TEST_CHANNEL = 'cats';
+const SLUG = 'cat-care';
+const WIKI_PAGE_ID = 'wiki-page-1';
+const FORUM_RULE = 'Be kind';
+
+type ReportWikiEditVariables = {
+  wikiPageId?: string;
+  wikiRevisionId?: string | null;
+  selectedForumRules?: string[];
+  selectedServerRules?: string[];
+  reportText?: string;
+  channelUniqueName?: string;
+};
+
+const buildWikiPage = () => ({
+  __typename: 'WikiPage',
+  id: WIKI_PAGE_ID,
+  title: 'Cat Care Guide',
+  slug: SLUG,
+  body: 'Current version of the page.',
+  editReason: 'Latest tweak',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-15T00:00:00Z',
+  VersionAuthor: { username: 'carol' },
+  ChildPages: [],
+  PastVersions: [
+    {
+      id: 'rev-2',
+      body: 'Second version of the page.',
+      editReason: 'Clarified wording',
+      createdAt: '2024-01-10T00:00:00Z',
+      Author: { username: 'bob' },
+    },
+    {
+      id: 'rev-1',
+      body: 'Original version of the page.',
+      editReason: null,
+      createdAt: '2024-01-05T00:00:00Z',
+      Author: { username: 'alice' },
+    },
+  ],
+  Channel: { uniqueName: TEST_CHANNEL },
+});
+
+test('reports a wiki edit with the shared broken-rules modal', async ({
+  page,
+  setupMockedPage,
+}) => {
+  let reportVariables: ReportWikiEditVariables | null = null;
+
+  const { diagnostics } = await setupMockedPage({
+    username: 'alice',
+    email: 'alice@example.com',
+    handlers: {
+      ...createBaseHandlers({
+        username: 'alice',
+        channelId: TEST_CHANNEL,
+        isModerator: true,
+        moderatorDisplayName: 'alice',
+        serverConfigOverrides: {
+          rules: DEFAULT_RULES_JSON,
+          DefaultModRole: DEFAULT_MOD_ROLE,
+          DefaultElevatedModRole: DEFAULT_MOD_ROLE,
+        },
+        channelOverrides: {
+          rules: DEFAULT_RULES_JSON,
+          DefaultModRole: DEFAULT_MOD_ROLE,
+          ElevatedModRole: DEFAULT_MOD_ROLE,
+        },
+      }),
+      getWikiPage: () => ({ data: { wikiPages: [buildWikiPage()] } }),
+      getServerRules: () => ({
+        data: { serverConfigs: [{ rules: DEFAULT_RULES_JSON }] },
+      }),
+      getChannelRules: () => ({
+        data: {
+          channels: [
+            buildChannel({
+              uniqueName: TEST_CHANNEL,
+              overrides: { rules: DEFAULT_RULES_JSON },
+            }),
+          ],
+        },
+      }),
+      reportWikiEdit: ({ body }) => {
+        reportVariables = body.variables as ReportWikiEditVariables;
+        return {
+          data: { reportWikiEdit: { id: 'issue-1', issueNumber: 1 } },
+        };
+      },
+    },
+  });
+
+  await page.goto(
+    `/forums/${TEST_CHANNEL}/wiki/revisions/diff/${SLUG}/most-recent-edit`
+  );
+
+  await page.getByRole('button', { name: 'Report Edit' }).click();
+
+  // Shared modal opens in wiki mode.
+  await expect(page.getByText('Report Wiki Edit')).toBeVisible();
+
+  // Select a forum rule and add context.
+  await page
+    .getByTestId('forum-rules-section')
+    .getByTestId('broken-rule-checkbox')
+    .first()
+    .check();
+  await page
+    .getByTestId('report-wiki edit-input')
+    .fill('This revision is vandalism.');
+
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(
+    page.getByText('Your report was submitted successfully.')
+  ).toBeVisible();
+
+  expect(reportVariables).toEqual({
+    wikiPageId: WIKI_PAGE_ID,
+    wikiRevisionId: 'rev-2',
+    selectedForumRules: [FORUM_RULE],
+    selectedServerRules: [],
+    reportText: 'This revision is vandalism.',
+    channelUniqueName: TEST_CHANNEL,
+  });
+  expect(diagnostics.pageErrors).toEqual([]);
+});

--- a/tests/playwright/mocked/wiki/wikiRevisions.spec.ts
+++ b/tests/playwright/mocked/wiki/wikiRevisions.spec.ts
@@ -94,7 +94,8 @@ const buildWikiPage = (overrides = {}) => ({
       body: 'Second version of the page.',
       editReason: 'Clarified wording',
       createdAt: '2024-01-10T00:00:00Z',
-      Author: { username: 'bob' },
+      // Authored by the test user, so they may redact it (author authorization).
+      Author: { username: TEST_USER },
     },
     {
       id: 'rev-1',
@@ -207,7 +208,7 @@ test.describe('Wiki revision history pages', () => {
       await expect(
         page.getByRole('heading', { name: 'Current Version', exact: true })
       ).toBeVisible();
-      await expect(page.getByText('From version by bob')).toBeVisible();
+      await expect(page.getByText('From version by alice')).toBeVisible();
       await expect(page.getByText('To version by carol')).toBeVisible();
       await expect(
         page.getByText('Second version of the page.', { exact: true })
@@ -297,6 +298,71 @@ test.describe('Wiki revision history pages', () => {
       );
       await expect(
         page.getByRole('heading', { name: 'Revision History For Wiki Page' })
+      ).toBeVisible();
+
+      expect(diagnostics.pageErrors).toEqual([]);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('the revision selector updates the comparison and stays in sync on refresh', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      getWikiPage: () => ({ data: { wikiPages: [buildWikiPage()] } }),
+    });
+
+    try {
+      await page.goto(
+        `/forums/${TEST_CHANNEL}/wiki/revisions/diff/${SLUG}/most-recent-edit`
+      );
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'getWikiPage'
+      );
+
+      // Most-recent comparison: rev-2 vs current.
+      await expect(
+        page.getByText('Current version of the page.', { exact: true })
+      ).toBeVisible();
+      await expect(
+        page.getByText('Original version of the page.', { exact: true })
+      ).toHaveCount(0);
+
+      // Select the older revision; the page updates in place (no return to list).
+      await page.locator('#wiki-revision-select').selectOption('rev-1');
+      await expect(page).toHaveURL(
+        new RegExp(`/wiki/revisions/diff/${SLUG}/rev-1$`)
+      );
+      await expect(
+        page.getByText('Original version of the page.', { exact: true })
+      ).toBeVisible();
+      await expect(
+        page.getByText('Current version of the page.', { exact: true })
+      ).toHaveCount(0);
+
+      // The diff stays in sync with the URL after a refresh.
+      await page.reload();
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'getWikiPage'
+      );
+      await expect(page).toHaveURL(
+        new RegExp(`/wiki/revisions/diff/${SLUG}/rev-1$`)
+      );
+      await expect(
+        page.getByText('Original version of the page.', { exact: true })
       ).toBeVisible();
 
       expect(diagnostics.pageErrors).toEqual([]);


### PR DESCRIPTION
Stacked on #179. Net-new test coverage for the wiki revision moderation workflows — no behavior changes (the only non-test change is a chart test fixture).

## Unit (Vitest)
- **Report UI**: `BrokenRulesModal` renders "Report Wiki Edit" in wiki mode.
- **Edit reasons / suspension** on the wiki form pages:
  - `create`: edit-reason field present; create flow submits `editReason`; suspended user sees the notice with the form hidden.
  - `create-child` / `edit`: edit-reason field present; suspended user → form hidden + notice.
  - `index` (home): edit buttons disabled + notice when suspended.
- **Profile `wiki-edits` tab**: page/revision link routing, title/channel/edit-reason display, and channel-filter query narrowing.
- **Contribution chart**: a wiki-edits fixture drives the selected-day summary count, the "Wiki Edits" details section, and the page/revision links.

## E2E (Playwright)
- **Report flow**: Report Edit → shared modal → select a rule → Submit calls `reportWikiEdit` with the wiki page id, revision id (`rev-2`), selected rules, report text, and channel; success notification shown.
- **Diff selector**: selecting another revision updates the comparison in place (no return to the list) and stays in sync with the URL after refresh.
- **wikiRevisions**: updated so the redact action is exercised by an *authorized* user (the test user authored the revision), reflecting the redaction gating added in #179.

Full unit suite green (593 files / 5006 tests). Wiki Playwright dir green (6/6) against a warm dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)