### PR TITLE
First channel-page E2E (Downloads-tab gate) + fix mock fixtures to carry __typename

### DIFF
--- a/tests/playwright/helpers/graphqlFixtures.ts
+++ b/tests/playwright/helpers/graphqlFixtures.ts
@@ -67,6 +67,7 @@ export type BasicUserFixture = UserFixture &
 
 export type ServerConfigFixture = Pick<
   ServerConfig,
+  | '__typename'
   | 'serverName'
   | 'serverIconURL'
   | 'serverDescription'
@@ -87,6 +88,7 @@ export type ServerConfigFixture = Pick<
 
 export type ChannelFixture = Pick<
   Channel,
+  | '__typename'
   | 'uniqueName'
   | 'displayName'
   | 'channelIconURL'
@@ -261,6 +263,7 @@ export const buildBasicUser = (
 export const buildServerConfig = (
   overrides: Override<ServerConfigFixture> = {}
 ): ServerConfigFixture => ({
+  __typename: 'ServerConfig',
   serverName: 'Listical',
   serverIconURL: '',
   serverDescription: '',
@@ -294,6 +297,7 @@ export const buildChannel = ({
   discussionChannelsCount?: number;
   overrides?: Override<ChannelFixture>;
 } = {}): ChannelFixture => ({
+  __typename: 'Channel',
   uniqueName,
   displayName,
   channelIconURL: '',

--- a/tests/playwright/mocked/channels/downloadsTabGate.spec.ts
+++ b/tests/playwright/mocked/channels/downloadsTabGate.spec.ts
@@ -43,9 +43,12 @@ const getMocks = (serverEnableDownloads: boolean) => ({
   getServerConfig: () => ({
     data: {
       serverConfigs: [
+        // buildServerConfig takes the override fields directly (no nested
+        // `overrides` key, unlike buildChannel).
         buildServerConfig({
           serverName: 'Listical',
-          overrides: { enableDownloads: serverEnableDownloads, enableEvents: true },
+          enableDownloads: serverEnableDownloads,
+          enableEvents: true,
         }),
       ],
     },
@@ -129,13 +132,25 @@ test.describe('Downloads tab — server enableDownloads gate', () => {
     }
   });
 
-  // NOTE: the negative case (server downloads disabled → no visible Downloads
-  // tab) is intentionally NOT asserted yet. ChannelTabs renders a `<ClientOnly>`
-  // SSR-fallback nav that iterates the UNFILTERED `baseTabs` (it does not apply
-  // the `serverDownloadsEnabled` filter that the real desktop/mobile navs use)
-  // and gives it the SAME `forum-tab-*` test id, so a Downloads tab stays
-  // visible even when the server disables downloads. That looks like a real
-  // gate hole in the fallback path; it should be fixed in ChannelTabs (and the
-  // fallback given a distinct test id) before the negative case can be asserted.
-  // Tracked in gennit-project/multiforum-nuxt#185.
+  test('hides the Downloads tab when the server has downloads disabled', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, getMocks(false));
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/discussions`);
+      // Wait for the tab bar to render before asserting the Downloads tab is
+      // absent, so the assertion can't pass merely because the page hasn't
+      // booted yet.
+      await expect(visibleTab(page, 'discussions')).not.toHaveCount(0);
+      await expect(visibleTab(page, 'downloads')).toHaveCount(0);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
 });

--- a/tests/playwright/mocked/channels/downloadsTabGate.spec.ts
+++ b/tests/playwright/mocked/channels/downloadsTabGate.spec.ts
@@ -1,0 +1,141 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../../helpers/testFixture';
+import {
+  buildBasicUser,
+  buildChannel,
+  buildServerConfig,
+} from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import { installGraphqlMocks } from '../../helpers/mockGraphql';
+
+// The Downloads tab is gated by BOTH the channel-level `downloadsEnabled` flag
+// AND the server-wide `ServerConfig.enableDownloads` switch (ChannelTabs.vue):
+// the tab only shows when the channel has downloads on AND the server allows
+// downloads at all. This is the UI side of the server-wide downloads gate
+// (the backend now enforces the same flag on download creation).
+const TEST_CHANNEL = 'downloads-forum';
+const TEST_USER = 'alice';
+
+const getMocks = (serverEnableDownloads: boolean) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username: TEST_USER, displayName: TEST_USER })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username: TEST_USER,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username: TEST_USER, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username: TEST_USER, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username: TEST_USER, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: {
+      serverConfigs: [
+        buildServerConfig({
+          serverName: 'Listical',
+          overrides: { enableDownloads: serverEnableDownloads, enableEvents: true },
+        }),
+      ],
+    },
+  }),
+  getChannel: () => ({
+    data: {
+      channels: [
+        buildChannel({
+          uniqueName: TEST_CHANNEL,
+          displayName: 'Downloads Forum',
+          // The channel itself has downloads turned on; whether the tab shows
+          // is then decided by the server-wide flag.
+          overrides: { downloadsEnabled: true, eventsEnabled: true },
+        }),
+      ],
+    },
+  }),
+  getChannelTags: () => ({
+    data: { channels: [{ __typename: 'Channel', uniqueName: TEST_CHANNEL, Tags: [] }] },
+  }),
+  getTags: () => ({ data: { tags: [] } }),
+  userIsModInChannel: () => ({
+    data: {
+      channels: [
+        {
+          __typename: 'Channel',
+          uniqueName: TEST_CHANNEL,
+          Admins: [],
+          SuspendedUsers: [],
+          Moderators: [],
+          SuspendedMods: [],
+        },
+      ],
+    },
+  }),
+  getDiscussionsInChannel: () => ({ data: { getDiscussionsInChannel: [] } }),
+  getChannelDownloadCount: () => ({
+    data: {
+      channels: [
+        {
+          __typename: 'Channel',
+          uniqueName: TEST_CHANNEL,
+          DiscussionChannelsAggregate: { count: 0 },
+        },
+      ],
+    },
+  }),
+});
+
+// Scope to the channel TAB bar specifically, and only count what's actually
+// VISIBLE to the user. Reasons:
+//  - Plain href is ambiguous (the global sidebar + per-forum section nav also
+//    link to /forums/<forum>/downloads); only the tab bar is enableDownloads-gated.
+//  - ChannelTabs renders a hidden SSR-fallback nav from the UNFILTERED baseTabs,
+//    so the gated tab can linger in the DOM while not being visible. Asserting on
+//    `:visible` tests the behavior the user actually sees.
+// The forum page renders ChannelTabs with :desktop="false" → forum-tab-mobile-*.
+const visibleTab = (page: Page, name: string) =>
+  page.locator(`[data-testid="forum-tab-mobile-${name}"]:visible`);
+
+test.describe('Downloads tab — server enableDownloads gate', () => {
+  test('shows the Downloads tab when the server allows downloads', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, getMocks(true));
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/discussions`);
+      // The Discussions tab always renders, anchoring the tab bar. (The forum
+      // renders both a desktop and a mobile tab bar, so each tab href appears
+      // more than once — assert on presence/count rather than a single node.)
+      await expect(visibleTab(page, 'discussions')).not.toHaveCount(0);
+      await expect(visibleTab(page, 'downloads')).not.toHaveCount(0);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  // NOTE: the negative case (server downloads disabled → no visible Downloads
+  // tab) is intentionally NOT asserted yet. ChannelTabs renders a `<ClientOnly>`
+  // SSR-fallback nav that iterates the UNFILTERED `baseTabs` (it does not apply
+  // the `serverDownloadsEnabled` filter that the real desktop/mobile navs use)
+  // and gives it the SAME `forum-tab-*` test id, so a Downloads tab stays
+  // visible even when the server disables downloads. That looks like a real
+  // gate hole in the fallback path; it should be fixed in ChannelTabs (and the
+  // fallback given a distinct test id) before the negative case can be asserted.
+  // Tracked in gennit-project/multiforum-nuxt#185.
+});


### PR DESCRIPTION
## What

Adds the **first channel-page Playwright test** (both gate directions) and fixes a fixtures gap that was blocking channel-page E2E coverage generally.

### Reusable infra fix (the important part)
`buildChannel` and `buildServerConfig` were missing `__typename`. Without it, Apollo's `InMemoryCache` can't normalize the entity, so the channel reached components with **only its key field (`uniqueName`)** — every channel-field-dependent piece of UI (tabs, banners, settings) silently received `undefined` and couldn't be tested. Adding `__typename` (`'Channel'` / `'ServerConfig'`) to the builders and their fixture types fixes this for **all future channel-page tests**. Existing channel specs (`channelLocking`) still pass.

### The test
`downloadsTabGate.spec.ts` verifies the forum **Downloads tab shows when `ServerConfig.enableDownloads` is on and is hidden when it's off** — the UI side of the server-wide downloads gate the backend now also enforces on download creation (multiforum-backend#88).

## Verification
- Both cases (enabled / disabled) + `channelLocking` run green locally (mocked Playwright).
- ESLint clean. (Local `vue-tsc` is broken — `vue-router/volar` — so CI is authoritative for typecheck.)

## Notes
Found during the Tier-1 coverage audit. The separate onboarding (`/create-username`) test is blocked by a different harness limitation, tracked in #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)