### PR TITLE
test(coverage): batch 2 — MarkdownPreview, EventListItem, TopNavSearch branch tests

### DIFF
--- a/components/MarkdownPreview.spec.ts
+++ b/components/MarkdownPreview.spec.ts
@@ -13,11 +13,29 @@ vi.mock('nuxt/app', () => ({
   useRouter: () => createMockRouter(),
 }));
 
+// Stub WarningModal so we can read its `open` prop and emit its events without
+// pulling in the real modal (which is auto-imported in the app, not here).
+const WarningModalStub = {
+  name: 'WarningModal',
+  props: ['open', 'body', 'title'],
+  emits: ['close', 'primary-button-click'],
+  template: '<div data-testid="warning-modal-stub" />',
+};
+
 const mountPreview = (props: Record<string, unknown>) =>
   mountWithDefaults(MarkdownPreview, {
     props,
-    global: { stubs: { MarkdownRenderer: true, VueEasyLightbox: true } },
+    global: {
+      stubs: {
+        MarkdownRenderer: true,
+        VueEasyLightbox: true,
+        WarningModal: WarningModalStub,
+      },
+    },
   });
+
+const warningModal = (wrapper: ReturnType<typeof mountPreview>) =>
+  wrapper.findComponent(WarningModalStub);
 
 const renderedText = (wrapper: ReturnType<typeof mountPreview>) =>
   wrapper.findComponent(MarkdownRenderer).props('text') as string;
@@ -43,5 +61,108 @@ describe('MarkdownPreview', () => {
     });
     // Truncated text keeps the first words and drops the rest.
     expect(renderedText(wrapper)).not.toContain('five');
+  });
+
+  describe('show more / show less', () => {
+    const longText = 'one two three four five six';
+
+    it('renders a "Show More" button when the text exceeds the word limit', () => {
+      const wrapper = mountPreview({
+        text: longText,
+        wordLimit: 3,
+        showShowMore: true,
+      });
+      const button = wrapper.get('button');
+      expect(button.text()).toBe('Show More');
+    });
+
+    it('reveals the full text and flips the label when toggled', async () => {
+      const wrapper = mountPreview({
+        text: longText,
+        wordLimit: 3,
+        showShowMore: true,
+      });
+      expect(renderedText(wrapper)).not.toContain('six');
+
+      await wrapper.get('button').trigger('click');
+
+      expect(renderedText(wrapper)).toContain('six');
+      expect(wrapper.get('button').text()).toBe('Show Less');
+    });
+
+    it('omits the toggle button when show-more is disabled', () => {
+      const wrapper = mountPreview({
+        text: longText,
+        wordLimit: 3,
+        showShowMore: false,
+      });
+      expect(wrapper.find('button').exists()).toBe(false);
+      // With show-more off the full text passes through untruncated.
+      expect(renderedText(wrapper)).toContain('six');
+    });
+  });
+
+  describe('external-link warning', () => {
+    // Simulate a click on a rendered anchor by injecting one into the root and
+    // letting the event bubble to the container's click handler.
+    const clickLink = async (
+      wrapper: ReturnType<typeof mountPreview>,
+      href: string
+    ) => {
+      const anchor = document.createElement('a');
+      anchor.href = href;
+      anchor.textContent = 'link';
+      wrapper.element.appendChild(anchor);
+      anchor.click();
+      await wrapper.vm.$nextTick();
+    };
+
+    it('opens the warning modal for an external link', async () => {
+      const wrapper = mountPreview({ text: 'words' });
+      expect(warningModal(wrapper).props('open')).toBe(false);
+
+      await clickLink(wrapper, 'https://external.example.com/path');
+
+      expect(warningModal(wrapper).props('open')).toBe(true);
+      expect(warningModal(wrapper).props('body')).toContain(
+        'external.example.com'
+      );
+    });
+
+    it('does not warn for an internal link', async () => {
+      const wrapper = mountPreview({ text: 'words' });
+      await clickLink(wrapper, `${window.location.origin}/forums/cats`);
+      expect(warningModal(wrapper).props('open')).toBe(false);
+    });
+
+    it('opens the link in a new tab on confirm and then closes', async () => {
+      const openSpy = vi
+        .spyOn(window, 'open')
+        .mockReturnValue(null);
+      const wrapper = mountPreview({ text: 'words' });
+      await clickLink(wrapper, 'https://external.example.com/path');
+
+      await warningModal(wrapper).vm.$emit('primary-button-click');
+      await wrapper.vm.$nextTick();
+
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://external.example.com/path',
+        '_blank',
+        'noopener,noreferrer'
+      );
+      expect(warningModal(wrapper).props('open')).toBe(false);
+      openSpy.mockRestore();
+    });
+
+    it('dismisses the warning modal on close', async () => {
+      const wrapper = mountPreview({ text: 'words' });
+      await clickLink(wrapper, 'https://external.example.com/path');
+      expect(warningModal(wrapper).props('open')).toBe(true);
+
+      await warningModal(wrapper).vm.$emit('close');
+      await wrapper.vm.$nextTick();
+
+      expect(warningModal(wrapper).props('open')).toBe(false);
+    });
   });
 });

