### PR TITLE
Fix public profile sidebar query gating

### DIFF
--- a/components/user/UserProfileSidebar.spec.ts
+++ b/components/user/UserProfileSidebar.spec.ts
@@ -5,6 +5,7 @@ import { mount } from '@vue/test-utils';
 import UserProfileSidebar from '@/components/user/UserProfileSidebar.vue';
 
 const h = vi.hoisted(() => ({
+  useQuery: vi.fn(),
   result: null as unknown,
   loading: null as unknown,
   error: null as unknown,
@@ -14,7 +15,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
-  useQuery: () => ({ result: h.result, loading: h.loading, error: h.error }),
+  useQuery: h.useQuery,
 }));
 vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
 vi.mock('@/composables/useAuthState', () => ({
@@ -56,9 +57,25 @@ beforeEach(() => {
   h.route = { params: { username: 'alice' } };
   h.username = ref('bob');
   h.profilePicURL = ref('');
+  h.useQuery.mockImplementation(() => ({
+    result: h.result,
+    loading: h.loading,
+    error: h.error,
+  }));
 });
 
 describe('UserProfileSidebar identity', () => {
+  it('enables the profile query for a logged-out visitor based on the route username', () => {
+    h.username = ref('');
+    mountSidebar();
+
+    const queryOptions = h.useQuery.mock.calls[0]?.[2] as
+      | { enabled?: { value: boolean } }
+      | undefined;
+
+    expect(queryOptions?.enabled?.value).toBe(true);
+  });
+
   it('shows the username when there is no display name', () => {
     h.route = { params: { username: 'alice' } };
     h.username = ref('alice');
@@ -154,9 +171,18 @@ describe('UserProfileSidebar content', () => {
 
   it('shows a loading message', () => {
     h.loading = ref(true);
+    h.result = ref(null);
     const wrapper = mountSidebar();
 
     expect(wrapper.text()).toContain('Loading');
+  });
+
+  it('keeps the last loaded profile data visible during a refetch', () => {
+    h.loading = ref(true);
+    const wrapper = mountSidebar();
+
+    expect(wrapper.text()).toContain('3 comment karma');
+    expect(wrapper.text()).not.toContain('Loading');
   });
 
   it('shows query errors', () => {

--- a/components/user/UserProfileSidebar.vue
+++ b/components/user/UserProfileSidebar.vue
@@ -44,12 +44,12 @@ const {
     username: username.value,
   }),
   {
-    enabled: !!usernameVar.value,
+    enabled: computed(() => !!username.value),
   }
 );
 
 const user = computed(() => {
-  if (getUserLoading.value || getUserError.value) {
+  if (getUserError.value) {
     return null;
   }
   return result.value?.users?.[0] || null;
@@ -168,7 +168,7 @@ const handleReportSuccess = () => {
   </div>
 
   <div class="w-full">
-    <p v-if="getUserLoading">Loading...</p>
+    <p v-if="getUserLoading && !user">Loading...</p>
     <div v-else-if="getUserError">
       <div v-for="(error, i) of getUserError?.graphQLErrors" :key="i">
         {{ error.message }}


### PR DESCRIPTION
## Summary

This PR fixes the profile sidebar so public profile data loads for logged-out visitors and does not disappear during query refetches.

Closes #197.

## What Changed

- changed `UserProfileSidebar` to enable `GET_USER` based on the route username being viewed, not the logged-in viewer username
- stopped clearing `user` whenever the sidebar query enters a loading state; the component now keeps the last successful result visible during refetches and only clears on actual error
- only shows the sidebar loading message when there is no loaded profile data yet
- added regression coverage for anonymous visitors, retained data during refetch, and the existing profile-picture/report behavior

## Why

The sidebar was gating a public profile query on `useUsername()`, which meant logged-out visitors never fetched the viewed user at all. It also returned `null` while loading, so any refetch blanked the sidebar content even when a prior result already existed.

Both behaviors made public profiles look empty and also interfered with the profile-picture reporting path.

## Validation

Passed:

- `npm run test:unit:run -- components/user/UserProfileSidebar.spec.ts`
- `npm run tsc`

Note:

- `npm run tsc` still prints the existing `vue-router/volar/sfc-route-blocks` export-resolution warning in this checkout, but it exits successfully.