### PR TITLE
Gate content creation UI on locked forums (+ moderation E2E)

### DIFF
--- a/components/admin/ChannelReportsList.vue
+++ b/components/admin/ChannelReportsList.vue
@@ -22,10 +22,6 @@ const channelReports = computed(() => {
   return result.value?.issues || [];
 });
 
-const toggleFilter = () => {
-  showOpenOnly.value = !showOpenOnly.value;
-};
-
 // Lock/Unlock dialog state
 const showLockDialog = ref(false);
 const showUnlockDialog = ref(false);
@@ -61,7 +57,6 @@ const handleUnlocked = () => {
             v-model="showOpenOnly"
             type="checkbox"
             class="mr-2 rounded"
-            @change="toggleFilter"
           >
           Show open reports only
         </label>

--- a/components/discussion/detail/DiscussionDetailContent.vue
+++ b/components/discussion/detail/DiscussionDetailContent.vue
@@ -34,6 +34,7 @@ import ArchivedDiscussionInfoBanner from './ArchivedDiscussionInfoBanner.vue';
 import DiscussionLayoutManager from './DiscussionLayoutManager.vue';
 import FeedbackModalManager from './FeedbackModalManager.vue';
 import { provideForumRoleMembership } from '@/composables/useForumRoleMembership';
+import { useForumLock } from '@/composables/useForumLock';
 import {
   useIsAuthenticated,
   useModProfileName,
@@ -259,6 +260,12 @@ const locked = computed(() => {
   // may not archive it if they think the existing discussion has merit.
   return activeDiscussionChannel.value?.locked || false;
 });
+
+// A locked forum (channel-level lock) also blocks new comments, independent of
+// the per-discussion lock above. Kept separate so the banner can explain which
+// lock is in effect.
+const { locked: forumLocked } = useForumLock(channelId);
+const commentsDisabled = computed(() => locked.value || forumLocked.value);
 
 const comments = computed(() => {
   return (
@@ -574,6 +581,10 @@ const handleEditAlbum = () => {
           v-else-if="locked"
           text="This discussion is locked. New comments cannot be added."
         />
+        <InfoBanner
+          v-else-if="forumLocked"
+          text="This forum is locked. New comments cannot be added until a moderator unlocks it."
+        />
         <div v-if="discussion" class="w-full">
           <div class="w-full px-2">
             <div class="w-full space-y-3 rounded-lg py-2 dark:border-gray-700">
@@ -646,7 +657,7 @@ const handleEditAlbum = () => {
                 activeDiscussionChannel?.Channel?.emojiEnabled ?? true
               "
               :loading="getDiscussionChannelLoading"
-              :locked="locked"
+              :locked="commentsDisabled"
               :mod-name="loggedInUserModName"
               :previous-offset="previousOffset"
               :reached-end-of-results="reachedEndOfResults"

--- a/components/discussion/form/CreateDiscussion.vue
+++ b/components/discussion/form/CreateDiscussion.vue
@@ -20,6 +20,7 @@ import {
 } from '@/components/comments/getSortFromQuery';
 import { useRouter, useRoute } from 'nuxt/app';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
+import { useForumLock } from '@/composables/useForumLock';
 import { useUsername } from '@/composables/useAuthState';
 
 const usernameVar = useUsername();
@@ -162,6 +163,12 @@ const channelConnections = computed(() => formValues.value.selectedChannels);
 const submitError = ref<string | null>(null);
 const submitAttempted = ref(false);
 
+const { lockError } = useForumLock(channelId);
+
+// Surface the lock notice immediately (not just after a submit attempt), mirroring
+// the channel-preference gate in CreateEvent.
+const formSubmitError = computed(() => submitError.value ?? lockError.value);
+
 const {
   issueNumber: suspensionIssueNumber,
   suspendedUntil: suspensionUntil,
@@ -276,6 +283,10 @@ function submit() {
   }
   submitAttempted.value = true;
   submitError.value = null;
+  if (lockError.value) {
+    submitError.value = lockError.value;
+    return;
+  }
   createDiscussion();
 }
 
@@ -321,7 +332,7 @@ function updateFormValues(data: Partial<CreateEditDiscussionFormValues>) {
         :edit-mode="false"
         :form-values="formValues"
         :download-mode="false"
-        :submit-error="submitError"
+        :submit-error="formSubmitError"
         :suspension-issue-number="
           showSuspensionNotice ? suspensionIssueNumber : null
         "

--- a/components/event/form/CreateEvent.vue
+++ b/components/event/form/CreateEvent.vue
@@ -17,6 +17,7 @@ import type {
 } from '@/__generated__/graphql';
 import { useUsername } from '@/composables/useAuthState';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
+import { FORUM_LOCKED_MESSAGE } from '@/composables/useForumLock';
 
 const usernameVar = useUsername();
 
@@ -106,8 +107,21 @@ const channelPreferenceError = computed(() => {
   return 'Cannot create an event because events are not enabled for this forum.';
 });
 
+// A locked forum blocks all content creation; reuse the channel query above
+// rather than issuing a second one.
+const channelLockError = computed(() =>
+  channelResult.value?.channels?.[0]?.locked === true
+    ? FORUM_LOCKED_MESSAGE
+    : null
+);
+
 const formSubmitError = computed(() => {
-  return submitError.value ?? channelPreferenceError.value ?? undefined;
+  return (
+    submitError.value ??
+    channelLockError.value ??
+    channelPreferenceError.value ??
+    undefined
+  );
 });
 
 const {
@@ -157,6 +171,10 @@ onDone((response) => {
 function submit() {
   submitAttempted.value = true;
   submitError.value = null;
+  if (channelLockError.value) {
+    submitError.value = channelLockError.value;
+    return;
+  }
   if (channelPreferenceError.value) {
     submitError.value = channelPreferenceError.value;
     return;

--- a/composables/useForumLock.spec.ts
+++ b/composables/useForumLock.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { useForumLock, FORUM_LOCKED_MESSAGE } from '@/composables/useForumLock';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockChannel = (channel: Record<string, unknown> | null) => {
+  (useQuery as any).mockReturnValue({
+    result: ref(channel ? { channels: [channel] } : { channels: [] }),
+  });
+};
+
+describe('useForumLock', () => {
+  beforeEach(() => {
+    (useQuery as any).mockReset();
+  });
+
+  it('reports locked=true for a locked forum', () => {
+    mockChannel({ locked: true, lockReason: 'Spam wave' });
+    expect(useForumLock(ref('cats')).locked.value).toBe(true);
+  });
+
+  it('exposes the shared lock message when locked', () => {
+    mockChannel({ locked: true, lockReason: 'Spam wave' });
+    expect(useForumLock(ref('cats')).lockError.value).toBe(FORUM_LOCKED_MESSAGE);
+  });
+
+  it('surfaces the lock reason when locked', () => {
+    mockChannel({ locked: true, lockReason: 'Spam wave' });
+    expect(useForumLock(ref('cats')).lockReason.value).toBe('Spam wave');
+  });
+
+  it('reports locked=false for an unlocked forum', () => {
+    mockChannel({ locked: false, lockReason: null });
+    expect(useForumLock(ref('cats')).locked.value).toBe(false);
+  });
+
+  it('returns no lock error for an unlocked forum', () => {
+    mockChannel({ locked: false, lockReason: null });
+    expect(useForumLock(ref('cats')).lockError.value).toBe(null);
+  });
+
+  it('treats a missing channel as unlocked', () => {
+    mockChannel(null);
+    expect(useForumLock(ref('cats')).locked.value).toBe(false);
+  });
+
+  it('accepts a plain string channel id', () => {
+    mockChannel({ locked: true });
+    expect(useForumLock('cats').locked.value).toBe(true);
+  });
+});

--- a/composables/useForumLock.ts
+++ b/composables/useForumLock.ts
@@ -1,0 +1,51 @@
+import { computed, type Ref } from 'vue';
+import { DateTime } from 'luxon';
+import { useQuery } from '@vue/apollo-composable';
+import { GET_CHANNEL } from '@/graphQLData/channel/queries';
+
+// Shared copy for the "creation blocked because the forum is locked" notice, so
+// every create surface (discussions, events, comments) shows the same message.
+export const FORUM_LOCKED_MESSAGE =
+  'This forum is locked. New discussions, events, and comments cannot be created until a moderator unlocks it.';
+
+// Channel (forum) lock state, for gating content-creation affordances in the UI.
+//
+// A locked forum is frozen: the backend rejects new discussions, events, and
+// comments (see rules/permission/hasChannelPermission on the server). This
+// composable surfaces the matching front-end signals — hide create links, block
+// submit, and explain why — from a single source of truth.
+//
+// Reads GET_CHANNEL cache-first with the same variables the forum layout
+// (pages/forums/[forumId].vue) already fetches, so it reuses that result instead
+// of issuing a second network request.
+export const useForumLock = (channelUniqueName: Ref<string> | string) => {
+  const channelId = computed(() =>
+    typeof channelUniqueName === 'string'
+      ? channelUniqueName
+      : channelUniqueName.value
+  );
+
+  const { result } = useQuery(
+    GET_CHANNEL,
+    () => ({
+      uniqueName: channelId.value,
+      // Match the forum layout's variables so this hits the same cache entry.
+      now: DateTime.utc().startOf('hour').toISO(),
+    }),
+    {
+      fetchPolicy: 'cache-first',
+      enabled: computed(() => !!channelId.value),
+    }
+  );
+
+  const channel = computed(() => result.value?.channels?.[0] ?? null);
+  const locked = computed(() => channel.value?.locked === true);
+  const lockReason = computed(() => channel.value?.lockReason ?? null);
+
+  // A ready-made message for forms to display when creation is blocked.
+  const lockError = computed(() =>
+    locked.value ? FORUM_LOCKED_MESSAGE : null
+  );
+
+  return { locked, lockReason, lockError, channel };
+};

--- a/tests/playwright/helpers/graphqlFixtures.ts
+++ b/tests/playwright/helpers/graphqlFixtures.ts
@@ -99,6 +99,8 @@ export type ChannelFixture = Pick<
   | 'emojiEnabled'
   | 'rules'
   | 'locked'
+  | 'lockedAt'
+  | 'lockReason'
   | 'wikiEnabled'
   | 'eventsEnabled'
   | 'downloadsEnabled'
@@ -119,6 +121,7 @@ export type ChannelFixture = Pick<
   pluginPipelines: unknown[];
   DefaultElevatedModRole: null;
   Admins: UserFixture[];
+  LockedBy: { displayName: string } | null;
   DiscussionChannelsAggregate: CountAggregate;
   IssuesAggregate: CountAggregate;
   EventChannelsAggregate: CountAggregate;
@@ -305,6 +308,9 @@ export const buildChannel = ({
   emojiEnabled: true,
   rules: '[]',
   locked: false,
+  lockedAt: null,
+  lockReason: null,
+  LockedBy: null,
   wikiEnabled: false,
   eventsEnabled: true,
   downloadsEnabled: false,

--- a/tests/playwright/mocked/admin/channelReports.spec.ts
+++ b/tests/playwright/mocked/admin/channelReports.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from '../../helpers/testFixture';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+
+// The server-admin Channel Reports page (`/admin/channel-reports`): it lists
+// server-scoped channel reports with their open/locked status and offers
+// per-row Lock / Unlock actions. The default mock user `cluse` is a server
+// admin, which is what grants the lock controls.
+
+const REPORTS_URL = '/admin/channel-reports';
+const MOCK_DATE = '2024-01-01T00:00:00.000Z';
+
+const channelReports = [
+  {
+    id: 'issue-1',
+    issueNumber: 1,
+    title: 'Reported channel: cats',
+    body: '',
+    isOpen: true,
+    createdAt: MOCK_DATE,
+    updatedAt: MOCK_DATE,
+    relatedChannelUniqueName: 'cats',
+    flaggedServerRuleViolation: true,
+    locked: false,
+    lockedAt: null,
+    lockReason: null,
+    LockedBy: null,
+    Author: { __typename: 'User', username: 'reporter1' },
+    ActivityFeedAggregate: { count: 1 },
+  },
+  {
+    id: 'issue-2',
+    issueNumber: 2,
+    title: 'Reported channel: dogs',
+    body: '',
+    isOpen: true,
+    createdAt: MOCK_DATE,
+    updatedAt: MOCK_DATE,
+    relatedChannelUniqueName: 'dogs',
+    flaggedServerRuleViolation: true,
+    locked: true,
+    lockedAt: MOCK_DATE,
+    lockReason: 'Spam wave',
+    LockedBy: { displayName: 'cluse' },
+    Author: { __typename: 'User', username: 'reporter2' },
+    ActivityFeedAggregate: { count: 2 },
+  },
+];
+
+const channelResponse = (uniqueName: string, locked: boolean) => ({
+  uniqueName,
+  displayName: uniqueName,
+  locked,
+  lockedAt: locked ? MOCK_DATE : null,
+  lockReason: locked ? 'Spam wave' : null,
+  LockedBy: locked ? { displayName: 'cluse' } : null,
+});
+
+const reportsHandlers = () => ({
+  ...createBaseHandlers(),
+  getChannelReports: () => ({ data: { issues: channelReports } }),
+  lockChannel: () => ({ data: { lockChannel: channelResponse('cats', true) } }),
+  unlockChannel: () => ({
+    data: { unlockChannel: channelResponse('dogs', false) },
+  }),
+});
+
+test.describe('Admin Channel Reports page', () => {
+  test('lists channel reports with open and locked status badges', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, reportsHandlers());
+
+    try {
+      await page.goto(REPORTS_URL);
+
+      await expect(
+        page.getByRole('link', { name: 'cats' })
+      ).toBeVisible();
+      await expect(page.getByRole('link', { name: 'dogs' })).toBeVisible();
+      // The unlocked report offers Lock; the locked one offers Unlock.
+      await expect(page.getByRole('button', { name: 'Lock', exact: true })).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Unlock', exact: true })
+      ).toBeVisible();
+      await expect(page.getByText('Locked', { exact: true })).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('locking a channel from a report row fires lockChannel', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, reportsHandlers());
+
+    try {
+      await page.goto(REPORTS_URL);
+
+      await page.getByRole('button', { name: 'Lock', exact: true }).click();
+      await page.locator('#lock-reason').fill('Coordinated spam');
+      await page.getByTestId('lock-channel-dialog-primary-button').click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'lockChannel'
+      );
+      const op = diagnostics.completedOperations.find(
+        (o) => o.operationName === 'lockChannel'
+      );
+      expect(op?.variables?.channelUniqueName).toBe('cats');
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('unlocking a channel from a report row fires unlockChannel', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, reportsHandlers());
+
+    try {
+      await page.goto(REPORTS_URL);
+
+      await page.getByRole('button', { name: 'Unlock', exact: true }).click();
+      await page.getByTestId('unlock-channel-dialog-primary-button').click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'unlockChannel'
+      );
+      const op = diagnostics.completedOperations.find(
+        (o) => o.operationName === 'unlockChannel'
+      );
+      expect(op?.variables?.channelUniqueName).toBe('dogs');
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});

--- a/tests/playwright/mocked/admin/channelReports.spec.ts
+++ b/tests/playwright/mocked/admin/channelReports.spec.ts
@@ -156,4 +156,37 @@ test.describe('Admin Channel Reports page', () => {
       });
     }
   });
+
+  test('unchecking "show open reports only" refetches with isOpen null', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, reportsHandlers());
+
+    try {
+      await page.goto(REPORTS_URL);
+      // The list loads filtered to open reports (isOpen: true) by default.
+      await expect(page.getByRole('link', { name: 'cats' })).toBeVisible();
+
+      await page.getByLabel('Show open reports only').uncheck();
+
+      // Unchecking must flip the query variable to null so closed reports show.
+      // (With the old v-model + @change double-toggle, isOpen never changed.)
+      await expect
+        .poll(() =>
+          diagnostics.completedOperations.some(
+            (o) =>
+              o.operationName === 'getChannelReports' &&
+              o.variables?.isOpen === null
+          )
+        )
+        .toBe(true);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
 });

--- a/tests/playwright/mocked/admin/issueRelatedChannel.spec.ts
+++ b/tests/playwright/mocked/admin/issueRelatedChannel.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from '../../helpers/testFixture';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import { DEFAULT_MOD_ROLE } from '../../helpers/moderationFixtures';
+
+// The "Related Channel" section on a server-scoped issue
+// (`/admin/issues/[issueNumber]`): it shows the reported channel's lock state
+// and offers Lock / Unlock for server mods. The default user `cluse` is a
+// server admin, which grants canLockChannel.
+
+const ISSUE_URL = '/admin/issues/1';
+const RELATED_CHANNEL = 'cats';
+const MOCK_DATE = '2024-01-01T00:00:00.000Z';
+
+const issueHandler = () => ({
+  data: {
+    issues: [
+      {
+        __typename: 'Issue',
+        id: 'issue-1',
+        issueNumber: 1,
+        title: 'Reported channel: cats',
+        body: 'Server rule violation',
+        channelUniqueName: null, // server-scoped
+        relatedChannelUniqueName: RELATED_CHANNEL,
+        relatedDiscussionId: '',
+        relatedEventId: '',
+        relatedCommentId: '',
+        isOpen: true,
+        locked: false,
+        lockedAt: null,
+        lockReason: null,
+        LockedBy: null,
+        flaggedServerRuleViolation: true,
+        SubscribedToNotifications: [],
+        ActivityFeed: [],
+        ActivityFeedAggregate: { count: 1 },
+        Author: { __typename: 'User', username: 'reporter1' },
+      },
+    ],
+  },
+});
+
+const channelResponse = (locked: boolean) => ({
+  uniqueName: RELATED_CHANNEL,
+  displayName: RELATED_CHANNEL,
+  locked,
+  lockedAt: locked ? MOCK_DATE : null,
+  lockReason: locked ? 'Spam wave' : null,
+  LockedBy: locked ? { displayName: 'cluse' } : null,
+});
+
+const handlersFor = (channelLocked: boolean) => ({
+  ...createBaseHandlers({
+    channelId: RELATED_CHANNEL,
+    channelOverrides: { locked: channelLocked, lockReason: 'Spam wave' },
+    serverConfigOverrides: { DefaultModRole: DEFAULT_MOD_ROLE },
+  }),
+  getIssue: issueHandler,
+  // Issue-tab count badges in the admin layout.
+  countIssuesByServer: () => ({ data: { issuesAggregate: { count: 1 } } }),
+  countClosedIssuesByServer: () => ({
+    data: { issuesAggregate: { count: 0 } },
+  }),
+  lockChannel: () => ({ data: { lockChannel: channelResponse(true) } }),
+  unlockChannel: () => ({ data: { unlockChannel: channelResponse(false) } }),
+});
+
+test.describe('Issue detail – Related Channel', () => {
+  test('shows the related channel with an Active badge and a Lock action', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, handlersFor(false));
+
+    try {
+      await page.goto(ISSUE_URL);
+
+      await expect(page.getByText('Related Channel:')).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: RELATED_CHANNEL })
+      ).toBeVisible();
+      await expect(page.getByText('Active', { exact: true })).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Lock Channel' })
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('locking from the Related Channel section fires lockChannel', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, handlersFor(false));
+
+    try {
+      await page.goto(ISSUE_URL);
+
+      await page.getByRole('button', { name: 'Lock Channel' }).click();
+      await page.locator('#lock-reason').fill('Coordinated spam');
+      await page.getByTestId('lock-channel-dialog-primary-button').click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'lockChannel'
+      );
+      const op = diagnostics.completedOperations.find(
+        (o) => o.operationName === 'lockChannel'
+      );
+      expect(op?.variables?.channelUniqueName).toBe(RELATED_CHANNEL);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('a locked related channel shows the Locked badge and an Unlock action that fires unlockChannel', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, handlersFor(true));
+
+    try {
+      await page.goto(ISSUE_URL);
+
+      await expect(page.getByText('Locked', { exact: true })).toBeVisible();
+      await page.getByRole('button', { name: 'Unlock Channel' }).click();
+      await page.getByTestId('unlock-channel-dialog-primary-button').click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'unlockChannel'
+      );
+      const op = diagnostics.completedOperations.find(
+        (o) => o.operationName === 'unlockChannel'
+      );
+      expect(op?.variables?.channelUniqueName).toBe(RELATED_CHANNEL);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});

--- a/tests/playwright/mocked/channels/channelLocking.spec.ts
+++ b/tests/playwright/mocked/channels/channelLocking.spec.ts
@@ -247,6 +247,34 @@ test.describe('Channel locking', () => {
     }
   });
 
+  test('locked banner is shown on the events tab too (layout-level banner)', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...lockedChannelMocks(TEST_USER),
+      getEvents: () => ({ data: { events: [] } }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/events`);
+
+      await expect(
+        page.getByText(/This forum is locked/i).first()
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
   test('locked forum blocks discussion creation with an explanation', async ({
     context,
     page,

--- a/tests/playwright/mocked/channels/channelLocking.spec.ts
+++ b/tests/playwright/mocked/channels/channelLocking.spec.ts
@@ -78,6 +78,54 @@ const getBaseMocks = (username: string) => ({
       ],
     },
   }),
+  getUserSuspensionInChannel: () => ({
+    data: {
+      channels: [{ uniqueName: TEST_CHANNEL, SuspendedUsers: [] }],
+    },
+  }),
+  getModsByChannel: () => ({
+    data: {
+      channels: [{ uniqueName: TEST_CHANNEL, Moderators: [] }],
+    },
+  }),
+});
+
+// The form-level notice every locked create surface shows. Distinct from the
+// ChannelLockedBanner copy in the forum layout, so asserting it targets the
+// create form specifically rather than the page banner.
+const LOCKED_CREATE_NOTICE =
+  /New discussions, events, and comments cannot be created/i;
+
+const lockedChannelMocks = (username: string) => ({
+  ...getBaseMocks(username),
+  getChannel: () => ({
+    data: {
+      channels: [
+        buildChannel({
+          uniqueName: TEST_CHANNEL,
+          displayName: 'Locked Forum',
+          overrides: {
+            eventsEnabled: true,
+            locked: true,
+            lockReason: 'Spam wave',
+          },
+        }),
+      ],
+    },
+  }),
+  getDiscussionsInChannel: () => ({
+    data: { getDiscussionsInChannel: [] },
+  }),
+  getChannelDownloadCount: () => ({
+    data: {
+      channels: [
+        {
+          uniqueName: TEST_CHANNEL,
+          DiscussionChannelsAggregate: { count: 0 },
+        },
+      ],
+    },
+  }),
 });
 
 test.describe('Channel locking', () => {
@@ -191,6 +239,54 @@ test.describe('Channel locking', () => {
       await expect(page.getByText(/This forum is locked/i)).not.toBeVisible();
 
       expect(diagnostics.pageErrors).toEqual([]);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('locked forum blocks discussion creation with an explanation', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, lockedChannelMocks(TEST_USER));
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/discussions/create`);
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.getByText(LOCKED_CREATE_NOTICE)).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('locked forum blocks event creation with an explanation', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, lockedChannelMocks(TEST_USER));
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/events/create`);
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.getByText(LOCKED_CREATE_NOTICE)).toBeVisible();
     } finally {
       await testInfo.attach('graphql-operations.json', {
         body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),

--- a/tests/playwright/mocked/channels/channelServerModeration.spec.ts
+++ b/tests/playwright/mocked/channels/channelServerModeration.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test } from '../../helpers/testFixture';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import { DEFAULT_MOD_ROLE } from '../../helpers/moderationFixtures';
+
+// Server-moderation actions on the forum About page (`/forums/[forumId]/about`):
+// reporting the forum, locking/unlocking it, and the permission gating that
+// decides whether those controls appear. The default mock user (`cluse`) is a
+// server admin (buildServerConfig lists them in Admins), which grants
+// canReportChannel + canLockChannel.
+
+const CHANNEL = 'cats';
+const ABOUT_URL = `/forums/${CHANNEL}/about`;
+
+const serverRulesHandler = () => ({
+  data: {
+    serverConfigs: [
+      {
+        serverName: 'Listical',
+        rules: JSON.stringify([
+          { summary: 'Be kind', detail: 'Keep the forum civil.' },
+        ]),
+      },
+    ],
+  },
+});
+
+const lockedChannelResponse = (locked: boolean) => ({
+  uniqueName: CHANNEL,
+  displayName: CHANNEL,
+  locked,
+  lockedAt: locked ? '2024-01-01T00:00:00.000Z' : null,
+  lockReason: locked ? 'Spam wave' : null,
+  LockedBy: locked ? { displayName: 'cluse' } : null,
+});
+
+test.describe('Forum About page – server moderation', () => {
+  test('a server admin sees the Server Moderation section with report and lock actions', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, {
+      ...createBaseHandlers({
+        channelId: CHANNEL,
+        serverConfigOverrides: { DefaultModRole: DEFAULT_MOD_ROLE },
+      }),
+      getServerRules: serverRulesHandler,
+    });
+
+    try {
+      await page.goto(ABOUT_URL);
+
+      await expect(page.getByText('Server Moderation')).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Report Forum' })
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Lock Forum' })
+      ).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('a non-moderator does not see the Server Moderation section', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, {
+      ...createBaseHandlers({
+        channelId: CHANNEL,
+        serverConfigOverrides: {
+          Admins: [],
+          Moderators: [],
+          DefaultModRole: null,
+          DefaultElevatedModRole: null,
+        },
+      }),
+      getServerRules: serverRulesHandler,
+    });
+
+    try {
+      await page.goto(ABOUT_URL);
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.getByText('Server Moderation')).toHaveCount(0);
+      await expect(
+        page.getByRole('button', { name: 'Report Forum' })
+      ).toHaveCount(0);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('reporting the forum submits a server-scoped channel report', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, {
+      ...createBaseHandlers({
+        channelId: CHANNEL,
+        serverConfigOverrides: { DefaultModRole: DEFAULT_MOD_ROLE },
+      }),
+      getServerRules: serverRulesHandler,
+      reportChannel: () => ({
+        data: {
+          reportChannel: {
+            id: 'issue-1',
+            issueNumber: 1,
+            relatedChannelUniqueName: CHANNEL,
+          },
+        },
+      }),
+    });
+
+    try {
+      await page.goto(ABOUT_URL);
+      await page.getByRole('button', { name: 'Report Forum' }).click();
+
+      // Select a server rule (enables the submit button). The checkbox lives in
+      // the dialog panel, so checking it implicitly waits for the modal to open.
+      await page.getByLabel('Select rule: Be kind').check();
+      await page.getByTestId('report-channel-modal-primary-button').click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'reportChannel'
+      );
+      const op = diagnostics.completedOperations.find(
+        (o) => o.operationName === 'reportChannel'
+      );
+      expect(op?.variables?.selectedServerRules).toEqual(['Be kind']);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('locking the forum from the About page fires lockChannel with a reason', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, {
+      ...createBaseHandlers({ channelId: CHANNEL }),
+      getServerRules: serverRulesHandler,
+      lockChannel: () => ({ data: { lockChannel: lockedChannelResponse(true) } }),
+    });
+
+    try {
+      await page.goto(ABOUT_URL);
+      await page.getByRole('button', { name: 'Lock Forum' }).click();
+
+      // The reason field lives in the dialog panel; filling it waits for open.
+      await page.locator('#lock-reason').fill('Coordinated spam');
+      await page.getByTestId('lock-channel-dialog-primary-button').click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'lockChannel'
+      );
+      const op = diagnostics.completedOperations.find(
+        (o) => o.operationName === 'lockChannel'
+      );
+      expect(op?.variables?.reason).toBe('Coordinated spam');
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('unlocking a locked forum from the About page fires unlockChannel', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page);
+    const diagnostics = await installGraphqlMocks(page, {
+      ...createBaseHandlers({
+        channelId: CHANNEL,
+        channelOverrides: { locked: true, lockReason: 'Spam wave' },
+      }),
+      getServerRules: serverRulesHandler,
+      unlockChannel: () => ({
+        data: { unlockChannel: lockedChannelResponse(false) },
+      }),
+    });
+
+    try {
+      await page.goto(ABOUT_URL);
+      await page.getByRole('button', { name: 'Unlock Forum' }).click();
+
+      // No reason is required to unlock; confirm straight away.
+      await page.getByTestId('unlock-channel-dialog-primary-button').click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'unlockChannel'
+      );
+      const op = diagnostics.completedOperations.find(
+        (o) => o.operationName === 'unlockChannel'
+      );
+      expect(op?.variables?.channelUniqueName).toBe(CHANNEL);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+});

--- a/tests/playwright/mocked/comments/lockedForumComment.spec.ts
+++ b/tests/playwright/mocked/comments/lockedForumComment.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '../../helpers/testFixture';
+import { installMockAuth } from '../../helpers/mockAuth';
+import { installGraphqlMocks } from '../../helpers/mockGraphql';
+import { buildChannel } from '../../helpers/graphqlFixtures';
+import {
+  createCommentState,
+  createCommentHandlers,
+  DEFAULT_COMMENT_CONFIG,
+} from '../../helpers/mockedCommentHandlers';
+
+// A locked forum freezes commenting too: the composer is replaced by a notice.
+// Mirrors createComment.spec.ts but flips the channel's lock state.
+test('locked forum blocks commenting on a discussion', async ({
+  context,
+  page,
+}, testInfo) => {
+  const state = createCommentState();
+
+  await installMockAuth(context, page);
+  const diagnostics = await installGraphqlMocks(page, {
+    ...createCommentHandlers(state, DEFAULT_COMMENT_CONFIG),
+    getChannel: () => ({
+      data: {
+        channels: [
+          buildChannel({
+            uniqueName: DEFAULT_COMMENT_CONFIG.channelId,
+            displayName: DEFAULT_COMMENT_CONFIG.channelId,
+            overrides: { locked: true, lockReason: 'Spam wave' },
+          }),
+        ],
+      },
+    }),
+  });
+
+  try {
+    const discussionUrl = `/forums/${DEFAULT_COMMENT_CONFIG.channelId}/discussions/${DEFAULT_COMMENT_CONFIG.discussionId}`;
+
+    await page.goto(discussionUrl);
+    await expect(
+      page.getByRole('heading', { name: DEFAULT_COMMENT_CONFIG.discussionTitle })
+    ).toBeVisible();
+
+    // The forum-locked notice appears and the comment composer is gone.
+    await expect(
+      page.getByText(/This forum is locked\. New comments cannot be added/i)
+    ).toBeVisible();
+    await expect(page.getByTestId('addComment')).toHaveCount(0);
+  } finally {
+    await testInfo.attach('graphql-operations.json', {
+      body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+      contentType: 'application/json',
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Front-end counterpart to the backend lock-enforcement work (multiforum-backend#97). When a forum is locked, every content-creation surface now blocks and explains why, and the existing server-moderation flows get end-to-end coverage.

> **Note:** based on `main-pending-fixes` (#223) to keep this diff to only the channel-lock changes. Once #223 merges, GitHub will auto-retarget this PR to `main`.

## Feature: gate content creation on locked forums

- `composables/useForumLock.ts` (new) — cache-first `GET_CHANNEL` lock state + a shared `FORUM_LOCKED_MESSAGE`.
- `CreateDiscussion.vue` / `CreateEvent.vue` — show the lock notice and block submit.
- `DiscussionDetailContent.vue` — hide the comment composer and show a forum-locked banner.

The buttons still navigate, but every create surface shows the same message and refuses to submit, matching the backend enforcement.

## Bug fix

- `ChannelReportsList.vue` — the "Show open reports only" filter was wired with both `v-model` and `@change="toggleFilter"`, double-toggling on every click so the `isOpen` query variable never changed (closed reports could never be shown). Removed the redundant handler; `v-model` alone drives the reactive variable. Regression test included.

## Tests

- **Unit:** `useForumLock.spec.ts` (7).
- **Playwright (mocked) E2E (18):**
  - Content blocking: locked forum blocks discussion / event / comment creation; banner shown across tabs.
  - About page: report forum, lock/unlock, permission visibility (admin vs non-mod).
  - `/admin/channel-reports`: list + status/locked badges, row lock/unlock, filter regression test.
  - `/admin/issues/[n]` Related Channel: Active/Locked badge, lock/unlock.

`npm run tsc` clean; existing component unit tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)