### PR TITLE
test(coverage): batch 4 — AlbumEditor, DownloadFilterBar, AddToFavoritesButton

### DIFF
--- a/components/discussion/form/AlbumEditor.spec.ts
+++ b/components/discussion/form/AlbumEditor.spec.ts
@@ -1,13 +1,21 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
+import { flushPromises } from '@vue/test-utils';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 
 import AlbumEditor from '@/components/discussion/form/AlbumEditor.vue';
 
-vi.mock('@/composables/useAuthState', async () => {
-  const { ref } = await import('vue');
-  return { useUsername: () => ref('alice'), setUsername: vi.fn() };
-});
+// Hoisted, controllable test seams: username (for the no-username branch) and
+// the URL-image creation spy (for the submit success/failure branches).
+const { usernameRef, createImageFromUrl } = vi.hoisted(() => ({
+  usernameRef: { value: 'alice' as string },
+  createImageFromUrl: vi.fn(),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => usernameRef,
+  setUsername: vi.fn(),
+}));
 vi.mock('@/composables/useAlbumImageUpload', () => ({
   useAlbumImageUpload: () => ({
     loadingStates: ref({}),
@@ -16,7 +24,7 @@ vi.mock('@/composables/useAlbumImageUpload', () => ({
     createImageError: ref(null),
     handleMultipleFiles: vi.fn(),
     handleDrop: vi.fn(),
-    createImageFromUrl: vi.fn(),
+    createImageFromUrl,
   }),
 }));
 vi.mock('@/composables/useAlbumAutoSave', () => ({
@@ -35,10 +43,26 @@ const AlbumImageItemStub = {
   template: '<div class="image-item-stub" />',
 };
 
+const AlbumDropZoneStub = {
+  name: 'AlbumDropZone',
+  emits: ['files-selected', 'drop', 'show-url-input'],
+  template: '<div class="drop-zone-stub" />',
+};
+
+// The component calls focusInput/setError/reset on the form ref; expose them so
+// optional-chaining calls don't blow up.
+const AlbumUrlInputFormStub = {
+  name: 'AlbumUrlInputForm',
+  props: ['isCreating'],
+  emits: ['submit', 'cancel'],
+  methods: { focusInput() {}, setError() {}, reset() {} },
+  template: '<div class="url-input-stub" />',
+};
+
 const stubs = {
   AlbumImageItem: AlbumImageItemStub,
-  AlbumDropZone: { template: '<div class="drop-zone-stub" />' },
-  AlbumUrlInputForm: { template: '<div />' },
+  AlbumDropZone: AlbumDropZoneStub,
+  AlbumUrlInputForm: AlbumUrlInputFormStub,
   ErrorBanner: { props: ['text'], template: '<div />' },
   LoadingSpinner: { template: '<div />' },
 };
@@ -66,6 +90,11 @@ const lastEmit = (wrapper: ReturnType<typeof mountEditor>) => {
 };
 
 describe('AlbumEditor', () => {
+  beforeEach(() => {
+    usernameRef.value = 'alice';
+    createImageFromUrl.mockReset();
+  });
+
   it('renders one image item per ordered image', () => {
     const wrapper = mountEditor();
     expect(wrapper.findAllComponents(AlbumImageItemStub)).toHaveLength(3);
@@ -94,5 +123,80 @@ describe('AlbumEditor', () => {
     wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('update-field', 'alt', 'new alt');
     const updated = lastEmit(wrapper).images.find((i) => i.id === 'a') as { alt: string };
     expect(updated.alt).toBe('new alt');
+  });
+
+  describe('reorder guards', () => {
+    it('ignores move-up on the first image', () => {
+      const wrapper = mountEditor();
+      wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('move-up');
+      expect(wrapper.emitted('updateFormValues')).toBeUndefined();
+    });
+
+    it('ignores move-down on the last image', () => {
+      const wrapper = mountEditor();
+      wrapper.findAllComponents(AlbumImageItemStub)[2].vm.$emit('move-down');
+      expect(wrapper.emitted('updateFormValues')).toBeUndefined();
+    });
+  });
+
+  describe('URL input flow', () => {
+    const showForm = async (wrapper: ReturnType<typeof mountEditor>) => {
+      wrapper.findComponent(AlbumDropZoneStub).vm.$emit('show-url-input');
+      await wrapper.vm.$nextTick();
+    };
+
+    it('reveals the URL form when the drop zone requests it', async () => {
+      const wrapper = mountEditor();
+      expect(wrapper.findComponent(AlbumUrlInputFormStub).exists()).toBe(false);
+      await showForm(wrapper);
+      expect(wrapper.findComponent(AlbumUrlInputFormStub).exists()).toBe(true);
+    });
+
+    it('hides the URL form on cancel', async () => {
+      const wrapper = mountEditor();
+      await showForm(wrapper);
+      wrapper.findComponent(AlbumUrlInputFormStub).vm.$emit('cancel');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.findComponent(AlbumUrlInputFormStub).exists()).toBe(false);
+    });
+
+    it('adds the created image and closes the form on a successful submit', async () => {
+      createImageFromUrl.mockResolvedValue({
+        id: 'd',
+        url: 'https://example.com/d.jpg',
+        alt: '',
+        caption: '',
+        copyright: '',
+      });
+      const wrapper = mountEditor();
+      await showForm(wrapper);
+      wrapper.findComponent(AlbumUrlInputFormStub).vm.$emit('submit', 'https://example.com/d.jpg');
+      await flushPromises();
+
+      expect(lastEmit(wrapper).images.map((i) => i.id)).toContain('d');
+      expect(wrapper.findComponent(AlbumUrlInputFormStub).exists()).toBe(false);
+    });
+
+    it('does not add an image when no username is set', async () => {
+      usernameRef.value = '';
+      const wrapper = mountEditor();
+      await showForm(wrapper);
+      wrapper.findComponent(AlbumUrlInputFormStub).vm.$emit('submit', 'https://example.com/d.jpg');
+      await flushPromises();
+
+      expect(createImageFromUrl).not.toHaveBeenCalled();
+      expect(wrapper.emitted('updateFormValues')).toBeUndefined();
+    });
+
+    it('keeps the form open when image creation fails', async () => {
+      createImageFromUrl.mockResolvedValue(null);
+      const wrapper = mountEditor();
+      await showForm(wrapper);
+      wrapper.findComponent(AlbumUrlInputFormStub).vm.$emit('submit', 'https://example.com/d.jpg');
+      await flushPromises();
+
+      expect(wrapper.emitted('updateFormValues')).toBeUndefined();
+      expect(wrapper.findComponent(AlbumUrlInputFormStub).exists()).toBe(true);
+    });
   });
 });

--- a/components/download/DownloadFilterBar.spec.ts
+++ b/components/download/DownloadFilterBar.spec.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { createMockRoute, createMockRouter } from '@/tests/utils/mockRouter';
+import SearchBar from '@/components/SearchBar.vue';
+import CheckBox from '@/components/CheckBox.vue';
 
 import DownloadFilterBar from '@/components/download/DownloadFilterBar.vue';
 
@@ -34,6 +36,10 @@ const mountBar = () =>
   });
 
 describe('DownloadFilterBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders the filter toggle button', () => {
     const wrapper = mountBar();
     expect(
@@ -61,5 +67,30 @@ describe('DownloadFilterBar', () => {
     expect(
       wrapper.find('[data-testid="show-archived-downloads"]').exists()
     ).toBe(true);
+  });
+
+  it('replaces the route with a search-input filter from the search bar', async () => {
+    const wrapper = mountBar();
+    await wrapper.get('[data-testid="download-search-button"]').trigger('click');
+    await wrapper.findComponent(SearchBar).vm.$emit('update-search-input', 'dogs');
+    expect(router.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ searchInput: 'dogs' }),
+      })
+    );
+  });
+
+  it('replaces the route with the archived filter when the checkbox toggles', async () => {
+    const wrapper = mountBar();
+    await wrapper.get('[data-testid="download-filter-button"]').trigger('click');
+    // updateShowArchived reads event.target.checked, so emit a synthetic event.
+    await wrapper
+      .findComponent(CheckBox)
+      .vm.$emit('input', { target: { checked: true } });
+    expect(router.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ showArchived: true }),
+      })
+    );
   });
 });

