### PR TITLE
[codex] Add sortable admin dashboard channel health table

### DIFF
--- a/components/admin/ChannelHealthTable.vue
+++ b/components/admin/ChannelHealthTable.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { ArrowDown, ArrowUp, ArrowUpDown, MessageSquare } from 'lucide-vue-next';
+import ChannelHealthTableRow from '@/components/admin/ChannelHealthTableRow.vue';
+
+type ChannelHealthSortKey =
+  | 'channelUniqueName'
+  | 'activityScore'
+  | 'uniqueContributorCount'
+  | 'openIssueCount'
+  | 'issueOpenedCount'
+  | 'oldestOpenIssueAgeDays'
+  | 'issuesPerHundredContributions'
+  | 'moderationActionCount'
+  | 'healthLabel';
+
+type SortDirection = 'asc' | 'desc';
+type SortAria = 'none' | 'ascending' | 'descending';
+
+type ChannelHealthRow = {
+  id: string;
+  channelUniqueName: string;
+  displayName?: string | null;
+  channelIconURL?: string | null;
+  voteCount: number;
+  uniqueContributorCount: number;
+  openIssueCount: number;
+  issueOpenedCount: number;
+  oldestOpenIssueAgeDays?: number | null;
+  issuesPerHundredContributions: number;
+  activityScore: number;
+  healthLabel: string;
+};
+
+const props = defineProps<{
+  rows: ChannelHealthRow[];
+  loading: boolean;
+  activeSortBy: ChannelHealthSortKey;
+  activeSortDirection: SortDirection;
+}>();
+
+const emit = defineEmits<{
+  sort: [sortBy: ChannelHealthSortKey];
+}>();
+
+const channelHealthColumnDefinitions: Array<{
+  key: ChannelHealthSortKey;
+  label: string;
+  title?: string;
+}> = [
+  { key: 'channelUniqueName', label: 'Channel' },
+  { key: 'activityScore', label: 'Activity' },
+  { key: 'uniqueContributorCount', label: 'Contributors' },
+  {
+    key: 'openIssueCount',
+    label: 'Open Issues',
+    title:
+      'Open issues only include admin/server-scoped issues: server-rule reports or issues opened without a channel scope.',
+  },
+  {
+    key: 'issueOpenedCount',
+    label: 'New Issues',
+    title:
+      'New issues only include admin/server-scoped issues in the selected date range.',
+  },
+  {
+    key: 'oldestOpenIssueAgeDays',
+    label: 'Stale Open',
+    title: 'Oldest currently open admin/server-scoped issue for this channel.',
+  },
+  {
+    key: 'issuesPerHundredContributions',
+    label: 'Pressure',
+    title:
+      'New admin/server-scoped issues per 100 discussions, comments, and events in the selected date range.',
+  },
+  { key: 'healthLabel', label: 'Status' },
+];
+
+const maxChannelActivity = computed(() => {
+  const values = props.rows.map((channel) => channel.activityScore);
+  return Math.max(...values, 1);
+});
+
+const maxChannelIssuePressure = computed(() => {
+  const values = props.rows.map((channel) => channel.issuesPerHundredContributions);
+  return Math.max(...values, 1);
+});
+
+const channelHealthColumns = computed(() => {
+  return channelHealthColumnDefinitions.map((column) => {
+    const isActive = props.activeSortBy === column.key;
+    const ariaSort: SortAria = !isActive
+      ? 'none'
+      : props.activeSortDirection === 'asc'
+        ? 'ascending'
+        : 'descending';
+    return {
+      ...column,
+      ariaSort,
+      sortIcon:
+        isActive && props.activeSortDirection === 'asc'
+          ? ArrowUp
+          : isActive
+            ? ArrowDown
+            : ArrowUpDown,
+      sortIconClass: isActive ? 'h-3.5 w-3.5' : 'h-3.5 w-3.5 opacity-50',
+    };
+  });
+});
+</script>
+
+<template>
+  <section class="space-y-4">
+    <div class="rounded-lg border border-gray-200 bg-white !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
+      <div class="flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+        <div>
+          <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+            Channel Health
+          </h2>
+          <p class="text-sm text-gray-600 dark:text-gray-300">
+            Ranked by activity and moderation load.
+          </p>
+        </div>
+        <MessageSquare class="h-5 w-5 text-gray-400" />
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
+          <thead class="bg-gray-100 text-left text-xs uppercase text-gray-500 dark:bg-gray-900 dark:text-gray-400">
+            <tr>
+              <th
+                v-for="column in channelHealthColumns"
+                :key="column.key"
+                class="px-4 py-3 font-medium"
+                :aria-sort="column.ariaSort"
+                :title="column.title"
+              >
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1 uppercase hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:hover:text-gray-100"
+                  @click="emit('sort', column.key)"
+                >
+                  {{ column.label }}
+                  <component
+                    :is="column.sortIcon"
+                    :class="column.sortIconClass"
+                  />
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+            <template v-if="loading">
+              <tr
+                v-for="index in 5"
+                :key="`loading-${index}`"
+                data-testid="channel-health-loading-row"
+              >
+                <td class="px-4 py-3">
+                  <div class="flex items-center gap-3">
+                    <div class="h-8 w-8 animate-pulse rounded-md bg-gray-100 dark:bg-gray-800" />
+                    <div class="space-y-2">
+                      <div class="h-3 w-28 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+                      <div class="h-2 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  v-for="columnIndex in 7"
+                  :key="columnIndex"
+                  class="px-4 py-3"
+                >
+                  <div class="h-3 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+                </td>
+              </tr>
+            </template>
+            <template v-else>
+              <ChannelHealthTableRow
+                v-for="row in rows"
+                :key="row.id"
+                :row="row"
+                :max-activity="maxChannelActivity"
+                :max-issue-pressure="maxChannelIssuePressure"
+              />
+            </template>
+            <tr v-if="!loading && rows.length === 0">
+              <td
+                colspan="8"
+                class="px-4 py-8 text-center text-gray-500 dark:text-gray-400"
+              >
+                No channel activity in this range.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</template>

--- a/components/admin/ChannelHealthTableRow.vue
+++ b/components/admin/ChannelHealthTableRow.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+type ChannelHealthRow = {
+  id: string;
+  channelUniqueName: string;
+  displayName?: string | null;
+  channelIconURL?: string | null;
+  voteCount: number;
+  uniqueContributorCount: number;
+  openIssueCount: number;
+  issueOpenedCount: number;
+  oldestOpenIssueAgeDays?: number | null;
+  issuesPerHundredContributions: number;
+  activityScore: number;
+  healthLabel: string;
+};
+
+const props = defineProps<{
+  row: ChannelHealthRow;
+  maxActivity: number;
+  maxIssuePressure: number;
+}>();
+
+const percent = (value: number, max: number) => {
+  if (max <= 0) return 0;
+  return Math.max(0, Math.min(100, (value / max) * 100));
+};
+
+const barPercent = (value: number, max: number) => {
+  if (value <= 0) return 0;
+  return Math.max(4, percent(value, max));
+};
+
+const channelInitials = computed(() => {
+  return props.row.channelUniqueName.slice(0, 2).toUpperCase();
+});
+
+const forumHref = computed(() => {
+  return `/forums/${props.row.channelUniqueName}`;
+});
+
+const activityBarWidth = computed(() => {
+  return `${percent(props.row.activityScore, props.maxActivity)}%`;
+});
+
+const hasOpenIssues = computed(() => props.row.openIssueCount > 0);
+
+const staleOpenIssueLabel = computed(() => {
+  if (!hasOpenIssues.value) return 'None';
+  if (props.row.oldestOpenIssueAgeDays == null) return 'Open';
+  return `${props.row.oldestOpenIssueAgeDays}d`;
+});
+
+const staleOpenIssueDescription = computed(() => {
+  if (!hasOpenIssues.value) {
+    return 'No open admin/server-scoped issues.';
+  }
+  if (props.row.oldestOpenIssueAgeDays == null) {
+    return `${props.row.openIssueCount} open admin/server-scoped issue${
+      props.row.openIssueCount === 1 ? '' : 's'
+    }.`;
+  }
+  return `${props.row.openIssueCount} open admin/server-scoped issue${
+    props.row.openIssueCount === 1 ? '' : 's'
+  }; oldest is ${props.row.oldestOpenIssueAgeDays} day${
+    props.row.oldestOpenIssueAgeDays === 1 ? '' : 's'
+  } old.`;
+});
+
+const staleOpenIssueClasses = computed(() => {
+  const age = props.row.oldestOpenIssueAgeDays || 0;
+  if (age >= 30) {
+    return 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-100';
+  }
+  if (age >= 7) {
+    return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-100';
+  }
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200';
+});
+
+const issuePressureLabel = computed(() => {
+  if (props.row.issuesPerHundredContributions === 0) return '0';
+  return props.row.issuesPerHundredContributions.toFixed(1);
+});
+
+const issuePressureDescription = computed(() => {
+  return `${issuePressureLabel.value} new admin/server-scoped issues per 100 contributions in this date range.`;
+});
+
+const issuePressureBarWidth = computed(() => {
+  return `${barPercent(
+    props.row.issuesPerHundredContributions,
+    props.maxIssuePressure
+  )}%`;
+});
+
+const issuePressureBarClasses = computed(() => {
+  return props.row.issuesPerHundredContributions >= 20
+    ? 'bg-yellow-500'
+    : 'bg-blue-500';
+});
+
+const healthLabelDescription = computed(() => {
+  if (props.row.healthLabel === 'Needs review') {
+    return 'Needs review means at least 10 open admin/server-scoped issues, or the oldest open admin/server-scoped issue is at least 14 days old.';
+  }
+  if (props.row.healthLabel === 'High moderation load') {
+    return 'High moderation load means at least 3 new admin/server-scoped issues and at least 20 new admin/server-scoped issues per 100 contributions in this date range.';
+  }
+  if (props.row.healthLabel === 'Healthy activity') {
+    return 'Healthy activity means at least 20 contributions and fewer than 5 new admin/server-scoped issues per 100 contributions in this date range.';
+  }
+  if (props.row.healthLabel === 'Quiet') {
+    return 'Quiet means this channel had no discussions, comments, or events in this date range.';
+  }
+  return 'Active means the channel had activity without crossing the review or high-load thresholds.';
+});
+
+const healthLabelClasses = computed(() => {
+  if (
+    props.row.healthLabel === 'Needs review' ||
+    props.row.healthLabel === 'High moderation load'
+  ) {
+    return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-100';
+  }
+  if (props.row.healthLabel === 'Healthy activity') {
+    return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-100';
+  }
+  if (props.row.healthLabel === 'Quiet') {
+    return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200';
+  }
+  return 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-100';
+});
+</script>
+
+<template>
+  <tr>
+    <td class="px-4 py-3">
+      <div class="flex items-center gap-3">
+        <img
+          v-if="row.channelIconURL"
+          :src="row.channelIconURL"
+          alt=""
+          class="h-8 w-8 rounded-md object-cover"
+        >
+        <div
+          v-else
+          class="flex h-8 w-8 items-center justify-center rounded-md bg-gray-100 text-xs font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+        >
+          {{ channelInitials }}
+        </div>
+        <div>
+          <NuxtLink
+            :to="forumHref"
+            class="font-medium text-gray-900 hover:underline dark:text-gray-100"
+          >
+            {{ row.displayName || row.channelUniqueName }}
+          </NuxtLink>
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            {{ row.channelUniqueName }}
+          </p>
+        </div>
+      </div>
+    </td>
+    <td class="px-4 py-3">
+      <div class="min-w-32">
+        <div class="mb-1 flex justify-between text-xs text-gray-500 dark:text-gray-400">
+          <span>{{ row.activityScore }}</span>
+          <span>{{ row.voteCount }} votes</span>
+        </div>
+        <div class="h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+          <div
+            class="h-full rounded-full bg-blue-500"
+            :style="{ width: activityBarWidth }"
+          />
+        </div>
+      </div>
+    </td>
+    <td class="px-4 py-3 text-gray-700 dark:text-gray-200">
+      {{ row.uniqueContributorCount }}
+    </td>
+    <td class="px-4 py-3 text-gray-700 dark:text-gray-200">
+      {{ row.openIssueCount }}
+    </td>
+    <td class="px-4 py-3 text-gray-700 dark:text-gray-200">
+      {{ row.issueOpenedCount }}
+    </td>
+    <td
+      class="px-4 py-3 text-gray-700 dark:text-gray-200"
+      :title="staleOpenIssueDescription"
+    >
+      <span
+        class="inline-flex rounded-full px-2 py-1 text-xs font-medium"
+        :class="staleOpenIssueClasses"
+      >
+        {{ staleOpenIssueLabel }}
+      </span>
+    </td>
+    <td
+      class="px-4 py-3 text-gray-700 dark:text-gray-200"
+      :title="issuePressureDescription"
+    >
+      <div class="min-w-28">
+        <div class="mb-1 text-xs font-medium text-gray-700 dark:text-gray-200">
+          {{ issuePressureLabel }}
+        </div>
+        <div class="h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+          <div
+            class="h-full rounded-full"
+            :class="issuePressureBarClasses"
+            :style="{ width: issuePressureBarWidth }"
+          />
+        </div>
+      </div>
+    </td>
+    <td class="px-4 py-3">
+      <span
+        class="inline-flex rounded-full px-2 py-1 text-xs font-medium"
+        :class="healthLabelClasses"
+        :title="healthLabelDescription"
+      >
+        {{ row.healthLabel }}
+      </span>
+    </td>
+  </tr>
+</template>

