### PR TITLE
Coverage: cover useImageUpload + extend MultiSelect (unit branch tests)

### DIFF
--- a/components/MultiSelect.spec.ts
+++ b/components/MultiSelect.spec.ts
@@ -59,4 +59,96 @@ describe('MultiSelect', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['a']]);
   });
+
+  const clickRow = async (wrapper: ReturnType<typeof mountSelect>, label: string) => {
+    const row = wrapper
+      .findAll('[class*="cursor-pointer"]')
+      .find((r) => r.text().includes(label));
+    (row!.element as HTMLElement).click();
+    await wrapper.vm.$nextTick();
+  };
+
+  describe('single-select mode', () => {
+    it('replaces the selection instead of accumulating', async () => {
+      const wrapper = mountSelect({ multiple: false, modelValue: ['a'] });
+      await wrapper.get('[data-testid="ms"]').trigger('click');
+      await clickRow(wrapper, 'Banana');
+      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['b']]);
+    });
+
+    it('closes the dropdown after a single selection', async () => {
+      const wrapper = mountSelect({ multiple: false, modelValue: [] });
+      await wrapper.get('[data-testid="ms"]').trigger('click');
+      expect(wrapper.text()).toContain('Cherry');
+      await clickRow(wrapper, 'Apple');
+      expect(wrapper.text()).not.toContain('Cherry');
+    });
+  });
+
+  describe('sections', () => {
+    const sections = [
+      {
+        title: 'Fruits',
+        selectAllLabel: 'All fruits',
+        options: [
+          { value: 'a', label: 'Apple' },
+          { value: 'b', label: 'Banana' },
+        ],
+      },
+    ];
+    const mountSections = (props: Record<string, unknown> = {}) =>
+      mountWithDefaults(MultiSelect, {
+        props: { options: [], sections, multiple: true, testId: 'ms', ...props },
+      });
+
+    it('renders the section title and a select-all row', async () => {
+      const wrapper = mountSections({ modelValue: [] });
+      await wrapper.get('[data-testid="ms"]').trigger('click');
+      expect(wrapper.text()).toContain('Fruits');
+      expect(wrapper.text()).toContain('All fruits');
+    });
+
+    it('select-all selects every option in the section', async () => {
+      const wrapper = mountSections({ modelValue: [] });
+      await wrapper.get('[data-testid="ms"]').trigger('click');
+      await wrapper.get('input[aria-label="All fruits"]').trigger('click');
+      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['a', 'b']]);
+    });
+
+    it('select-all deselects when the section is already fully selected', async () => {
+      const wrapper = mountSections({ modelValue: ['a', 'b'] });
+      await wrapper.get('[data-testid="ms"]').trigger('click');
+      const selectAll = wrapper.get('input[aria-label="All fruits"]');
+      expect((selectAll.element as HTMLInputElement).checked).toBe(true);
+      await selectAll.trigger('click');
+      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([[]]);
+    });
+  });
+
+  describe('search', () => {
+    it('emits the search query when typing in the search box', async () => {
+      const wrapper = mountWithDefaults(MultiSelect, {
+        props: {
+          options: [],
+          sections: [
+            {
+              title: 'Fruits',
+              options: [
+                { value: 'a', label: 'Apple' },
+                { value: 'b', label: 'Banana' },
+              ],
+            },
+          ],
+          searchable: true,
+          searchPlaceholder: 'Search fruits',
+          multiple: true,
+          testId: 'ms',
+          modelValue: [],
+        },
+      });
+      await wrapper.get('[data-testid="ms"]').trigger('click');
+      await wrapper.get('input[placeholder="Search fruits"]').setValue('Apple');
+      expect(wrapper.emitted('search')?.at(-1)).toEqual(['Apple']);
+    });
+  });
 });

--- a/composables/useImageUpload.spec.ts
+++ b/composables/useImageUpload.spec.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
     error: { value: null },
   });
   getUploadFileName.mockReturnValue('alice-123.jpg');
