### PR TITLE
Test download Activity tab; fix description ErrorBanner import

### DIFF
--- a/components/discussion/detail/DownloadTabNavigation.spec.ts
+++ b/components/discussion/detail/DownloadTabNavigation.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+
+vi.mock('nuxt/app', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: ref({ publicCollectionsContaining: [] }),
+    loading: ref(false),
+    error: ref(null),
+  }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref(''),
+}));
+
+const NuxtLinkStub = {
+  name: 'NuxtLink',
+  props: ['to'],
+  template: '<a><slot /></a>',
+};
+
+const mountNav = async (routeName: string) => {
+  const Component = (await import('./DownloadTabNavigation.vue')).default;
+  return shallowMount(Component, {
+    props: { discussionId: 'd1', channelId: 'cats', aggregateCommentCount: 5 },
+    global: {
+      mocks: { $route: { name: routeName } },
+      stubs: {
+        NuxtLink: NuxtLinkStub,
+        NuxtPage: true,
+        MarkdownPreview: true,
+        PublicCollectionListItem: true,
+        PencilIcon: true,
+      },
+    },
+  });
+};
+
+describe('DownloadTabNavigation', () => {
+  it('renders Description, Comments, and Activity tabs routed to the nested pages', async () => {
+    const wrapper = await mountNav('forums-forumId-downloads-discussionId');
+    const links = wrapper.findAllComponents(NuxtLinkStub);
+
+    expect(links).toHaveLength(3);
+
+    expect(links[0].text()).toBe('Description');
+    expect(links[0].props('to').name).toBe(
+      'forums-forumId-downloads-discussionId'
+    );
+
+    expect(links[1].text()).toContain('Comments (5)');
+    expect(links[1].props('to').name).toBe(
+      'forums-forumId-downloads-discussionId-comments'
+    );
+
+    expect(links[2].text()).toBe('Activity');
+    expect(links[2].props('to').name).toBe(
+      'forums-forumId-downloads-discussionId-activity'
+    );
+  });
+
+  it('applies the active style to the Activity tab when on the activity route', async () => {
+    const wrapper = await mountNav(
+      'forums-forumId-downloads-discussionId-activity'
+    );
+    const links = wrapper.findAllComponents(NuxtLinkStub);
+
+    expect(links[2].classes()).toContain('border-orange-500');
+    // Description is inactive while on the activity route.
+    expect(links[0].classes()).toContain('border-transparent');
+  });
+});

--- a/components/discussion/detail/activityFeed/DiscussionTitleVersions.spec.ts
+++ b/components/discussion/detail/activityFeed/DiscussionTitleVersions.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import DiscussionTitleVersions from './DiscussionTitleVersions.vue';
+
+vi.mock('@/utils', () => ({ timeAgo: () => 'just now' }));
+
+// PastTitleVersions are returned newest-first by the query.
+const buildDiscussion = (overrides: Record<string, unknown> = {}) => ({
+  title: 'Current Title',
+  PastTitleVersions: [
+    {
+      id: 'v2',
+      body: 'Second Title',
+      createdAt: '2024-02-01T00:00:00Z',
+      Author: { username: 'bob' },
+    },
+    {
+      id: 'v1',
+      body: 'First Title',
+      createdAt: '2024-01-01T00:00:00Z',
+      Author: { username: 'alice' },
+    },
+  ],
+  ...overrides,
+});
+
+const mountVersions = (discussion: Record<string, unknown>) =>
+  mount(DiscussionTitleVersions, { props: { discussion: discussion as never } });
+
+describe('DiscussionTitleVersions', () => {
+  it('renders nothing when there are no past title versions', () => {
+    const wrapper = mountVersions(buildDiscussion({ PastTitleVersions: [] }));
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('shows the most recent title change with old (strikethrough) → new and author', () => {
+    const wrapper = mountVersions(buildDiscussion());
+
+    expect(wrapper.text()).toContain('Title Edit History');
+    // Most recent transition: Second Title -> Current Title, by bob.
+    expect(wrapper.text()).toContain('bob');
+    expect(wrapper.text()).toContain('Current Title');
+
+    const struck = wrapper.findAll('.line-through').map((s) => s.text());
+    expect(struck).toContain('Second Title');
+
+    // Older edit is collapsed by default.
+    expect(wrapper.text()).not.toContain('First Title');
+  });
+
+  it('expands older edits on demand', async () => {
+    const wrapper = mountVersions(buildDiscussion());
+
+    const showButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Show 1 older edit'));
+    expect(showButton).toBeTruthy();
+
+    await showButton!.trigger('click');
+
+    expect(wrapper.text()).toContain('First Title');
+    expect(wrapper.text()).toContain('alice');
+    expect(
+      wrapper.findAll('button').some((b) => b.text().includes('Hide older edits'))
+    ).toBe(true);
+  });
+
+  it('falls back to [Deleted] when a past version has no author', () => {
+    const wrapper = mountVersions(
+      buildDiscussion({
+        PastTitleVersions: [
+          {
+            id: 'v1',
+            body: 'First Title',
+            createdAt: '2024-01-01T00:00:00Z',
+            Author: null,
+          },
+        ],
+      })
+    );
+
+    expect(wrapper.text()).toContain('[Deleted]');
+  });
+});

--- a/components/discussion/detail/activityFeed/LabelChangeHistory.spec.ts
+++ b/components/discussion/detail/activityFeed/LabelChangeHistory.spec.ts
@@ -64,6 +64,22 @@ describe('LabelChangeHistory item', () => {
   });
 });
 