--- a/components/admin/ServerDashboardActivityChart.vue
+++ b/components/admin/ServerDashboardActivityChart.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { CalendarDays } from 'lucide-vue-next';
+
+type ServerHealthTimeSeriesPoint = {
+  date: string;
+  discussions: number;
+  comments: number;
+  events: number;
+};
+
+const props = defineProps<{
+  timeSeries: ServerHealthTimeSeriesPoint[];
+}>();
+
+const maxActivity = computed(() => {
+  const values = props.timeSeries.map(
+    (point) => point.discussions + point.comments + point.events
+  );
+  return Math.max(...values, 1);
+});
+
+const formatDateLabel = (date: string) => {
+  if (!date) return '';
+  return new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+const percent = (value: number, max: number) => {
+  if (max <= 0) return 0;
+  return Math.max(0, Math.min(100, (value / max) * 100));
+};
+</script>
+
+<template>
+  <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
+    <div class="mb-4 flex items-center justify-between gap-3">
+      <div>
+        <h2 class="text-base font-semibold !text-gray-900 dark:!text-gray-100">
+          Activity
+        </h2>
+        <p class="text-sm text-gray-600 dark:text-gray-300">
+          Discussions, comments, and events by day.
+        </p>
+      </div>
+      <CalendarDays class="h-5 w-5 text-gray-400" />
+    </div>
+
+    <div class="flex h-64 items-end gap-2 overflow-x-auto overflow-y-visible pb-12">
+      <div
+        v-for="point in timeSeries"
+        :key="point.date"
+        class="relative flex min-w-6 flex-1 flex-col items-center justify-end gap-1"
+        :title="`${formatDateLabel(point.date)}: ${point.discussions + point.comments + point.events}`"
+      >
+        <div class="flex h-44 w-full max-w-7 flex-col justify-end overflow-hidden rounded-t bg-gray-100 dark:bg-gray-800">
+          <div
+            class="bg-blue-500"
+            :style="{ height: `${percent(point.discussions, maxActivity)}%` }"
+          />
+          <div
+            class="bg-orange-500"
+            :style="{ height: `${percent(point.comments, maxActivity)}%` }"
+          />
+          <div
+            class="bg-green-500"
+            :style="{ height: `${percent(point.events, maxActivity)}%` }"
+          />
+        </div>
+        <span class="absolute -bottom-9 left-1/2 hidden w-14 origin-top-left -translate-x-1 -rotate-45 whitespace-nowrap text-left text-[10px] leading-none text-gray-500 sm:block">
+          {{ formatDateLabel(point.date) }}
+        </span>
+      </div>
+    </div>
+
+    <div class="mt-3 flex flex-wrap gap-4 text-xs text-gray-600 dark:text-gray-300">
+      <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-blue-500" />Discussions</span>
+      <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-orange-500" />Comments</span>
+      <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-green-500" />Events</span>
+    </div>
+  </div>
+</template>

--- a/components/admin/ServerDashboardIssueAging.vue
+++ b/components/admin/ServerDashboardIssueAging.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Clock3 } from 'lucide-vue-next';
+
+type IssueAgingBucket = {
+  label: string;
+  minDays: number;
+  maxDays?: number | null;
+  count: number;
+};
+
+const props = defineProps<{
+  issueAging: IssueAgingBucket[];
+}>();
+
+const maxIssueAgeBucket = computed(() => {
+  const values = props.issueAging.map((bucket) => bucket.count);
+  return Math.max(...values, 1);
+});
+
+const percent = (value: number, max: number) => {
+  if (max <= 0) return 0;
+  return Math.max(0, Math.min(100, (value / max) * 100));
+};
+
+const barPercent = (value: number, max: number) => {
+  if (value <= 0) return 0;
+  return Math.max(4, percent(value, max));
+};
+</script>
+
+<template>
+  <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
+    <div class="mb-4 flex items-center justify-between gap-3">
+      <div>
+        <h2 class="text-base font-semibold !text-gray-900 dark:!text-gray-100">
+          Issue Aging
+        </h2>
+        <p class="text-sm text-gray-600 dark:text-gray-300">
+          Open admin/server-scoped issues by age bucket.
+        </p>
+      </div>
+      <Clock3 class="h-5 w-5 text-gray-400" />
+    </div>
+
+    <div class="space-y-3">
+      <div
+        v-for="bucket in issueAging"
+        :key="bucket.label"
+        class="grid grid-cols-[5rem_minmax(0,1fr)_3rem] items-center gap-3 text-sm"
+      >
+        <span class="font-medium text-gray-700 dark:text-gray-200">
+          {{ bucket.label }}
+        </span>
+        <div class="h-3 overflow-hidden rounded-sm bg-gray-100 dark:bg-gray-800">
+          <div
+            class="h-full rounded-sm bg-yellow-500"
+            :style="{ width: `${barPercent(bucket.count, maxIssueAgeBucket)}%` }"
+          />
+        </div>
+        <span class="text-right text-gray-600 dark:text-gray-300">
+          {{ bucket.count }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/admin/ServerDashboardMetricCards.vue
+++ b/components/admin/ServerDashboardMetricCards.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import {
+  Archive,
+  Clock3,
+  Flag,
+  ShieldAlert,
+  ThumbsUp,
+  Users,
+} from 'lucide-vue-next';
+
+type ServerHealthSummary = {
+  activeChannelCount: number;
+  discussionCount: number;
+  commentCount: number;
+  eventCount: number;
+  voteCount: number;
+  openIssueCount: number;
+  issueOpenedCount: number;
+  issueClosedCount: number;
+  moderationActionCount: number;
+  archivedContentCount: number;
+  lockedContentCount: number;
+  medianOpenIssueAgeDays?: number | null;
+};
+
+const props = defineProps<{
+  summary: ServerHealthSummary;
+}>();
+
+const totalContributions = computed(() => {
+  return (
+    props.summary.discussionCount +
+    props.summary.commentCount +
+    props.summary.eventCount
+  );
+});
+
+const metricCards = computed(() => {
+  return [
+    {
+      label: 'Active Channels',
+      value: props.summary.activeChannelCount,
+      detail: `${totalContributions.value} contributions`,
+      icon: Users,
+      tone: 'blue',
+    },
+    {
+      label: 'Admin Open Issues',
+      value: props.summary.openIssueCount,
+      detail: `${props.summary.issueOpenedCount} new this period`,
+      icon: Flag,
+      tone: props.summary.openIssueCount > 0 ? 'yellow' : 'green',
+    },
+    {
+      label: 'Admin Issue Age',
+      value:
+        props.summary.medianOpenIssueAgeDays == null
+          ? '0d'
+          : `${Math.round(props.summary.medianOpenIssueAgeDays)}d`,
+      detail: 'median open admin issue age',
+      icon: Clock3,
+      tone: (props.summary.medianOpenIssueAgeDays || 0) >= 7 ? 'yellow' : 'green',
+    },
+    {
+      label: 'Mod Actions',
+      value: props.summary.moderationActionCount,
+      detail: `${props.summary.issueClosedCount} issues closed`,
+      icon: ShieldAlert,
+      tone: 'slate',
+    },
+    {
+      label: 'Votes',
+      value: props.summary.voteCount,
+      detail: `${props.summary.commentCount} comments`,
+      icon: ThumbsUp,
+      tone: 'blue',
+    },
+    {
+      label: 'Archived',
+      value: props.summary.archivedContentCount,
+      detail: `${props.summary.lockedContentCount} locked`,
+      icon: Archive,
+      tone: props.summary.archivedContentCount > 0 ? 'yellow' : 'slate',
+    },
+  ];
+});
+
+const formatNumber = (value: number | string) => {
+  if (typeof value === 'string') return value;
+  return new Intl.NumberFormat().format(value);
+};
+</script>
+
+<template>
+  <section class="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+    <div
+      v-for="card in metricCards"
+      :key="card.label"
+      class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <p class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+            {{ card.label }}
+          </p>
+          <p class="mt-2 text-2xl font-semibold !text-gray-900 dark:!text-gray-100">
+            {{ formatNumber(card.value) }}
+          </p>
+        </div>
+        <component
+          :is="card.icon"
+          class="h-5 w-5"
+          :class="{
+            'text-blue-600 dark:text-blue-300': card.tone === 'blue',
+            'text-yellow-600 dark:text-yellow-300': card.tone === 'yellow',
+            'text-green-600 dark:text-green-300': card.tone === 'green',
+            'text-gray-500 dark:text-gray-300': card.tone === 'slate',
+          }"
+        />
+      </div>
+      <p class="mt-3 text-sm text-gray-600 dark:text-gray-300">
+        {{ card.detail }}
+      </p>
+    </div>
+  </section>
+</template>