-  isFileSizeValid.mockReturnValue({ valid: true });
+  isFileSizeValid.mockReturnValue({ valid: true, message: '' });
 });
 
 describe('useImageUpload.uploadFile', () => {

--- a/composables/useImageUpload.spec.ts
+++ b/composables/useImageUpload.spec.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useMutation } from '@vue/apollo-composable';
+import { useImageUpload } from './useImageUpload';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: vi.fn(),
+}));
+
+const { usernameRef } = vi.hoisted(() => ({
+  usernameRef: { value: 'alice' as string },
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => usernameRef,
+}));
+
+const { uploadAndGetEmbeddedLink, getUploadFileName, isFileSizeValid } =
+  vi.hoisted(() => ({
+    uploadAndGetEmbeddedLink: vi.fn(),
+    getUploadFileName: vi.fn(() => 'alice-123.jpg'),
+    isFileSizeValid: vi.fn(() => ({ valid: true })),
+  }));
+// `@/utils` and `@/utils/index` resolve to the same module, so both mocks must
+// expose every export this composable imports from either specifier.
+vi.mock('@/utils', () => ({
+  uploadAndGetEmbeddedLink,
+  getUploadFileName,
+  isFileSizeValid,
+}));
+vi.mock('@/utils/index', () => ({
+  uploadAndGetEmbeddedLink,
+  getUploadFileName,
+  isFileSizeValid,
+}));
+
+const mockMutate = vi.fn();
+const makeFile = (name = 'pic.png', type = 'image/png') =>
+  new File(['x'], name, { type });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  usernameRef.value = 'alice';
+  (useMutation as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    mutate: mockMutate,
+    error: { value: null },
+  });
+  getUploadFileName.mockReturnValue('alice-123.jpg');
+  isFileSizeValid.mockReturnValue({ valid: true });
+});
+
+describe('useImageUpload.uploadFile', () => {
+  it('fails when there is no logged-in username', async () => {
+    usernameRef.value = '';
+    const { uploadFile } = useImageUpload();
+    const result = await uploadFile(makeFile());
+    expect(result).toEqual({
+      success: false,
+      error: 'Not logged in or username not found',
+    });
+  });
+
+  it('fails when no signed URL is returned', async () => {
+    mockMutate.mockResolvedValue({ data: { createSignedStorageURL: { url: '' } } });
+    const { uploadFile } = useImageUpload();
+    const result = await uploadFile(makeFile());
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/signed URL/i);
+  });
+
+  it('fails when the upload returns no embedded link', async () => {
+    mockMutate.mockResolvedValue({
+      data: { createSignedStorageURL: { url: 'https://signed' } },
+    });
+    uploadAndGetEmbeddedLink.mockResolvedValue('');
+    const { uploadFile } = useImageUpload();
+    const result = await uploadFile(makeFile());
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no URL/i);
+  });
+
+  it('returns the embedded link on success and toggles isUploading', async () => {
+    mockMutate.mockResolvedValue({
+      data: { createSignedStorageURL: { url: 'https://signed' } },
+    });
+    uploadAndGetEmbeddedLink.mockResolvedValue('https://cdn/pic.png');
+    const { uploadFile, isUploading } = useImageUpload();
+
+    const promise = uploadFile(makeFile());
+    expect(isUploading.value).toBe(true);
+    const result = await promise;
+
+    expect(result).toEqual({ success: true, embeddedLink: 'https://cdn/pic.png' });
+    expect(isUploading.value).toBe(false);
+  });
+
+  it('derives a content type from the filename when file.type is missing', async () => {
+    mockMutate.mockResolvedValue({
+      data: { createSignedStorageURL: { url: 'https://signed' } },
+    });
+    uploadAndGetEmbeddedLink.mockResolvedValue('https://cdn/x.webp');
+    const { uploadFile } = useImageUpload();
+
+    await uploadFile(makeFile('x.webp', '')); // no MIME type
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'image/webp' })
+    );
+  });
+
+  it('passes channel connections from the option callback', async () => {
+    mockMutate.mockResolvedValue({
+      data: { createSignedStorageURL: { url: 'https://signed' } },
+    });
+    uploadAndGetEmbeddedLink.mockResolvedValue('https://cdn/x.png');
+    const { uploadFile } = useImageUpload({
+      getChannelConnections: () => ['cats', 'dogs'],
+    });
+
+    await uploadFile(makeFile());
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ channelConnections: ['cats', 'dogs'] })
+    );
+  });
+
+  it('returns the error message when the upload throws', async () => {
+    mockMutate.mockRejectedValue(new Error('network down'));
+    const { uploadFile, isUploading } = useImageUpload();
+    const result = await uploadFile(makeFile());
+    expect(result).toEqual({ success: false, error: 'network down' });
+    expect(isUploading.value).toBe(false);
+  });
+});
+
+describe('useImageUpload helpers', () => {
+  it('validateFileSize delegates to isFileSizeValid', () => {
+    isFileSizeValid.mockReturnValue({ valid: false, message: 'too big' });
+    const { validateFileSize } = useImageUpload();
+    expect(validateFileSize(makeFile())).toEqual({ valid: false, message: 'too big' });
+  });
+
+  it('createUploadPlaceholder sanitizes the filename and embeds the id', () => {
+    const { createUploadPlaceholder } = useImageUpload();
+    const { markdown, placeholderText } = createUploadPlaceholder(
+      makeFile('my pic!.png'),
+      'up1'
+    );
+    expect(placeholderText).toBe('Uploading image...');
+    expect(markdown).toBe('![my pic_.png](Uploading image... (id:up1))');
+  });
+
+  it('createImageMarkdown sanitizes the filename', () => {
+    const { createImageMarkdown } = useImageUpload();
+    expect(createImageMarkdown('a*b.png', 'https://cdn/a.png')).toBe(
+      '![a_b.png](https://cdn/a.png)'
+    );
+  });
+
+  it('createErrorMarkdown truncates the error to 50 chars', () => {
+    const { createErrorMarkdown } = useImageUpload();
+    const long = 'e'.repeat(80);
+    const md = createErrorMarkdown('x.png', long);
+    expect(md).toContain('Upload failed: x.png');
+    expect(md).toContain(`Error: ${'e'.repeat(50)}`);
+    expect(md).not.toContain('e'.repeat(51));
+  });
+
+  it('createPlaceholderRegex matches the placeholder it was built from', () => {
+    const { createUploadPlaceholder, createPlaceholderRegex } = useImageUpload();
+    const { markdown, placeholderText } = createUploadPlaceholder(makeFile(), 'abc');
+    const re = createPlaceholderRegex(placeholderText, 'abc');
+    expect(re.test(markdown)).toBe(true);
+  });
+});

