### PR TITLE
E2E coverage for admin server-settings pages (Tier-1)

### DIFF
--- a/tests/playwright/mocked/admin/serverSettings.spec.ts
+++ b/tests/playwright/mocked/admin/serverSettings.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '../../helpers/testFixture';
+import { buildBasicUser, buildServerConfig } from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import { installGraphqlMocks } from '../../helpers/mockGraphql';
+
+// Server settings pages (admin/settings/*) read the single ServerConfig and let
+// an admin edit it. These are admin-only configuration surfaces that had no
+// end-to-end coverage; here we verify each tab renders its form for an admin.
+const TEST_USER = 'alice';
+
+const getMocks = (overrides: { enableDownloads?: boolean } = {}) => ({
+  getBasicUserInfo: () => ({
+    data: { users: [buildBasicUser({ username: TEST_USER, displayName: TEST_USER })] },
+  }),
+  getUser: () => ({
+    data: {
+      users: [
+        {
+          username: TEST_USER,
+          notifyOnReplyToDiscussionByDefault: true,
+          notifyOnReplyToEventByDefault: true,
+        },
+      ],
+    },
+  }),
+  getUserFavorites: () => ({
+    data: { users: [{ username: TEST_USER, FavoriteChannels: [], Collections: [] }] },
+  }),
+  GetUserFavoriteChannels: () => ({
+    data: { users: [{ username: TEST_USER, FavoriteChannels: [] }] },
+  }),
+  GetUserChannelCollectionsWithChannels: () => ({
+    data: { users: [{ username: TEST_USER, Collections: [] }] },
+  }),
+  getServerConfig: () => ({
+    data: {
+      serverConfigs: [
+        buildServerConfig({
+          serverName: 'Listical',
+          enableEvents: true,
+          enableDownloads: overrides.enableDownloads ?? true,
+        }),
+      ],
+    },
+  }),
+});
+
+test.describe('Server settings (admin)', () => {
+  test('downloads tab renders the enable-downloads toggle', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, getMocks({ enableDownloads: true }));
+
+    try {
+      await page.goto('/admin/settings/downloads', { waitUntil: 'domcontentloaded' });
+      await expect(
+        page.getByText('Enable downloads tab in individual forums')
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  const tabs = [
+    { path: 'basic', text: 'Server Description' },
+    { path: 'calendar', text: 'Enable events/calendar tab in individual forums' },
+    { path: 'rules', text: 'Forum Rules' },
+  ];
+
+  for (const tab of tabs) {
+    test(`${tab.path} tab renders its settings form`, async ({
+      context,
+      page,
+    }, testInfo) => {
+      await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+      const diagnostics = await installGraphqlMocks(page, getMocks());
+
+      try {
+        await page.goto(`/admin/settings/${tab.path}`, { waitUntil: 'domcontentloaded' });
+        await expect(page.getByText(tab.text)).toBeVisible();
+      } finally {
+        await testInfo.attach('graphql-operations.json', {
+          body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+          contentType: 'application/json',
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## What

Adds Playwright E2E coverage for the **admin server-settings** pages (`admin/settings/{basic,downloads,calendar,rules}`), which had no end-to-end coverage. Each tab renders its settings form for an authenticated admin:

- **downloads** → the "Enable downloads tab in individual forums" toggle (the UI side of the server-side `enableDownloads` gate, multiforum-backend#88)
- **basic** → server description form
- **calendar** → events/calendar toggle
- **rules** → forum rules editor

All four run green locally; ESLint clean.

## Scope note (honest)

This is a **partial** Tier-1 deliverable. The other Tier-1 admin surfaces — `admin/dashboard`, `admin/roles` (+ `forums/[forumId]/edit/roles`), and the membership editors (`edit/mods`, `edit/owners`, suspended-*) — render their main content behind data/loading conditions that need more per-page mock-shape work (the dashboard health query and the roles `GET_SERVER_PERMISSIONS` shape). They're deferred to follow-up PRs rather than shipped as red tests here. `create-username` remains blocked by the harness limitation in #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)