--- a/components/admin/ServerDashboardSecondaryStats.vue
+++ b/components/admin/ServerDashboardSecondaryStats.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { Download, Lock } from 'lucide-vue-next';
+
+defineProps<{
+  downloadCount: number;
+  suspensionCount: number;
+}>();
+</script>
+
+<template>
+  <div class="grid gap-3 sm:grid-cols-2">
+    <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
+      <Download class="mb-3 h-5 w-5 text-gray-400" />
+      <p class="text-2xl font-semibold !text-gray-900 dark:!text-gray-100">
+        {{ downloadCount }}
+      </p>
+      <p class="text-sm text-gray-600 dark:text-gray-300">Downloads</p>
+    </div>
+    <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
+      <Lock class="mb-3 h-5 w-5 text-gray-400" />
+      <p class="text-2xl font-semibold !text-gray-900 dark:!text-gray-100">
+        {{ suspensionCount }}
+      </p>
+      <p class="text-sm text-gray-600 dark:text-gray-300">Suspensions</p>
+    </div>
+  </div>
+</template>

--- a/graphQLData/admin/queries.js
+++ b/graphQLData/admin/queries.js
@@ -185,6 +185,100 @@ export const GET_SERVER_HEALTH_DASHBOARD = gql`
   }
 `;
 
+export const GET_SERVER_HEALTH_DASHBOARD_OVERVIEW = gql`
+  query getServerHealthDashboardOverview(
+    $startDate: String
+    $endDate: String
+    $channelUniqueNames: [String!]
+  ) {
+    getServerHealthDashboard(
+      startDate: $startDate
+      endDate: $endDate
+      channelUniqueNames: $channelUniqueNames
+    ) {
+      startDate
+      endDate
+      generatedAt
+      summary {
+        activeChannelCount
+        discussionCount
+        commentCount
+        eventCount
+        downloadCount
+        voteCount
+        openIssueCount
+        issueOpenedCount
+        issueClosedCount
+        moderationActionCount
+        archivedContentCount
+        lockedContentCount
+        suspensionCount
+        medianOpenIssueAgeDays
+      }
+      timeSeries {
+        date
+        discussions
+        comments
+        events
+        downloads
+        issuesOpened
+        moderationActions
+      }
+      issueAging {
+        label
+        minDays
+        maxDays
+        count
+      }
+    }
+  }
+`;
+
+export const GET_SERVER_HEALTH_CHANNEL_HEALTH = gql`
+  query getServerHealthChannelHealth(
+    $startDate: String
+    $endDate: String
+    $channelUniqueNames: [String!]
+    $limit: Int
+    $sortBy: String
+    $sortDirection: String
+  ) {
+    getServerHealthDashboard(
+      startDate: $startDate
+      endDate: $endDate
+      channelUniqueNames: $channelUniqueNames
+      limit: $limit
+      sortBy: $sortBy
+      sortDirection: $sortDirection
+    ) {
+      startDate
+      endDate
+      generatedAt
+      channelHealth {
+        id
+        channelUniqueName
+        displayName
+        channelIconURL
+        discussionCount
+        commentCount
+        eventCount
+        downloadCount
+        voteCount
+        uniqueContributorCount
+        openIssueCount
+        issueOpenedCount
+        moderationActionCount
+        archivedContentCount
+        lockedContentCount
+        oldestOpenIssueAgeDays
+        issuesPerHundredContributions
+        activityScore
+        healthLabel
+      }
+    }
+  }
+`;
+
 export const GET_SERVER_PERMISSIONS = gql`
   query getServerConfig($serverName: String!) {
     serverConfigs(where: { serverName: $serverName }) {

--- a/graphQLData/admin/queries.js
+++ b/graphQLData/admin/queries.js
@@ -106,12 +106,16 @@ export const GET_SERVER_HEALTH_DASHBOARD = gql`
     $endDate: String
     $channelUniqueNames: [String!]
     $limit: Int
