### PR TITLE
test(coverage): forum-create + library pages (bucket 2)

### DIFF
--- a/pages/forums/create.spec.ts
+++ b/pages/forums/create.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { defineComponent, h as createEl } from 'vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+
+import CreateForumPage from './create.vue';
+
+const h = vi.hoisted(() => ({
+  mutate: null as unknown as ReturnType<typeof vi.fn>,
+  push: null as unknown as ReturnType<typeof vi.fn>,
+  onDoneCb: null as unknown as (r: unknown) => void,
+  onErrorCb: null as unknown as () => void,
+}));
+
+vi.mock('nuxt/app', () => ({
+  useRouter: () => ({ push: h.push }),
+}));
+
+vi.mock('@vue/apollo-composable', async () => {
+  const { ref } = await import('vue');
+  h.mutate = vi.fn();
+  h.push = vi.fn();
+  return {
+    useMutation: () => ({
+      mutate: h.mutate,
+      error: ref(null),
+      loading: ref(false),
+      onDone: (cb: (r: unknown) => void) => {
+        h.onDoneCb = cb;
+      },
+      onError: (cb: () => void) => {
+        h.onErrorCb = cb;
+      },
+    }),
+  };
+});
+
+vi.mock('@/composables/useAuthState', async () => {
+  const { ref } = await import('vue');
+  return { useUsername: () => ref('alice') };
+});
+
+vi.mock('@/composables/useSuspensionNotice', async () => {
+  const { ref } = await import('vue');
+  return {
+    useServerSuspensionNotice: () => ({
+      issueNumber: ref(null),
+      suspendedUntil: ref(null),
+      suspendedIndefinitely: ref(false),
+      channelId: ref(''),
+    }),
+  };
+});
+
+vi.mock('@/graphQLData/channel/mutations', () => ({ CREATE_CHANNEL: 'm' }));
+
+const FieldsStub = {
+  name: 'CreateEditChannelFields',
+  props: ['formValues', 'submitError', 'createChannelLoading'],
+  emits: ['submit', 'update-form-values'],
+  template: '<div class="fields" />',
+};
+
+const RequireAuthUnauth = defineComponent({
+  name: 'RequireAuth',
+  setup(_p, { slots }) {
+    return () => createEl('div', slots['does-not-have-auth']?.());
+  },
+});
+
+const mountPage = (extraStubs: Record<string, unknown> = {}) =>
+  mountWithDefaults(CreateForumPage, {
+    global: { stubs: { CreateEditChannelFields: FieldsStub, ...extraStubs } },
+  });
+
+const fields = (wrapper: ReturnType<typeof mountPage>) =>
+  wrapper.findComponent(FieldsStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Create forum page', () => {
+  it('renders the channel form for authorized users', () => {
+    expect(fields(mountPage()).exists()).toBe(true);
+  });
+
+  it('shows a permission message for unauthorized users', () => {
+    const wrapper = mountPage({ RequireAuth: RequireAuthUnauth });
+    expect(wrapper.text()).toContain("don't have permission");
+  });
+
+  it('merges field updates into the form values', async () => {
+    const wrapper = mountPage();
+    await fields(wrapper).vm.$emit('update-form-values', { displayName: 'Cats' });
+    expect(fields(wrapper).props('formValues').displayName).toBe('Cats');
+  });
+
+  it('submits a channel create input built from the form values', async () => {
+    const wrapper = mountPage();
+    await fields(wrapper).vm.$emit('update-form-values', {
+      uniqueName: 'cats',
+      displayName: 'Cats',
+      selectedTags: ['pets'],
+    });
+    await fields(wrapper).vm.$emit('submit');
+
+    expect(h.mutate).toHaveBeenCalledTimes(1);
+    const input = h.mutate.mock.calls[0][0].createChannelInput[0];
+    expect(input.uniqueName).toBe('cats');
+    expect(input.Tags.connectOrCreate[0].where.node.text).toBe('pets');
+    expect(input.Admins.connect[0].where.node.username).toBe('alice');
+  });
+
+  it('navigates to the new forum once creation completes', () => {
+    mountPage();
+    h.onDoneCb({
+      data: { createChannels: { channels: [{ uniqueName: 'cats' }] } },
+    });
+    expect(h.push).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { forumId: 'cats' } })
+    );
+  });
+
+  it('surfaces an error when creation returns no channel', async () => {
+    const wrapper = mountPage();
+    h.onDoneCb({ data: { createChannels: { channels: [] } } });
+    await wrapper.vm.$nextTick();
+    expect(fields(wrapper).props('submitError')).toContain('Unable to create forum');
+  });
+});

