### PR TITLE
test(TextEditor): mount the real editor + cover the image-upload flow

### DIFF
--- a/components/TextEditor.spec.ts
+++ b/components/TextEditor.spec.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { flushPromises } from '@vue/test-utils';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import TextEditor from '@/components/TextEditor.vue';
 import {
   formatText,
   formatBold,
@@ -12,6 +16,88 @@ import {
   calculateRemainingChars,
 } from '@/utils/textFormatting';
 import { isFileSizeValid } from '@/utils/index';
+
+// --- Mounted-component setup (the existing tests above only exercise the
+// extracted utils; these mount the real TextEditor textarea editor) ---
+vi.mock('vuetify', () => ({ useDisplay: () => ({ width: ref(1024) }) }));
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({
+    mutate: vi.fn(),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+    loading: ref(false),
+    error: ref(null),
+  }),
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+// Mock the image-upload composable so the upload flow (placeholder insertion,
+// success/failure replacement, size validation) is drivable without Apollo.
+const { uploadFileMock, validateFileSizeMock } = vi.hoisted(() => ({
+  uploadFileMock: vi.fn(),
+  validateFileSizeMock: vi.fn(() => ({ valid: true, message: '' })),
+}));
+vi.mock('@/composables/useImageUpload', () => ({
+  useImageUpload: () => ({
+    uploadFile: uploadFileMock,
+    validateFileSize: validateFileSizeMock,
+    createUploadPlaceholder: (file: File, id: string) => ({
+      markdown: `![uploading ${file.name}](placeholder-${id})`,
+      placeholderText: `uploading ${file.name}`,
+    }),
+    createImageMarkdown: (name: string, link: string) => `![${name}](${link})`,
+    createErrorMarkdown: (name: string, err: string) =>
+      `[upload failed: ${name} — ${err}]`,
+    createPlaceholderRegex: (_text: string, id: string) =>
+      new RegExp(`!\\[uploading [^\\]]+\\]\\(placeholder-${id}\\)`),
+    createSignedStorageUrlError: ref(null),
+  }),
+}));
+
+const fileChange = (file: File) => ({
+  event: { target: { files: [file] } } as unknown as Event & {
+    target: HTMLInputElement | null;
+  },
+  fieldName: '',
+});
+
+const editorStubs = {
+  TextEditorToolbar: {
+    name: 'TextEditorToolbar',
+    emits: ['format', 'toggle-emoji', 'toggle-fullscreen'],
+    template: '<div class="toolbar-stub" />',
+  },
+  AddImage: { name: 'AddImage', emits: ['file-change'], template: '<div />' },
+  BotSuggestionsPopover: true,
+  ModSuggestionsPopover: true,
+  CharCounter: {
+    name: 'CharCounter',
+    props: ['current', 'max'],
+    template: '<div class="char-counter">{{ current }}/{{ max }}</div>',
+  },
+  EmojiPickerWrapper: true,
+  MarkdownRenderer: {
+    name: 'MarkdownRenderer',
+    props: ['text'],
+    template: '<div class="markdown-preview">{{ text }}</div>',
+  },
+  TextEditorFullScreen: true,
+  // headlessui tab primitives — render as transparent click targets.
+  Tab: { template: '<button><slot /></button>' },
+  TabGroup: { template: '<div><slot /></div>' },
+  TabList: { template: '<div><slot /></div>' },
+};
+
+const mountEditor = (props: Record<string, unknown> = {}) =>
+  mountWithDefaults(TextEditor, {
+    props: { disableAutoFocus: true, ...props },
+    global: { stubs: editorStubs },
+  });
+
+const textarea = (wrapper: ReturnType<typeof mountEditor>) =>
+  wrapper.get('[data-testid="texteditor-textarea"]');
 
 // Test the text formatting functions
 describe('TextEditor formatting functions', () => {
@@ -154,5 +240,114 @@ describe('Emoji Insertion', () => {
     // because they're represented by multiple UTF-16 code units
     const newCursorPosition = position + emoji.length;
     expect(newCursorPosition).toBe(7); // Emoji "👋" has a length of 2 in JavaScript
+  });
+});
+
+// Mount the real component and drive its textarea/toolbar/tab handlers.
+describe('TextEditor (mounted)', () => {
+  it('renders the initial value in the textarea', () => {
+    const wrapper = mountEditor({ initialValue: 'hello world' });
+    expect(
+      (textarea(wrapper).element as HTMLTextAreaElement).value
+    ).toBe('hello world');
+  });
+
+  it('emits update as the user types', async () => {
+    const wrapper = mountEditor();
+    await textarea(wrapper).setValue('typed text');
+    expect(wrapper.emitted('update')?.at(-1)).toEqual(['typed text']);
+  });
+
+  it('updates the cursor index on keyup without error', async () => {
+    const wrapper = mountEditor({ initialValue: 'abc' });
+    await textarea(wrapper).trigger('keyup');
+    await textarea(wrapper).trigger('click');
+    expect(textarea(wrapper).exists()).toBe(true);
+  });
+
+  it('ignores keydown when no autocomplete is active', async () => {
+    const wrapper = mountEditor();
+    await textarea(wrapper).trigger('keydown', { key: 'Enter' });
+    // No autocomplete suggestions, so Enter is not intercepted and nothing emits.
+    expect(wrapper.emitted('update')).toBeUndefined();
+  });
+
+  it('shows the character counter only when enabled', () => {
+    expect(mountEditor({ showCharCounter: true }).find('.char-counter').exists()).toBe(
+      true
+    );
+    expect(mountEditor().find('.char-counter').exists()).toBe(false);
+  });
+
+  it('renders a markdown preview when the Preview tab is selected', async () => {
+    const wrapper = mountEditor({ initialValue: 'preview me' });
+    expect(wrapper.find('.markdown-preview').exists()).toBe(false);
+
+    const previewTab = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Preview'));
+    await previewTab!.trigger('click');
+
+    expect(wrapper.find('.markdown-preview').text()).toContain('preview me');
+  });
+
+  it('applies a toolbar format command and emits the updated text', async () => {
+    const wrapper = mountEditor({ initialValue: 'bold' });
+    await wrapper
+      .findComponent({ name: 'TextEditorToolbar' })
+      .vm.$emit('format', 'bold');
+    expect(wrapper.emitted('update')).toBeTruthy();
+    expect(String(wrapper.emitted('update')?.at(-1)?.[0])).toContain('**');
+  });
+});
+
+describe('TextEditor (image upload)', () => {
+  beforeEach(() => {
+    uploadFileMock.mockReset();
+    validateFileSizeMock.mockReset().mockReturnValue({ valid: true, message: '' });
+  });
+
+  const pngFile = () => new File(['x'], 'pic.png', { type: 'image/png' });
+
+  it('replaces the placeholder with the uploaded image markdown on success', async () => {
+    uploadFileMock.mockResolvedValue({
+      success: true,
+      embeddedLink: 'https://cdn.example.com/pic.png',
+    });
+    const wrapper = mountEditor({ initialValue: '' });
+    await wrapper
+      .findComponent({ name: 'AddImage' })
+      .vm.$emit('file-change', fileChange(pngFile()));
+    await flushPromises();
+
+    const last = String(wrapper.emitted('update')?.at(-1)?.[0]);
+    expect(last).toContain('https://cdn.example.com/pic.png');
+  });
+
+  it('inserts error markdown when the upload fails', async () => {
+    uploadFileMock.mockResolvedValue({ success: false, error: 'server said no' });
+    const wrapper = mountEditor({ initialValue: '' });
+    await wrapper
+      .findComponent({ name: 'AddImage' })
+      .vm.$emit('file-change', fileChange(pngFile()));
+    await flushPromises();
+
+    const last = String(wrapper.emitted('update')?.at(-1)?.[0]);
+    expect(last).toContain('upload failed');
+  });
+
+  it('rejects an oversized file before uploading', async () => {
+    validateFileSizeMock.mockReturnValue({ valid: false, message: 'too big' });
+    const alertSpy = vi.fn();
+    vi.stubGlobal('alert', alertSpy);
+    const wrapper = mountEditor({ initialValue: '' });
+    await wrapper
+      .findComponent({ name: 'AddImage' })
+      .vm.$emit('file-change', fileChange(pngFile()));
+    await flushPromises();
+
+    expect(alertSpy).toHaveBeenCalledWith('too big');
+    expect(uploadFileMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
   });
 });


### PR DESCRIPTION
## Summary

The existing `TextEditor.spec.ts` only tested the **extracted utils** (formatting, emoji, char-count) — it never mounted the component. This adds a mounted-component suite that drives the real `<textarea>` editor.

New tests cover: typing → `update` emit, cursor/keydown handling (incl. the no-autocomplete keydown path), the character counter, the write/preview tab swap (MarkdownRenderer), toolbar `format` commands, and the **image-upload flow** — placeholder insertion, success replacement, failure error-markdown, and the oversized-file guard — via a mocked `useImageUpload`.

## Coverage

`TextEditor.vue` line coverage **60% → 64%**. Note: combined coverage is ~flat because TextEditor is a *shared* component that other specs already render incidentally — the image-upload block was the only chunk not previously covered. The value here is **explicit, regression-guarding component tests** (the old spec mounted nothing), not a big coverage delta.

## Also investigated (not included)

`event/map/Map.vue` — the other big target — is already mounted in its spec; its remaining ~71 uncovered lines are imperative `google.maps` marker/clusterer glue (pure logic already extracted to `utils/mapMarkerLogic.ts`). Covering it needs a large `google.maps` mock surface for low ROL — better left for a logic-extraction refactor.

## Notes
- Pure test change — no production code touched.
- Local `vue-tsc` is broken, so CI's `unit-tests` job is authoritative for the typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)