### PR TITLE
test(channel-flags,events): cover flag toggles; fix series edit-scope modal

### DIFF
--- a/components/comments/CommentButtons.spec.ts
+++ b/components/comments/CommentButtons.spec.ts
@@ -223,6 +223,12 @@ describe('CommentButtons', () => {
       });
       expect(downvote(wrapper)).toBe(true);
     });
+
+    // Feedback-flag dimension (orthogonal to author): when the channel disables
+    // feedback, the downvote is hidden even for a non-author viewer.
+    it('hides downvoting when feedback is disabled in the channel', () => {
+      expect(downvote(mountButtons({ enableFeedback: false }))).toBe(false);
+    });
   });
 
   describe('edit controls', () => {

--- a/components/discussion/detail/RegularDiscussionLayout.spec.ts
+++ b/components/discussion/detail/RegularDiscussionLayout.spec.ts
@@ -41,7 +41,7 @@ const mountLayout = (props: Record<string, unknown> = {}) =>
       stubs: {
         DiscussionBody: discussionBodyStub,
         DiscussionAlbum: { name: 'DiscussionAlbum', props: ['stlFiles'], template: '<div class="album" />' },
-        DiscussionVotes: { name: 'DiscussionVotes', emits: ['handle-click-give-feedback'], template: '<div class="votes" />' },
+        DiscussionVotes: { name: 'DiscussionVotes', props: ['showDownvote', 'showEmojiButton'], emits: ['handle-click-give-feedback'], template: '<div class="votes" />' },
         MarkAsAnsweredButton: { name: 'MarkAsAnsweredButton', template: '<div class="answered" />' },
         DiscussionTitleVersions: { name: 'DiscussionTitleVersions', template: '<div class="versions" />' },
         CrosspostedDiscussionEmbed: { name: 'CrosspostedDiscussionEmbed', template: '<div class="crosspost" />' },
@@ -136,5 +136,45 @@ describe('RegularDiscussionLayout config', () => {
     await wrapper.getComponent({ name: 'DiscussionVotes' }).vm.$emit('handle-click-give-feedback');
 
     expect(wrapper.emitted('handleClickGiveFeedback')).toBeTruthy();
+  });
+
+  it('disables markdown images on the body when markdownImagesEnabled is false', () => {
+    const wrapper = mountLayout({
+      activeDiscussionChannel: channel({ markdownImagesEnabled: false }),
+    });
+
+    expect(wrapper.getComponent(discussionBodyStub).props('allowImages')).toBe(false);
+  });
+
+  it('allows markdown images on the body by default', () => {
+    const wrapper = mountLayout();
+
+    expect(wrapper.getComponent(discussionBodyStub).props('allowImages')).toBe(true);
+  });
+
+  it('hides the album when image uploads are disabled even if the discussion has images', async () => {
+    const wrapper = mountLayout({
+      discussion: discussion({ Album: { Images: [{ id: 'i1' }] } }),
+      activeDiscussionChannel: channel({ imageUploadsEnabled: false }),
+    });
+    await flushPromises();
+
+    expect(wrapper.find('.album').exists()).toBe(false);
+  });
+
+  it('hides the downvote for a non-author when feedbackEnabled is false', () => {
+    h.username = ref('bob');
+    const wrapper = mountLayout({
+      activeDiscussionChannel: channel({ feedbackEnabled: false }),
+    });
+
+    expect(wrapper.getComponent({ name: 'DiscussionVotes' }).props('showDownvote')).toBe(false);
+  });
+
+  it('shows the downvote for a non-author when feedback is enabled', () => {
+    h.username = ref('bob');
+    const wrapper = mountLayout();
+
+    expect(wrapper.getComponent({ name: 'DiscussionVotes' }).props('showDownvote')).toBe(true);
   });
 });

--- a/components/event/form/EditScopeModal.vue
+++ b/components/event/form/EditScopeModal.vue
@@ -56,6 +56,7 @@ const handleClose = () => {
       role="dialog"
       aria-modal="true"
       aria-labelledby="edit-scope-title"
+      data-testid="edit-scope-modal"
     >
       <!-- Backdrop -->
       <div

--- a/tests/playwright/mocked/events/editSeriesEvent.spec.ts
+++ b/tests/playwright/mocked/events/editSeriesEvent.spec.ts
@@ -152,12 +152,7 @@ const getCommonMocks = (username: string) => ({
   }),
 });
 
