### PR TITLE
Gate the wiki-create page on wikiEnabled (#230)

### DIFF
--- a/pages/forums/[forumId]/wiki/create.spec.ts
+++ b/pages/forums/[forumId]/wiki/create.spec.ts
@@ -2,12 +2,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import PrimaryButton from '@/components/PrimaryButton.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
+import InfoBanner from '@/components/InfoBanner.vue';
 import TextInput from '@/components/TextInput.vue';
 import TextEditor from '@/components/TextEditor.vue';
 
 const suspension = vi.hoisted(() => ({
   active: null as unknown,
   issueNumber: null as number | null,
+}));
+const channel = vi.hoisted(() => ({
+  wikiEnabled: true as boolean | null,
 }));
 const createMutate = vi.hoisted(() => vi.fn());
 
@@ -24,6 +28,13 @@ vi.mock('@vue/apollo-composable', async () => {
       loading: ref(false),
       error: ref(null),
       onDone: vi.fn(),
+    }),
+    useQuery: () => ({
+      result: ref({
+        channels: [{ uniqueName: 'cats', wikiEnabled: channel.wikiEnabled }],
+      }),
+      loading: ref(false),
+      error: ref(null),
     }),
   };
 });
@@ -60,6 +71,7 @@ describe('wiki create page', () => {
   beforeEach(() => {
     suspension.active = null;
     suspension.issueNumber = null;
+    channel.wikiEnabled = true;
     createMutate.mockReset();
   });
 
@@ -79,6 +91,26 @@ describe('wiki create page', () => {
 
     expect(wrapper.find('form').exists()).toBe(false);
     expect(wrapper.findComponent(SuspensionNotice).exists()).toBe(true);
+  });
+
+  it('hides the form when the forum has the wiki disabled', async () => {
+    channel.wikiEnabled = false;
+    const wrapper = await mountPage();
+
+    expect(wrapper.find('form').exists()).toBe(false);
+  });
+
+  it('shows a wiki-disabled notice when the forum has the wiki disabled', async () => {
+    channel.wikiEnabled = false;
+    const wrapper = await mountPage();
+
+    expect(wrapper.findComponent(InfoBanner).exists()).toBe(true);
+  });
+
+  it('does not show the wiki-disabled notice when the wiki is enabled', async () => {
+    const wrapper = await mountPage();
+
+    expect(wrapper.findComponent(InfoBanner).exists()).toBe(false);
   });
 
   it('submits the entered edit reason with the create mutation', async () => {

--- a/pages/forums/[forumId]/wiki/create.vue
+++ b/pages/forums/[forumId]/wiki/create.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { DateTime } from 'luxon';
 import { useRoute, useRouter } from 'nuxt/app';
-import { useMutation } from '@vue/apollo-composable';
+import { useMutation, useQuery } from '@vue/apollo-composable';
 import { CREATE_WIKI_PAGE } from '@/graphQLData/channel/mutations';
+import { GET_CHANNEL } from '@/graphQLData/channel/queries';
 import TextEditor from '@/components/TextEditor.vue';
 import TextInput from '@/components/TextInput.vue';
 import PrimaryButton from '@/components/PrimaryButton.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
+import InfoBanner from '@/components/InfoBanner.vue';
 import GoBack from '@/components/GoBack.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
@@ -33,6 +36,25 @@ const {
   suspendedIndefinitely,
   channelId: suspensionChannelId,
 } = useChannelSuspensionNotice(forumId);
+
+// A forum can turn its wiki off; the create page should explain that rather
+// than rendering an editor whose submit the backend will reject. Reuse the
+// forum layout's channel query (cache-first) to read the flag.
+const { result: channelResult } = useQuery(
+  GET_CHANNEL,
+  computed(() => ({
+    uniqueName: forumId,
+    now: DateTime.utc().startOf('hour').toISO(),
+  })),
+  {
+    fetchPolicy: 'cache-first',
+    enabled: computed(() => !!forumId),
+  }
+);
+
+const wikiDisabled = computed(
+  () => channelResult.value?.channels?.[0]?.wikiEnabled === false
+);
 
 const wikiEditBlockedBySuspension = computed(() => {
   return !!usernameVar.value && !!activeSuspension.value;
@@ -61,6 +83,7 @@ const {
 
 // Handle form submission
 function handleSubmit() {
+  if (wikiDisabled.value) return;
   if (wikiEditBlockedBySuspension.value) return;
   if (!formValues.value.title || !formValues.value.body) return;
   const channelUpdateInput = {
@@ -115,6 +138,11 @@ onDone(() => {
         </div>
 
         <ErrorBanner v-if="creationError" :text="creationError.message" />
+        <InfoBanner
+          v-if="wikiDisabled"
+          data-testid="wiki-disabled-banner"
+          text="The wiki is disabled in this forum, so wiki pages cannot be created. A forum owner can enable it in the forum's settings."
+        />
         <SuspensionNotice
           v-if="showWikiEditSuspensionNotice"
           class="mb-4"
@@ -126,7 +154,7 @@ onDone(() => {
         />
 
         <form
-          v-if="!wikiEditBlockedBySuspension"
+          v-if="!wikiEditBlockedBySuspension && !wikiDisabled"
           class="space-y-6"
           @submit.prevent="handleSubmit"
         >


### PR DESCRIPTION
Closes #230.

## Problem

`pages/forums/[forumId]/wiki/create.vue` only blocked wiki creation for suspended users — it ignored the channel's `wikiEnabled` flag. In a forum with the wiki disabled, the page still rendered the full editor; the backend (`validateWikiChannelsEnabled`) then rejected the submit, so the user only found out after trying.

## Change

Read the channel's `wikiEnabled` via a cache-first `GET_CHANNEL` query (reusing the forum layout's fetch, like `CreateEvent` does for `eventsEnabled`). When the wiki is disabled:
- show an `InfoBanner` ("The wiki is disabled in this forum…"),
- hide the editor form,
- guard `handleSubmit` as a backstop.

## Tests

Extended `pages/forums/[forumId]/wiki/create.spec.ts` (6/6 passing): with `wikiEnabled: false` the form is hidden and the disabled banner shows; with it enabled the form renders and no banner appears. `npm run tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)