### PR TITLE
Wire up the date-range / expo-hours event schedule mode (#232)

### DIFF
--- a/components/event/form/CreateEvent.spec.ts
+++ b/components/event/form/CreateEvent.spec.ts
@@ -241,4 +241,43 @@ describe('CreateEvent', () => {
 
     expect(Array.isArray(mockMutate.mock.calls[0][0].input)).toBe(true);
   });
+
+  // Date-range mode (#232): one occurrence per day in each range, at that
+  // range's hours.
+  it('expands a date range into one occurrence per day for "dateRange" mode', async () => {
+    // Heard Museum "Lumenous": Dec 16–18, 6–9pm (three nights).
+    await submitWithFormValues({
+      dateMode: 'dateRange',
+      dateRangeGroups: [
+        {
+          startDate: '2030-12-16',
+          endDate: '2030-12-18',
+          startTimeOfDay: '18:00',
+          endTimeOfDay: '21:00',
+        },
+      ],
+    });
+
+    expect(mockMutate.mock.calls[0][0].input.occurrences).toHaveLength(3);
+  });
+
+  it('expands multiple date ranges with distinct per-range hours (expo style)', async () => {
+    // Expo hours: day 1 12:00–19:30; days 2–4 09:00–17:00; day 5 09:00–12:00.
+    await submitWithFormValues({
+      dateMode: 'dateRange',
+      dateRangeGroups: [
+        { startDate: '2030-03-06', endDate: '2030-03-06', startTimeOfDay: '12:00', endTimeOfDay: '19:30' },
+        { startDate: '2030-03-07', endDate: '2030-03-09', startTimeOfDay: '09:00', endTimeOfDay: '17:00' },
+        { startDate: '2030-03-10', endDate: '2030-03-10', startTimeOfDay: '09:00', endTimeOfDay: '12:00' },
+      ],
+    });
+
+    const occ = mockMutate.mock.calls[0][0].input.occurrences;
+    // 1 + 3 + 1 = 5 occurrences, sorted, with the first day's distinct hours.
+    expect({
+      count: occ.length,
+      firstStartHour: occ[0].startTime.slice(11, 16),
+      secondStartHour: occ[1].startTime.slice(11, 16),
+    }).toEqual({ count: 5, firstStartHour: '12:00', secondStartHour: '09:00' });
+  });
 });

--- a/components/event/form/CreateEvent.vue
+++ b/components/event/form/CreateEvent.vue
@@ -13,6 +13,7 @@ import { GET_CHANNEL } from '@/graphQLData/channel/queries';
 import { getTimePieces } from '@/utils';
 import getDefaultEventFormValues from '@/utils/defaultEventFormValues';
 import { generateOccurrences } from '@/utils/generateOccurrences';
