### PR TITLE
test(suspension): mod-action event parity, real WF5 assertion, re-enable case

### DIFF
--- a/components/mod/ModerationWizard.spec.ts
+++ b/components/mod/ModerationWizard.spec.ts
@@ -31,7 +31,7 @@ vi.mock('@/composables/useAuthState', async () => {
 });
 
 describe('ModerationWizard', () => {
-  const mountWrapper = () =>
+  const mountWrapper = (propOverrides: Record<string, unknown> = {}) =>
     mount(ModerationWizard, {
       props: {
         issue: {
@@ -44,6 +44,7 @@ describe('ModerationWizard', () => {
         isSuspendedMod: true,
         canEditComments: true,
         reportCount: 1,
+        ...propOverrides,
       },
       global: {
         stubs: {
@@ -103,5 +104,13 @@ describe('ModerationWizard', () => {
     const wrapper = mountWrapper();
 
     expect(wrapper.get('[data-test="edit-comment"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('re-enables the archive button once the moderator is no longer suspended', () => {
+    const wrapper = mountWrapper({ isSuspendedMod: false });
+
+    expect(
+      wrapper.get('[data-testid="archive-button"]').attributes('data-disabled')
+    ).toBe('false');
   });
 });

--- a/tests/playwright/mocked/suspensions/suspendedModNotices.spec.ts
+++ b/tests/playwright/mocked/suspensions/suspendedModNotices.spec.ts
@@ -5,6 +5,7 @@ import {
   buildChannel,
   buildServerConfig,
   buildDiscussion,
+  buildEvent,
   buildUser,
 } from '../../helpers/graphqlFixtures';
 import { installMockAuth } from '../../helpers/mockAuth';
@@ -396,15 +397,93 @@ test.describe('Mod suspension notices', () => {
       // Verify user is authenticated
       await expect(page.getByRole('button', { name: 'Log Out' })).toBeVisible({ timeout: 5000 });
 
-      // Suspended mod (as user) should still see comment form since their USER account is not suspended
-      // The comment form should be accessible
-      const commentTextarea = page.locator('textarea[placeholder*="comment"], [data-testid="comment-input"]').first();
+      // The suspended mod's USER account is not suspended, so the comment
+      // composer must be available — this is the behavior the test name claims.
+      // (The old version only ran `expect(true).toBe(true)` inside an
+      // `if (visible)` guard, so it passed even when the composer was absent.)
+      await expect(page.getByTestId('addComment')).toBeVisible();
 
-      // If comment form exists and is visible, the test passes
-      // (This verifies mod suspension doesn't affect user commenting ability)
-      if (await commentTextarea.isVisible()) {
-        expect(true).toBe(true);
-      }
+      expect(diagnostics.pageErrors).toEqual([]);
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('suspended mod sees no mod actions on event page', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: MOD_USER,
+      email: 'mod@example.com',
+    });
+
+    const mockEvent = buildEvent({
+      id: 'event-1',
+      eventChannelId: 'event-channel-1',
+      channelUniqueName: TEST_CHANNEL,
+      title: 'Test Event',
+      posterUsername: 'alice',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(MOD_USER),
+      // The user's mod profile is suspended in the channel.
+      userIsModInChannel: () => ({
+        data: {
+          channels: [
+            {
+              uniqueName: TEST_CHANNEL,
+              Admins: [],
+              SuspendedUsers: [],
+              Moderators: [
+                { displayName: MOD_PROFILE_NAME, User: { username: MOD_USER } },
+              ],
+              SuspendedMods: [buildModSuspension()],
+            },
+          ],
+        },
+      }),
+      getModSuspensionStatus: () => ({
+        data: {
+          channels: [
+            { uniqueName: TEST_CHANNEL, SuspendedMods: [buildModSuspension()] },
+          ],
+        },
+      }),
+      getEvent: () => ({ data: { events: [mockEvent] } }),
+      getEventComments: () => ({
+        data: { getEventComments: { Event: mockEvent, Comments: [] } },
+      }),
+      getEventRootCommentAggregate: () => ({
+        data: {
+          events: [{ id: 'event-1', CommentsAggregate: { count: 0 } }],
+        },
+      }),
+      getEventChannelID: () => ({
+        data: { eventChannels: [{ id: 'event-channel-1', archived: false }] },
+      }),
+      getEvents: () => ({
+        data: { eventsAggregate: { count: 1 }, events: [mockEvent] },
+      }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/events/event-1`);
+
+      await expect(page.getByText('Test Event').first()).toBeVisible({
+        timeout: 30000,
+      });
+      await expect(page.getByRole('button', { name: 'Log Out' })).toBeVisible({
+        timeout: 5000,
+      });
+
+      // Parity with the discussion page: a suspended mod sees no mod actions.
+      await expect(page.getByRole('button', { name: /archive/i })).not.toBeVisible();
+      await expect(page.getByRole('button', { name: /report/i })).not.toBeVisible();
 
       expect(diagnostics.pageErrors).toEqual([]);
     } finally {


### PR DESCRIPTION
## What

Frontend test coverage for the Moderator Suspension Verification workflows. While auditing I found **WF2 (issue-action disabling) and WF8 (account-separation copy) are already covered** by `ModerationWizard.spec.ts` and `IssueCommentForm.spec.ts`, so this fills the genuine gaps:

- **WF1 — event-page parity (e2e):** a suspended mod sees no mod actions on an **event** detail page (the existing suite only covered the discussion page).
- **WF5 — fix a vacuous test:** "suspended mod can still post comments as regular user" previously ran `expect(true).toBe(true)` inside an `if (await textarea.isVisible())` guard, against a `[data-testid="comment-input"]` selector that doesn't exist — so it passed even if the composer were absent. Now it asserts the real comment composer (`data-testid="addComment"`) is visible.
- **WF6 — re-enable (unit):** `ModerationWizard` re-enables the archive button once `isSuspendedMod` is false, complementing the existing suspended-disabled cases.

## Scope notes
- **WF2/WF8 already covered** (no new tests): `ModerationWizard.spec.ts` asserts archive/suspend/edit buttons disabled + the "does not suspend your user account" message; `IssueCommentForm.spec.ts` asserts the lock button hidden, close/comment buttons disabled, and the mod-only-suspension copy.
- **WF6 is unit-level.** The full "unsuspend in another session → refresh → buttons re-enable" e2e needs a heavyweight issue-detail page mock with no existing scaffold; the permission→disabled→enabled chain is already covered by `permissionUtils.spec` + `ModerationWizard.spec` (with this addition). Happy to add the full e2e as a follow-up if wanted.

## Testing
- `npm run tsc` — clean · `npx eslint` on changed files — clean
- `npm run test:unit -- components/mod/ModerationWizard.spec.ts` — 5/5
- `npx playwright test .../suspensions/suspendedModNotices.spec.ts` — 3/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)