+    $sortBy: String
+    $sortDirection: String
   ) {
     getServerHealthDashboard(
       startDate: $startDate
       endDate: $endDate
       channelUniqueNames: $channelUniqueNames
       limit: $limit
+      sortBy: $sortBy
+      sortDirection: $sortDirection
     ) {
       startDate
       endDate
@@ -142,6 +146,7 @@ export const GET_SERVER_HEALTH_DASHBOARD = gql`
         moderationActions
       }
       channelHealth {
+        id
         channelUniqueName
         displayName
         channelIconURL

--- a/pages/admin/dashboard.spec.ts
+++ b/pages/admin/dashboard.spec.ts
@@ -93,19 +93,40 @@ const mountDashboard = async (
   options: {
     resultValue?: typeof dashboardResult | null;
     loading?: boolean;
+    overviewResultValue?: typeof dashboardResult | null;
+    channelResultValue?: typeof dashboardResult | null;
+    overviewLoading?: boolean;
+    channelLoading?: boolean;
   } = {}
 ) => {
-  const resultRef = ref(
-    options.resultValue === undefined ? dashboardResult : options.resultValue
+  const getResultValue = (
+    value: typeof dashboardResult | null | undefined
+  ) => {
+    if (value !== undefined) return value;
+    return options.resultValue === undefined ? dashboardResult : options.resultValue;
+  };
+  const overviewResultRef = ref(
+    getResultValue(options.overviewResultValue)
   );
-  const loadingRef = ref(options.loading || false);
-  const refetch = vi.fn();
+  const channelResultRef = ref(
+    getResultValue(options.channelResultValue)
+  );
+  const overviewLoadingRef = ref(options.overviewLoading ?? options.loading ?? false);
+  const channelLoadingRef = ref(options.channelLoading ?? options.loading ?? false);
+  const refetchOverview = vi.fn();
+  const refetchChannelHealth = vi.fn();
 
-  mockedUseQuery.mockReturnValue({
-    result: resultRef,
-    loading: loadingRef,
+  mockedUseQuery.mockReturnValueOnce({
+    result: overviewResultRef,
+    loading: overviewLoadingRef,
     error: ref(null),
-    refetch,
+    refetch: refetchOverview,
+  });
+  mockedUseQuery.mockReturnValueOnce({
+    result: channelResultRef,
+    loading: channelLoadingRef,
+    error: ref(null),
+    refetch: refetchChannelHealth,
   });
   const Page = (await import('./dashboard.vue')).default;
   const wrapper = mount(Page, {
@@ -118,7 +139,15 @@ const mountDashboard = async (
       },
     },
   });
-  return { wrapper, resultRef, loadingRef, refetch };
+  return {
+    wrapper,
+    overviewResultRef,
+    channelResultRef,
+    overviewLoadingRef,
+    channelLoadingRef,
+    refetchOverview,
+    refetchChannelHealth,
+  };
 };
 
 beforeEach(() => {
@@ -206,5 +235,23 @@ describe('admin dashboard page', () => {
     expect(
       wrapper.findAll('[data-testid="channel-health-loading-row"]')
     ).toHaveLength(0);
+  });
+
+  it('keeps overview sections mounted when only sorted channel rows are loading', async () => {
+    const { wrapper } = await mountDashboard({
+      overviewResultValue: dashboardResult,
+      channelResultValue: null,
+      channelLoading: true,
+    });
+
+    expect(wrapper.text()).toContain('Active Channels');
+    expect(wrapper.text()).toContain('Activity');
+    expect(wrapper.text()).toContain('Issue Aging');
+    expect(
+      wrapper.find('[data-testid="dashboard-initial-loading"]').exists()
+    ).toBe(false);
+    expect(
+      wrapper.findAll('[data-testid="channel-health-loading-row"]')
+    ).toHaveLength(5);
   });
 });

--- a/pages/admin/dashboard.spec.ts
+++ b/pages/admin/dashboard.spec.ts
@@ -51,6 +51,7 @@ const dashboardResult = {
     ],
     channelHealth: [
       {
+        id: 'general',
         channelUniqueName: 'general',
         displayName: 'General',
         channelIconURL: null,
@@ -88,15 +89,26 @@ const dashboardResult = {
   },
 };
 
-const mountDashboard = async () => {
+const mountDashboard = async (
+  options: {
+    resultValue?: typeof dashboardResult | null;
+    loading?: boolean;
+  } = {}
+) => {
+  const resultRef = ref(
+    options.resultValue === undefined ? dashboardResult : options.resultValue
+  );
+  const loadingRef = ref(options.loading || false);
+  const refetch = vi.fn();
+
   mockedUseQuery.mockReturnValue({
-    result: ref(dashboardResult),
-    loading: ref(false),
+    result: resultRef,
+    loading: loadingRef,
     error: ref(null),
-    refetch: vi.fn(),
+    refetch,
   });
   const Page = (await import('./dashboard.vue')).default;
-  return mount(Page, {
+  const wrapper = mount(Page, {
     global: {
       stubs: {
         NuxtLink: {
@@ -106,6 +118,7 @@ const mountDashboard = async () => {
       },
     },
   });
+  return { wrapper, resultRef, loadingRef, refetch };
 };
 
 beforeEach(() => {
@@ -123,7 +136,7 @@ beforeEach(() => {
 
 describe('admin dashboard page', () => {
   it('renders summary metrics from the health dashboard query', async () => {
-    const wrapper = await mountDashboard();
+    const { wrapper } = await mountDashboard();
 
     expect(wrapper.text()).toContain('Server Dashboard');
     expect(wrapper.text()).toContain('Active Channels');
@@ -132,12 +145,66 @@ describe('admin dashboard page', () => {
     expect(wrapper.text()).toContain('4');
   });
 
-  it('renders channel health and attention items', async () => {
-    const wrapper = await mountDashboard();
+  it('renders channel health issue pressure columns', async () => {
+    const { wrapper } = await mountDashboard();
 
     expect(wrapper.text()).toContain('General');
     expect(wrapper.text()).toContain('Needs review');
-    expect(wrapper.text()).toContain('new this period');
-    expect(wrapper.text()).toContain('Stale open issues');
+    expect(wrapper.text()).toContain('Open Issues');
+    expect(wrapper.text()).toContain('New Issues');
+    expect(wrapper.text()).toContain('Stale Open');
+    expect(wrapper.text()).toContain('Pressure');
+    expect(wrapper.text()).toContain('9d');
+    expect(wrapper.text()).toContain('26.6');
+  });
+
+  it('updates query params when sorting the channel health table', async () => {
+    const replace = vi.fn();
+    mockedUseRouter.mockReturnValue({ replace });
+    const { wrapper } = await mountDashboard();
+
+    const staleHeader = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Stale Open'));
+    expect(staleHeader).toBeTruthy();
+
+    await staleHeader?.trigger('click');
+
+    expect(replace).toHaveBeenCalledWith({
+      query: {
+        startDate: '2026-05-27',
+        endDate: '2026-06-26',
+        sort: 'oldestOpenIssueAgeDays',
+        sortDirection: 'desc',
+      },
+    });
+  });
+
+  it('shows the initial dashboard skeleton when loading without cached data', async () => {
+    const { wrapper } = await mountDashboard({
+      resultValue: null,
+      loading: true,
+    });
+
+    expect(wrapper.text()).toContain('Server Dashboard');
+    expect(
+      wrapper.find('[data-testid="dashboard-initial-loading"]').exists()
+    ).toBe(true);
+    expect(
+      wrapper.findAll('[data-testid="channel-health-loading-row"]')
+    ).toHaveLength(0);
+  });
+
+  it('renders cached channel rows immediately when loading has a current result', async () => {
+    const { wrapper } = await mountDashboard({ loading: true });
+
+    expect(wrapper.text()).toContain('General');
+    expect(wrapper.text()).toContain('Needs review');
+    expect(
+      wrapper.find('[data-testid="dashboard-initial-loading"]').exists()
+    ).toBe(false);
+    expect(
+      wrapper.findAll('[data-testid="channel-health-loading-row"]')
+    ).toHaveLength(0);
   });
 });

--- a/pages/admin/dashboard.vue
+++ b/pages/admin/dashboard.vue
@@ -8,7 +8,10 @@ import ServerDashboardIssueAging from '@/components/admin/ServerDashboardIssueAg
 import ServerDashboardMetricCards from '@/components/admin/ServerDashboardMetricCards.vue';
 import ServerDashboardSecondaryStats from '@/components/admin/ServerDashboardSecondaryStats.vue';
 import { RefreshCw } from 'lucide-vue-next';
-import { GET_SERVER_HEALTH_DASHBOARD } from '@/graphQLData/admin/queries';
+import {
+  GET_SERVER_HEALTH_CHANNEL_HEALTH,
+  GET_SERVER_HEALTH_DASHBOARD_OVERVIEW,
+} from '@/graphQLData/admin/queries';
 
 type ServerHealthSummary = {
   activeChannelCount: number;
@@ -72,7 +75,6 @@ type DashboardData = {
   generatedAt: string;
   summary: ServerHealthSummary;
   timeSeries: ServerHealthTimeSeriesPoint[];
-  channelHealth: ChannelHealthRow[];
   issueAging: IssueAgingBucket[];
 };
 
@@ -152,7 +154,12 @@ const activeSortDirection = computed(() =>
   getSortDirectionFromQuery(route.query.sortDirection)
 );
 
-const dashboardVariables = computed(() => ({
+const dashboardOverviewVariables = computed(() => ({
+  startDate: startDate.value,
+  endDate: endDate.value,
+}));
+
+const channelHealthVariables = computed(() => ({
   startDate: startDate.value,
   endDate: endDate.value,
   limit: channelLimit.value,
@@ -193,9 +200,28 @@ watch([startDate, endDate], ([nextStartDate, nextEndDate]) => {
   });
 });
 
-const { result, loading, error, refetch } = useQuery(
-  GET_SERVER_HEALTH_DASHBOARD,
-  dashboardVariables,
+const {
+  result: overviewResult,
+  loading: overviewLoading,
+  error: overviewError,
+  refetch: refetchOverview,
+} = useQuery(
+  GET_SERVER_HEALTH_DASHBOARD_OVERVIEW,
+  dashboardOverviewVariables,
+  {
+    fetchPolicy: 'cache-and-network',
+    prefetch: false,
+  }
+);
+
+const {
+  result: channelHealthResult,
+  loading: channelHealthLoading,
+  error: channelHealthError,
+  refetch: refetchChannelHealth,
+} = useQuery(
+  GET_SERVER_HEALTH_CHANNEL_HEALTH,
+  channelHealthVariables,
   {
     fetchPolicy: 'cache-and-network',
     prefetch: false,
@@ -203,20 +229,34 @@ const { result, loading, error, refetch } = useQuery(
 );
 
 const dashboard = computed<DashboardData | null>(() => {
-  return result.value?.getServerHealthDashboard || null;
+  return overviewResult.value?.getServerHealthDashboard || null;
 });
 
 const showInitialDashboardSkeleton = computed(() => {
-  return loading.value && !dashboard.value;
+  return overviewLoading.value && !dashboard.value;
 });
 
 const isChannelHealthLoading = computed(() => {
-  return loading.value && !!dashboard.value && channelRows.value.length === 0;
+  return (
+    channelHealthLoading.value &&
+    !!dashboard.value &&
+    channelRows.value.length === 0
+  );
 });
 
-const channelRows = computed(() => dashboard.value?.channelHealth || []);
+const channelRows = computed(
+  () => channelHealthResult.value?.getServerHealthDashboard?.channelHealth || []
+);
 const issueAging = computed(() => dashboard.value?.issueAging || []);
 const timeSeries = computed(() => dashboard.value?.timeSeries || []);
+const dashboardError = computed(
+  () => overviewError.value || channelHealthError.value
+);
+
+const refreshDashboard = () => {
+  refetchOverview(dashboardOverviewVariables.value);
+  refetchChannelHealth(channelHealthVariables.value);
+};
 
 const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
   const nextDirection =
@@ -272,7 +312,7 @@ const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
         <button
           type="button"
           class="inline-flex h-10 items-center gap-2 rounded-md border border-gray-300 px-3 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-800"
-          @click="refetch(dashboardVariables)"
+          @click="refreshDashboard"
         >
           <RefreshCw class="h-4 w-4" />
           Refresh
@@ -302,10 +342,10 @@ const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
       </template>
 
       <div
-        v-if="error"
+        v-if="dashboardError"
         class="rounded-md border border-red-200 bg-red-100 px-4 py-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-900/30 dark:text-red-100"
       >
-        {{ error.message }}
+        {{ dashboardError.message }}
       </div>
 
       <div

--- a/pages/admin/dashboard.vue
+++ b/pages/admin/dashboard.vue
@@ -2,23 +2,12 @@
 import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useQuery } from '@vue/apollo-composable';
-import ChannelHealthTableRow from '@/components/admin/ChannelHealthTableRow.vue';
-import {
-  ArrowDown,
-  ArrowUp,
-  ArrowUpDown,
-  Archive,
-  CalendarDays,
-  Clock3,
-  Download,
-  Flag,
-  Lock,
-  MessageSquare,
-  RefreshCw,
-  ShieldAlert,
-  ThumbsUp,
-  Users,
-} from 'lucide-vue-next';
+import ChannelHealthTable from '@/components/admin/ChannelHealthTable.vue';
+import ServerDashboardActivityChart from '@/components/admin/ServerDashboardActivityChart.vue';
+import ServerDashboardIssueAging from '@/components/admin/ServerDashboardIssueAging.vue';
+import ServerDashboardMetricCards from '@/components/admin/ServerDashboardMetricCards.vue';
+import ServerDashboardSecondaryStats from '@/components/admin/ServerDashboardSecondaryStats.vue';
+import { RefreshCw } from 'lucide-vue-next';
 import { GET_SERVER_HEALTH_DASHBOARD } from '@/graphQLData/admin/queries';
 
 type ServerHealthSummary = {
@@ -77,15 +66,6 @@ type IssueAgingBucket = {
   count: number;
 };
 
-type AttentionItem = {
-  severity: 'INFO' | 'WARNING' | 'CRITICAL' | string;
-  title: string;
-  description: string;
-  channelUniqueName?: string | null;
-  metric?: string | null;
-  value?: number | null;
-};
-
 type DashboardData = {
   startDate: string;
   endDate: string;
@@ -94,7 +74,6 @@ type DashboardData = {
   timeSeries: ServerHealthTimeSeriesPoint[];
   channelHealth: ChannelHealthRow[];
   issueAging: IssueAgingBucket[];
-  attentionItems: AttentionItem[];
 };
 
 type ChannelHealthSortKey =
@@ -109,7 +88,6 @@ type ChannelHealthSortKey =
   | 'healthLabel';
 
 type SortDirection = 'asc' | 'desc';
-type SortAria = 'none' | 'ascending' | 'descending';
 
 const defaultSortBy: ChannelHealthSortKey = 'activityScore';
 const defaultSortDirection: SortDirection = 'desc';
@@ -124,39 +102,6 @@ const channelHealthSortKeys = new Set<ChannelHealthSortKey>([
   'moderationActionCount',
   'healthLabel',
 ]);
-const channelHealthColumnDefinitions: Array<{
-  key: ChannelHealthSortKey;
-  label: string;
-  title?: string;
-}> = [
-  { key: 'channelUniqueName', label: 'Channel' },
-  { key: 'activityScore', label: 'Activity' },
-  { key: 'uniqueContributorCount', label: 'Contributors' },
-  {
-    key: 'openIssueCount',
-    label: 'Open Issues',
-    title:
-      'Open issues only include admin/server-scoped issues: server-rule reports or issues opened without a channel scope.',
-  },
-  {
-    key: 'issueOpenedCount',
-    label: 'New Issues',
-    title:
-      'New issues only include admin/server-scoped issues in the selected date range.',
-  },
-  {
-    key: 'oldestOpenIssueAgeDays',
-    label: 'Stale Open',
-    title: 'Oldest currently open admin/server-scoped issue for this channel.',
-  },
-  {
-    key: 'issuesPerHundredContributions',
-    label: 'Pressure',
-    title:
-      'New admin/server-scoped issues per 100 discussions, comments, and events in the selected date range.',
-  },
-  { key: 'healthLabel', label: 'Status' },
-];
 
 const toDateInputValue = (date: Date) => date.toISOString().split('T')[0] || '';
 
@@ -269,125 +214,9 @@ const isChannelHealthLoading = computed(() => {
   return loading.value && !!dashboard.value && channelRows.value.length === 0;
 });
 
-const summary = computed<ServerHealthSummary | null>(() => {
-  return dashboard.value?.summary || null;
-});
-
-const totalContributions = computed(() => {
-  if (!summary.value) return 0;
-  return (
-    summary.value.discussionCount +
-    summary.value.commentCount +
-    summary.value.eventCount
-  );
-});
-
-const maxActivity = computed(() => {
-  const values =
-    dashboard.value?.timeSeries.map(
-      (point) => point.discussions + point.comments + point.events
-    ) || [];
-  return Math.max(...values, 1);
-});
-
-const maxIssueAgeBucket = computed(() => {
-  const values =
-    dashboard.value?.issueAging.map((bucket) => bucket.count) || [];
-  return Math.max(...values, 1);
-});
-
-const maxChannelActivity = computed(() => {
-  const values =
-    dashboard.value?.channelHealth.map((channel) => channel.activityScore) ||
-    [];
-  return Math.max(...values, 1);
-});
-
-const metricCards = computed(() => {
-  const data = summary.value;
-  if (!data) return [];
-  return [
-    {
-      label: 'Active Channels',
-      value: data.activeChannelCount,
-      detail: `${totalContributions.value} contributions`,
-      icon: Users,
-      tone: 'blue',
-    },
-    {
-      label: 'Admin Open Issues',
-      value: data.openIssueCount,
-      detail: `${data.issueOpenedCount} new this period`,
-      icon: Flag,
-      tone: data.openIssueCount > 0 ? 'yellow' : 'green',
-    },
-    {
-      label: 'Admin Issue Age',
-      value:
-        data.medianOpenIssueAgeDays == null
-          ? '0d'
-          : `${Math.round(data.medianOpenIssueAgeDays)}d`,
-      detail: 'median open admin issue age',
-      icon: Clock3,
-      tone: (data.medianOpenIssueAgeDays || 0) >= 7 ? 'yellow' : 'green',
-    },
-    {
-      label: 'Mod Actions',
-      value: data.moderationActionCount,
-      detail: `${data.issueClosedCount} issues closed`,
-      icon: ShieldAlert,
-      tone: 'slate',
-    },
-    {
-      label: 'Votes',
-      value: data.voteCount,
-      detail: `${data.commentCount} comments`,
-      icon: ThumbsUp,
-      tone: 'blue',
-    },
-    {
-      label: 'Archived',
-      value: data.archivedContentCount,
-      detail: `${data.lockedContentCount} locked`,
-      icon: Archive,
-      tone: data.archivedContentCount > 0 ? 'yellow' : 'slate',
-    },
-  ];
-});
-
 const channelRows = computed(() => dashboard.value?.channelHealth || []);
 const issueAging = computed(() => dashboard.value?.issueAging || []);
 const timeSeries = computed(() => dashboard.value?.timeSeries || []);
-
-const formatNumber = (value: number | string) => {
-  if (typeof value === 'string') return value;
-  return new Intl.NumberFormat().format(value);
-};
-
-const formatDateLabel = (date: string) => {
-  if (!date) return '';
-  return new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-  });
-};
-
-const percent = (value: number, max: number) => {
-  if (max <= 0) return 0;
-  return Math.max(0, Math.min(100, (value / max) * 100));
-};
-
-const barPercent = (value: number, max: number) => {
-  if (value <= 0) return 0;
-  return Math.max(4, percent(value, max));
-};
-
-const maxChannelIssuePressure = computed(() => {
-  const values = channelRows.value.map(
-    (channel) => channel.issuesPerHundredContributions
-  );
-  return Math.max(...values, 1);
-});
 
 const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
   const nextDirection =
@@ -403,29 +232,6 @@ const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
     },
   });
 };
-
-const channelHealthColumns = computed(() => {
-  return channelHealthColumnDefinitions.map((column) => {
-    const isActive = activeSortBy.value === column.key;
-    const ariaSort: SortAria = !isActive
-      ? 'none'
-      : activeSortDirection.value === 'asc'
-        ? 'ascending'
-        : 'descending';
-    return {
-      ...column,
-      ariaSort,
-      sortIcon:
-        isActive && activeSortDirection.value === 'asc'
-          ? ArrowUp
-          : isActive
-            ? ArrowDown
-            : ArrowUpDown,
-      sortIconClass: isActive ? 'h-3.5 w-3.5' : 'h-3.5 w-3.5 opacity-50',
-    };
-  });
-});
-
 </script>
 
 <template>
@@ -515,298 +321,27 @@ const channelHealthColumns = computed(() => {
       </div>
 
       <template v-else-if="dashboard">
-        <section class="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
-          <div
-            v-for="card in metricCards"
-            :key="card.label"
-            class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
-          >
-            <div class="flex items-start justify-between gap-3">
-              <div>
-                <p
-                  class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"
-                >
-                  {{ card.label }}
-                </p>
-                <p
-                  class="font-semibold mt-2 text-2xl !text-gray-900 dark:!text-gray-100"
-                >
-                  {{ formatNumber(card.value) }}
-                </p>
-              </div>
-              <component
-                :is="card.icon"
-                class="h-5 w-5"
-                :class="{
-                  'text-blue-600 dark:text-blue-300': card.tone === 'blue',
-                  'text-yellow-600 dark:text-yellow-300':
-                    card.tone === 'yellow',
-                  'text-green-600 dark:text-green-300': card.tone === 'green',
-                  'text-gray-500 dark:text-gray-300': card.tone === 'slate',
-                }"
-              />
-            </div>
-            <p class="mt-3 text-sm text-gray-600 dark:text-gray-300">
-              {{ card.detail }}
-            </p>
-          </div>
-        </section>
+        <ServerDashboardMetricCards :summary="dashboard.summary" />
 
         <section
           class="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
         >
-          <div
-            class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
-          >
-            <div class="mb-4 flex items-center justify-between gap-3">
-              <div>
-                <h2
-                  class="font-semibold text-base !text-gray-900 dark:!text-gray-100"
-                >
-                  Activity
-                </h2>
-                <p class="text-sm text-gray-600 dark:text-gray-300">
-                  Discussions, comments, and events by day.
-                </p>
-              </div>
-              <CalendarDays class="h-5 w-5 text-gray-400" />
-            </div>
-
-            <div
-              class="flex h-64 items-end gap-2 overflow-x-auto overflow-y-visible pb-12"
-            >
-              <div
-                v-for="point in timeSeries"
-                :key="point.date"
-                class="relative flex min-w-6 flex-1 flex-col items-center justify-end gap-1"
-                :title="`${formatDateLabel(point.date)}: ${point.discussions + point.comments + point.events}`"
-              >
-                <div
-                  class="flex h-44 w-full max-w-7 flex-col justify-end overflow-hidden rounded-t bg-gray-100 dark:bg-gray-800"
-                >
-                  <div
-                    class="bg-blue-500"
-                    :style="{
-                      height: `${percent(point.discussions, maxActivity)}%`,
-                    }"
-                  />
-                  <div
-                    class="bg-orange-500"
-                    :style="{
-                      height: `${percent(point.comments, maxActivity)}%`,
-                    }"
-                  />
-                  <div
-                    class="bg-green-500"
-                    :style="{
-                      height: `${percent(point.events, maxActivity)}%`,
-                    }"
-                  />
-                </div>
-                <span
-                  class="absolute -bottom-9 left-1/2 hidden w-14 origin-top-left -translate-x-1 -rotate-45 whitespace-nowrap text-left text-[10px] leading-none text-gray-500 sm:block"
-                >
-                  {{ formatDateLabel(point.date) }}
-                </span>
-              </div>
-            </div>
-
-            <div
-              class="mt-3 flex flex-wrap gap-4 text-xs text-gray-600 dark:text-gray-300"
-            >
-              <span class="inline-flex items-center gap-1"
-                ><span
-                  class="h-2 w-2 rounded-full bg-blue-500"
-                />Discussions</span
-              >
-              <span class="inline-flex items-center gap-1"
-                ><span
-                  class="h-2 w-2 rounded-full bg-orange-500"
-                />Comments</span
-              >
-              <span class="inline-flex items-center gap-1"
-                ><span class="h-2 w-2 rounded-full bg-green-500" />Events</span
-              >
-            </div>
-          </div>
-
-          <div
-            class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
-          >
-            <div class="mb-4 flex items-center justify-between gap-3">
-              <div>
-                <h2
-                  class="font-semibold text-base !text-gray-900 dark:!text-gray-100"
-                >
-                  Issue Aging
-                </h2>
-                <p class="text-sm text-gray-600 dark:text-gray-300">
-                  Open admin/server-scoped issues by age bucket.
-                </p>
-              </div>
-              <Clock3 class="h-5 w-5 text-gray-400" />
-            </div>
-
-            <div class="space-y-3">
-              <div
-                v-for="bucket in issueAging"
-                :key="bucket.label"
-                class="grid grid-cols-[5rem_minmax(0,1fr)_3rem] items-center gap-3 text-sm"
-              >
-                <span class="font-medium text-gray-700 dark:text-gray-200">
-                  {{ bucket.label }}
-                </span>
-                <div
-                  class="h-3 overflow-hidden rounded-sm bg-gray-100 dark:bg-gray-800"
-                >
-                  <div
-                    class="h-full rounded-sm bg-yellow-500"
-                    :style="{
-                      width: `${barPercent(bucket.count, maxIssueAgeBucket)}%`,
-                    }"
-                  />
-                </div>
-                <span class="text-right text-gray-600 dark:text-gray-300">
-                  {{ bucket.count }}
-                </span>
-              </div>
-            </div>
-          </div>
+          <ServerDashboardActivityChart :time-series="timeSeries" />
+          <ServerDashboardIssueAging :issue-aging="issueAging" />
         </section>
 
-        <section class="space-y-4">
-          <div
-            class="rounded-lg border border-gray-200 bg-white !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
-          >
-            <div
-              class="flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-800"
-            >
-              <div>
-                <h2
-                  class="font-semibold text-base text-gray-900 dark:text-gray-100"
-                >
-                  Channel Health
-                </h2>
-                <p class="text-sm text-gray-600 dark:text-gray-300">
-                  Ranked by activity and moderation load.
-                </p>
-              </div>
-              <MessageSquare class="h-5 w-5 text-gray-400" />
-            </div>
+        <ChannelHealthTable
+          :rows="channelRows"
+          :loading="isChannelHealthLoading"
+          :active-sort-by="activeSortBy"
+          :active-sort-direction="activeSortDirection"
+          @sort="updateChannelSort"
+        />
 
-            <div class="overflow-x-auto">
-              <table
-                class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800"
-              >
-                <thead
-                  class="bg-gray-100 text-left text-xs uppercase text-gray-500 dark:bg-gray-900 dark:text-gray-400"
-                >
-                  <tr>
-                    <th
-                      v-for="column in channelHealthColumns"
-                      :key="column.key"
-                      class="px-4 py-3 font-medium"
-                      :aria-sort="column.ariaSort"
-                      :title="column.title"
-                    >
-                      <button
-                        type="button"
-                        class="inline-flex items-center gap-1 uppercase hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:hover:text-gray-100"
-                        @click="updateChannelSort(column.key)"
-                      >
-                        {{ column.label }}
-                        <component
-                          :is="column.sortIcon"
-                          :class="column.sortIconClass"
-                        />
-                      </button>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
-                  <template v-if="isChannelHealthLoading">
-                    <tr
-                      v-for="index in 5"
-                      :key="`loading-${index}`"
-                      data-testid="channel-health-loading-row"
-                    >
-                      <td class="px-4 py-3">
-                        <div class="flex items-center gap-3">
-                          <div
-                            class="h-8 w-8 animate-pulse rounded-md bg-gray-100 dark:bg-gray-800"
-                          />
-                          <div class="space-y-2">
-                            <div
-                              class="h-3 w-28 animate-pulse rounded bg-gray-100 dark:bg-gray-800"
-                            />
-                            <div
-                              class="h-2 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-800"
-                            />
-                          </div>
-                        </div>
-                      </td>
-                      <td
-                        v-for="columnIndex in 7"
-                        :key="columnIndex"
-                        class="px-4 py-3"
-                      >
-                        <div
-                          class="h-3 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-800"
-                        />
-                      </td>
-                    </tr>
-                  </template>
-                  <template v-else>
-                    <ChannelHealthTableRow
-                      v-for="row in channelRows"
-                      :key="row.id"
-                      :row="row"
-                      :max-activity="maxChannelActivity"
-                      :max-issue-pressure="maxChannelIssuePressure"
-                    />
-                  </template>
-                  <tr
-                    v-if="!isChannelHealthLoading && channelRows.length === 0"
-                  >
-                    <td
-                      colspan="8"
-                      class="px-4 py-8 text-center text-gray-500 dark:text-gray-400"
-                    >
-                      No channel activity in this range.
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          <div class="grid gap-3 sm:grid-cols-2">
-            <div
-              class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
-            >
-              <Download class="mb-3 h-5 w-5 text-gray-400" />
-              <p
-                class="font-semibold text-2xl !text-gray-900 dark:!text-gray-100"
-              >
-                {{ summary?.downloadCount || 0 }}
-              </p>
-              <p class="text-sm text-gray-600 dark:text-gray-300">Downloads</p>
-            </div>
-            <div
-              class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
-            >
-              <Lock class="mb-3 h-5 w-5 text-gray-400" />
-              <p
-                class="font-semibold text-2xl !text-gray-900 dark:!text-gray-100"
-              >
-                {{ summary?.suspensionCount || 0 }}
-              </p>
-              <p class="text-sm text-gray-600 dark:text-gray-300">
-                Suspensions
-              </p>
-            </div>
-          </div>
-        </section>
+        <ServerDashboardSecondaryStats
+          :download-count="dashboard.summary.downloadCount"
+          :suspension-count="dashboard.summary.suspensionCount"
+        />
       </template>
     </ClientOnly>
   </div>

--- a/pages/admin/dashboard.vue
+++ b/pages/admin/dashboard.vue
@@ -40,28 +40,6 @@ type ServerHealthTimeSeriesPoint = {
   moderationActions: number;
 };
 
-type ChannelHealthRow = {
-  id: string;
-  channelUniqueName: string;
-  displayName?: string | null;
-  channelIconURL?: string | null;
-  discussionCount: number;
-  commentCount: number;
-  eventCount: number;
-  downloadCount: number;
-  voteCount: number;
-  uniqueContributorCount: number;
-  openIssueCount: number;
-  issueOpenedCount: number;
-  moderationActionCount: number;
-  archivedContentCount: number;
-  lockedContentCount: number;
-  oldestOpenIssueAgeDays?: number | null;
-  issuesPerHundredContributions: number;
-  activityScore: number;
-  healthLabel: string;
-};
-
 type IssueAgingBucket = {
   label: string;
   minDays: number;
@@ -297,7 +275,7 @@ const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
             v-model="startDate"
             type="date"
             class="rounded-md border-gray-300 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
-          />
+          >
         </label>
         <label
           class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300"
@@ -307,7 +285,7 @@ const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
             v-model="endDate"
             type="date"
             class="rounded-md border-gray-300 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
-          />
+          >
         </label>
         <button
           type="button"

--- a/pages/admin/dashboard.vue
+++ b/pages/admin/dashboard.vue
@@ -2,11 +2,13 @@
 import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useQuery } from '@vue/apollo-composable';
+import ChannelHealthTableRow from '@/components/admin/ChannelHealthTableRow.vue';
 import {
-  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   Archive,
   CalendarDays,
-  CheckCircle2,
   Clock3,
   Download,
   Flag,
@@ -47,6 +49,7 @@ type ServerHealthTimeSeriesPoint = {
 };
 
 type ChannelHealthRow = {
+  id: string;
   channelUniqueName: string;
   displayName?: string | null;
   channelIconURL?: string | null;
@@ -94,6 +97,67 @@ type DashboardData = {
   attentionItems: AttentionItem[];
 };
 
+type ChannelHealthSortKey =
+  | 'channelUniqueName'
+  | 'activityScore'
+  | 'uniqueContributorCount'
+  | 'openIssueCount'
+  | 'issueOpenedCount'
+  | 'oldestOpenIssueAgeDays'
+  | 'issuesPerHundredContributions'
+  | 'moderationActionCount'
+  | 'healthLabel';
+
+type SortDirection = 'asc' | 'desc';
+type SortAria = 'none' | 'ascending' | 'descending';
+
+const defaultSortBy: ChannelHealthSortKey = 'activityScore';
+const defaultSortDirection: SortDirection = 'desc';
+const channelHealthSortKeys = new Set<ChannelHealthSortKey>([
+  'channelUniqueName',
+  'activityScore',
+  'uniqueContributorCount',
+  'openIssueCount',
+  'issueOpenedCount',
+  'oldestOpenIssueAgeDays',
+  'issuesPerHundredContributions',
+  'moderationActionCount',
+  'healthLabel',
+]);
+const channelHealthColumnDefinitions: Array<{
+  key: ChannelHealthSortKey;
+  label: string;
+  title?: string;
+}> = [
+  { key: 'channelUniqueName', label: 'Channel' },
+  { key: 'activityScore', label: 'Activity' },
+  { key: 'uniqueContributorCount', label: 'Contributors' },
+  {
+    key: 'openIssueCount',
+    label: 'Open Issues',
+    title:
+      'Open issues only include admin/server-scoped issues: server-rule reports or issues opened without a channel scope.',
+  },
+  {
+    key: 'issueOpenedCount',
+    label: 'New Issues',
+    title:
+      'New issues only include admin/server-scoped issues in the selected date range.',
+  },
+  {
+    key: 'oldestOpenIssueAgeDays',
+    label: 'Stale Open',
+    title: 'Oldest currently open admin/server-scoped issue for this channel.',
+  },
+  {
+    key: 'issuesPerHundredContributions',
+    label: 'Pressure',
+    title:
+      'New admin/server-scoped issues per 100 discussions, comments, and events in the selected date range.',
+  },
+  { key: 'healthLabel', label: 'Status' },
+];
+
 const toDateInputValue = (date: Date) => date.toISOString().split('T')[0] || '';
 
 const today = new Date();
@@ -111,6 +175,18 @@ const isDateInputValue = (value: string | null): value is string => {
   return !!value && /^\d{4}-\d{2}-\d{2}$/.test(value);
 };
 
+const getSortByFromQuery = (value: unknown): ChannelHealthSortKey => {
+  const sortBy = getQueryString(value);
+  if (sortBy && channelHealthSortKeys.has(sortBy as ChannelHealthSortKey)) {
+    return sortBy as ChannelHealthSortKey;
+  }
+  return defaultSortBy;
+};
+
+const getSortDirectionFromQuery = (value: unknown): SortDirection => {
+  return value === 'asc' || value === 'desc' ? value : defaultSortDirection;
+};
+
 const defaultStartDate = toDateInputValue(defaultStart);
 const defaultEndDate = toDateInputValue(today);
 
@@ -126,10 +202,17 @@ const endDate = ref(
 );
 const channelLimit = ref(20);
 
+const activeSortBy = computed(() => getSortByFromQuery(route.query.sort));
+const activeSortDirection = computed(() =>
+  getSortDirectionFromQuery(route.query.sortDirection)
+);
+
 const dashboardVariables = computed(() => ({
   startDate: startDate.value,
   endDate: endDate.value,
   limit: channelLimit.value,
+  sortBy: activeSortBy.value,
+  sortDirection: activeSortDirection.value,
 }));
 
 watch(
@@ -178,6 +261,14 @@ const dashboard = computed<DashboardData | null>(() => {
   return result.value?.getServerHealthDashboard || null;
 });
 
+const showInitialDashboardSkeleton = computed(() => {
+  return loading.value && !dashboard.value;
+});
+
+const isChannelHealthLoading = computed(() => {
+  return loading.value && !!dashboard.value && channelRows.value.length === 0;
+});
+
 const summary = computed<ServerHealthSummary | null>(() => {
   return dashboard.value?.summary || null;
 });
@@ -200,13 +291,15 @@ const maxActivity = computed(() => {
 });
 
 const maxIssueAgeBucket = computed(() => {
-  const values = dashboard.value?.issueAging.map((bucket) => bucket.count) || [];
+  const values =
+    dashboard.value?.issueAging.map((bucket) => bucket.count) || [];
   return Math.max(...values, 1);
 });
 
 const maxChannelActivity = computed(() => {
   const values =
-    dashboard.value?.channelHealth.map((channel) => channel.activityScore) || [];
+    dashboard.value?.channelHealth.map((channel) => channel.activityScore) ||
+    [];
   return Math.max(...values, 1);
 });
 
@@ -236,10 +329,7 @@ const metricCards = computed(() => {
           : `${Math.round(data.medianOpenIssueAgeDays)}d`,
       detail: 'median open admin issue age',
       icon: Clock3,
-      tone:
-        (data.medianOpenIssueAgeDays || 0) >= 7
-          ? 'yellow'
-          : 'green',
+      tone: (data.medianOpenIssueAgeDays || 0) >= 7 ? 'yellow' : 'green',
     },
     {
       label: 'Mod Actions',
@@ -266,7 +356,6 @@ const metricCards = computed(() => {
 });
 
 const channelRows = computed(() => dashboard.value?.channelHealth || []);
-const attentionItems = computed(() => dashboard.value?.attentionItems || []);
 const issueAging = computed(() => dashboard.value?.issueAging || []);
 const timeSeries = computed(() => dashboard.value?.timeSeries || []);
 
@@ -293,60 +382,59 @@ const barPercent = (value: number, max: number) => {
   return Math.max(4, percent(value, max));
 };
 
-const issuePressureLabel = (row: ChannelHealthRow) => {
-  if (row.issuesPerHundredContributions === 0) return '0';
-  return row.issuesPerHundredContributions.toFixed(1);
+const maxChannelIssuePressure = computed(() => {
+  const values = channelRows.value.map(
+    (channel) => channel.issuesPerHundredContributions
+  );
+  return Math.max(...values, 1);
+});
+
+const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
+  const nextDirection =
+    activeSortBy.value === sortBy && activeSortDirection.value === 'desc'
+      ? 'asc'
+      : 'desc';
+
+  router.replace({
+    query: {
+      ...route.query,
+      sort: sortBy,
+      sortDirection: nextDirection,
+    },
+  });
 };
 
-const issuePressureDescription = (row: ChannelHealthRow) => {
-  return `${issuePressureLabel(row)} new admin/server-scoped issues per 100 contributions in this date range.`;
-};
+const channelHealthColumns = computed(() => {
+  return channelHealthColumnDefinitions.map((column) => {
+    const isActive = activeSortBy.value === column.key;
+    const ariaSort: SortAria = !isActive
+      ? 'none'
+      : activeSortDirection.value === 'asc'
+        ? 'ascending'
+        : 'descending';
+    return {
+      ...column,
+      ariaSort,
+      sortIcon:
+        isActive && activeSortDirection.value === 'asc'
+          ? ArrowUp
+          : isActive
+            ? ArrowDown
+            : ArrowUpDown,
+      sortIconClass: isActive ? 'h-3.5 w-3.5' : 'h-3.5 w-3.5 opacity-50',
+    };
+  });
+});
 
-const healthLabelDescription = (row: ChannelHealthRow) => {
-  if (row.healthLabel === 'Needs review') {
-    return 'Needs review means at least 10 open admin/server-scoped issues, or the oldest open admin/server-scoped issue is at least 14 days old.';
-  }
-  if (row.healthLabel === 'High moderation load') {
-    return 'High moderation load means at least 3 new admin/server-scoped issues and at least 20 new admin/server-scoped issues per 100 contributions in this date range.';
-  }
-  if (row.healthLabel === 'Healthy activity') {
-    return 'Healthy activity means at least 20 contributions and fewer than 5 new admin/server-scoped issues per 100 contributions in this date range.';
-  }
-  if (row.healthLabel === 'Quiet') {
-    return 'Quiet means this channel had no discussions, comments, or events in this date range.';
-  }
-  return 'Active means the channel had activity without crossing the review or high-load thresholds.';
-};
-
-const severityClasses = (severity: string) => {
-  if (severity === 'CRITICAL') {
-    return 'border-red-200 bg-red-100 !text-red-900 dark:border-red-900/60 dark:bg-red-900/30 dark:!text-red-100';
-  }
-  if (severity === 'WARNING') {
-    return 'border-yellow-200 bg-yellow-100 !text-yellow-900 dark:border-yellow-900/60 dark:bg-yellow-900/30 dark:!text-yellow-100';
-  }
-  return 'border-blue-200 bg-blue-100 !text-blue-900 dark:border-blue-900/60 dark:bg-blue-900/30 dark:!text-blue-100';
-};
-
-const healthLabelClasses = (label: string) => {
-  if (label === 'Needs review' || label === 'High moderation load') {
-    return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-100';
-  }
-  if (label === 'Healthy activity') {
-    return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-100';
-  }
-  if (label === 'Quiet') {
-    return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200';
-  }
-  return 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-100';
-};
 </script>
 
 <template>
   <div class="space-y-5 px-2 py-4 dark:text-white md:px-4">
-    <header class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <header
+      class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"
+    >
       <div>
-        <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+        <h1 class="font-semibold text-2xl text-gray-900 dark:text-gray-100">
           Server Dashboard
         </h1>
         <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
@@ -355,21 +443,25 @@ const healthLabelClasses = (label: string) => {
       </div>
 
       <div class="flex flex-wrap items-end gap-3">
-        <label class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300">
+        <label
+          class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300"
+        >
           Start
           <input
             v-model="startDate"
             type="date"
             class="rounded-md border-gray-300 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
-          >
+          />
         </label>
-        <label class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300">
+        <label
+          class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300"
+        >
           End
           <input
             v-model="endDate"
             type="date"
             class="rounded-md border-gray-300 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
-          >
+          />
         </label>
         <button
           type="button"
@@ -391,9 +483,15 @@ const healthLabelClasses = (label: string) => {
             class="h-28 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800"
           />
         </div>
-        <div class="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]">
-          <div class="h-72 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800" />
-          <div class="h-72 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800" />
+        <div
+          class="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
+        >
+          <div
+            class="h-72 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800"
+          />
+          <div
+            class="h-72 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800"
+          />
         </div>
       </template>
 
@@ -404,7 +502,11 @@ const healthLabelClasses = (label: string) => {
         {{ error.message }}
       </div>
 
-      <div v-if="loading && !dashboard" class="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+      <div
+        v-if="showInitialDashboardSkeleton"
+        data-testid="dashboard-initial-loading"
+        class="grid gap-3 md:grid-cols-3 xl:grid-cols-6"
+      >
         <div
           v-for="index in 6"
           :key="index"
@@ -413,304 +515,298 @@ const healthLabelClasses = (label: string) => {
       </div>
 
       <template v-else-if="dashboard">
-      <section class="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
-        <div
-          v-for="card in metricCards"
-          :key="card.label"
-          class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
-        >
-          <div class="flex items-start justify-between gap-3">
-            <div>
-              <p class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
-                {{ card.label }}
-              </p>
-              <p class="mt-2 text-2xl font-semibold !text-gray-900 dark:!text-gray-100">
-                {{ formatNumber(card.value) }}
-              </p>
-            </div>
-            <component
-              :is="card.icon"
-              class="h-5 w-5"
-              :class="{
-                'text-blue-600 dark:text-blue-300': card.tone === 'blue',
-                'text-yellow-600 dark:text-yellow-300': card.tone === 'yellow',
-                'text-green-600 dark:text-green-300': card.tone === 'green',
-                'text-gray-500 dark:text-gray-300': card.tone === 'slate',
-              }"
-            />
-          </div>
-          <p class="mt-3 text-sm text-gray-600 dark:text-gray-300">
-            {{ card.detail }}
-          </p>
-        </div>
-      </section>
-
-      <section class="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]">
-        <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
-          <div class="mb-4 flex items-center justify-between gap-3">
-            <div>
-              <h2 class="text-base font-semibold !text-gray-900 dark:!text-gray-100">
-                Activity
-              </h2>
-              <p class="text-sm text-gray-600 dark:text-gray-300">
-                Discussions, comments, and events by day.
-              </p>
-            </div>
-            <CalendarDays class="h-5 w-5 text-gray-400" />
-          </div>
-
-          <div class="flex h-64 items-end gap-2 overflow-x-auto overflow-y-visible pb-12">
-            <div
-              v-for="point in timeSeries"
-              :key="point.date"
-              class="relative flex min-w-6 flex-1 flex-col items-center justify-end gap-1"
-              :title="`${formatDateLabel(point.date)}: ${point.discussions + point.comments + point.events}`"
-            >
-              <div class="flex h-44 w-full max-w-7 flex-col justify-end overflow-hidden rounded-t bg-gray-100 dark:bg-gray-800">
-                <div
-                  class="bg-blue-500"
-                  :style="{ height: `${percent(point.discussions, maxActivity)}%` }"
-                />
-                <div
-                  class="bg-orange-500"
-                  :style="{ height: `${percent(point.comments, maxActivity)}%` }"
-                />
-                <div
-                  class="bg-green-500"
-                  :style="{ height: `${percent(point.events, maxActivity)}%` }"
-                />
-              </div>
-              <span class="absolute -bottom-9 left-1/2 hidden w-14 origin-top-left -translate-x-1 -rotate-45 whitespace-nowrap text-left text-[10px] leading-none text-gray-500 sm:block">
-                {{ formatDateLabel(point.date) }}
-              </span>
-            </div>
-          </div>
-
-          <div class="mt-3 flex flex-wrap gap-4 text-xs text-gray-600 dark:text-gray-300">
-            <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-blue-500" />Discussions</span>
-            <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-orange-500" />Comments</span>
-            <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-green-500" />Events</span>
-          </div>
-        </div>
-
-        <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
-          <div class="mb-4 flex items-center justify-between gap-3">
-            <div>
-              <h2 class="text-base font-semibold !text-gray-900 dark:!text-gray-100">
-                Issue Aging
-              </h2>
-              <p class="text-sm text-gray-600 dark:text-gray-300">
-                Open admin/server-scoped issues by age bucket.
-              </p>
-            </div>
-            <Clock3 class="h-5 w-5 text-gray-400" />
-          </div>
-
-          <div class="space-y-3">
-            <div
-              v-for="bucket in issueAging"
-              :key="bucket.label"
-              class="grid grid-cols-[5rem_minmax(0,1fr)_3rem] items-center gap-3 text-sm"
-            >
-              <span class="font-medium text-gray-700 dark:text-gray-200">
-                {{ bucket.label }}
-              </span>
-              <div class="h-3 overflow-hidden rounded-sm bg-gray-100 dark:bg-gray-800">
-                <div
-                  class="h-full rounded-sm bg-yellow-500"
-                  :style="{ width: `${barPercent(bucket.count, maxIssueAgeBucket)}%` }"
-                />
-              </div>
-              <span class="text-right text-gray-600 dark:text-gray-300">
-                {{ bucket.count }}
-              </span>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.95fr)]">
-        <div class="rounded-lg border border-gray-200 bg-white !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
-          <div class="flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-800">
-            <div>
-              <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">
-                Channel Health
-              </h2>
-              <p class="text-sm text-gray-600 dark:text-gray-300">
-                Ranked by activity and moderation load.
-              </p>
-            </div>
-            <MessageSquare class="h-5 w-5 text-gray-400" />
-          </div>
-
-          <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800">
-              <thead class="bg-gray-100 text-left text-xs uppercase text-gray-500 dark:bg-gray-900 dark:text-gray-400">
-                <tr>
-                  <th class="px-4 py-3 font-medium">Channel</th>
-                  <th class="px-4 py-3 font-medium">Activity</th>
-                  <th class="px-4 py-3 font-medium">Contributors</th>
-                  <th class="px-4 py-3 font-medium">
-                    <span class="group relative inline-flex">
-                      <button
-                        type="button"
-                        class="cursor-help uppercase underline decoration-dotted underline-offset-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                      >
-                      Issues
-                      </button>
-                      <span class="pointer-events-none absolute left-0 top-full z-20 mt-2 hidden w-64 rounded-md border border-gray-200 bg-white p-2 text-left text-xs normal-case leading-snug text-gray-700 shadow-lg group-focus-within:block group-hover:block dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100">
-                        Open and new issues here only include admin/server-scoped issues: server-rule reports or issues opened without a channel scope.
-                      </span>
-                    </span>
-                  </th>
-                  <th class="px-4 py-3 font-medium">
-                    <span class="group relative inline-flex">
-                      <button
-                        type="button"
-                        class="cursor-help uppercase underline decoration-dotted underline-offset-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                      >
-                      Pressure
-                      </button>
-                      <span class="pointer-events-none absolute right-0 top-full z-20 mt-2 hidden w-64 rounded-md border border-gray-200 bg-white p-2 text-left text-xs normal-case leading-snug text-gray-700 shadow-lg group-focus-within:block group-hover:block dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100">
-                        New admin/server-scoped issues per 100 discussions, comments, and events in the selected date range.
-                      </span>
-                    </span>
-                  </th>
-                  <th class="px-4 py-3 font-medium">Status</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
-                <tr v-for="row in channelRows" :key="row.channelUniqueName">
-                  <td class="px-4 py-3">
-                    <div class="flex items-center gap-3">
-                      <img
-                        v-if="row.channelIconURL"
-                        :src="row.channelIconURL"
-                        alt=""
-                        class="h-8 w-8 rounded-md object-cover"
-                      >
-                      <div v-else class="flex h-8 w-8 items-center justify-center rounded-md bg-gray-100 text-xs font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300">
-                        {{ row.channelUniqueName.slice(0, 2).toUpperCase() }}
-                      </div>
-                      <div>
-                        <nuxt-link
-                          :to="`/forums/${row.channelUniqueName}`"
-                          class="font-medium text-gray-900 hover:underline dark:text-gray-100"
-                        >
-                          {{ row.displayName || row.channelUniqueName }}
-                        </nuxt-link>
-                        <p class="text-xs text-gray-500 dark:text-gray-400">
-                          {{ row.channelUniqueName }}
-                        </p>
-                      </div>
-                    </div>
-                  </td>
-                  <td class="px-4 py-3">
-                    <div class="min-w-32">
-                      <div class="mb-1 flex justify-between text-xs text-gray-500 dark:text-gray-400">
-                        <span>{{ row.activityScore }}</span>
-                        <span>{{ row.voteCount }} votes</span>
-                      </div>
-                      <div class="h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
-                        <div
-                          class="h-full rounded-full bg-blue-500"
-                          :style="{ width: `${percent(row.activityScore, maxChannelActivity)}%` }"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td class="px-4 py-3 text-gray-700 dark:text-gray-200">
-                    {{ row.uniqueContributorCount }}
-                  </td>
-                  <td class="px-4 py-3 text-gray-700 dark:text-gray-200">
-                    <div>{{ row.openIssueCount }} open</div>
-                    <div class="text-xs text-gray-500 dark:text-gray-400">
-                      {{ row.issueOpenedCount }} new this period
-                    </div>
-                  </td>
-                  <td
-                    class="px-4 py-3 text-gray-700 dark:text-gray-200"
-                    :title="issuePressureDescription(row)"
-                  >
-                    {{ issuePressureLabel(row) }}
-                  </td>
-                  <td class="px-4 py-3">
-                    <span
-                      class="inline-flex rounded-full px-2 py-1 text-xs font-medium"
-                      :class="healthLabelClasses(row.healthLabel)"
-                      :title="healthLabelDescription(row)"
-                    >
-                      {{ row.healthLabel }}
-                    </span>
-                  </td>
-                </tr>
-                <tr v-if="channelRows.length === 0">
-                  <td colspan="6" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
-                    No channel activity in this range.
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div class="space-y-4">
-          <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
-            <div class="mb-4 flex items-center justify-between gap-3">
+        <section class="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+          <div
+            v-for="card in metricCards"
+            :key="card.label"
+            class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
+          >
+            <div class="flex items-start justify-between gap-3">
               <div>
-                <h2 class="text-base font-semibold !text-gray-900 dark:!text-gray-100">
-                  Attention
-                </h2>
-                <p class="text-sm text-gray-600 dark:text-gray-300">
-                  Channels with stale or concentrated moderation load.
+                <p
+                  class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400"
+                >
+                  {{ card.label }}
+                </p>
+                <p
+                  class="font-semibold mt-2 text-2xl !text-gray-900 dark:!text-gray-100"
+                >
+                  {{ formatNumber(card.value) }}
                 </p>
               </div>
-              <AlertTriangle class="h-5 w-5 text-yellow-500" />
+              <component
+                :is="card.icon"
+                class="h-5 w-5"
+                :class="{
+                  'text-blue-600 dark:text-blue-300': card.tone === 'blue',
+                  'text-yellow-600 dark:text-yellow-300':
+                    card.tone === 'yellow',
+                  'text-green-600 dark:text-green-300': card.tone === 'green',
+                  'text-gray-500 dark:text-gray-300': card.tone === 'slate',
+                }"
+              />
+            </div>
+            <p class="mt-3 text-sm text-gray-600 dark:text-gray-300">
+              {{ card.detail }}
+            </p>
+          </div>
+        </section>
+
+        <section
+          class="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
+        >
+          <div
+            class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
+          >
+            <div class="mb-4 flex items-center justify-between gap-3">
+              <div>
+                <h2
+                  class="font-semibold text-base !text-gray-900 dark:!text-gray-100"
+                >
+                  Activity
+                </h2>
+                <p class="text-sm text-gray-600 dark:text-gray-300">
+                  Discussions, comments, and events by day.
+                </p>
+              </div>
+              <CalendarDays class="h-5 w-5 text-gray-400" />
             </div>
 
-            <div v-if="attentionItems.length" class="space-y-3">
+            <div
+              class="flex h-64 items-end gap-2 overflow-x-auto overflow-y-visible pb-12"
+            >
               <div
-                v-for="item in attentionItems"
-                :key="`${item.title}-${item.channelUniqueName}-${item.metric}`"
-                class="rounded-md border px-3 py-3"
-                :class="severityClasses(item.severity)"
+                v-for="point in timeSeries"
+                :key="point.date"
+                class="relative flex min-w-6 flex-1 flex-col items-center justify-end gap-1"
+                :title="`${formatDateLabel(point.date)}: ${point.discussions + point.comments + point.events}`"
               >
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <h3 class="text-sm font-semibold !text-current">{{ item.title }}</h3>
-                    <p class="mt-1 text-sm !text-current opacity-90">{{ item.description }}</p>
-                  </div>
-                  <ShieldAlert class="h-4 w-4 shrink-0" />
+                <div
+                  class="flex h-44 w-full max-w-7 flex-col justify-end overflow-hidden rounded-t bg-gray-100 dark:bg-gray-800"
+                >
+                  <div
+                    class="bg-blue-500"
+                    :style="{
+                      height: `${percent(point.discussions, maxActivity)}%`,
+                    }"
+                  />
+                  <div
+                    class="bg-orange-500"
+                    :style="{
+                      height: `${percent(point.comments, maxActivity)}%`,
+                    }"
+                  />
+                  <div
+                    class="bg-green-500"
+                    :style="{
+                      height: `${percent(point.events, maxActivity)}%`,
+                    }"
+                  />
                 </div>
+                <span
+                  class="absolute -bottom-9 left-1/2 hidden w-14 origin-top-left -translate-x-1 -rotate-45 whitespace-nowrap text-left text-[10px] leading-none text-gray-500 sm:block"
+                >
+                  {{ formatDateLabel(point.date) }}
+                </span>
               </div>
             </div>
+
             <div
-              v-else
-              class="flex items-center gap-2 rounded-md border border-green-200 bg-green-100 px-3 py-3 text-sm text-green-800 dark:border-green-900/60 dark:bg-green-900/30 dark:text-green-100"
+              class="mt-3 flex flex-wrap gap-4 text-xs text-gray-600 dark:text-gray-300"
             >
-              <CheckCircle2 class="h-4 w-4" />
-              No attention items in this range.
+              <span class="inline-flex items-center gap-1"
+                ><span
+                  class="h-2 w-2 rounded-full bg-blue-500"
+                />Discussions</span
+              >
+              <span class="inline-flex items-center gap-1"
+                ><span
+                  class="h-2 w-2 rounded-full bg-orange-500"
+                />Comments</span
+              >
+              <span class="inline-flex items-center gap-1"
+                ><span class="h-2 w-2 rounded-full bg-green-500" />Events</span
+              >
             </div>
           </div>
 
-          <div class="grid grid-cols-2 gap-3">
-            <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
+          <div
+            class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
+          >
+            <div class="mb-4 flex items-center justify-between gap-3">
+              <div>
+                <h2
+                  class="font-semibold text-base !text-gray-900 dark:!text-gray-100"
+                >
+                  Issue Aging
+                </h2>
+                <p class="text-sm text-gray-600 dark:text-gray-300">
+                  Open admin/server-scoped issues by age bucket.
+                </p>
+              </div>
+              <Clock3 class="h-5 w-5 text-gray-400" />
+            </div>
+
+            <div class="space-y-3">
+              <div
+                v-for="bucket in issueAging"
+                :key="bucket.label"
+                class="grid grid-cols-[5rem_minmax(0,1fr)_3rem] items-center gap-3 text-sm"
+              >
+                <span class="font-medium text-gray-700 dark:text-gray-200">
+                  {{ bucket.label }}
+                </span>
+                <div
+                  class="h-3 overflow-hidden rounded-sm bg-gray-100 dark:bg-gray-800"
+                >
+                  <div
+                    class="h-full rounded-sm bg-yellow-500"
+                    :style="{
+                      width: `${barPercent(bucket.count, maxIssueAgeBucket)}%`,
+                    }"
+                  />
+                </div>
+                <span class="text-right text-gray-600 dark:text-gray-300">
+                  {{ bucket.count }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="space-y-4">
+          <div
+            class="rounded-lg border border-gray-200 bg-white !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
+          >
+            <div
+              class="flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-800"
+            >
+              <div>
+                <h2
+                  class="font-semibold text-base text-gray-900 dark:text-gray-100"
+                >
+                  Channel Health
+                </h2>
+                <p class="text-sm text-gray-600 dark:text-gray-300">
+                  Ranked by activity and moderation load.
+                </p>
+              </div>
+              <MessageSquare class="h-5 w-5 text-gray-400" />
+            </div>
+
+            <div class="overflow-x-auto">
+              <table
+                class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-800"
+              >
+                <thead
+                  class="bg-gray-100 text-left text-xs uppercase text-gray-500 dark:bg-gray-900 dark:text-gray-400"
+                >
+                  <tr>
+                    <th
+                      v-for="column in channelHealthColumns"
+                      :key="column.key"
+                      class="px-4 py-3 font-medium"
+                      :aria-sort="column.ariaSort"
+                      :title="column.title"
+                    >
+                      <button
+                        type="button"
+                        class="inline-flex items-center gap-1 uppercase hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:hover:text-gray-100"
+                        @click="updateChannelSort(column.key)"
+                      >
+                        {{ column.label }}
+                        <component
+                          :is="column.sortIcon"
+                          :class="column.sortIconClass"
+                        />
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+                  <template v-if="isChannelHealthLoading">
+                    <tr
+                      v-for="index in 5"
+                      :key="`loading-${index}`"
+                      data-testid="channel-health-loading-row"
+                    >
+                      <td class="px-4 py-3">
+                        <div class="flex items-center gap-3">
+                          <div
+                            class="h-8 w-8 animate-pulse rounded-md bg-gray-100 dark:bg-gray-800"
+                          />
+                          <div class="space-y-2">
+                            <div
+                              class="h-3 w-28 animate-pulse rounded bg-gray-100 dark:bg-gray-800"
+                            />
+                            <div
+                              class="h-2 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-800"
+                            />
+                          </div>
+                        </div>
+                      </td>
+                      <td
+                        v-for="columnIndex in 7"
+                        :key="columnIndex"
+                        class="px-4 py-3"
+                      >
+                        <div
+                          class="h-3 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-800"
+                        />
+                      </td>
+                    </tr>
+                  </template>
+                  <template v-else>
+                    <ChannelHealthTableRow
+                      v-for="row in channelRows"
+                      :key="row.id"
+                      :row="row"
+                      :max-activity="maxChannelActivity"
+                      :max-issue-pressure="maxChannelIssuePressure"
+                    />
+                  </template>
+                  <tr
+                    v-if="!isChannelHealthLoading && channelRows.length === 0"
+                  >
+                    <td
+                      colspan="8"
+                      class="px-4 py-8 text-center text-gray-500 dark:text-gray-400"
+                    >
+                      No channel activity in this range.
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="grid gap-3 sm:grid-cols-2">
+            <div
+              class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
+            >
               <Download class="mb-3 h-5 w-5 text-gray-400" />
-              <p class="text-2xl font-semibold !text-gray-900 dark:!text-gray-100">
+              <p
+                class="font-semibold text-2xl !text-gray-900 dark:!text-gray-100"
+              >
                 {{ summary?.downloadCount || 0 }}
               </p>
               <p class="text-sm text-gray-600 dark:text-gray-300">Downloads</p>
             </div>
-            <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
+            <div
+              class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
+            >
               <Lock class="mb-3 h-5 w-5 text-gray-400" />
-              <p class="text-2xl font-semibold !text-gray-900 dark:!text-gray-100">
+              <p
+                class="font-semibold text-2xl !text-gray-900 dark:!text-gray-100"
+              >
                 {{ summary?.suspensionCount || 0 }}
               </p>
-              <p class="text-sm text-gray-600 dark:text-gray-300">Suspensions</p>
+              <p class="text-sm text-gray-600 dark:text-gray-300">
+                Suspensions
+              </p>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
       </template>
     </ClientOnly>
   </div>


### PR DESCRIPTION
## Summary

Adds sortable Channel Health controls to the admin server dashboard and splits the page into smaller section components.

- Adds sortable table headers driven by `sort` and `sortDirection` query params
- Moves stale open issues and issue pressure into Channel Health columns
- Splits the dashboard into focused child components for metric cards, activity, issue aging, channel health, secondary stats, and channel rows
- Splits frontend dashboard data loading into overview and Channel Health queries so sorting the table does not unmount the cards/charts above it

Pairs with backend PR https://github.com/gennit-project/multiforum-backend/pull/107.

## Validation

- `npx vitest run pages/admin/dashboard.spec.ts`
- `npm run tsc` (passes with the existing `vue-router/volar/sfc-route-blocks` warning)