+import { expandDateRangeGroups } from '@/utils/expandDateRangeGroups';
 import type { CreateEditEventFormValues, DateOccurrence } from '@/types/Event';
 import type {
   EventCreateInput,
@@ -83,8 +84,9 @@ const eventCreateInput = computed<EventCreateInput>(() => {
 const channelConnections = computed(() => formValues.value.selectedChannels);
 
 // A series is created when the user picks more than a single date. The final
-// occurrence list comes from the manual list ("multiple") or is generated from
-// the repeat pattern ("recurring"). "single" uses the single-event mutation.
+// occurrence list comes from the manual list ("multiple"), is generated from
+// the repeat pattern ("recurring"), or is expanded from date ranges
+// ("dateRange"). "single" uses the single-event mutation.
 const isSeries = computed(() => formValues.value.dateMode !== 'single');
 
 const seriesOccurrences = computed<DateOccurrence[]>(() => {
@@ -94,6 +96,9 @@ const seriesOccurrences = computed<DateOccurrence[]>(() => {
       startTime: formValues.value.startTime,
       endTime: formValues.value.endTime,
     });
+  }
+  if (formValues.value.dateMode === 'dateRange') {
+    return expandDateRangeGroups(formValues.value.dateRangeGroups);
   }
   return formValues.value.occurrences ?? [];
 });

--- a/components/event/form/EventScheduleFields.spec.ts
+++ b/components/event/form/EventScheduleFields.spec.ts
@@ -68,6 +68,13 @@ describe('EventScheduleFields', () => {
     );
   });
 
+  it('renders the date-range mode option', () => {
+    const wrapper = mountFields();
+    expect(wrapper.find('[data-testid="date-mode-dateRange"]').exists()).toBe(
+      true
+    );
+  });
+
   it('emits a date mode change when a different mode is selected', async () => {
     const wrapper = mountFields();
     await wrapper
@@ -119,6 +126,22 @@ describe('EventScheduleFields', () => {
         .trigger('change');
       expect(wrapper.emitted('updateFormValues')?.[1]?.[0]).toMatchObject({
         repeatPattern: expect.objectContaining({ type: 'WEEKLY' }),
+      });
+    });
+
+    it('seeds a date-range group when switching to date-range mode', async () => {
+      const wrapper = mountFields({ dateRangeGroups: [] });
+      await wrapper
+        .get('[data-testid="date-mode-dateRange"]')
+        .find('input')
+        .trigger('change');
+      expect(wrapper.emitted('updateFormValues')?.[1]?.[0]).toMatchObject({
+        dateRangeGroups: [
+          expect.objectContaining({
+            startDate: expect.any(String),
+            startTimeOfDay: expect.any(String),
+          }),
+        ],
       });
     });
   });

--- a/components/event/form/EventScheduleFields.vue
+++ b/components/event/form/EventScheduleFields.vue
@@ -6,10 +6,12 @@ import type {
   CreateEditEventFormValues,
   DateMode,
   DateOccurrence,
+  DateRangeGroup as DateRangeGroupType,
   RepeatPattern,
 } from '@/types/Event';
 import { getDuration } from '@/utils';
 import { generateOccurrences } from '@/utils/generateOccurrences';
+import { expandDateRangeGroups } from '@/utils/expandDateRangeGroups';
 import {
   applyTimeToTimestamp,
   computeStartDateChange,
@@ -18,6 +20,7 @@ import {
 import DateTimePickersRow from './DateTimePickersRow.vue';
 import OccurrencesList from './OccurrencesList.vue';
 import RepeatPatternPicker from './RepeatPatternPicker.vue';
+import DateRangeGroups from './DateRangeGroup.vue';
 import CheckBox from '@/components/CheckBox.vue';
 import ErrorMessage from '@/components/ErrorMessage.vue';
 
@@ -42,6 +45,11 @@ const dateModeOptions = [
     label: 'Recurring',
     value: 'recurring' as DateMode,
     description: 'Repeat pattern',
+  },
+  {
+    label: 'Date ranges',
+    value: 'dateRange' as DateMode,
+    description: 'Ranges with daily hours',
   },
 ];
 
@@ -72,7 +80,48 @@ const updateDateMode = (mode: DateMode) => {
     };
     emit('updateFormValues', { repeatPattern: defaultPattern });
   }
+
+  // Seed a first date-range group when switching to date-range mode.
+  if (mode === 'dateRange' && props.formValues.dateRangeGroups.length === 0) {
+    const today = DateTime.now().toFormat('yyyy-MM-dd');
+    const defaultGroup: DateRangeGroupType = {
+      startDate: today,
+      endDate: today,
+      startTimeOfDay: '09:00',
+      endTimeOfDay: '17:00',
+    };
+    emit('updateFormValues', { dateRangeGroups: [defaultGroup] });
+  }
 };
