### PR TITLE
Remove broken auth middleware from invite pages

### DIFF
--- a/pages/admin/accept-admin-invite.spec.ts
+++ b/pages/admin/accept-admin-invite.spec.ts
@@ -6,7 +6,8 @@ import { ref } from 'vue';
 import AcceptAdminInvite from './accept-admin-invite.vue';
 
 // Mock definePageMeta globally before importing the component
-vi.stubGlobal('definePageMeta', vi.fn());
+const definePageMetaMock = vi.fn();
+vi.stubGlobal('definePageMeta', definePageMetaMock);
 
 const mockPush = vi.fn();
 const mockMutate = vi.fn();
@@ -46,6 +47,10 @@ describe('accept-admin-invite', () => {
     mockMutate.mockReset();
     mockOnDone.mockReset();
     mockUsernameVar.value = null;
+  });
+
+  it('does not declare a missing auth route middleware', () => {
+    expect(definePageMetaMock).not.toHaveBeenCalled();
   });
 
   it('shows sign in required when not authenticated', () => {

--- a/pages/admin/accept-admin-invite.vue
+++ b/pages/admin/accept-admin-invite.vue
@@ -6,11 +6,6 @@ import { config } from '@/config';
 import { ACCEPT_SERVER_ADMIN_INVITE } from '@/graphQLData/admin/mutations';
 import { useUsername } from '@/composables/useAuthState';
 
-// @ts-ignore - definePageMeta is auto-imported by Nuxt
-definePageMeta({
-  middleware: 'auth',
-});
-
 const usernameVar = useUsername();
 
 const router = useRouter();

--- a/pages/admin/accept-mod-invite.spec.ts
+++ b/pages/admin/accept-mod-invite.spec.ts
@@ -6,7 +6,8 @@ import { ref } from 'vue';
 import AcceptModInvite from './accept-mod-invite.vue';
 
 // Mock definePageMeta globally before importing the component
-vi.stubGlobal('definePageMeta', vi.fn());
+const definePageMetaMock = vi.fn();
+vi.stubGlobal('definePageMeta', definePageMetaMock);
 
 const mockPush = vi.fn();
 const mockMutate = vi.fn();
@@ -50,6 +51,10 @@ describe('accept-mod-invite', () => {
     mockOnDone.mockReset();
     mockUsernameVar.value = null;
     mockModProfileNameVar.value = null;
+  });
+
+  it('does not declare a missing auth route middleware', () => {
+    expect(definePageMetaMock).not.toHaveBeenCalled();
   });
 
   it('shows sign in required when not authenticated', () => {

--- a/pages/admin/accept-mod-invite.vue
+++ b/pages/admin/accept-mod-invite.vue
@@ -6,11 +6,6 @@ import { config } from '@/config';
 import { ACCEPT_SERVER_MOD_INVITE } from '@/graphQLData/admin/mutations';
 import { useUsername, useModProfileName } from '@/composables/useAuthState';
 
-// @ts-ignore - definePageMeta is auto-imported by Nuxt
-definePageMeta({
-  middleware: 'auth',
-});
-
 const usernameVar = useUsername();
 const modProfileNameVar = useModProfileName();
 


### PR DESCRIPTION
## Summary

This PR fixes the admin and moderator invite-acceptance pages that currently throw `Unknown route middleware: 'auth'` on load.

Closes #226.

## What Changed

- removed the nonexistent `middleware: 'auth'` page meta from `pages/admin/accept-admin-invite.vue`
- removed the same nonexistent middleware reference from `pages/admin/accept-mod-invite.vue`
- added regression assertions in both page unit specs that these pages do not declare the missing route middleware

## Why

These pages already handle unauthenticated users in their own render logic by showing a signed-out state. The extra `definePageMeta({ middleware: 'auth' })` layer was not only redundant, it was fatal because there is no `middleware/auth.ts` in the app.

Removing the broken route-middleware declaration restores page initialization while preserving the existing sign-in-required UX.

## Validation

Passed:

- `npm run test:unit:run -- pages/admin/accept-admin-invite.spec.ts pages/admin/accept-mod-invite.spec.ts`

Attempted but blocked locally:

- `npx playwright test tests/playwright/mocked/admin/serverInvites.spec.ts`

The Playwright rerun in this checkout failed before the spec executed because the Nuxt dev webServer could not allocate a random local port (`Unable to find a random port on host "127.0.0.1"`).