### PR TITLE
test(coverage): TimePicker + album detail page

### DIFF
--- a/components/event/form/TimePicker.spec.ts
+++ b/components/event/form/TimePicker.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import TimePicker from './TimePicker.vue';
+
+const mountPicker = (props: Record<string, unknown> = {}) =>
+  mount(TimePicker, { props: { value: '09:00', ...props } });
+
+const trigger = (wrapper: ReturnType<typeof mountPicker>) =>
+  wrapper.get('[data-testid="time-picker"]');
+
+const option = (wrapper: ReturnType<typeof mountPicker>, label: string) =>
+  wrapper.findAll('.cursor-pointer').find((d) => d.text() === label);
+
+describe('TimePicker', () => {
+  it('renders the value in 12-hour format', () => {
+    expect(mountPicker({ value: '14:30' }).text()).toContain('2:30 PM');
+  });
+
+  it('falls back to the raw value for an invalid time', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(mountPicker({ value: 'not-a-time' }).text()).toContain('not-a-time');
+  });
+
+  it('opens the dropdown when clicked', async () => {
+    const wrapper = mountPicker();
+    expect(option(wrapper, '12:15 AM')).toBeUndefined();
+    await trigger(wrapper).trigger('click');
+    expect(option(wrapper, '12:15 AM')).toBeTruthy();
+  });
+
+  it('emits the 24-hour value when a time is selected', async () => {
+    const wrapper = mountPicker();
+    await trigger(wrapper).trigger('click');
+    await option(wrapper, '12:15 AM')!.trigger('click');
+    expect(wrapper.emitted('update')?.at(-1)).toEqual(['00:15']);
+  });
+
+  it('closes the dropdown after selecting a time', async () => {
+    const wrapper = mountPicker();
+    await trigger(wrapper).trigger('click');
+    await option(wrapper, '12:15 AM')!.trigger('click');
+    expect(option(wrapper, '12:15 AM')).toBeUndefined();
+  });
+
+  it('does not open when disabled', async () => {
+    const wrapper = mountPicker({ disabled: true });
+    await trigger(wrapper).trigger('click');
+    expect(option(wrapper, '12:15 AM')).toBeUndefined();
+  });
+});

--- a/pages/u/[username]/albums/[albumId].spec.ts
+++ b/pages/u/[username]/albums/[albumId].spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+
+import AlbumDetailPage from './[albumId].vue';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+const h = vi.hoisted(() => ({
+  route: { params: { username: 'alice', albumId: 'al1' } as Record<string, unknown> },
+  resultRef: null as unknown as { value: unknown },
+  loadingRef: null as unknown as { value: boolean },
+  errorRef: null as unknown as { value: unknown },
+  copyUrl: null as unknown as ReturnType<typeof vi.fn>,
+}));
+
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route, useHead: vi.fn() }));
+
+vi.mock('@vue/apollo-composable', async () => {
+  const { ref } = await import('vue');
+  h.resultRef = ref(null);
+  h.loadingRef = ref(false);
+  h.errorRef = ref(null);
+  return {
+    useQuery: () => ({
+      result: h.resultRef,
+      loading: h.loadingRef,
+      error: h.errorRef,
+    }),
+  };
+});
+
+vi.mock('@/composables/useCopyCurrentUrl', async () => {
+  const { ref } = await import('vue');
+  h.copyUrl = vi.fn();
+  return {
+    useCopyCurrentUrl: () => ({
+      showCopiedNotification: ref(false),
+      copyCurrentUrl: h.copyUrl,
+    }),
+  };
+});
+
+vi.mock('@/graphQLData/image/queries', () => ({ GET_ALBUM_DETAILS: 'q' }));
+
+const stubs = {
+  AlbumThumbnailGrid: {
+    name: 'AlbumThumbnailGrid',
+    props: ['images'],
+    template: '<div class="thumb-grid" />',
+  },
+  Notification: { name: 'Notification', props: ['show', 'title'], template: '<div />' },
+  LinkIcon: { template: '<i />' },
+};
+
+const mountAlbum = () => mountWithDefaults(AlbumDetailPage, { global: { stubs } });
+
+const setAlbum = (album: Record<string, unknown> | null) => {
+  h.resultRef.value = { albums: album ? [album] : [] };
+};
+
+const baseAlbum = (over: Record<string, unknown> = {}) => ({
+  id: 'al1',
+  Owner: { username: 'alice', displayName: 'Alice' },
+  Images: [
+    { id: 'a', url: 'u/a' },
+    { id: 'b', url: 'u/b' },
+    { id: 'c', url: 'u/c' },
+  ],
+  imageOrder: ['a', 'b', 'c'],
+  Discussions: [],
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.route = { params: { username: 'alice', albumId: 'al1' } };
+  h.resultRef.value = null;
+  h.loadingRef.value = false;
+  h.errorRef.value = null;
+});
+
+describe('Album detail page', () => {
+  it('shows the loading state', () => {
+    h.loadingRef.value = true;
+    expect(mountAlbum().text()).toContain('Loading album');
+  });
+
+  it('shows the not-found state when the album is missing', () => {
+    setAlbum(null);
+    expect(mountAlbum().text()).toContain('Album Not Found');
+  });
+
+  it('shows the not-found state on query error', () => {
+    h.errorRef.value = { message: 'boom' };
+    expect(mountAlbum().text()).toContain('Album Not Found');
+  });
+
+  it('warns when the album belongs to a different user', () => {
+    setAlbum(baseAlbum({ Owner: { username: 'bob' } }));
+    const wrapper = mountAlbum();
+    expect(wrapper.text()).toContain('Invalid URL');
+    expect(wrapper.text()).toContain('bob');
+  });
+
+  it('renders the album with its owner and image count', () => {
+    setAlbum(baseAlbum());
+    const wrapper = mountAlbum();
+    expect(wrapper.text()).toContain('Album by Alice');
+    expect(wrapper.text()).toContain('Images (3)');
+  });
+
+  it('orders the images by imageOrder', () => {
+    setAlbum(baseAlbum({ imageOrder: ['c', 'a'] }));
+    const wrapper = mountAlbum();
+    const images = wrapper
+      .findComponent({ name: 'AlbumThumbnailGrid' })
+      .props('images') as Array<{ id: string }>;
+    expect(images.map((i) => i.id)).toEqual(['c', 'a']);
+  });
+
+  it('copies the album link when Share is clicked', async () => {
+    setAlbum(baseAlbum());
+    const wrapper = mountAlbum();
+    await wrapper.get('button').trigger('click');
+    expect(h.copyUrl).toHaveBeenCalled();
+  });
+
+  it('shows a related discussion when present', () => {
+    setAlbum(
+      baseAlbum({
+        Discussions: [
+          {
+            id: 'd1',
+            title: 'Trip photos',
+            DiscussionChannels: [{ channelUniqueName: 'cats' }],
+            Author: { username: 'alice' },
+          },
+        ],
+      })
+    );
+    const wrapper = mountAlbum();
+    expect(wrapper.text()).toContain('Related Discussion');
+    expect(wrapper.text()).toContain('Trip photos');
+  });
+});


### PR DESCRIPTION
## Summary

Two more no-spec targets:

- **`components/event/form/TimePicker.vue`** — 12-hour formatting, invalid-value fallback, dropdown open, emitting the 24-hour value on select, close-after-select, and the disabled no-op.
- **`pages/u/[username]/albums/[albumId].vue`** — loading / not-found / wrong-user states, owner + image-count rendering, `imageOrder` ordering, the Share/copy-link button, and the related-discussion section.

14 tests, all on real components. Pure test additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)