### PR TITLE
test: cover Share clipboard, comment-search nav, super-upvote error state

### DIFF
--- a/components/superUpvote/SuperUpvoteModal.spec.ts
+++ b/components/superUpvote/SuperUpvoteModal.spec.ts
@@ -111,6 +111,14 @@ describe('SuperUpvoteModal validation', () => {
     expect(sendButton(wrapper).attributes('disabled')).toBeDefined();
   });
 
+  it('shows the textarea error state when over the character limit', async () => {
+    const wrapper = mountModal();
+
+    await wrapper.get('textarea').setValue('x'.repeat(501));
+
+    expect(wrapper.get('textarea').classes()).toContain('border-red-500');
+  });
+
   it('shows characters remaining', () => {
     const wrapper = mountModal();
 

--- a/composables/useCopyCurrentUrl.spec.ts
+++ b/composables/useCopyCurrentUrl.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useCopyCurrentUrl } from '@/composables/useCopyCurrentUrl';
+
+// The composable backs the "Share" button on the image- and album-detail pages:
+// it copies the current route's absolute URL and briefly shows a "Link copied!"
+// notification (auto-resetting after 2s). These tests lock in that behavior,
+// which is otherwise only covered by manual QA.
+
+const writeText = vi.fn();
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ path: '/u/alice/images/img1' }),
+  useRouter: () => ({
+    resolve: () => ({ href: '/u/alice/images/img1' }),
+  }),
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  writeText.mockReset().mockResolvedValue(undefined);
+  vi.stubGlobal('navigator', { clipboard: { writeText } });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('useCopyCurrentUrl', () => {
+  it('writes the current route URL to the clipboard', async () => {
+    const { copyCurrentUrl } = useCopyCurrentUrl();
+
+    await copyCurrentUrl();
+
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/u/alice/images/img1')
+    );
+  });
+
+  it('flips the copied notification on after a successful copy', async () => {
+    const { showCopiedNotification, copyCurrentUrl } = useCopyCurrentUrl();
+
+    await copyCurrentUrl();
+
+    expect(showCopiedNotification.value).toBe(true);
+  });
+
+  it('resets the copied notification after the 2s timeout', async () => {
+    const { showCopiedNotification, copyCurrentUrl } = useCopyCurrentUrl();
+
+    await copyCurrentUrl();
+    vi.advanceTimersByTime(2000);
+
+    expect(showCopiedNotification.value).toBe(false);
+  });
+
+  it('does not flip the notification when the clipboard write fails', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { showCopiedNotification, copyCurrentUrl } = useCopyCurrentUrl();
+
+    await copyCurrentUrl();
+    errorSpy.mockRestore();
+
+    expect(showCopiedNotification.value).toBe(false);
+  });
+});

--- a/pages/comments/search.spec.ts
+++ b/pages/comments/search.spec.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
-import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, mount } from '@vue/test-utils';
 import { ref, defineComponent, h } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 
 const routeQuery: Record<string, unknown> = {};
+const mockRouterPush = vi.fn();
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ query: routeQuery }),
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockRouterPush, resolve: (r: unknown) => r }),
   useHead: vi.fn(),
 }));
 
@@ -44,6 +45,10 @@ const mountWith = async (opts: {
   });
 };
 