+describe('LabelChangeHistory badge styling', () => {
+  it('styles an added label green without strikethrough', () => {
+    const wrapper = mountHistory([change({ actionType: 'added' })]);
+
+    expect(wrapper.html()).toContain('bg-green-100');
+    expect(wrapper.find('.line-through').exists()).toBe(false);
+  });
+
+  it('styles a removed label red with strikethrough', () => {
+    const wrapper = mountHistory([change({ actionType: 'removed' })]);
+
+    expect(wrapper.html()).toContain('bg-red-100');
+    expect(wrapper.find('.line-through').exists()).toBe(true);
+  });
+});
+
 describe('LabelChangeHistory collapse', () => {
   const three = [
     change({ id: 'c1', labelDisplayName: 'First' }),

--- a/pages/forums/[forumId]/downloads/[discussionId]/activity.spec.ts
+++ b/pages/forums/[forumId]/downloads/[discussionId]/activity.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import DiscussionTitleVersions from '@/components/discussion/detail/activityFeed/DiscussionTitleVersions.vue';
+import LabelChangeHistory from '@/components/discussion/detail/activityFeed/LabelChangeHistory.vue';
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { discussionId: 'd1', forumId: 'cats' } }),
@@ -35,5 +36,37 @@ describe('download activity page', () => {
       DiscussionChannels: [],
     });
     expect(wrapper.findComponent(DiscussionTitleVersions).exists()).toBe(true);
+  });
+
+  it('renders label-change history when the download has label changes', async () => {
+    const wrapper = await mountWith({
+      PastTitleVersions: [],
+      DiscussionChannels: [
+        {
+          channelUniqueName: 'cats',
+          LabelChangeHistory: [
+            { id: 'l1', actionType: 'added', labelDisplayName: 'Bug' },
+          ],
+        },
+      ],
+    });
+    expect(wrapper.findComponent(LabelChangeHistory).exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('No activity to display yet.');
+  });
+
+  it('renders both title and label history when both exist', async () => {
+    const wrapper = await mountWith({
+      PastTitleVersions: [{ id: 't1' }],
+      DiscussionChannels: [
+        {
+          channelUniqueName: 'cats',
+          LabelChangeHistory: [
+            { id: 'l1', actionType: 'removed', labelDisplayName: 'Bug' },
+          ],
+        },
+      ],
+    });
+    expect(wrapper.findComponent(DiscussionTitleVersions).exists()).toBe(true);
+    expect(wrapper.findComponent(LabelChangeHistory).exists()).toBe(true);
   });
 });