+
+// Handlers for the DateRangeGroups editor.
+const handleDateRangeGroupUpdate = (
+  index: number,
+  group: DateRangeGroupType
+) => {
+  const newGroups = [...props.formValues.dateRangeGroups];
+  newGroups[index] = group;
+  emit('updateFormValues', { dateRangeGroups: newGroups });
+};
+
+const handleDateRangeGroupAdd = (group: DateRangeGroupType) => {
+  emit('updateFormValues', {
+    dateRangeGroups: [...props.formValues.dateRangeGroups, group],
+  });
+};
+
+const handleDateRangeGroupRemove = (index: number) => {
+  emit('updateFormValues', {
+    dateRangeGroups: props.formValues.dateRangeGroups.filter(
+      (_, i) => i !== index
+    ),
+  });
+};
+
+// How many individual occurrences the current date-range groups expand to.
+const dateRangeOccurrenceCount = computed(
+  () => expandDateRangeGroups(props.formValues.dateRangeGroups).length
+);
 
 // Handlers for OccurrencesList
 const handleOccurrenceUpdate = (index: number, occurrence: DateOccurrence) => {
@@ -398,6 +447,37 @@ const toggleMultiDayEvent = () => {
       <div class="mt-3">
         <CheckBox
           test-id="all-day-input-recurring"
+          :checked="formValues.isAllDay"
+          label="All day events"
+          @update="toggleIsAllDayField"
+        />
+      </div>
+    </div>
+
+    <!-- Date-range mode: one occurrence per day in each range, at that range's
+         hours (supports "expo hours" via multiple ranges). -->
+    <div v-else-if="currentDateMode === 'dateRange'">
+      <DateRangeGroups
+        :groups="formValues.dateRangeGroups"
+        :is-all-day="formValues.isAllDay"
+        @update="handleDateRangeGroupUpdate"
+        @add="handleDateRangeGroupAdd"
+        @remove="handleDateRangeGroupRemove"
+      />
+
+      <p
+        v-if="dateRangeOccurrenceCount > 0"
+        data-testid="date-range-occurrence-count"
+        class="mt-3 text-sm text-gray-600 dark:text-gray-400"
+      >
+        Creates {{ dateRangeOccurrenceCount }}
+        {{ dateRangeOccurrenceCount === 1 ? 'event' : 'events' }}.
+      </p>
+
+      <!-- All-day checkbox for date ranges -->
+      <div class="mt-3">
+        <CheckBox
+          test-id="all-day-input-daterange"
           :checked="formValues.isAllDay"
           label="All day events"
           @update="toggleIsAllDayField"

--- a/types/Event.ts
+++ b/types/Event.ts
@@ -1,6 +1,6 @@
 import type { EventSort } from '@/__generated__/graphql';
 
-export type DateMode = 'single' | 'multiple' | 'recurring';
+export type DateMode = 'single' | 'multiple' | 'recurring' | 'dateRange';
 
 export interface DateOccurrence {
   startTime: string;


### PR DESCRIPTION
Closes #232.

## Summary
The date-range building blocks were already present but dormant — `components/event/form/DateRangeGroup.vue` and `utils/expandDateRangeGroups.ts` (both with their own specs), plus `dateRangeGroups` in the form values. `DateMode` just didn't include `'dateRange'`, so nothing surfaced them. This wires them in (much like #229 connected series creation).

## Change
- **`types/Event.ts`** — `DateMode` gains `'dateRange'`.
- **`EventScheduleFields.vue`** — a "Date ranges" mode that seeds a default group, renders the `DateRangeGroups` editor, shows a "Creates N events" hint, and emits group add/update/remove.
- **`CreateEvent.vue`** — `seriesOccurrences` expands the date-range groups (`expandDateRangeGroups`) into occurrences for the series mutation.

## Covers the issue's examples
- **"Dec 16–18, 6–9pm"** → one date-range group → 3 occurrences. ✅
- **Expo hours** (Wed 12–7:30; Thu–Sat 9–5; Sun 9–12) → multiple groups with **distinct per-range times** → 5 occurrences. ✅
- **"Oct–May, Saturdays 9am–1pm"** → already expressible via the existing **recurring** mode (`WEEKLY` + `daysOfWeek` + `ON_DATE` end). 

## Tests
- `EventScheduleFields.spec.ts` — the date-range option renders; switching seeds a default group.
- `CreateEvent.spec.ts` — a single range expands to 3 occurrences; expo ranges expand to 5 with distinct start hours (12:00 vs 09:00).
- 29 event-form unit tests pass. `DateRangeGroup` + `expandDateRangeGroups` already have their own specs.

> The lone local `tsc` error (`utils/generateOccurrences.ts`, a luxon `DateTime<boolean>` typing issue) is unrelated — it's from the in-progress luxon upgrade in shared `node_modules`, not this branch's pinned deps.

Follow-up: a Playwright submission test for the date-range form could be added alongside the existing `createSeriesEvent.spec.ts` (driving the date/time pickers), but the generation logic is fully unit-covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)