-// NOTE: Edit tests are currently skipped because they require complex auth setup
-// with ownership verification. The mock auth system needs enhancement to properly
-// set the auth username on page load for RequireAuth ownership checks to work.
-// TODO: Fix test-auth.client.ts plugin to properly sync auth state for ownership checks.
-
-test.describe.skip('Edit Series Event', () => {
+test.describe('Edit Series Event', () => {
   test('shows scope modal when editing series event', async ({ context, page }) => {
     await installMockAuth(context, page, {
       username: TEST_USERNAME,

--- a/tests/playwright/mocked/events/seriesListDisplay.spec.ts
+++ b/tests/playwright/mocked/events/seriesListDisplay.spec.ts
@@ -1,10 +1,9 @@
 import { expect, test } from '../../helpers/testFixture';
 import {
-  MOCK_DATE,
   buildBasicUser,
   buildChannel,
+  buildEvent,
   buildServerConfig,
-  buildUser,
 } from '../../helpers/graphqlFixtures';
 import { installMockAuth } from '../../helpers/mockAuth';
 import { installGraphqlMocks } from '../../helpers/mockGraphql';
@@ -19,79 +18,92 @@ const futureDate = (daysFromNow: number): string => {
   return date.toISOString();
 };
 
+type Occurrence = { id: string; startTime: string; endTime: string; canceled: boolean };
+
+const defaultOccurrences = (): Occurrence[] => [
+  { id: 'event-1', startTime: futureDate(7), endTime: futureDate(7), canceled: false },
+  { id: 'event-2', startTime: futureDate(14), endTime: futureDate(14), canceled: false },
+  { id: 'event-3', startTime: futureDate(21), endTime: futureDate(21), canceled: false },
+  { id: 'event-4', startTime: futureDate(28), endTime: futureDate(28), canceled: false },
+];
+
+const seriesData = (occurrences: Occurrence[]) => ({
+  id: 'series-1',
+  title: 'Weekly Meetup',
+  repeatPattern: {
+    type: 'WEEKLY',
+    count: 1,
+    daysOfWeek: [3],
+    endType: 'AFTER_COUNT',
+    endCount: occurrences.length,
+    endDate: null,
+  },
+  Occurrences: occurrences,
+});
+
+// The GET_EVENTS list query is normalized by Apollo, which needs __typename on
+// each object to key it in the cache. Detail queries (getEvent) render a single
+// object fine without it, but a list whose items lack __typename comes back as
+// empty objects (undefined id/startTime). Stamp __typename onto the event and
+// the nested objects the list query selects.
+const withTypenames = (event: Record<string, any>) => ({
+  ...event,
+  __typename: 'Event',
+  EventChannels: (event.EventChannels ?? []).map((ec: Record<string, any>) => ({
+    ...ec,
+    __typename: 'EventChannel',
+    Channel: ec.Channel ? { ...ec.Channel, __typename: 'Channel' } : ec.Channel,
+  })),
+  Poster: event.Poster ? { ...event.Poster, __typename: 'User' } : event.Poster,
+  EventSeries: event.EventSeries
+    ? {
+        ...event.EventSeries,
+        __typename: 'EventSeries',
+        Occurrences: (event.EventSeries.Occurrences ?? []).map(
+          (occ: Record<string, any>) => ({ ...occ, __typename: 'Event' })
+        ),
+      }
+    : event.EventSeries,
+});
+
+// Build on the shared buildEvent fixture (the shape proven to render in the
+// other event list tests), then layer the series fields on via overrides so the
+// list item resolves a real id/date and shows the series UI.
 const buildSeriesEvent = (overrides: Partial<{
   id: string;
   title: string;
   startTime: string;
-}> = {}) => ({
-  id: overrides.id || 'event-1',
-  title: overrides.title || 'Weekly Meetup',
-  description: 'Test event description',
-  startTime: overrides.startTime || futureDate(7),
-  endTime: futureDate(7),
-  locationName: 'Test Location',
-  address: '123 Test St',
-  virtualEventUrl: '',
-  startTimeDayOfWeek: 2,
-  startTimeHourOfDay: 18,
-  canceled: false,
-  isHostedByOP: true,
-  isAllDay: false,
-  coverImageURL: '',
-  createdAt: MOCK_DATE,
-  updatedAt: MOCK_DATE,
-  free: true,
-  isInPrivateResidence: false,
-  location: { latitude: 33.4484, longitude: -112.074 },
-  cost: '',
-  occurrenceIndex: 0,
-  RecurringEvent: null,
-  EventSeries: {
-    id: 'series-1',
-    title: 'Weekly Meetup',
-    repeatPattern: {
-      type: 'WEEKLY',
-      count: 1,
-      daysOfWeek: [3],
-      endType: 'AFTER_COUNT',
-      endCount: 4,
-      endDate: null,
-    },
-    Occurrences: [
-      { id: 'event-1', startTime: futureDate(7), endTime: futureDate(7), canceled: false },
-      { id: 'event-2', startTime: futureDate(14), endTime: futureDate(14), canceled: false },
-      { id: 'event-3', startTime: futureDate(21), endTime: futureDate(21), canceled: false },
-      { id: 'event-4', startTime: futureDate(28), endTime: futureDate(28), canceled: false },
-    ],
-  },
-  Tags: [],
-  CommentsAggregate: { count: 0 },
-  EventChannels: [
-    {
-      id: 'event-channel-1',
-      eventId: overrides.id || 'event-1',
+  occurrences: Occurrence[];
+}> = {}) =>
+  // Merge the series fields outside buildEvent's typed `overrides` (the shared
+  // EventFixture types occurrenceIndex/EventSeries as null), into the loosely
+  // typed withTypenames input.
+  withTypenames({
+    ...buildEvent({
+      id: overrides.id ?? 'event-1',
+      title: overrides.title ?? 'Weekly Meetup',
       channelUniqueName: TEST_CHANNEL,
-      archived: false,
-      Channel: {
-        uniqueName: TEST_CHANNEL,
-        displayName: TEST_CHANNEL,
-        channelIconURL: '',
-      },
-    },
-  ],
-  SubscribedToNotifications: [],
-  SubscribedToEventUpdates: [],
-  Poster: buildUser({ username: TEST_USERNAME }),
-});
+      posterUsername: TEST_USERNAME,
+    }),
+    occurrenceIndex: 0,
+    EventSeries: seriesData(overrides.occurrences ?? defaultOccurrences()),
+    ...(overrides.startTime
+      ? { startTime: overrides.startTime, endTime: overrides.startTime }
+      : {}),
+  });
 
 const buildSingleEvent = (overrides: Partial<{
   id: string;
   title: string;
-}> = {}) => ({
-  ...buildSeriesEvent(overrides),
-  EventSeries: null,
-  occurrenceIndex: null,
-});
+}> = {}) =>
+  withTypenames(
+    buildEvent({
+      id: overrides.id ?? 'event-1',
+      title: overrides.title ?? 'Single Event',
+      channelUniqueName: TEST_CHANNEL,
+      posterUsername: TEST_USERNAME,
+    })
+  );
 
 const getCommonMocks = (username: string) => ({
   getBasicUserInfo: () => ({
@@ -165,11 +177,20 @@ const getCommonMocks = (username: string) => ({
   }),
 });
 
-// NOTE: List display tests are currently skipped because they require additional
-// GraphQL query mocking for the events list page. The page makes queries that
-// aren't fully mocked, causing 500 errors.
-// TODO: Add missing mock handlers for event list page queries.
-
+// NOTE: Still skipped, but the original blockers are now fixed in this file:
+//   - route corrected to /forums/:forumId/events (the forum events page is
+//     pages/forums/[forumId]/events/index.vue → EventListView → GET_EVENTS)
+//   - list-item selector corrected to the dynamic data-testid="event-list-item-<title>"
+//   - fixtures rebuilt on the shared buildEvent, then stamped with __typename
+//     (the GET_EVENTS result is normalized by Apollo; without __typename the list
+//     items come back as empty objects with undefined id/startTime)
+//   - duplicate-title waits use .first() (the title renders in several spots)
+// With those, the series UI does render (verified: the "Also on:" occurrence
+// buttons appear). What remains is local flakiness: the forum events-list page
+// intermittently fails to hydrate under `nuxt dev` in mocked runs (blank page,
+// no console/page error), so a reliable green pass could not be confirmed in this
+// environment. Re-enable and verify in CI, where the dev server is more stable.
+// TODO: confirm green in CI, then remove .skip.
 test.describe.skip('Series List Display', () => {
   test('shows series icon for events that are part of a series', async ({ context, page }) => {
     await installMockAuth(context, page, {
@@ -190,18 +211,18 @@ test.describe.skip('Series List Display', () => {
       }),
     });
 
-    await page.goto(`/forums/${TEST_CHANNEL}/events/list`);
+    await page.goto(`/forums/${TEST_CHANNEL}/events`);
 
     // Wait for events to load
-    await expect(page.getByText('Series Event')).toBeVisible();
+    await expect(page.getByText('Series Event').first()).toBeVisible();
 
     // Series event should have a series indicator
-    const seriesEventItem = page.locator('[data-testid="event-list-item"]').filter({ hasText: 'Series Event' });
+    const seriesEventItem = page.locator('[data-testid^="event-list-item-"]').filter({ hasText: 'Series Event' });
     const seriesIcon = seriesEventItem.locator('[title="Part of a series"]');
     await expect(seriesIcon).toBeVisible();
 
     // Single event should NOT have a series indicator
-    const singleEventItem = page.locator('[data-testid="event-list-item"]').filter({ hasText: 'Single Event' });
+    const singleEventItem = page.locator('[data-testid^="event-list-item-"]').filter({ hasText: 'Single Event' });
     const noSeriesIcon = singleEventItem.locator('[title="Part of a series"]');
     await expect(noSeriesIcon).not.toBeVisible();
   });
@@ -222,10 +243,10 @@ test.describe.skip('Series List Display', () => {
       }),
     });
 
-    await page.goto(`/forums/${TEST_CHANNEL}/events/list`);
+    await page.goto(`/forums/${TEST_CHANNEL}/events`);
 
     // Wait for event to load
-    await expect(page.getByText('Weekly Meetup')).toBeVisible();
+    await expect(page.getByText('Weekly Meetup').first()).toBeVisible();
 
     // Should show "Also on:" with occurrence buttons
     await expect(page.getByText('Also on:')).toBeVisible();
@@ -266,10 +287,10 @@ test.describe.skip('Series List Display', () => {
       }),
     });
 
-    await page.goto(`/forums/${TEST_CHANNEL}/events/list`);
+    await page.goto(`/forums/${TEST_CHANNEL}/events`);
 
     // Wait for event to load
-    await expect(page.getByText('Weekly Meetup')).toBeVisible();
+    await expect(page.getByText('Weekly Meetup').first()).toBeVisible();
     await expect(page.getByText('Also on:')).toBeVisible();
 
     // Click on the first occurrence button (should be a date like "Jan 14")
@@ -324,10 +345,10 @@ test.describe.skip('Series List Display', () => {
       }),
     });
 
-    await page.goto(`/forums/${TEST_CHANNEL}/events/list`);
+    await page.goto(`/forums/${TEST_CHANNEL}/events`);
 
     // Wait for event to load
-    await expect(page.getByText('Weekly Meetup')).toBeVisible();
+    await expect(page.getByText('Weekly Meetup').first()).toBeVisible();
 
     // Should show "+N more" indicator since there are more than maxVisible (4) occurrences
     await expect(page.getByText(/\+\d+ more/)).toBeVisible();


### PR DESCRIPTION
## What

Frontend test coverage for channel feature-flag toggles, plus event-series spec fixes (including one real component bug).

### Channel feature-flag unit tests
- **`RegularDiscussionLayout.spec.ts`** — `markdownImagesEnabled` (→ `allowImages`), `imageUploadsEnabled` (→ album hidden), and `feedbackEnabled` (→ downvote) on discussions.
- **`CommentButtons.spec.ts`** — `feedbackEnabled` (→ downvote) on comments.
- (emoji + feedback-modal toggles were already covered — verified, not duplicated.)

### Event series
- **`EditScopeModal.vue`** — add missing `data-testid="edit-scope-modal"`. The series edit-scope modal had no targetable testid, so the edit-this/this-and-future/all-in-series flow couldn't be asserted. **Un-skips `editSeriesEvent.spec.ts` (3 tests now pass).**
- **`seriesListDisplay.spec.ts`** — fixes the real blockers behind its skip: corrected route (`/forums/:forumId/events`), the dynamic `event-list-item-<title>` testid, `__typename` normalization for the `GET_EVENTS` list, and duplicate-title `.first()` waits. The series UI ("Also on:" occurrence buttons) was verified to render. **Kept `.skip`'d** pending resolution of event-list hydration/render flakiness — see gennit-project/multiforum-nuxt#220.

## Test plan

- `npm run test:unit -- --run components/discussion/detail/RegularDiscussionLayout.spec.ts components/comments/CommentButtons.spec.ts` → 19/19
- `npx playwright test tests/playwright/mocked/events/editSeriesEvent.spec.ts` → 3/3

## Notes

`seriesListDisplay.spec.ts` remains skipped due to local `nuxt dev` hydration flakiness on the events list page (blank page, no console error). All other blockers are fixed; re-enable + verify in CI per #220.

Closes nothing; relates to #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)