### PR TITLE
test(coverage): admin server-settings page

### DIFF
--- a/pages/admin/settings.spec.ts
+++ b/pages/admin/settings.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+
+import ServerSettingsPage from './settings.vue';
+
+const h = vi.hoisted(() => ({
+  result: null as unknown as { value: unknown },
+  error: null as unknown as { value: unknown },
+  loading: null as unknown as { value: boolean },
+  mutate: null as unknown as ReturnType<typeof vi.fn>,
+  onResultCb: null as unknown as (r: unknown) => void,
+  onDoneCb: null as unknown as () => void,
+}));
+
+vi.mock('@vue/apollo-composable', async () => {
+  const { ref } = await import('vue');
+  h.result = ref(null);
+  h.error = ref(null);
+  h.loading = ref(false);
+  h.mutate = vi.fn();
+  return {
+    useQuery: () => ({
+      result: h.result,
+      error: h.error,
+      loading: h.loading,
+      onResult: (cb: (r: unknown) => void) => {
+        h.onResultCb = cb;
+      },
+    }),
+    useMutation: () => ({
+      mutate: h.mutate,
+      loading: ref(false),
+      error: ref(null),
+      onDone: (cb: () => void) => {
+        h.onDoneCb = cb;
+      },
+    }),
+  };
+});
+
+vi.mock('@/config', () => ({ config: { serverName: 'test-server' } }));
+vi.mock('@/graphQLData/admin/queries', () => ({ GET_SERVER_CONFIG: 'q' }));
+vi.mock('@/graphQLData/admin/mutations', () => ({ UPDATE_SERVER_CONFIG: 'm' }));
+
+const FieldsStub = {
+  name: 'CreateEditServerFields',
+  props: ['formValues'],
+  emits: ['submit', 'update-form-values'],
+  template: '<div class="server-fields" />',
+};
+
+const mountPage = () =>
+  mountWithDefaults(ServerSettingsPage, {
+    global: {
+      stubs: {
+        CreateEditServerFields: FieldsStub,
+        Notification: { name: 'Notification', props: ['title'], template: '<div class="notification" />' },
+      },
+    },
+  });
+
+const fields = (wrapper: ReturnType<typeof mountPage>) =>
+  wrapper.findComponent(FieldsStub);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.result.value = null;
+  h.error.value = null;
+  h.loading.value = false;
+});
+
+describe('Admin server settings page', () => {
+  it('renders the server settings form', () => {
+    expect(fields(mountPage()).exists()).toBe(true);
+  });
+
+  it('populates the form when the server config query resolves', async () => {
+    const wrapper = mountPage();
+    h.onResultCb({
+      data: {
+        serverConfigs: [
+          {
+            serverDescription: 'My server',
+            rules: '[{"summary":"Be nice"}]',
+            allowedFileTypes: ['pdf'],
+            enableDownloads: true,
+            enableEvents: false,
+            pluginRegistries: ['https://r'],
+          },
+        ],
+      },
+    });
+    await wrapper.vm.$nextTick();
+    const fv = fields(wrapper).props('formValues') as {
+      serverDescription: string;
+      enableDownloads: boolean;
+      rules: unknown[];
+    };
+    expect(fv.serverDescription).toBe('My server');
+    expect(fv.enableDownloads).toBe(true);
+    expect(fv.rules).toHaveLength(1);
+  });
+
+  it('merges field updates into the form values', async () => {
+    const wrapper = mountPage();
+    await fields(wrapper).vm.$emit('update-form-values', {
+      serverDescription: 'Updated',
+    });
+    expect(fields(wrapper).props('formValues').serverDescription).toBe('Updated');
+  });
+
+  it('submits the server update input built from the form values', async () => {
+    const wrapper = mountPage();
+    await fields(wrapper).vm.$emit('update-form-values', {
+      serverDescription: 'Updated',
+      rules: [{ summary: 'Rule' }],
+    });
+    await fields(wrapper).vm.$emit('submit');
+    expect(h.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          serverDescription: 'Updated',
+          rules: JSON.stringify([{ summary: 'Rule' }]),
+        }),
+      })
+    );
+  });
+
+  it('shows a saved-changes notification when the update completes', async () => {
+    const wrapper = mountPage();
+    h.onDoneCb();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findComponent({ name: 'Notification' }).exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`pages/admin/settings.vue` (0% → 56%): renders the settings form, populates form values when the server-config query resolves (parsing the rules JSON via the `onResult` callback), merges field updates, builds + submits the server update input, and shows the saved-changes notification on done.

5 tests on the real page. Pure test additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)