--- a/composables/useImageUpload.spec.ts
+++ b/composables/useImageUpload.spec.ts
@@ -17,7 +17,9 @@ const { uploadAndGetEmbeddedLink, getUploadFileName, isFileSizeValid } =
   vi.hoisted(() => ({
     uploadAndGetEmbeddedLink: vi.fn(),
     getUploadFileName: vi.fn(() => 'alice-123.jpg'),
-    isFileSizeValid: vi.fn(() => ({ valid: true })),
+    // Seed the full {valid, message} shape so later mockReturnValue calls that
+    // include `message` stay within the inferred return type.
+    isFileSizeValid: vi.fn(() => ({ valid: true, message: '' })),
   }));
 // `@/utils` and `@/utils/index` resolve to the same module, so both mocks must
 // expose every export this composable imports from either specifier.


### PR DESCRIPTION
## What

First increment of the **unit branch-coverage** push toward 80% combined. This shifts from the E2E render-smoke tests (which cover page *render*) to **unit interaction tests** — the right tool for component/composable *branch* coverage, which is the untapped headroom.

- **`composables/useImageUpload.spec.ts` (new):** upload success + every error branch (not logged in, no signed URL, no embedded link, throw), filename-derived content type, channel-connection passthrough, `isUploading` toggle, and the markdown/placeholder/regex helpers. **44/44 lines → fully covered.**
- **`components/MultiSelect.spec.ts` (extended):** single-select (replace + close-on-select), `sections` rendering, select-all (select + deselect-when-fully-selected), and the search emit. **65 → 33 uncovered lines.**

## Calibration (why this matters for the 80% target)
Measured against the `coverage-audit` data:
- ~**75 lines recovered ≈ +0.35 combined points** from these 2 specs.
- `utils/` is already 97.5% covered and all of `composables/` holds <1 point total — **there is no shortcut.** The ~1,060 lines needed for 75→80% live in **components**, so the path is ~20 more component spec extensions like `MultiSelect` (~30–60 lines each). This PR is one such increment + the calibration to plan the rest.

## Verification
- 24 tests green locally; ESLint clean. (Local `vue-tsc` broken — CI authoritative for typecheck.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)