--- a/components/favorites/AddToFavoritesButton.spec.ts
+++ b/components/favorites/AddToFavoritesButton.spec.ts
@@ -84,6 +84,51 @@ describe('AddToFavoritesButton', () => {
   });
 });
 
+describe('AddToFavoritesButton sizing', () => {
+  it.each([
+    ['small', 'h-4 w-4'],
+    ['large', 'h-6 w-6'],
+    ['medium', 'h-5 w-5'],
+  ])('renders the %s icon size', (size, expected) => {
+    const wrapper = mountButton({ size });
+    expect(wrapper.get('svg').classes().join(' ')).toContain(expected);
+  });
+
+  it('defaults to the medium icon size', () => {
+    const wrapper = mountButton();
+    expect(wrapper.get('svg').classes().join(' ')).toContain('h-5 w-5');
+  });
+});
+
+describe('AddToFavoritesButton tooltip', () => {
+  it('shows the tooltip on hover and hides it on leave', async () => {
+    // The tooltip is rendered via <Teleport to="body">, so it lands in the
+    // document body rather than the component's own subtree.
+    const wrapper = mountButton({ isFavorited: false });
+    const button = wrapper.get('[aria-label]');
+
+    await button.trigger('mouseenter');
+    const tooltip = document.body.querySelector('.pointer-events-none');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent?.trim()).toBe('Add to favorites');
+
+    await button.trigger('mouseleave');
+    expect(document.body.querySelector('.pointer-events-none')).toBeNull();
+    wrapper.unmount();
+  });
+});
+
+describe('AddToFavoritesButton collection changes', () => {
+  it('re-emits favoriteChange from the collection popover', () => {
+    const wrapper = mountWithDefaults(AddToFavoritesButton, {
+      props: { isFavorited: true, allowAddToList: true },
+      global: { stubs: { AddToListPopover: PopoverStub } },
+    });
+    wrapper.getComponent(PopoverStub).vm.$emit('favorite-change', true);
+    expect(wrapper.emitted('favoriteChange')?.[0]).toEqual([true]);
+  });
+});
+
 describe('AddToFavoritesButton (unauthenticated)', () => {
   it('still renders a favorites button labelled to add', () => {
     const wrapper = mountUnauthButton({ displayName: 'Trivia' });


### PR DESCRIPTION
## Summary

Batch 4 of the unit-coverage push toward 80% combined coverage. Extends three already-spec'd, **zero-Apollo** components with interaction/branch tests.

| Component | tests | newly covered |
|---|---|---|
| `AlbumEditor` | 5 → 12 | reorder guards (first/last image), URL-input flow: reveal/cancel, successful submit (creates image + closes form), no-username no-op, failure keeps form open |
| `DownloadFilterBar` | 3 → 5 | search-input filter (search bar emit) and archived-downloads checkbox both `router.replace` via `updateFilters` |
| `AddToFavoritesButton` | 8 → 14 | `sizeClasses` (small/large/medium + default), teleported hover tooltip (show/hide + text), `favoriteChange` re-emit from the collection popover |

Composable seams in AlbumEditor (`createImageFromUrl`, username) are hoisted so the submit success/failure/no-username branches are reachable.

## Coverage

Unit line coverage **71.71% → 72.40% (+0.69 pt)**. Full vitest suite green.

## Notes
- Pure test additions — no production code changed.
- Continues the cadence from #198 / #199 / #201. Local `vue-tsc` is broken, so CI's `unit-tests` job is authoritative for the typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)