### PR TITLE
E2E test infrastructure: fixtures for roles/dashboard + admin dashboard & roles coverage

### DIFF
--- a/tests/playwright/helpers/graphqlFixtures.ts
+++ b/tests/playwright/helpers/graphqlFixtures.ts
@@ -282,6 +282,115 @@ export const buildServerConfig = (
   ...overrides,
 });
 
+// ---------------------------------------------------------------------------
+// Roles / permissions fixtures (for admin/roles, edit/roles, GET_SERVER_PERMISSIONS).
+// Returned objects are intentionally loosely typed — they only need the right
+// runtime shape for the mocked GraphQL handler, not to satisfy a generated type.
+// ---------------------------------------------------------------------------
+export const buildServerRole = (overrides: Record<string, unknown> = {}) => ({
+  __typename: 'ServerRole' as const,
+  name: 'Standard User Role',
+  description: 'Default role for a standard signed-in user.',
+  canCreateChannel: true,
+  canCreateDiscussion: true,
+  canCreateEvent: true,
+  canCreateComment: true,
+  canUpvoteDiscussion: true,
+  canUpvoteComment: true,
+  canUploadFile: true,
+  canGiveFeedback: true,
+  canManageServerSettings: false,
+  canManagePlugins: false,
+  canManageRoles: false,
+  canManageMods: false,
+  canManageAdmins: false,
+  canManageSuperAdmins: false,
+  ...overrides,
+});
+
+export const buildModServerRole = (overrides: Record<string, unknown> = {}) => ({
+  __typename: 'ModServerRole' as const,
+  name: 'Basic Server Mod Role',
+  description: 'Baseline server moderator capabilities.',
+  canHideComment: false,
+  canHideEvent: false,
+  canHideDiscussion: false,
+  canLockChannel: false,
+  canEditComments: false,
+  canEditDiscussions: false,
+  canEditEvents: false,
+  canGiveFeedback: true,
+  canOpenSupportTickets: true,
+  canCloseSupportTickets: false,
+  canReport: true,
+  canSuspendUser: false,
+  ...overrides,
+});
+
+// A ServerConfig populated for the roles/permissions management page: role
+// tiers + pending invites resolved (GET_SERVER_PERMISSIONS, op `getServerConfig`).
+export const buildServerPermissionsConfig = (
+  overrides: Record<string, unknown> = {}
+) => ({
+  ...buildServerConfig(),
+  Moderators: [] as unknown[],
+  PendingAdminInvites: [] as unknown[],
+  PendingModInvites: [] as unknown[],
+  DefaultServerRole: buildServerRole(),
+  DefaultModRole: buildModServerRole(),
+  DefaultElevatedModRole: buildModServerRole({
+    name: 'Elevated Server Mod Role',
+    canHideComment: true,
+    canHideDiscussion: true,
+    canSuspendUser: true,
+  }),
+  DefaultSuspendedRole: buildServerRole({
+    name: 'Suspended Server Role',
+    canCreateDiscussion: false,
+    canCreateComment: false,
+  }),
+  DefaultSuspendedModRole: buildModServerRole({
+    name: 'Suspended Server Mod Role',
+    canReport: false,
+    canGiveFeedback: false,
+    canOpenSupportTickets: false,
+  }),
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Server health dashboard fixture (admin/dashboard, GET_SERVER_HEALTH_DASHBOARD).
+// ---------------------------------------------------------------------------
+export const buildServerHealthDashboard = (
+  overrides: Record<string, unknown> = {}
+) => ({
+  __typename: 'ServerHealthDashboard' as const,
+  startDate: '2026-06-01',
+  endDate: '2026-06-28',
+  generatedAt: MOCK_DATE,
+  summary: {
+    activeChannelCount: 1,
+    discussionCount: 0,
+    commentCount: 0,
+    eventCount: 0,
+    downloadCount: 0,
+    voteCount: 0,
+    openIssueCount: 0,
+    issueOpenedCount: 0,
+    issueClosedCount: 0,
+    moderationActionCount: 0,
+    archivedContentCount: 0,
+    lockedContentCount: 0,
+    suspensionCount: 0,
+    medianOpenIssueAgeDays: 0,
+  },
+  timeSeries: [] as unknown[],
+  channelHealth: [] as unknown[],
+  issueAging: [] as unknown[],
+  attentionItems: [] as unknown[],
+  ...overrides,
+});
+
 export const buildChannel = ({
   uniqueName = 'cats',
   displayName = uniqueName,

--- a/tests/playwright/mocked/admin/serverDashboardAndRoles.spec.ts
+++ b/tests/playwright/mocked/admin/serverDashboardAndRoles.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '../../helpers/testFixture';
+import {
+  buildServerHealthDashboard,
+  buildServerPermissionsConfig,
+} from '../../helpers/graphqlFixtures';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import { installMockAuth } from '../../helpers/mockAuth';
+import { installGraphqlMocks } from '../../helpers/mockGraphql';
+
+// Admin server-health dashboard and the server-roles management page. Both are
+// admin-only, data-gated surfaces: their content only renders once the
+// dashboard health query / the GET_SERVER_PERMISSIONS (op `getServerConfig`)
+// query resolve with valid shapes. These tests exercise the shared
+// createBaseHandlers base plus the buildServerHealthDashboard /
+// buildServerPermissionsConfig fixtures added for exactly this purpose.
+const TEST_USER = 'alice';
+
+test.describe('Admin dashboard + roles', () => {
+  test('server dashboard renders for an admin', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, {
+      ...createBaseHandlers({ username: TEST_USER }),
+      getServerHealthDashboard: () => ({
+        data: { getServerHealthDashboard: buildServerHealthDashboard() },
+      }),
+    });
+
+    try {
+      await page.goto('/admin/dashboard', { waitUntil: 'domcontentloaded' });
+      await expect(
+        page.getByRole('heading', { name: 'Server Dashboard' })
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('server roles page renders the roles editor for an admin', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, {
+      ...createBaseHandlers({ username: TEST_USER }),
+      // GET_SERVER_PERMISSIONS reuses the `getServerConfig` operation name but
+      // needs the role tiers + pending invites populated.
+      getServerConfig: () => ({
+        data: { serverConfigs: [buildServerPermissionsConfig()] },
+      }),
+      // The roles page also lists channel-scoped mod roles.
+      GetModChannelRoles: () => ({ data: { modChannelRoles: [] } }),
+    });
+
+    try {
+      await page.goto('/admin/roles', { waitUntil: 'domcontentloaded' });
+      await expect(page.getByRole('heading', { name: 'Server Roles' })).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## What

Builds the shared **E2E test infrastructure** so future channel/forum/admin page tests are cheap, and proves it by landing the two pages that blocked the earlier Tier-1 pass.

### New fixtures (`graphqlFixtures.ts`)
The hard pages are **data-gated** — their content only renders once a rich query shape resolves. These fixtures provide valid default shapes:
- `buildServerRole` / `buildModServerRole` — server + mod role objects with capability fields.
- `buildServerPermissionsConfig` — a `ServerConfig` with the role tiers + pending invites populated (for `GET_SERVER_PERMISSIONS`, which reuses the `getServerConfig` op name).
- `buildServerHealthDashboard` — the full server-health dashboard shape (summary counts + empty series/tables).

### Proven by new tests (`serverDashboardAndRoles.spec.ts`)
Both built on the **existing shared `createBaseHandlers`** base + the new fixtures:
- `admin/dashboard` renders for an admin.
- `admin/roles` renders the roles editor (the UI side of the role/capability system).

These were exactly the blockers noted in #190; with the shared base + fixtures in place, the remaining admin/forum E2E pages become mostly "goto + assert."

## Safety
`buildServerConfig` and `buildChannel` are **unchanged** — the new builders are additive. Existing channel specs (`channelLocking`) still pass. New builders are loosely typed (they only need the right runtime shape for the mock handler).

## Verification
- dashboard + roles + `channelLocking` run green locally; ESLint clean.
- (Local `vue-tsc` is broken — `vue-router/volar` — so CI is authoritative for typecheck.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)