### PR TITLE
E2E: issue lifecycle + wiki authoring (Tier-2)

### DIFF
--- a/tests/playwright/mocked/issues/issueLifecycle.spec.ts
+++ b/tests/playwright/mocked/issues/issueLifecycle.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '../../helpers/testFixture';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import { installMockAuth } from '../../helpers/mockAuth';
+import { installGraphqlMocks } from '../../helpers/mockGraphql';
+
+// Forum issue lifecycle pages — creation + the open/closed queues. Issue DETAIL
+// is already covered (mod/issueDetail.spec); these cover the create form and the
+// list views, which had no E2E.
+const TEST_USER = 'alice';
+const TEST_CHANNEL = 'cats';
+
+const base = () =>
+  createBaseHandlers({ username: TEST_USER, channelId: TEST_CHANNEL });
+
+const issuesRow = () => ({
+  data: {
+    channels: [
+      {
+        __typename: 'Channel',
+        uniqueName: TEST_CHANNEL,
+        Issues: [],
+        IssuesAggregate: { count: 0 },
+      },
+    ],
+  },
+});
+
+test.describe('Forum issue lifecycle', () => {
+  test('issue create page renders the create-issue form', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, {
+      ...base(),
+      getIssuesByChannel: issuesRow,
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/issues/create`, { waitUntil: 'domcontentloaded' });
+      await expect(
+        page.getByPlaceholder('What do you need help with?')
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('issues index renders the open-issues list', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, {
+      ...base(),
+      getIssuesByChannel: issuesRow,
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/issues`, { waitUntil: 'domcontentloaded' });
+      await expect(page.getByPlaceholder('Search issues')).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('closed issues page renders the closed-issues list', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, {
+      ...base(),
+      getClosedIssuesByChannel: issuesRow,
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/issues/closed`, { waitUntil: 'domcontentloaded' });
+      await expect(page.getByPlaceholder('Search closed issues')).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});

--- a/tests/playwright/mocked/wiki/wikiAuthoring.spec.ts
+++ b/tests/playwright/mocked/wiki/wikiAuthoring.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from '../../helpers/testFixture';
+import { buildChannel } from '../../helpers/graphqlFixtures';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import { installMockAuth } from '../../helpers/mockAuth';
+import { installGraphqlMocks } from '../../helpers/mockGraphql';
+
+// Wiki authoring pages (create / create-child / edit). Only wiki moderation was
+// previously covered; these exercise the authoring forms.
+const TEST_USER = 'alice';
+const TEST_CHANNEL = 'cats';
+
+const base = () =>
+  createBaseHandlers({
+    username: TEST_USER,
+    channelId: TEST_CHANNEL,
+    channelOverrides: { wikiEnabled: true },
+  });
+
+test.describe('Wiki authoring', () => {
+  test('wiki create page renders the create form', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, { ...base() });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/wiki/create`, { waitUntil: 'domcontentloaded' });
+      await expect(
+        page.getByRole('heading', { name: 'Create Wiki Page' })
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('wiki create-child page renders the add-page form', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    // create-child shows "Add Wiki Page" only when a wiki home page already
+    // exists; otherwise it prompts to create the home page first. Seed a
+    // WikiHomePage on the channel (spread buildChannel to keep the shell fields).
+    const diagnostics = await installGraphqlMocks(page, {
+      ...base(),
+      getChannel: () => ({
+        data: {
+          channels: [
+            {
+              ...buildChannel({
+                uniqueName: TEST_CHANNEL,
+                overrides: { wikiEnabled: true },
+              }),
+              WikiHomePage: {
+                __typename: 'WikiPage',
+                id: 'wiki-home',
+                title: 'Home',
+                slug: 'home',
+                body: '',
+                ChildPages: [],
+              },
+            },
+          ],
+        },
+      }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/wiki/create-child`, { waitUntil: 'domcontentloaded' });
+      await expect(
+        page.getByRole('heading', { name: 'Add Wiki Page' })
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('wiki edit page renders the edit form for an existing page', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, { username: TEST_USER, email: 'alice@example.com' });
+    const diagnostics = await installGraphqlMocks(page, {
+      ...base(),
+      getWikiPage: () => ({
+        data: {
+          wikiPages: [
+            {
+              __typename: 'WikiPage',
+              title: 'Test Wiki Page',
+              body: 'Body content',
+              slug: 'test-page',
+              VersionAuthor: null,
+              ChildPages: [],
+            },
+          ],
+        },
+      }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/wiki/edit/test-page`, { waitUntil: 'domcontentloaded' });
+      await expect(
+        page.getByRole('heading', { name: 'Edit Wiki Page' })
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## What

First Tier-2 batch, both built on the shared `createBaseHandlers` base (the payoff of the fixtures investment — each test is mostly "goto → assert").

**Issue lifecycle** (`forums/[forumId]/issues/*`) — detail was already covered; this adds:
- create → the create-issue form
- index → the open-issues list (search bar)
- closed → the closed-issues list

**Wiki authoring** (`forums/[forumId]/wiki/*`) — only wiki *moderation* was covered; this adds:
- create → create form
- create-child → add-page form (seeds a `WikiHomePage` so the "Add Wiki Page" branch renders rather than the "create a home page first" prompt)
- edit/[slug] → edit form for an existing page

## Verification
- 6 tests green locally; ESLint clean. (Local `vue-tsc` is broken — `vue-router/volar` — so CI is authoritative for typecheck.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)