### PR TITLE
feat(mod): block issue editing for suspended mods (WF3)

### DIFF
--- a/components/mod/IssueBodyEditor.spec.ts
+++ b/components/mod/IssueBodyEditor.spec.ts
@@ -65,4 +65,16 @@ describe('IssueBodyEditor', () => {
       mountEditor({ updateIssueBodyError: { message: 'Failed' } }).find('.err').text()
     ).toBe('Failed');
   });
+
+  it('hides the Edit button from a suspended moderator who authored the issue', () => {
+    expect(mountEditor({ isSuspendedMod: true }).text()).not.toContain('Edit');
+  });
+
+  it('shows a suspension notice clarifying the user account stays active', () => {
+    expect(
+      mountEditor({ isSuspendedMod: true })
+        .get('[data-testid="issue-edit-suspension-notice"]')
+        .text()
+    ).toContain('does not suspend your user account');
+  });
 });

--- a/components/mod/IssueBodyEditor.vue
+++ b/components/mod/IssueBodyEditor.vue
@@ -10,6 +10,7 @@ defineProps<{
   issueBody?: string | null;
   isIssueAuthor: boolean;
   isLocked: boolean;
+  isSuspendedMod?: boolean;
   isEditingIssueBody: boolean;
   editedIssueBody: string;
   updateIssueBodyLoading: boolean;
@@ -27,7 +28,10 @@ const emit = defineEmits<{
   <div class="py-2">
     <div class="mb-2 flex items-center justify-between gap-2">
       <h3 class="text-lg font-semibold">Issue details</h3>
-      <div v-if="isIssueAuthor && !isLocked" class="flex items-center gap-2">
+      <div
+        v-if="isIssueAuthor && !isLocked && !isSuspendedMod"
+        class="flex items-center gap-2"
+      >
         <GenericButton
           v-if="!isEditingIssueBody"
           :text="'Edit'"
@@ -48,6 +52,14 @@ const emit = defineEmits<{
         </template>
       </div>
     </div>
+    <p
+      v-if="isIssueAuthor && isSuspendedMod"
+      class="mb-2 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200"
+      data-testid="issue-edit-suspension-notice"
+    >
+      Your moderator account is suspended, so you cannot edit this issue. This
+      does not suspend your user account.
+    </p>
     <MarkdownPreview
       v-if="issueBody && !isEditingIssueBody"
       :text="issueBody"

--- a/components/mod/IssueDetail.vue
+++ b/components/mod/IssueDetail.vue
@@ -424,6 +424,7 @@ const {
   activeIssueId,
   isIssueAuthor,
   isLocked,
+  isSuspendedMod,
   refetchIssue: resetActivityFeed,
 });
 
@@ -792,6 +793,7 @@ useAutoUnsubscribe({
             :issue-body="activeIssue?.body"
             :is-issue-author="isIssueAuthor"
             :is-locked="isLocked"
+            :is-suspended-mod="isSuspendedMod"
             :is-editing-issue-body="isEditingIssueBody"
             :edited-issue-body="editedIssueBody"
             :update-issue-body-loading="updateIssueBodyLoading"
@@ -817,6 +819,7 @@ useAutoUnsubscribe({
           :issue-body="activeIssue?.body"
           :is-issue-author="isIssueAuthor"
           :is-locked="isLocked"
+          :is-suspended-mod="isSuspendedMod"
           :is-editing-issue-body="isEditingIssueBody"
           :edited-issue-body="editedIssueBody"
           :update-issue-body-loading="updateIssueBodyLoading"

--- a/composables/useIssueBodyEdit.spec.ts
+++ b/composables/useIssueBodyEdit.spec.ts
@@ -29,6 +29,7 @@ describe('useIssueBodyEdit', () => {
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
+      isSuspendedMod: ref(false),
       refetchIssue,
     });
 
@@ -41,6 +42,7 @@ describe('useIssueBodyEdit', () => {
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
+      isSuspendedMod: ref(false),
       refetchIssue,
     });
 
@@ -55,6 +57,7 @@ describe('useIssueBodyEdit', () => {
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(true),
+      isSuspendedMod: ref(false),
       refetchIssue,
     });
 
@@ -70,6 +73,7 @@ describe('useIssueBodyEdit', () => {
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
+      isSuspendedMod: ref(false),
       refetchIssue,
     });
 
@@ -85,6 +89,7 @@ describe('useIssueBodyEdit', () => {
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
+      isSuspendedMod: ref(false),
       refetchIssue,
     });
 
@@ -103,12 +108,44 @@ describe('useIssueBodyEdit', () => {
     });
   });
 
+  it('does not enter edit mode when the moderator is suspended', () => {
+    const bodyEdit = useIssueBodyEdit({
+      activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as any),
+      activeIssueId: ref('issue-1'),
+      isIssueAuthor: ref(true),
+      isLocked: ref(false),
+      isSuspendedMod: ref(true),
+      refetchIssue,
+    });
+
+    bodyEdit.startIssueBodyEdit();
+
+    expect(bodyEdit.isEditingIssueBody.value).toBe(false);
+  });
+
+  it('does not save the issue body when the moderator is suspended', async () => {
+    const bodyEdit = useIssueBodyEdit({
+      activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as any),
+      activeIssueId: ref('issue-1'),
+      isIssueAuthor: ref(true),
+      isLocked: ref(false),
+      isSuspendedMod: ref(true),
+      refetchIssue,
+    });
+
+    bodyEdit.editedIssueBody.value = 'Changed';
+    await bodyEdit.saveIssueBody();
+
+    expect(updateIssueBody.mock.calls.length).toBe(0);
+  });
+
   it('exits edit mode without saving when the body is unchanged', async () => {
     const bodyEdit = useIssueBodyEdit({
       activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as any),
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
+      isSuspendedMod: ref(false),
       refetchIssue,
     });
 

--- a/composables/useIssueBodyEdit.ts
+++ b/composables/useIssueBodyEdit.ts
@@ -17,6 +17,7 @@ type UseIssueBodyEditParams = {
   activeIssueId: Ref<string> | ComputedRef<string>;
   isIssueAuthor: Ref<boolean> | ComputedRef<boolean>;
   isLocked: Ref<boolean> | ComputedRef<boolean>;
+  isSuspendedMod: Ref<boolean> | ComputedRef<boolean | undefined>;
   refetchIssue: () => Promise<unknown> | undefined;
 };
 
@@ -25,6 +26,7 @@ export function useIssueBodyEdit({
   activeIssueId,
   isIssueAuthor,
   isLocked,
+  isSuspendedMod,
   refetchIssue,
 }: UseIssueBodyEditParams) {
   const isEditingIssueBody = ref(false);
@@ -54,7 +56,9 @@ export function useIssueBodyEdit({
   });
 
   const startIssueBodyEdit = () => {
-    if (!isIssueAuthor.value || isLocked.value) return;
+    // A suspended mod cannot edit the issue, even one they authored — editing is
+    // a moderation action gated by the mod profile, not the user account.
+    if (!isIssueAuthor.value || isLocked.value || isSuspendedMod.value) return;
     editedIssueBody.value = activeIssue.value?.body || '';
     isEditingIssueBody.value = true;
   };
@@ -66,6 +70,8 @@ export function useIssueBodyEdit({
 
   const saveIssueBody = async () => {
     if (!activeIssue.value) return;
+    // Defense in depth: never persist an edit while the mod is suspended.
+    if (isSuspendedMod.value) return;
     if (!editedIssueBody.value.trim()) return;
 
     if (!issueBodyHasChanges.value) {


### PR DESCRIPTION
## What

Closes the WF3 gap from the Moderator Suspension Verification review: a suspended mod could still **edit an issue they authored**. `useIssueBodyEdit` only checked `isIssueAuthor && !isLocked` — no suspension guard, unlike `useIssueLock` which already takes `isSuspendedMod`. Editing an issue is a moderation action, so it should be gated by the mod profile's suspension.

> **Behavior change** (not just tests) — flagging for review of the design decision.

### Changes
- **`useIssueBodyEdit`** now takes `isSuspendedMod` and blocks `startIssueBodyEdit` (can't enter edit mode) and `saveIssueBody` (defense in depth) when suspended — mirroring `useIssueLock`.
- **`IssueBodyEditor`** hides the Edit controls and shows an account-separation notice ("…does not suspend your user account") for a suspended author.
- **`IssueDetail`** passes `isSuspendedMod` through to both editor instances.

### Tests
- `useIssueBodyEdit.spec.ts`: does not enter edit mode / does not save while suspended (existing 6 cases updated for the new required param).
- `IssueBodyEditor.spec.ts`: Edit button hidden for a suspended author; suspension notice shown.

### Scope note
Covered at the composable + component level (the guard and its UI). A full issue-detail-page E2E would need a heavyweight mock with no existing scaffold; happy to add as a follow-up if wanted.

## Testing
- `npm run tsc` — clean · `npx eslint` — 0 errors
- `npm run test:unit:run` — 5385/5385 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)