### PR TITLE
test(coverage): EventFilterBar handlers + getEventWhere branches

### DIFF
--- a/components/event/list/filters/EventFilterBar.spec.ts
+++ b/components/event/list/filters/EventFilterBar.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { createMockRoute, createMockRouter } from '@/tests/utils/mockRouter';
 
@@ -27,11 +27,65 @@ const heavyStubs = {
   Popper: true,
 };
 
+// Slot-rendering stubs so the filter controls (which live deep inside
+// SearchBar/LocationSearchBar -> client-only -> Popper #content) actually mount
+// and can emit the events the bar wires its update handlers to.
+const openStubs = {
+  ...heavyStubs,
+  SearchBar: { name: 'SearchBar', template: '<div><slot /></div>' },
+  LocationSearchBar: {
+    name: 'LocationSearchBar',
+    emits: ['update-location-input'],
+    template: '<div><slot /></div>',
+  },
+  Popper: {
+    name: 'Popper',
+    template: '<div><slot /><slot name="content" /></div>',
+  },
+  'client-only': { template: '<div><slot /></div>' },
+  ClientOnly: { template: '<div><slot /></div>' },
+  SelectCanceled: {
+    name: 'SelectCanceled',
+    emits: ['update-show-canceled'],
+    template: '<div />',
+  },
+  SelectFree: {
+    name: 'SelectFree',
+    emits: ['update-show-only-free'],
+    template: '<div />',
+  },
+  GenericButton: {
+    name: 'GenericButton',
+    inheritAttrs: true,
+    props: ['text'],
+    template: '<button>{{ text }}</button>',
+  },
+};
+
 const mountBar = (props: Record<string, unknown> = {}) =>
   mountWithDefaults(EventFilterBar, {
     props: { allowHidingMainFilters: true, ...props },
     global: { stubs: heavyStubs },
   });