--- a/components/event/list/EventListItem.spec.ts
+++ b/components/event/list/EventListItem.spec.ts
@@ -5,6 +5,17 @@ import { makeEvent } from '@/tests/utils/factories';
 import type { Event } from '@/__generated__/graphql';
 
 import EventListItem from '@/components/event/list/EventListItem.vue';
+import Tag from '@/components/TagComponent.vue';
+
+// Minimal EventChannel shape the component reads (channelUniqueName / archived /
+// CommentsAggregate). Typed loosely so test fixtures stay terse.
+const eventChannel = (overrides: Record<string, unknown> = {}): any => ({
+  __typename: 'EventChannel',
+  channelUniqueName: 'cats',
+  archived: false,
+  CommentsAggregate: { __typename: 'EventChannelCommentsAggregationSelection', count: 0 },
+  ...overrides,
+});
 
 // Demonstrates the round-2 test infra working together: a fixture factory
 // (makeEvent), the router mock, and the one-call mount harness.
@@ -17,12 +28,13 @@ vi.mock('nuxt/app', () => ({
   useRouter: () => router,
 }));
 
-const mountItem = (event: Event) =>
+const mountItem = (event: Event, extraProps: Record<string, unknown> = {}) =>
   mountWithDefaults(EventListItem, {
     props: {
       event,
       currentChannelId: 'cats',
       showMap: false,
+      ...extraProps,
     },
     global: {
       stubs: {
@@ -36,6 +48,11 @@ const mountItem = (event: Event) =>
 describe('EventListItem', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // handleClick (on the <li>) probes matchMedia on desktop; jsdom omits it.
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockReturnValue({ matches: false }),
+    });
   });
 
   it('renders the event title from a factory-built event', () => {
@@ -53,5 +70,68 @@ describe('EventListItem', () => {
     expect(
       wrapper.find('[data-testid="event-list-item-Trivia Night"]').exists()
     ).toBe(true);
+  });
+
+  describe('status badges', () => {
+    it('shows an Archived badge when any channel posting is archived', () => {
+      const wrapper = mountItem(
+        makeEvent({ EventChannels: [eventChannel({ archived: true })] })
+      );
+      expect(wrapper.text()).toContain('Archived');
+    });
+
+    it('does not show an Archived badge when no posting is archived', () => {
+      const wrapper = mountItem(
+        makeEvent({ EventChannels: [eventChannel({ archived: false })] })
+      );
+      expect(wrapper.text()).not.toContain('Archived');
+    });
+
+    it('shows a Canceled badge for a canceled event', () => {
+      const wrapper = mountItem(makeEvent({ canceled: true }));
+      expect(wrapper.text()).toContain('Canceled');
+    });
+
+    it('shows the location name and an Online event note', () => {
+      const wrapper = mountItem(
+        makeEvent({
+          locationName: 'The Park',
+          virtualEventUrl: 'https://example.com/live',
+        })
+      );
+      expect(wrapper.text()).toContain('The Park');
+      expect(wrapper.text()).toContain('Online event');
+    });
+  });
+
+  describe('selection', () => {
+    it('emits select with the event id and title when selectable', async () => {
+      const wrapper = mountItem(makeEvent({ id: 'e1', title: 'Picnic' }), {
+        isSelectable: true,
+        selectedEventId: 'e1',
+      });
+      await wrapper.get('button[type="button"]').trigger('click');
+      expect(wrapper.emitted('select')?.[0]).toEqual([
+        { eventId: 'e1', title: 'Picnic' },
+      ]);
+    });
+
+    it('does not emit select when the item is not selectable', async () => {
+      const wrapper = mountItem(makeEvent({ id: 'e1', title: 'Picnic' }));
+      await wrapper.get('button[type="button"]').trigger('click');
+      expect(wrapper.emitted('select')).toBeUndefined();
+    });
+  });
+
+  describe('tag filtering', () => {
+    it('adds a tag to the route query when a tag is clicked', async () => {
+      const wrapper = mountItem(
+        makeEvent({ Tags: [{ __typename: 'Tag', text: 'music' }] as never })
+      );
+      await wrapper.findComponent(Tag).trigger('click');
+      expect(router.replace).toHaveBeenCalledWith({
+        query: { tags: 'music' },
+      });
+    });
   });
 });

--- a/components/nav/TopNavSearch.spec.ts
+++ b/components/nav/TopNavSearch.spec.ts
@@ -17,8 +17,9 @@ vi.mock('@/utils', () => ({
     channels.length ? channels.join(', ') : 'All Forums',
 }));
 
-const mountSearch = () =>
+const mountSearch = (props: Record<string, unknown> = {}) =>
   mountWithDefaults(TopNavSearch, {
+    props,
     global: {
       stubs: {
         FilterChip: true,
@@ -39,6 +40,7 @@ const submitSearch = async (
 describe('TopNavSearch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it('pushes the discussions route for the default search type', async () => {
@@ -67,5 +69,92 @@ describe('TopNavSearch', () => {
         query: expect.objectContaining({ searchOpen: 'true' }),
       })
     );
+  });
+
+  describe('popover open/close', () => {
+    it('opens on the "/" shortcut and closes on Escape', async () => {
+      const wrapper = mountSearch();
+      expect(wrapper.text()).not.toContain('Recent searches');
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.text()).toContain('Recent searches');
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.text()).not.toContain('Recent searches');
+      wrapper.unmount();
+    });
+
+    it('ignores the "/" shortcut while typing in an input', async () => {
+      const wrapper = mountSearch();
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '/', bubbles: true })
+      );
+      await wrapper.vm.$nextTick();
+      expect(wrapper.text()).not.toContain('Recent searches');
+      input.remove();
+      wrapper.unmount();
+    });
+
+    it('closes when a click lands outside the component', async () => {
+      const wrapper = mountSearch();
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.text()).toContain('Recent searches');
+
+      document.body.dispatchEvent(
+        new MouseEvent('mousedown', { bubbles: true })
+      );
+      await wrapper.vm.$nextTick();
+      expect(wrapper.text()).not.toContain('Recent searches');
+      wrapper.unmount();
+    });
+
+    it('toggles open and closed from the icon-only search button', async () => {
+      const wrapper = mountSearch({ iconOnly: true });
+      const button = wrapper.get(
+        '[data-testid="mobile-top-nav-search-button"]'
+      );
+
+      await button.trigger('click');
+      expect(wrapper.text()).toContain('Recent searches');
+
+      await button.trigger('click');
+      expect(wrapper.text()).not.toContain('Recent searches');
+      wrapper.unmount();
+    });
+  });
+
+  describe('recent searches', () => {
+    it('starts empty', async () => {
+      const wrapper = mountSearch();
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.text()).toContain('No recent searches yet.');
+      wrapper.unmount();
+    });
+
+    it('records a submitted search and re-runs it on click', async () => {
+      const wrapper = mountSearch();
+      await submitSearch(wrapper, 'dogs');
+
+      // Re-open the popover; the just-recorded search should be listed.
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }));
+      await wrapper.vm.$nextTick();
+      const recent = wrapper.get('ul[aria-label="Recent searches"] button');
+      expect(recent.text()).toContain('dogs');
+
+      router.push.mockClear();
+      await recent.trigger('click');
+      expect(router.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({ searchInput: 'dogs' }),
+        })
+      );
+      wrapper.unmount();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Batch 2 of the unit-coverage push toward 80% combined coverage. Extends the existing specs of three already-spec'd, **zero-Apollo** components with interaction/branch tests (mount → trigger handlers/branches → assert emits/state).

| Component | tests | what's newly covered |
|---|---|---|
| `MarkdownPreview` | 3 → 10 | show-more/less toggle; external-link warning modal (warn external, skip internal, open-in-new-tab on confirm, dismiss on close) |
| `EventListItem` | 3 → 10 | Archived/Canceled/location/Online badges; `select` emit gated by `isSelectable`; tag-click → route query |
| `TopNavSearch` | 3 → 9 | `/` shortcut + Escape; ignore `/` while typing in an input; outside-click close; icon-only toggle; recent-search record + replay |

## Coverage

Unit line coverage **71.34% → 71.71% (+0.37 pt)** vs `main`. Full vitest suite green.

## Notes
- Pure test additions — no production code changed.
- Continues the cadence from #198; same per-PR delta (~0.35 pt). Local `vue-tsc` is broken, so CI's `unit-tests` job is authoritative for the typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)