--- a/pages/library.spec.ts
+++ b/pages/library.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { defineComponent, h as createEl } from 'vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+
+import LibraryPage from './library.vue';
+
+const h = vi.hoisted(() => ({
+  counts: null as unknown as { value: unknown },
+  downloads: null as unknown as { value: unknown },
+  owned: null as unknown as { value: unknown },
+  collections: null as unknown as { value: unknown },
+  qi: 0,
+}));
+
+vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
+
+vi.mock('@vue/apollo-composable', async () => {
+  const { ref } = await import('vue');
+  h.counts = ref(null);
+  h.downloads = ref(null);
+  h.owned = ref(null);
+  h.collections = ref(null);
+  const order = [h.counts, h.downloads, h.owned, h.collections];
+  return {
+    useQuery: () => ({ result: order[h.qi++] ?? ref(null), refetch: vi.fn() }),
+  };
+});
+
+vi.mock('@/composables/useAuthState', async () => {
+  const { ref } = await import('vue');
+  return {
+    useUsername: () => ref('alice'),
+    useIsAuthenticated: () => ref(true),
+  };
+});
+
+const RequireAuthUnauth = defineComponent({
+  name: 'RequireAuth',
+  setup(_p, { slots }) {
+    return () => createEl('div', slots['does-not-have-auth']?.());
+  },
+});
+
+const mountLibrary = (extraStubs: Record<string, unknown> = {}) =>
+  mountWithDefaults(LibraryPage, {
+    global: {
+      mocks: {
+        $route: { query: {}, params: {}, path: '/library', fullPath: '/library' },
+      },
+      stubs: { NuxtPage: true, ...extraStubs },
+    },
+  });
+
+const setCounts = (channels: number, discussions: number, images: number) => {
+  h.counts.value = {
+    users: [
+      {
+        FavoriteChannelsAggregate: { count: channels },
+        FavoriteDiscussionsAggregate: { count: discussions },
+        FavoriteImagesAggregate: { count: images },
+        FavoriteCommentsAggregate: { count: 0 },
+      },
+    ],
+  };
+  h.downloads.value = { users: [{ FavoriteDiscussionsAggregate: { count: 0 } }] };
+  h.owned.value = { users: [{ OwnedDownloadsAggregate: { count: 0 } }] };
+  h.collections.value = { users: [{ Collections: [] }] };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.qi = 0;
+  h.counts.value = null;
+  h.downloads.value = null;
+  h.owned.value = null;
+  h.collections.value = null;
+});
+
+describe('Library page', () => {
+  it('prompts unauthenticated users to sign in', () => {
+    const wrapper = mountLibrary({ RequireAuth: RequireAuthUnauth });
+    expect(wrapper.text()).toContain('Sign In Required');
+  });
+
+  it('renders the favorite collections with their counts', () => {
+    setCounts(3, 1, 2);
+    const wrapper = mountLibrary();
+    // The count parens distinguish collection cards from the filter buttons.
+    expect(wrapper.text()).toContain('(3)'); // favorite forums
+    expect(wrapper.text()).toContain('(2)'); // favorite images
+  });
+
+  it('renders custom collections from the query', () => {
+    setCounts(0, 0, 0);
+    h.collections.value = {
+      users: [
+        {
+          Collections: [
+            {
+              id: 'c1',
+              name: 'My Reading List',
+              description: 'stuff to read',
+              collectionType: 'DISCUSSIONS',
+              visibility: 'PRIVATE',
+              itemCount: 4,
+            },
+          ],
+        },
+      ],
+    };
+    expect(mountLibrary().text()).toContain('My Reading List');
+  });
+
+  it('filters collections by type', async () => {
+    setCounts(3, 1, 2);
+    const wrapper = mountLibrary();
+    expect(wrapper.text()).toContain('(3)'); // forums shown under "all"
+
+    const imagesFilter = wrapper
+      .findAll('button')
+      .find((b) => b.text().trim() === 'Images');
+    await imagesFilter!.trigger('click');
+
+    // Only the images favorite remains; the forums card (3) is filtered out.
+    expect(wrapper.text()).toContain('(2)');
+    expect(wrapper.text()).not.toContain('(3)');
+  });
+});


### PR DESCRIPTION
## Summary

Two of the bucket-2 net-new pages (no prior unit spec, not E2E-covered):

- **`pages/forums/create.vue`** (0% → 77%) — channel form render (authed) + permission message (unauthed), field-update merging, the channel create-input build (tag connect-or-create + admin connect) on submit, navigation on done, and the no-channel error path.
- **`pages/library.vue`** (0% → 81%) — sign-in prompt, favorite collections with counts, custom collections from the query, and type filtering.

10 tests on real pages. Pure test additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)