+
+// Mount with the filters open and a channel scope (so the location/distance
+// controls render).
+const mountOpen = () =>
+  mountWithDefaults(EventFilterBar, {
+    props: { allowHidingMainFilters: true, showMainFiltersByDefault: true },
+    global: { stubs: openStubs },
+  });
+
+const lastReplaceQuery = () => {
+  const calls = router.replace.mock.calls;
+  return (calls.at(-1)?.[0] as { query: Record<string, unknown> })?.query ?? {};
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  route.params = {};
+  route.query = {};
+});
 
 describe('EventFilterBar', () => {
   it('renders the main-filters toggle when hiding is allowed', () => {
@@ -56,5 +110,72 @@ describe('EventFilterBar', () => {
     expect(
       wrapper.get('[data-testid="toggle-main-filters-button"]').text()
     ).toBe('Hide filters');
+  });
+});
+
+describe('EventFilterBar filter handlers', () => {
+  beforeEach(() => {
+    // A channel scope makes showLocationSearchBarAndDistanceButtons true so the
+    // distance / cancel / free controls render.
+    route.params = { forumId: 'cats' };
+  });
+
+  it('writes showCanceledEvents when the cancel filter is enabled', async () => {
+    const wrapper = mountOpen();
+    await wrapper
+      .findComponent({ name: 'SelectCanceled' })
+      .vm.$emit('update-show-canceled', true);
+    expect(lastReplaceQuery()).toMatchObject({ showCanceledEvents: true });
+  });
+
+  it('clears showCanceledEvents when the cancel filter is disabled', async () => {
+    const wrapper = mountOpen();
+    await wrapper
+      .findComponent({ name: 'SelectCanceled' })
+      .vm.$emit('update-show-canceled', false);
+    expect(router.replace).toHaveBeenCalled();
+    expect(lastReplaceQuery()).not.toHaveProperty('showCanceledEvents');
+  });
+
+  it('writes showOnlyFreeEvents when the free filter is enabled', async () => {
+    const wrapper = mountOpen();
+    await wrapper
+      .findComponent({ name: 'SelectFree' })
+      .vm.$emit('update-show-only-free', true);
+    expect(lastReplaceQuery()).toMatchObject({ showOnlyFreeEvents: true });
+  });
+
+  it('sets any-distance (radius 0 + address filter) for the 0 distance option', async () => {
+    const wrapper = mountOpen();
+    const anyDistance = wrapper.find('[data-testid="distance-0"]');
+    expect(anyDistance.exists()).toBe(true);
+    await anyDistance.trigger('click');
+    expect(lastReplaceQuery()).toMatchObject({ radius: 0 });
+  });
+
+  it('sets a numeric radius for a non-zero distance option', async () => {
+    const wrapper = mountOpen();
+    const distanceButton = wrapper
+      .findAll('[data-testid^="distance-"]')
+      .find((b) => b.attributes('data-testid') !== 'distance-0');
+    await distanceButton!.trigger('click');
+    const query = lastReplaceQuery();
+    expect(typeof query.radius).toBe('number');
+    expect(query.radius).not.toBe(0);
+  });
+
+  it('updates filters from a location selection', async () => {
+    const wrapper = mountOpen();
+    await wrapper.findComponent({ name: 'LocationSearchBar' }).vm.$emit(
+      'update-location-input',
+      {
+        name: 'Phoenix',
+        formatted_address: 'Phoenix, AZ',
+        lat: 33.4,
+        lng: -112,
+        referencePointAddress: 'Phoenix, AZ',
+      }
+    );
+    expect(router.replace).toHaveBeenCalled();
   });
 });

--- a/components/event/list/filters/getEventWhere.coverage.spec.ts
+++ b/components/event/list/filters/getEventWhere.coverage.spec.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from 'vitest';
+import getEventWhere from './getEventWhere';
+import { LocationFilterTypes } from './locationFilterTypes';
+import { timeShortcutValues } from './eventSearchOptions';
+import type { SearchEventValues } from '@/types/Event';
+
+// NOTE: getEventWhere captures `const now = DateTime.now()` at MODULE load, so
+// the sibling getEventWhere.spec.ts loads it via a dynamic import + vi.resetModules
+// to control the clock for exact-timestamp assertions. That dynamic-import pattern
+// means v8 coverage never attributes those tests to getEventWhere.ts. This spec
+// imports the module statically so its branches register as covered; it asserts
+// the structural filter conditions (which are time-independent) and that each
+// time shortcut produces a date range.
+
+const defaultFilterValues: SearchEventValues = {
+  timeShortcut: timeShortcutValues.NONE,
+  tags: [],
+  channels: [],
+  searchInput: '',
+  showCanceledEvents: false,
+  free: false,
+  locationFilter: LocationFilterTypes.NONE,
+  hasVirtualEventUrl: false,
+  showArchived: false,
+};
+
+type BuildInput = {
+  filterValues?: Partial<SearchEventValues>;
+  showMap?: boolean;
+  channelId?: string;
+  onlineOnly?: boolean;
+};
+
+const build = ({
+  filterValues = {},
+  showMap = false,
+  channelId = '',
+  onlineOnly = false,
+}: BuildInput = {}) =>
+  getEventWhere({
+    filterValues: { ...defaultFilterValues, ...filterValues },
+    showMap,
+    channelId,
+    onlineOnly,
+  });
+
+// The AND array always ends with the two endTime range conditions.
+const conditions = (where: ReturnType<typeof build>) =>
+  (where.AND ?? []) as Array<Record<string, unknown>>;
+
+const hasCondition = (
+  where: ReturnType<typeof build>,
+  match: Record<string, unknown>
+) =>
+  conditions(where).some((c) =>
+    expect
+      .objectContaining(match)
+      .asymmetricMatch?.(c)
+  );
+
+describe('getEventWhere (structural coverage)', () => {
+  describe('archived / channel scoping', () => {
+    it('requires a non-archived channel in sitewide view', () => {
+      const where = build();
+      expect(where.AND).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            EventChannels_SOME: expect.objectContaining({ archived: false }),
+          }),
+        ])
+      );
+    });
+
+    it('drops the archived constraint when showArchived is set (sitewide)', () => {
+      const where = build({ filterValues: { showArchived: true } });
+      const channelCond = conditions(where).find((c) => 'EventChannels_SOME' in c);
+      expect(channelCond?.EventChannels_SOME).not.toHaveProperty('archived');
+    });
+
+    it('scopes to a single channel (non-archived) when channelId is set', () => {
+      const where = build({ channelId: 'cats' });
+      expect(where.AND).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            EventChannels_SOME: { channelUniqueName: 'cats', archived: false },
+          }),
+        ])
+      );
+    });
+
+    it('includes archived channel events when showArchived is set with a channelId', () => {
+      const where = build({ channelId: 'cats', filterValues: { showArchived: true } });
+      expect(where.AND).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            EventChannels_SOME: { channelUniqueName: 'cats' },
+          }),
+        ])
+      );
+    });
+
+    it('matches selected channels in sitewide view', () => {
+      const where = build({ filterValues: { channels: ['cats', ''] } });
+      expect(where.AND).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            EventChannels_SOME: expect.objectContaining({
+              OR: [{ channelUniqueName_CONTAINS: 'cats', archived: false }],
+            }),
+          }),
+        ])
+      );
+    });
+  });
+
+  describe('boolean filters', () => {
+    it('adds a free filter when free is true', () => {
+      expect(hasCondition(build({ filterValues: { free: true } }), { free: true })).toBe(true);
+    });
+
+    it('omits the free filter when free is false', () => {
+      expect(conditions(build()).some((c) => 'free' in c)).toBe(false);
+    });
+
+    it('hides canceled events by default', () => {
+      expect(hasCondition(build(), { canceled: false })).toBe(true);
+    });
+
+    it('shows canceled events when requested', () => {
+      const where = build({ filterValues: { showCanceledEvents: true } });
+      expect(conditions(where).some((c) => 'canceled' in c)).toBe(false);
+    });
+
+    it('filters for virtual events when hasVirtualEventUrl is set', () => {
+      expect(
+        hasCondition(build({ filterValues: { hasVirtualEventUrl: true } }), {
+          NOT: { virtualEventUrl: null },
+        })
+      ).toBe(true);
+    });
+
+    it('filters for online events when onlineOnly is set', () => {
+      expect(
+        hasCondition(build({ onlineOnly: true }), { NOT: { virtualEventUrl: null } })
+      ).toBe(true);
+    });
+  });
+
+  describe('text search', () => {
+    it('builds a case-insensitive title/description match', () => {
+      const where = build({ filterValues: { searchInput: 'jazz' } });
+      expect(where.AND).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            OR: [
+              { title_MATCHES: '(?i).*jazz.*' },
+              { description_MATCHES: '(?i).*jazz.*' },
+            ],
+          }),
+        ])
+      );
+    });
+  });
+
+  describe('location filters', () => {
+    it('requires a location on the map for NONE + showMap', () => {
+      expect(
+        hasCondition(build({ showMap: true }), { NOT: { location: null } })
+      ).toBe(true);
+    });
+
+    it('requires a location name for ONLY_WITH_ADDRESS', () => {
+      expect(
+        hasCondition(
+          build({ filterValues: { locationFilter: LocationFilterTypes.ONLY_WITH_ADDRESS } }),
+          { NOT: { locationName: null } }
+        )
+      ).toBe(true);
+    });
+
+    it('requires a physical location for ONLY_VIRTUAL on the map', () => {
+      expect(
+        hasCondition(
+          build({
+            showMap: true,
+            filterValues: { locationFilter: LocationFilterTypes.ONLY_VIRTUAL },
+          }),
+          { location: null }
+        )
+      ).toBe(true);
+    });
+
+    it('builds a radius filter for WITHIN_RADIUS with coordinates', () => {
+      const where = build({
+        filterValues: {
+          locationFilter: LocationFilterTypes.WITHIN_RADIUS,
+          radius: 25,
+          latitude: 33.4,
+          longitude: -112,
+        },
+      });
+      expect(where.AND).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            location_LTE: expect.objectContaining({ distance: 25000 }),
+          }),
+        ])
+      );
+    });
+
+    it('falls back to any-distance (locationName) for radius 0', () => {
+      expect(
+        hasCondition(
+          build({
+            filterValues: {
+              locationFilter: LocationFilterTypes.WITHIN_RADIUS,
+              radius: 0,
+            },
+          }),
+          { NOT: { locationName: null } }
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('tag filter', () => {
+    it('matches any of the selected tags', () => {
+      const where = build({ filterValues: { tags: ['music', 'art'] } });
+      expect(where.AND).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            Tags_SOME: {
+              OR: [{ text_CONTAINS: 'music' }, { text_CONTAINS: 'art' }],
+            },
+          }),
+        ])
+      );
+    });
+  });
+
+  describe('time shortcuts', () => {
+    it.each(Object.values(timeShortcutValues))(
+      'produces an endTime range for the "%s" shortcut',
+      (timeShortcut) => {
+        const where = build({ filterValues: { timeShortcut } });
+        expect(conditions(where).some((c) => 'endTime_GT' in c)).toBe(true);
+        expect(conditions(where).some((c) => 'endTime_LT' in c)).toBe(true);
+      }
+    );
+
+    it('defaults to a now..+2y range for NONE', () => {
+      const where = build();
+      const gt = conditions(where).find((c) => 'endTime_GT' in c)?.endTime_GT as string;
+      const lt = conditions(where).find((c) => 'endTime_LT' in c)?.endTime_LT as string;
+      expect(new Date(lt).getTime() - new Date(gt).getTime()).toBeGreaterThan(
+        // ~2 years in ms, minus a margin
+        1.9 * 365 * 24 * 60 * 60 * 1000
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Both targets you flagged:

- **`EventFilterBar.vue`** (~39% → ~67%): drives the filter update handlers that live deep inside `SearchBar`/`LocationSearchBar` → `client-only` → `Popper` `#content`, reached via slot-rendering stubs — `updateShowCanceled` (on/off), `updateShowOnlyFree`, `updateSelectedDistance` (any-distance/radius-0 vs numeric radius), and `updateLocationInput`.
- **`getEventWhere.ts`**: a statically-imported spec exercising every branch — archived/channel scoping, free/canceled/virtual/online, text search, all location-filter cases, tags, and each time shortcut (28 tests).

## Heads-up on `getEventWhere`

The existing `getEventWhere.spec.ts` loads the module via dynamic `import()` + `vi.resetModules()` (to control the module-level `const now = DateTime.now()` for exact-timestamp assertions). v8 coverage can't attribute that pattern, so those tests register **zero** coverage. My new spec imports statically so coverage *would* register — **but** `getEventWhere.ts` is a `.ts` file under `components/`, and the vitest coverage `include` only counts `components/**/*.vue`, `composables|utils/**/*.ts`, and `pages/**/*.vue`. So this is a **test-quality** win (real branch coverage of the filter builder), not a coverage-% change. If you'd like it to count, the cleanest path is moving the logic to `utils/` — happy to do that as a follow-up.

Pure test additions — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)