+beforeEach(() => {
+  mockRouterPush.mockClear();
+});
+
 describe('comment search page', () => {
   it('prompts for a search term when the input is empty', async () => {
     const wrapper = await mountWith({ searchInput: '' });
@@ -66,5 +71,110 @@ describe('comment search page', () => {
       count: 0,
     });
     expect(wrapper.text()).toContain('No comments match your search.');
+  });
+});
+
+// A search result card is itself a permalink: clicking the card navigates to the
+// matched comment, while the nested author/context/"View comment" links use
+// @click.stop so they reach their own destinations instead of the comment
+// permalink. These tests cover that interaction (previously manual-only).
+describe('comment search result navigation', () => {
+  const discussionComment = {
+    id: 'comment-1',
+    text: 'a matching comment',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    CommentAuthor: {
+      __typename: 'User',
+      username: 'bob',
+      displayName: 'Bob',
+      profilePicURL: '',
+    },
+    DiscussionChannel: {
+      channelUniqueName: 'cats',
+      discussionId: 'discussion-1',
+      Discussion: { title: 'Great topic' },
+    },
+  };
+
+  const RouterLinkStub = { props: ['to'], template: '<a><slot /></a>' };
+  const passthrough = (tag = 'div') => ({ template: `<${tag}><slot /></${tag}>` });
+
+  const mountResults = async () => {
+    routeQuery.searchInput = 'matching';
+    mockedUseQuery.mockReturnValue({
+      result: ref({
+        comments: [discussionComment],
+        commentsAggregate: { count: 1 },
+      }),
+      loading: ref(false),
+      error: ref(null),
+      fetchMore: vi.fn(),
+    });
+    const Page = (await import('./search.vue')).default;
+    return mount(Page, {
+      global: {
+        stubs: {
+          NuxtLayout: NuxtLayoutStub,
+          RouterLink: RouterLinkStub,
+          SearchBar: passthrough(),
+          FilterChip: passthrough(),
+          ChannelIcon: passthrough('span'),
+          SearchableForumList: passthrough(),
+          AvatarComponent: passthrough('span'),
+          MarkdownPreview: passthrough(),
+          LoadMore: passthrough(),
+        },
+      },
+    });
+  };
+
+  it('navigates to the comment permalink when the card is clicked', async () => {
+    const wrapper = await mountResults();
+
+    await wrapper.get('[role="link"]').trigger('click');
+
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'forums-forumId-discussions-discussionId-comments-commentId',
+        params: expect.objectContaining({
+          forumId: 'cats',
+          discussionId: 'discussion-1',
+          commentId: 'comment-1',
+        }),
+      })
+    );
+  });
+
+  it('does not trigger card navigation when the author link is clicked', async () => {
+    const wrapper = await mountResults();
+    const authorLink = wrapper
+      .findAll('a')
+      .find((a) => a.text().includes('Bob'))!;
+
+    await authorLink.trigger('click');
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger card navigation when the context link is clicked', async () => {
+    const wrapper = await mountResults();
+    const contextLink = wrapper
+      .findAll('a')
+      .find((a) => a.text().includes('Great topic'))!;
+
+    await contextLink.trigger('click');
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger card navigation when the "View comment" link is clicked', async () => {
+    const wrapper = await mountResults();
+    const viewLink = wrapper
+      .findAll('a')
+      .find((a) => a.text().includes('View comment'))!;
+
+    await viewLink.trigger('click');
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes three manual-only test gaps identified while auditing the super-upvote / scratchpad and related QA checklists. These behaviors previously had no automated coverage.

- **`composables/useCopyCurrentUrl.spec.ts` (new)** — the Share button's copy-to-clipboard + "Link copied!" notification logic (used by both the image- and album-detail pages) was untested. Covers the clipboard write, the notification toggle, the 2s auto-reset, and the failure path.
- **`pages/comments/search.spec.ts`** — adds result-card navigation coverage: clicking a card opens the matched comment permalink, while the nested author / context / "View comment" links use `@click.stop` and do **not** trigger card navigation.
- **`components/superUpvote/SuperUpvoteModal.spec.ts`** — asserts the textarea's red error state when over the 500-char limit (previously only the disabled Send button was checked).

## Notes / scope

- **In-discussion comment search UI was intentionally not tested**: it is currently gated behind `v-if="false"` in `CommentSection.vue` (`<!-- hidden until feature is complete -->`). The underlying `filterCommentsBySearch` logic is already unit-tested; testing the hidden markup would be testing dead UI.
- Backend-only assertions (e.g. "deleting a scratchpad entry keeps the super-upvote relationship", exact notification strings) and brittle CSS checks (mobile comment padding) were left to manual/backend testing by design.

## Test plan

- `npm run test:unit -- --run composables/useCopyCurrentUrl.spec.ts pages/comments/search.spec.ts components/superUpvote/SuperUpvoteModal.spec.ts` → 24 passed
- `npm run tsc` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)