--- a/pages/forums/[forumId]/downloads/[discussionId]/description.spec.ts
+++ b/pages/forums/[forumId]/downloads/[discussionId]/description.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import ErrorBanner from '@/components/ErrorBanner.vue';
+import DiscussionTitleVersions from '@/components/discussion/detail/activityFeed/DiscussionTitleVersions.vue';
+
+const mutationError = vi.hoisted(
+  () => ({ value: null as null | { message: string } })
+);
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { discussionId: 'd1' } }),
+}));
+
+vi.mock('@vue/apollo-composable', async () => {
+  const { ref } = await import('vue');
+  return {
+    useMutation: () => ({
+      mutate: vi.fn(),
+      error: ref(mutationError.value),
+      loading: ref(false),
+      onDone: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/composables/useAuthState', async () => {
+  const { ref } = await import('vue');
+  return { useUsername: () => ref('alice') };
+});
+
+const discussion = {
+  title: 'A download',
+  body: 'Download body text',
+  Author: { username: 'alice' },
+};
+
+const mountPage = async () => {
+  const Page = (await import('./description.vue')).default;
+  return shallowMount(Page, { props: { discussion: discussion as never } });
+};
+
+describe('download description tab', () => {
+  beforeEach(() => {
+    mutationError.value = null;
+  });
+
+  it('shows the edit button for the owner', async () => {
+    const wrapper = await mountPage();
+    expect(
+      wrapper.find('[data-testid="edit-download-button"]').exists()
+    ).toBe(true);
+  });
+
+  it('does not render title edit history on the description tab', async () => {
+    const wrapper = await mountPage();
+    expect(wrapper.findComponent(DiscussionTitleVersions).exists()).toBe(false);
+  });
+
+  it('shows an error banner in edit mode when the update fails', async () => {
+    mutationError.value = { message: 'Update failed' };
+    const wrapper = await mountPage();
+
+    await wrapper.find('[data-testid="edit-download-button"]').trigger('click');
+
+    const banner = wrapper.findComponent(ErrorBanner);
+    expect(banner.exists()).toBe(true);
+    expect(banner.props('text')).toBe('Update failed');
+  });
+});

--- a/pages/forums/[forumId]/downloads/[discussionId]/description.vue
+++ b/pages/forums/[forumId]/downloads/[discussionId]/description.vue
@@ -10,6 +10,7 @@ import TextEditor from '@/components/TextEditor.vue';
 import PrimaryButton from '@/components/PrimaryButton.vue';
 import GenericButton from '@/components/GenericButton.vue';
 import CharCounter from '@/components/CharCounter.vue';
+import ErrorBanner from '@/components/ErrorBanner.vue';
 import { MAX_CHARS_IN_DISCUSSION_BODY } from '@/utils/constants';
 import type {
   Discussion,


### PR DESCRIPTION
Coverage for the download detail **Activity tab** (label-change + title-edit history), plus one bug fix surfaced while writing the tests.

## Fix
`pages/forums/[forumId]/downloads/[discussionId]/description.vue` used `<ErrorBanner>` without importing it — the edit-error branch would fail to render. Added the import, guarded by a new test.

## Tests (Vitest)
- **`DownloadTabNavigation.spec.ts`** (new) — Description/Comments/Activity tabs render, route to the nested pages, and apply active styling to the current tab. *(Workflow 1)*
- **`DiscussionTitleVersions.spec.ts`** (new) — most-recent title change (old strikethrough → new) with author, "Show older edits" expand, `[Deleted]` author fallback. *(Workflow 3)*
- **`LabelChangeHistory.spec.ts`** (extended) — added = green badge (no strikethrough), removed = red badge + strikethrough. *(Workflow 2)*
- **`activity.spec.ts`** (extended) — renders label-change history; renders both title + label history when both exist. *(Workflows 2–3; empty state already covered)*
- **`description.spec.ts`** (new) — owner edit button shown; title edit history is **not** on the Description tab; ErrorBanner renders in edit mode on update failure (guards the fix). *(Workflow 3)*

## Not included — full-page Playwright e2e
The download detail route fires ~8 GraphQL operations (large `GET_DISCUSSION`, comments + aggregates, channel, server config, public collections). The repo already has a `downloads/downloadLabels.spec.ts` deliberately `.skip`ped for this reason ("functionality covered by unit tests"). The unit specs above cover every workflow assertion directly, so I followed that existing call rather than build the extensive/fragile mock set.

Full unit suite green (595 files / 5041 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)