### PR TITLE
Admin dashboard and issue enhancements

### DIFF
--- a/components/admin/ChannelHealthTable.vue
+++ b/components/admin/ChannelHealthTable.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { ArrowDown, ArrowUp, ArrowUpDown, MessageSquare } from 'lucide-vue-next';
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  MessageSquare,
+} from 'lucide-vue-next';
 import ChannelHealthTableRow from '@/components/admin/ChannelHealthTableRow.vue';
 
 type ChannelHealthSortKey =
@@ -37,6 +42,7 @@ const props = defineProps<{
   loading: boolean;
   activeSortBy: ChannelHealthSortKey;
   activeSortDirection: SortDirection;
+  detailRouteBase?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -108,6 +114,10 @@ const channelHealthColumns = computed(() => {
     };
   });
 });
+
+const tableColumnCount = computed(() => {
+  return channelHealthColumnDefinitions.length + (props.detailRouteBase ? 1 : 0);
+});
 </script>
 
 <template>
@@ -148,6 +158,12 @@ const channelHealthColumns = computed(() => {
                   />
                 </button>
               </th>
+              <th
+                v-if="detailRouteBase"
+                class="px-4 py-3 text-right font-medium"
+              >
+                <span class="sr-only">Details</span>
+              </th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
@@ -173,6 +189,12 @@ const channelHealthColumns = computed(() => {
                 >
                   <div class="h-3 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
                 </td>
+                <td
+                  v-if="detailRouteBase"
+                  class="px-4 py-3"
+                >
+                  <div class="ml-auto h-8 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+                </td>
               </tr>
             </template>
             <template v-else>
@@ -182,11 +204,12 @@ const channelHealthColumns = computed(() => {
                 :row="row"
                 :max-activity="maxChannelActivity"
                 :max-issue-pressure="maxChannelIssuePressure"
+                :detail-route-base="detailRouteBase"
               />
             </template>
             <tr v-if="!loading && rows.length === 0">
               <td
-                colspan="8"
+                :colspan="tableColumnCount"
                 class="px-4 py-8 text-center text-gray-500 dark:text-gray-400"
               >
                 No channel activity in this range.

--- a/components/admin/ChannelHealthTableRow.vue
+++ b/components/admin/ChannelHealthTableRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { ArrowRight } from 'lucide-vue-next';
 
 type ChannelHealthRow = {
   id: string;
@@ -20,6 +21,7 @@ const props = defineProps<{
   row: ChannelHealthRow;
   maxActivity: number;
   maxIssuePressure: number;
+  detailRouteBase?: string | null;
 }>();
 
 const percent = (value: number, max: number) => {
@@ -38,6 +40,11 @@ const channelInitials = computed(() => {
 
 const forumHref = computed(() => {
   return `/forums/${props.row.channelUniqueName}`;
+});
+
+const detailHref = computed(() => {
+  if (!props.detailRouteBase) return null;
+  return `${props.detailRouteBase}/${encodeURIComponent(props.row.channelUniqueName)}`;
 });
 
 const activityBarWidth = computed(() => {
@@ -222,6 +229,18 @@ const healthLabelClasses = computed(() => {
       >
         {{ row.healthLabel }}
       </span>
+    </td>
+    <td
+      v-if="detailHref"
+      class="px-4 py-3 text-right"
+    >
+      <NuxtLink
+        :to="detailHref"
+        class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-800"
+      >
+        Details
+        <ArrowRight class="h-3.5 w-3.5" />
+      </NuxtLink>
     </td>
   </tr>
 </template>

--- a/components/admin/IssueFilterBar.spec.ts
+++ b/components/admin/IssueFilterBar.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
 import SearchBar from '@/components/SearchBar.vue';
+import { issueSortValues } from '@/utils/issueSortOptions';
 
 const buildWrapper = () => {
   return mount(IssueFilterBar, {
@@ -12,9 +13,17 @@ const buildWrapper = () => {
       startDate: '2026-05-01',
       endDate: '2026-07-01',
       showOnlyServerRuleViolations: true,
+      selectedSort: issueSortValues.NEWEST,
+      selectedSortLabel: 'Newest',
     },
     global: {
       stubs: {
+        TextButtonDropdown: {
+          name: 'TextButtonDropdown',
+          props: ['label', 'items', 'showSortIcon'],
+          emits: ['clicked-item'],
+          template: '<button class="sort-dropdown" @click="$emit(\'clicked-item\', \'oldest\')" />',
+        },
         FilterChip: {
           name: 'FilterChip',
           template: '<div><slot name="icon" /><slot name="content" /></div>',
@@ -69,5 +78,13 @@ describe('IssueFilterBar', () => {
     expect(wrapper.emitted('update:showOnlyServerRuleViolations')).toEqual([
       [false],
     ]);
+  });
+
+  it('emits sort updates', async () => {
+    const wrapper = buildWrapper();
+
+    await wrapper.get('.sort-dropdown').trigger('click');
+
+    expect(wrapper.emitted('update:sort')).toEqual([[issueSortValues.OLDEST]]);
   });
 });

--- a/components/admin/IssueFilterBar.spec.ts
+++ b/components/admin/IssueFilterBar.spec.ts
@@ -22,7 +22,8 @@ const buildWrapper = () => {
           name: 'TextButtonDropdown',
           props: ['label', 'items', 'showSortIcon'],
           emits: ['clicked-item'],
-          template: '<button class="sort-dropdown" @click="$emit(\'clicked-item\', \'oldest\')" />',
+          template:
+            '<button class="text-dropdown" @click="$emit(\'clicked-item\', showSortIcon ? \'oldest\' : \'all\')" />',
         },
         FilterChip: {
           name: 'FilterChip',
@@ -68,12 +69,10 @@ describe('IssueFilterBar', () => {
     expect(wrapper.emitted('toggle-selected-channel')).toEqual([['cats']]);
   });
 
-  it('emits checkbox updates', async () => {
+  it('emits issue scope updates', async () => {
     const wrapper = buildWrapper();
 
-    await wrapper
-      .get('[data-testid="show-only-server-rule-violations"]')
-      .setValue(false);
+    await wrapper.findAll('.text-dropdown')[1].trigger('click');
 
     expect(wrapper.emitted('update:showOnlyServerRuleViolations')).toEqual([
       [false],
@@ -83,7 +82,7 @@ describe('IssueFilterBar', () => {
   it('emits sort updates', async () => {
     const wrapper = buildWrapper();
 
-    await wrapper.get('.sort-dropdown').trigger('click');
+    await wrapper.findAll('.text-dropdown')[0].trigger('click');
 
     expect(wrapper.emitted('update:sort')).toEqual([[issueSortValues.OLDEST]]);
   });

--- a/components/admin/IssueFilterBar.spec.ts
+++ b/components/admin/IssueFilterBar.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
+import SearchBar from '@/components/SearchBar.vue';
+
+const buildWrapper = () => {
+  return mount(IssueFilterBar, {
+    props: {
+      searchInput: 'spam',
+      selectedChannels: ['announcements'],
+      channelLabel: '1 channel',
+      startDate: '2026-05-01',
+      endDate: '2026-07-01',
+      showOnlyServerRuleViolations: true,
+    },
+    global: {
+      stubs: {
+        FilterChip: {
+          name: 'FilterChip',
+          template: '<div><slot name="icon" /><slot name="content" /></div>',
+        },
+        SearchableForumList: {
+          name: 'SearchableForumList',
+          props: ['selectedChannels'],
+          emits: ['toggle-selection'],
+          template: '<button class="forum-list" @click="$emit(\'toggle-selection\', \'cats\')" />',
+        },
+      },
+    },
+  });
+};
+
+describe('IssueFilterBar', () => {
+  it('emits search updates', async () => {
+    const wrapper = buildWrapper();
+
+    await wrapper
+      .getComponent(SearchBar)
+      .vm.$emit('update-search-input', 'needle');
+
+    expect(wrapper.emitted('update-search-input')).toEqual([['needle']]);
+  });
+
+  it('emits date updates', async () => {
+    const wrapper = buildWrapper();
+
+    await wrapper.get('[data-testid="admin-issues-start-date"]').setValue('2026-06-01');
+    await wrapper.get('[data-testid="admin-issues-end-date"]').setValue('2026-06-30');
+
+    expect(wrapper.emitted('update:startDate')).toEqual([['2026-06-01']]);
+    expect(wrapper.emitted('update:endDate')).toEqual([['2026-06-30']]);
+  });
+
+  it('emits selected channel toggles', async () => {
+    const wrapper = buildWrapper();
+
+    await wrapper.get('.forum-list').trigger('click');
+
+    expect(wrapper.emitted('toggle-selected-channel')).toEqual([['cats']]);
+  });
+
+  it('emits checkbox updates', async () => {
+    const wrapper = buildWrapper();
+
+    await wrapper
+      .get('[data-testid="show-only-server-rule-violations"]')
+      .setValue(false);
+
+    expect(wrapper.emitted('update:showOnlyServerRuleViolations')).toEqual([
+      [false],
+    ]);
+  });
+});

--- a/components/admin/IssueFilterBar.vue
+++ b/components/admin/IssueFilterBar.vue
@@ -3,6 +3,8 @@ import SearchBar from '@/components/SearchBar.vue';
 import FilterChip from '@/components/FilterChip.vue';
 import ChannelIcon from '@/components/icons/ChannelIcon.vue';
 import SearchableForumList from '@/components/channel/SearchableForumList.vue';
+import TextButtonDropdown from '@/components/TextButtonDropdown.vue';
+import { issueSortOptions, type IssueSortValue } from '@/utils/issueSortOptions';
 
 defineProps<{
   searchInput: string;
@@ -11,6 +13,8 @@ defineProps<{
   startDate: string;
   endDate: string;
   showOnlyServerRuleViolations: boolean;
+  selectedSort: IssueSortValue;
+  selectedSortLabel: string;
 }>();
 
 const emit = defineEmits<{
@@ -19,6 +23,7 @@ const emit = defineEmits<{
   'update:endDate': [value: string];
   'toggle-selected-channel': [channel: string];
   'update:showOnlyServerRuleViolations': [value: boolean];
+  'update:sort': [value: string];
 }>();
 </script>
 
@@ -68,6 +73,12 @@ const emit = defineEmits<{
       </label>
     </div>
     <div class="flex flex-wrap items-center justify-end gap-2">
+      <TextButtonDropdown
+        :label="selectedSortLabel"
+        :items="issueSortOptions"
+        :show-sort-icon="true"
+        @clicked-item="emit('update:sort', $event)"
+      />
       <FilterChip
         :label="channelLabel"
         :highlighted="selectedChannels.length > 0"

--- a/components/admin/IssueFilterBar.vue
+++ b/components/admin/IssueFilterBar.vue
@@ -1,0 +1,106 @@
+<script lang="ts" setup>
+import SearchBar from '@/components/SearchBar.vue';
+import FilterChip from '@/components/FilterChip.vue';
+import ChannelIcon from '@/components/icons/ChannelIcon.vue';
+import SearchableForumList from '@/components/channel/SearchableForumList.vue';
+
+defineProps<{
+  searchInput: string;
+  selectedChannels: string[];
+  channelLabel: string;
+  startDate: string;
+  endDate: string;
+  showOnlyServerRuleViolations: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update-search-input': [value: string];
+  'update:startDate': [value: string];
+  'update:endDate': [value: string];
+  'toggle-selected-channel': [channel: string];
+  'update:showOnlyServerRuleViolations': [value: boolean];
+}>();
+</script>
+
+<template>
+  <div class="flex flex-col gap-3 px-4 pb-4">
+    <SearchBar
+      :initial-value="searchInput"
+      :search-placeholder="'Search issues'"
+      :test-id="'server-issue-search-input'"
+      :debounce-ms="500"
+      @update-search-input="emit('update-search-input', $event)"
+    />
+    <div class="flex flex-wrap items-end gap-3">
+      <label
+        class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300"
+      >
+        Start
+        <input
+          :value="startDate"
+          type="date"
+          data-testid="admin-issues-start-date"
+          class="rounded-md border-gray-300 px-2 py-1 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
+          @input="
+            emit(
+              'update:startDate',
+              ($event.target as HTMLInputElement).value
+            )
+          "
+        >
+      </label>
+      <label
+        class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300"
+      >
+        End
+        <input
+          :value="endDate"
+          type="date"
+          data-testid="admin-issues-end-date"
+          class="rounded-md border-gray-300 px-2 py-1 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
+          @input="
+            emit(
+              'update:endDate',
+              ($event.target as HTMLInputElement).value
+            )
+          "
+        >
+      </label>
+    </div>
+    <div class="flex flex-wrap items-center justify-end gap-2">
+      <FilterChip
+        :label="channelLabel"
+        :highlighted="selectedChannels.length > 0"
+        data-testid="admin-issues-channel-filter"
+      >
+        <template #icon>
+          <ChannelIcon class="-ml-0.5 mr-2 h-4 w-4" />
+        </template>
+        <template #content>
+          <div class="relative w-96">
+            <SearchableForumList
+              :selected-channels="selectedChannels"
+              @toggle-selection="emit('toggle-selected-channel', $event)"
+            />
+          </div>
+        </template>
+      </FilterChip>
+      <input
+        id="show-only-server-rule-violations"
+        type="checkbox"
+        :checked="showOnlyServerRuleViolations"
+        class="mr-2"
+        data-testid="show-only-server-rule-violations"
+        @change="
+          emit(
+            'update:showOnlyServerRuleViolations',
+            ($event.target as HTMLInputElement).checked
+          )
+        "
+      >
+      <label for="show-only-server-rule-violations" class="mr-2"
+        >Show only server rule violations</label
+      >
+    </div>
+  </div>
+</template>

--- a/components/admin/IssueFilterBar.vue
+++ b/components/admin/IssueFilterBar.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { computed } from 'vue';
 import SearchBar from '@/components/SearchBar.vue';
 import FilterChip from '@/components/FilterChip.vue';
 import ChannelIcon from '@/components/icons/ChannelIcon.vue';
@@ -6,7 +7,7 @@ import SearchableForumList from '@/components/channel/SearchableForumList.vue';
 import TextButtonDropdown from '@/components/TextButtonDropdown.vue';
 import { issueSortOptions, type IssueSortValue } from '@/utils/issueSortOptions';
 
-defineProps<{
+const props = defineProps<{
   searchInput: string;
   selectedChannels: string[];
   channelLabel: string;
@@ -25,6 +26,21 @@ const emit = defineEmits<{
   'update:showOnlyServerRuleViolations': [value: boolean];
   'update:sort': [value: string];
 }>();
+
+const issueScopeOptions = [
+  {
+    label: 'All issues',
+    value: 'all',
+  },
+  {
+    label: 'Server rule violations',
+    value: 'serverRuleViolations',
+  },
+];
+
+const issueScopeLabel = computed(() =>
+  props.showOnlyServerRuleViolations ? 'Server rule violations' : 'All issues'
+);
 </script>
 
 <template>
@@ -79,6 +95,16 @@ const emit = defineEmits<{
         :show-sort-icon="true"
         @clicked-item="emit('update:sort', $event)"
       />
+      <TextButtonDropdown
+        :label="issueScopeLabel"
+        :items="issueScopeOptions"
+        @clicked-item="
+          emit(
+            'update:showOnlyServerRuleViolations',
+            $event === 'serverRuleViolations'
+          )
+        "
+      />
       <FilterChip
         :label="channelLabel"
         :highlighted="selectedChannels.length > 0"
@@ -96,22 +122,6 @@ const emit = defineEmits<{
           </div>
         </template>
       </FilterChip>
-      <input
-        id="show-only-server-rule-violations"
-        type="checkbox"
-        :checked="showOnlyServerRuleViolations"
-        class="mr-2"
-        data-testid="show-only-server-rule-violations"
-        @change="
-          emit(
-            'update:showOnlyServerRuleViolations',
-            ($event.target as HTMLInputElement).checked
-          )
-        "
-      >
-      <label for="show-only-server-rule-violations" class="mr-2"
-        >Show only server rule violations</label
-      >
     </div>
   </div>
 </template>

--- a/components/dashboard/ChannelHealthDetailView.spec.ts
+++ b/components/dashboard/ChannelHealthDetailView.spec.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { useRoute, useRouter } from 'vue-router';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(),
+  useRouter: vi.fn(),
+}));
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+const mockedUseRoute = useRoute as unknown as ReturnType<typeof vi.fn>;
+const mockedUseRouter = useRouter as unknown as ReturnType<typeof vi.fn>;
+
+const dashboardResult = {
+  getServerHealthDashboard: {
+    startDate: '2026-05-27',
+    endDate: '2026-06-26',
+    generatedAt: '2026-06-26T12:00:00Z',
+    summary: {
+      discussionCount: 5,
+      commentCount: 12,
+      eventCount: 1,
+      downloadCount: 3,
+      voteCount: 44,
+      openIssueCount: 4,
+      issueOpenedCount: 6,
+      issueClosedCount: 2,
+      moderationActionCount: 8,
+      archivedContentCount: 1,
+      lockedContentCount: 1,
+      medianOpenIssueAgeDays: 5,
+    },
+    timeSeries: [
+      {
+        date: '2026-06-25',
+        discussions: 2,
+        comments: 6,
+        events: 1,
+        downloads: 1,
+        issuesOpened: 1,
+        moderationActions: 3,
+      },
+    ],
+    channelHealth: [
+      {
+        id: 'general',
+        channelUniqueName: 'general',
+        displayName: 'General',
+        channelIconURL: null,
+        discussionCount: 4,
+        commentCount: 10,
+        eventCount: 1,
+        downloadCount: 2,
+        voteCount: 30,
+        uniqueContributorCount: 6,
+        openIssueCount: 3,
+        issueOpenedCount: 4,
+        moderationActionCount: 5,
+        archivedContentCount: 1,
+        lockedContentCount: 0,
+        oldestOpenIssueAgeDays: 9,
+        issuesPerHundredContributions: 26.6,
+        activityScore: 15,
+        healthLabel: 'Needs review',
+      },
+    ],
+    issueAging: [
+      { label: '<1 day', minDays: 0, maxDays: 0, count: 0 },
+      { label: '8-30 days', minDays: 8, maxDays: 30, count: 3 },
+    ],
+  },
+};
+
+const mountDetail = async () => {
+  const result = ref(dashboardResult);
+  const loading = ref(false);
+  const refetch = vi.fn();
+
+  mockedUseQuery.mockReturnValue({
+    result,
+    loading,
+    error: ref(null),
+    refetch,
+  });
+
+  const Component = (await import('./ChannelHealthDetailView.vue')).default;
+  const wrapper = mount(Component, {
+    props: {
+      channelUniqueName: 'general',
+      audienceLabel: 'Admin dashboard',
+      backHref: '/admin/dashboard',
+      backLabel: 'Back to server dashboard',
+    },
+    global: {
+      stubs: {
+        NuxtLink: {
+          props: ['to'],
+          template: '<a :href="to"><slot /></a>',
+        },
+        ClientOnly: {
+          template: '<slot /><slot name="fallback" />',
+        },
+      },
+    },
+  });
+
+  return { wrapper, refetch };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseRoute.mockReturnValue({
+    query: {
+      startDate: '2026-05-27',
+      endDate: '2026-06-26',
+    },
+  });
+  mockedUseRouter.mockReturnValue({
+    replace: vi.fn(),
+  });
+});
+
+describe('ChannelHealthDetailView', () => {
+  it('queries dashboard data scoped to one channel', async () => {
+    await mountDetail();
+
+    expect(mockedUseQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        value: {
+          startDate: '2026-05-27',
+          endDate: '2026-06-26',
+          channelUniqueNames: ['general'],
+          limit: 1,
+        },
+      }),
+      expect.objectContaining({
+        fetchPolicy: 'cache-and-network',
+        prefetch: false,
+      })
+    );
+  });
+
+  it('renders the scoped metrics and charts', async () => {
+    const { wrapper } = await mountDetail();
+
+    expect(wrapper.text()).toContain('General');
+    expect(wrapper.text()).toContain('Channel health detail for the admin dashboard.');
+    expect(wrapper.text()).toContain('Contributions');
+    expect(wrapper.text()).toContain('15');
+    expect(wrapper.text()).toContain('Issue Aging');
+    expect(wrapper.html()).toContain('href="/admin/dashboard"');
+    expect(wrapper.html()).toContain('href="/forums/general"');
+  });
+
+  it('refetches the scoped dashboard when refresh is clicked', async () => {
+    const { wrapper, refetch } = await mountDetail();
+
+    await wrapper.get('button').trigger('click');
+
+    expect(refetch).toHaveBeenCalledWith({
+      startDate: '2026-05-27',
+      endDate: '2026-06-26',
+      channelUniqueNames: ['general'],
+      limit: 1,
+    });
+  });
+});

--- a/components/dashboard/ChannelHealthDetailView.vue
+++ b/components/dashboard/ChannelHealthDetailView.vue
@@ -1,0 +1,382 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { useRoute, useRouter } from 'vue-router';
+import { ArrowLeft, RefreshCw } from 'lucide-vue-next';
+import ServerDashboardActivityChart from '@/components/admin/ServerDashboardActivityChart.vue';
+import ServerDashboardIssueAging from '@/components/admin/ServerDashboardIssueAging.vue';
+import { GET_SERVER_HEALTH_DASHBOARD } from '@/graphQLData/admin/queries';
+
+type ServerHealthSummary = {
+  discussionCount: number;
+  commentCount: number;
+  eventCount: number;
+  downloadCount: number;
+  voteCount: number;
+  openIssueCount: number;
+  issueOpenedCount: number;
+  issueClosedCount: number;
+  moderationActionCount: number;
+  archivedContentCount: number;
+  lockedContentCount: number;
+  medianOpenIssueAgeDays?: number | null;
+};
+
+type ServerHealthTimeSeriesPoint = {
+  date: string;
+  discussions: number;
+  comments: number;
+  events: number;
+  downloads: number;
+  issuesOpened: number;
+  moderationActions: number;
+};
+
+type IssueAgingBucket = {
+  label: string;
+  minDays: number;
+  maxDays?: number | null;
+  count: number;
+};
+
+type ChannelHealthRow = {
+  id: string;
+  channelUniqueName: string;
+  displayName?: string | null;
+  channelIconURL?: string | null;
+  discussionCount: number;
+  commentCount: number;
+  eventCount: number;
+  downloadCount: number;
+  voteCount: number;
+  uniqueContributorCount: number;
+  openIssueCount: number;
+  issueOpenedCount: number;
+  moderationActionCount: number;
+  archivedContentCount: number;
+  lockedContentCount: number;
+  oldestOpenIssueAgeDays?: number | null;
+  issuesPerHundredContributions: number;
+  activityScore: number;
+  healthLabel: string;
+};
+
+type DashboardData = {
+  startDate: string;
+  endDate: string;
+  generatedAt: string;
+  summary: ServerHealthSummary;
+  timeSeries: ServerHealthTimeSeriesPoint[];
+  channelHealth: ChannelHealthRow[];
+  issueAging: IssueAgingBucket[];
+};
+
+const props = withDefaults(
+  defineProps<{
+    channelUniqueName: string;
+    audienceLabel?: string;
+    backHref?: string | null;
+    backLabel?: string;
+  }>(),
+  {
+    audienceLabel: 'Dashboard',
+    backHref: null,
+    backLabel: 'Back',
+  }
+);
+
+const toDateInputValue = (date: Date) => date.toISOString().split('T')[0] || '';
+
+const route = useRoute();
+const router = useRouter();
+
+const getQueryString = (value: unknown) => {
+  return typeof value === 'string' && value ? value : null;
+};
+
+const isDateInputValue = (value: string | null): value is string => {
+  return !!value && /^\d{4}-\d{2}-\d{2}$/.test(value);
+};
+
+const today = new Date();
+const defaultStart = new Date(today);
+defaultStart.setDate(today.getDate() - 30);
+
+const defaultStartDate = toDateInputValue(defaultStart);
+const defaultEndDate = toDateInputValue(today);
+
+const startDate = ref(
+  isDateInputValue(getQueryString(route.query.startDate))
+    ? getQueryString(route.query.startDate) || defaultStartDate
+    : defaultStartDate
+);
+const endDate = ref(
+  isDateInputValue(getQueryString(route.query.endDate))
+    ? getQueryString(route.query.endDate) || defaultEndDate
+    : defaultEndDate
+);
+
+watch(
+  () => [route.query.startDate, route.query.endDate],
+  ([queryStartDate, queryEndDate]) => {
+    const nextStartDate = getQueryString(queryStartDate);
+    const nextEndDate = getQueryString(queryEndDate);
+
+    if (isDateInputValue(nextStartDate) && nextStartDate !== startDate.value) {
+      startDate.value = nextStartDate;
+    }
+
+    if (isDateInputValue(nextEndDate) && nextEndDate !== endDate.value) {
+      endDate.value = nextEndDate;
+    }
+  }
+);
+
+watch([startDate, endDate], ([nextStartDate, nextEndDate]) => {
+  if (
+    route.query.startDate === nextStartDate &&
+    route.query.endDate === nextEndDate
+  ) {
+    return;
+  }
+
+  router.replace({
+    query: {
+      ...route.query,
+      startDate: nextStartDate,
+      endDate: nextEndDate,
+    },
+  });
+});
+
+const queryVariables = computed(() => ({
+  startDate: startDate.value,
+  endDate: endDate.value,
+  channelUniqueNames: [props.channelUniqueName],
+  limit: 1,
+}));
+
+const { result, loading, error, refetch } = useQuery(
+  GET_SERVER_HEALTH_DASHBOARD,
+  queryVariables,
+  {
+    fetchPolicy: 'cache-and-network',
+    prefetch: false,
+  }
+);
+
+const dashboard = computed<DashboardData | null>(() => {
+  return result.value?.getServerHealthDashboard || null;
+});
+
+const channel = computed<ChannelHealthRow | null>(() => {
+  return dashboard.value?.channelHealth?.[0] || null;
+});
+
+const timeSeries = computed(() => dashboard.value?.timeSeries || []);
+const issueAging = computed(() => dashboard.value?.issueAging || []);
+const showInitialSkeleton = computed(() => loading.value && !dashboard.value);
+
+const contributions = computed(() => {
+  if (!channel.value) return 0;
+  return (
+    channel.value.discussionCount +
+    channel.value.commentCount +
+    channel.value.eventCount
+  );
+});
+
+const summaryCards = computed(() => {
+  if (!channel.value) return [];
+
+  return [
+    {
+      label: 'Contributions',
+      value: contributions.value,
+      detail: `${channel.value.voteCount} votes`,
+    },
+    {
+      label: 'Contributors',
+      value: channel.value.uniqueContributorCount,
+      detail: `${channel.value.activityScore} activity score`,
+    },
+    {
+      label: 'Open Issues',
+      value: channel.value.openIssueCount,
+      detail: `${channel.value.issueOpenedCount} new this period`,
+    },
+    {
+      label: 'Issue Pressure',
+      value:
+        channel.value.issuesPerHundredContributions === 0
+          ? '0'
+          : channel.value.issuesPerHundredContributions.toFixed(1),
+      detail: 'new issues per 100 contributions',
+    },
+    {
+      label: 'Mod Actions',
+      value: channel.value.moderationActionCount,
+      detail: `${channel.value.archivedContentCount} archived`,
+    },
+    {
+      label: 'Stale Open',
+      value:
+        channel.value.oldestOpenIssueAgeDays == null
+          ? 'None'
+          : `${channel.value.oldestOpenIssueAgeDays}d`,
+      detail:
+        dashboard.value?.summary.medianOpenIssueAgeDays == null
+          ? 'median open issue age unavailable'
+          : `${Math.round(dashboard.value.summary.medianOpenIssueAgeDays)}d median open age`,
+    },
+  ];
+});
+
+const detailHeading = computed(() => {
+  return channel.value?.displayName || props.channelUniqueName;
+});
+
+const forumHref = computed(() => `/forums/${props.channelUniqueName}`);
+
+const refreshDashboard = () => {
+  refetch(queryVariables.value);
+};
+</script>
+
+<template>
+  <div class="space-y-5 px-2 py-4 dark:text-white md:px-4">
+    <header
+      class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"
+    >
+      <div>
+        <NuxtLink
+          v-if="backHref"
+          :to="backHref"
+          class="inline-flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+        >
+          <ArrowLeft class="h-4 w-4" />
+          {{ backLabel }}
+        </NuxtLink>
+        <h1 class="mt-2 font-semibold text-2xl text-gray-900 dark:text-gray-100">
+          {{ detailHeading }}
+        </h1>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          Channel health detail for the {{ audienceLabel.toLowerCase() }}.
+        </p>
+        <div
+          v-if="channel"
+          class="mt-3 flex flex-wrap items-center gap-2 text-sm"
+        >
+          <span class="rounded-full bg-blue-100 px-2.5 py-1 font-medium text-blue-800 dark:bg-blue-900/40 dark:text-blue-100">
+            {{ channel.healthLabel }}
+          </span>
+          <span class="text-gray-500 dark:text-gray-400">
+            {{ channel.channelUniqueName }}
+          </span>
+          <a
+            :href="forumHref"
+            class="font-medium text-blue-700 hover:underline dark:text-blue-300"
+          >
+            Open channel
+          </a>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-end gap-3">
+        <label
+          class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300"
+        >
+          Start
+          <input
+            v-model="startDate"
+            type="date"
+            class="rounded-md border-gray-300 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
+          >
+        </label>
+        <label
+          class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300"
+        >
+          End
+          <input
+            v-model="endDate"
+            type="date"
+            class="rounded-md border-gray-300 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
+          >
+        </label>
+        <button
+          type="button"
+          class="inline-flex h-10 items-center gap-2 rounded-md border border-gray-300 px-3 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-800"
+          @click="refreshDashboard"
+        >
+          <RefreshCw class="h-4 w-4" />
+          Refresh
+        </button>
+      </div>
+    </header>
+
+    <ClientOnly>
+      <template #fallback>
+        <div class="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+          <div
+            v-for="index in 6"
+            :key="index"
+            class="h-28 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800"
+          />
+        </div>
+      </template>
+
+      <div
+        v-if="error"
+        class="rounded-md border border-red-200 bg-red-100 px-4 py-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-900/30 dark:text-red-100"
+      >
+        {{ error.message }}
+      </div>
+
+      <div
+        v-if="showInitialSkeleton"
+        data-testid="channel-health-detail-loading"
+        class="grid gap-3 md:grid-cols-3 xl:grid-cols-6"
+      >
+        <div
+          v-for="index in 6"
+          :key="index"
+          class="h-28 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800"
+        />
+      </div>
+
+      <template v-else-if="channel">
+        <section class="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+          <div
+            v-for="card in summaryCards"
+            :key="card.label"
+            class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100"
+          >
+            <p class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+              {{ card.label }}
+            </p>
+            <p class="mt-2 text-2xl font-semibold !text-gray-900 dark:!text-gray-100">
+              {{ card.value }}
+            </p>
+            <p class="mt-3 text-sm text-gray-600 dark:text-gray-300">
+              {{ card.detail }}
+            </p>
+          </div>
+        </section>
+
+        <section
+          class="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
+        >
+          <ServerDashboardActivityChart :time-series="timeSeries" />
+          <ServerDashboardIssueAging :issue-aging="issueAging" />
+        </section>
+      </template>
+
+      <div
+        v-else
+        class="rounded-lg border border-dashed border-gray-300 px-4 py-6 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+      >
+        No channel health data was returned for this channel in the selected range.
+      </div>
+    </ClientOnly>
+  </div>
+</template>

--- a/components/discussion/list/DiscussionFilterBar.vue
+++ b/components/discussion/list/DiscussionFilterBar.vue
@@ -141,7 +141,7 @@ const isExpanded = computed(() => {
         <button
           v-if="showAboutButton"
           type="button"
-          class="hidden items-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-xs font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 md:inline-flex"
+          class="hidden items-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-xs font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 md:inline-flex lg:hidden"
           @click="emit('openAbout')"
         >
           About

--- a/components/discussion/list/SitewideDiscussionList.vue
+++ b/components/discussion/list/SitewideDiscussionList.vue
@@ -250,6 +250,18 @@ const filterByChannel = (channel: string) => {
             class="min-w-0 flex-1 md:px-2 lg:h-[calc(100vh-3.5rem)] lg:basis-0 lg:overflow-y-auto"
           >
             <slot :open-about="() => (isSitewideSidebarOpen = true)" />
+            <div class="mt-2 flex justify-end lg:pr-2">
+              <button
+                v-if="serverConfig"
+                type="button"
+                class="hidden items-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-xs font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 lg:inline-flex"
+                :aria-expanded="isSitewideSidebarOpen"
+                aria-controls="sitewide-sidebar-drawer"
+                @click="isSitewideSidebarOpen = true"
+              >
+                About
+              </button>
+            </div>
             <div
               v-if="
                 discussionLoading && (!discussions || discussions.length === 0)

--- a/components/mod/ModIssueListItem.spec.ts
+++ b/components/mod/ModIssueListItem.spec.ts
@@ -72,6 +72,14 @@ describe('ModIssueListItem content', () => {
 
     expect(wrapper.text()).toContain('by [Deleted]');
   });
+
+  it('uses top-level authorName when present', () => {
+    const wrapper = mountItem({
+      issue: issue({ Author: null, authorName: 'backend-author' }),
+    });
+
+    expect(wrapper.text()).toContain('by backend-author');
+  });
 });
 
 describe('ModIssueListItem badges', () => {
@@ -97,6 +105,14 @@ describe('ModIssueListItem badges', () => {
     const wrapper = mountItem({ issue: issue({ ActivityFeedAggregate: { count: 3 } }) });
 
     expect(wrapper.text()).toContain('3 reports');
+  });
+
+  it('uses top-level reportCount when present', () => {
+    const wrapper = mountItem({
+      issue: issue({ ActivityFeedAggregate: undefined, reportCount: 4 }),
+    });
+
+    expect(wrapper.text()).toContain('4 reports');
   });
 
   it('hides the report badge when the count is zero', () => {
@@ -136,6 +152,19 @@ describe('ModIssueListItem badges', () => {
 
     expect(wrapper.get('[data-testid="issue-channel-tags"]').text()).toContain('cats');
   });
+
+  it('uses top-level channel fields when Channel is absent', () => {
+    const wrapper = mountItem({
+      issue: issue({
+        Channel: null,
+        channelUniqueName: 'dogs',
+        channelIconURL: 'dogs.png',
+      }),
+    });
+
+    expect(wrapper.find('.channel-stack').text()).toContain('dogs');
+    expect(wrapper.get('[data-testid="issue-channel-tags"]').text()).toContain('dogs');
+  });
 });
 
 describe('ModIssueListItem selection', () => {
@@ -154,6 +183,18 @@ describe('ModIssueListItem selection', () => {
 
     // With no Channel the title renders as plain text, not a button.
     expect(wrapper.findAll('button')).toHaveLength(0);
+  });
+
+  it('emits select using top-level channelUniqueName when Channel is absent', async () => {
+    const wrapper = mountItem({
+      issue: issue({ Channel: null, channelUniqueName: 'dogs' }),
+    });
+
+    await selectButton(wrapper).trigger('click');
+
+    expect(wrapper.emitted('select')?.[0]).toEqual([
+      { issueNumber: 7, title: 'A reported thing', channelId: 'dogs' },
+    ]);
   });
 
   it('highlights the selected issue', () => {

--- a/components/mod/ModIssueListItem.vue
+++ b/components/mod/ModIssueListItem.vue
@@ -9,6 +9,10 @@ import TagComponent from '@/components/TagComponent.vue';
 type Issue = GeneratedIssue & {
   issueNumber: number;
   locked?: boolean | null;
+  channelUniqueName?: string | null;
+  channelIconURL?: string | null;
+  authorName?: string | null;
+  reportCount?: number | null;
 };
 
 const props = defineProps({
@@ -39,6 +43,10 @@ const formatDate = (date: string) => {
 };
 
 const issueAuthorName = (issue: Issue) => {
+  if (issue.authorName) {
+    return issue.authorName;
+  }
+
   if (issue.Author?.__typename === 'ModerationProfile') {
     return issue.Author.displayName || '[Deleted]';
   }
@@ -51,7 +59,8 @@ const issueAuthorName = (issue: Issue) => {
 };
 
 const reportCount = computed(() => {
-  const count = props.issue?.ActivityFeedAggregate?.count;
+  const count =
+    props.issue?.reportCount ?? props.issue?.ActivityFeedAggregate?.count;
   return typeof count === 'number' ? count : null;
 });
 
@@ -61,11 +70,13 @@ const reportCountLabel = computed(() => {
 });
 
 const handleSelect = () => {
-  if (!props.issue?.issueNumber || !props.issue.Channel?.uniqueName) return;
+  const channelId =
+    props.issue.Channel?.uniqueName || props.issue.channelUniqueName;
+  if (!props.issue?.issueNumber || !channelId) return;
   emit('select', {
     issueNumber: props.issue.issueNumber,
     title: props.issue.title || '',
-    channelId: props.issue.Channel.uniqueName,
+    channelId,
   });
 };
 
@@ -84,11 +95,15 @@ const isRelatedToWiki = computed(() => {
 });
 
 const relatedChannels = computed(() => {
-  if (props.issue?.Channel?.uniqueName) {
+  const uniqueName =
+    props.issue?.Channel?.uniqueName || props.issue?.channelUniqueName;
+
+  if (uniqueName) {
     return [
       {
-        uniqueName: props.issue.Channel.uniqueName,
-        iconURL: props.issue.Channel.channelIconURL || '',
+        uniqueName,
+        iconURL:
+          props.issue.Channel?.channelIconURL || props.issue.channelIconURL || '',
       },
     ];
   }
@@ -125,7 +140,10 @@ const relatedChannelNames = computed(() =>
       />
 
       <div class="flex-col">
-        <span v-if="issue.Channel" class="flex flex-wrap items-center gap-2">
+        <span
+          v-if="issue.Channel || issue.channelUniqueName"
+          class="flex flex-wrap items-center gap-2"
+        >
           <nuxt-link
             v-if="issue.issueNumber"
             class="hover:underline dark:text-gray-200 lg:hidden"
@@ -133,7 +151,7 @@ const relatedChannelNames = computed(() =>
               name: 'forums-forumId-issues-issueNumber',
               params: {
                 issueNumber: issue.issueNumber,
-                forumId: issue.Channel?.uniqueName,
+                forumId: issue.Channel?.uniqueName || issue.channelUniqueName,
               },
             }"
             @click="handleSelect"
@@ -220,7 +238,7 @@ const relatedChannelNames = computed(() =>
           {{
             `Opened on ${formatDate(issue.createdAt)} by ${issueAuthorName(
               issue
-            )} in ${issue.Channel?.uniqueName || '[Deleted]'}`
+            )} in ${issue.Channel?.uniqueName || issue.channelUniqueName || '[Deleted]'}`
           }}
         </div>
       </div>

--- a/graphQLData/issue/queries.js
+++ b/graphQLData/issue/queries.js
@@ -354,8 +354,8 @@ export const GET_CLOSED_ISSUES_BY_CHANNEL = gql`
 `;
 
 export const GET_ISSUES = gql`
-  query getIssues($issueWhere: IssueWhere, $issueSort: [IssueSort!]) {
-    issues(where: $issueWhere, options: { sort: $issueSort }) {
+  query getIssues($issueWhere: IssueWhere) {
+    issues(where: $issueWhere, options: { sort: { createdAt: DESC } }) {
       id
       issueNumber
       title
@@ -392,6 +392,53 @@ export const GET_ISSUES = gql`
       }
       ActivityFeedAggregate(where: { actionType: "report" }) {
         count
+      }
+    }
+  }
+`;
+
+export const GET_SITE_WIDE_ISSUE_LIST = gql`
+  query getSiteWideIssueList(
+    $searchInput: String
+    $selectedChannels: [String!]
+    $startDate: String
+    $endDate: String
+    $showOnlyServerRuleViolations: Boolean
+    $isOpen: Boolean!
+    $options: IssueListOptions
+  ) {
+    getSiteWideIssueList(
+      searchInput: $searchInput
+      selectedChannels: $selectedChannels
+      startDate: $startDate
+      endDate: $endDate
+      showOnlyServerRuleViolations: $showOnlyServerRuleViolations
+      isOpen: $isOpen
+      options: $options
+    ) {
+      aggregateIssueCount
+      issues {
+        id
+        issueNumber
+        title
+        body
+        isOpen
+        createdAt
+        updatedAt
+        relatedCommentId
+        relatedDiscussionId
+        relatedEventId
+        relatedImageId
+        relatedWikiPageId
+        relatedWikiRevisionId
+        relatedUsername
+        flaggedServerRuleViolation
+        locked
+        lockReason
+        channelUniqueName
+        channelIconURL
+        authorName
+        reportCount
       }
     }
   }

--- a/graphQLData/issue/queries.js
+++ b/graphQLData/issue/queries.js
@@ -354,8 +354,8 @@ export const GET_CLOSED_ISSUES_BY_CHANNEL = gql`
 `;
 
 export const GET_ISSUES = gql`
-  query getIssues($issueWhere: IssueWhere) {
-    issues(where: $issueWhere, options: { sort: { createdAt: DESC } }) {
+  query getIssues($issueWhere: IssueWhere, $issueSort: [IssueSort!]) {
+    issues(where: $issueWhere, options: { sort: $issueSort }) {
       id
       issueNumber
       title

--- a/graphQLData/mod/queries.js
+++ b/graphQLData/mod/queries.js
@@ -11,8 +11,8 @@ export const COUNT_OPEN_ISSUES = gql`
 `;
 
 export const SERVER_SCOPED_ISSUE_COUNT = gql`
-  query countIssuesByServer {
-    issuesAggregate(where: { isOpen: true }) {
+  query countIssuesByServer($issueWhere: IssueWhere) {
+    issuesAggregate(where: $issueWhere) {
       count
     }
   }
@@ -29,8 +29,8 @@ export const COUNT_CLOSED_ISSUES = gql`
 `;
 
 export const SERVER_SCOPED_CLOSED_ISSUE_COUNT = gql`
-  query countClosedIssuesByServer {
-    issuesAggregate(where: { isOpen: false }) {
+  query countClosedIssuesByServer($issueWhere: IssueWhere) {
+    issuesAggregate(where: $issueWhere) {
       count
     }
   }

--- a/pages/admin/dashboard.spec.ts
+++ b/pages/admin/dashboard.spec.ts
@@ -128,13 +128,13 @@ const mountDashboard = async (
     error: ref(null),
     refetch: refetchChannelHealth,
   });
-  const Page = (await import('./dashboard.vue')).default;
+  const Page = (await import('./dashboard/index.vue')).default;
   const wrapper = mount(Page, {
     global: {
       stubs: {
         NuxtLink: {
           props: ['to'],
-          template: '<a><slot /></a>',
+          template: '<a :href="to"><slot /></a>',
         },
       },
     },
@@ -185,6 +185,7 @@ describe('admin dashboard page', () => {
     expect(wrapper.text()).toContain('Pressure');
     expect(wrapper.text()).toContain('9d');
     expect(wrapper.text()).toContain('26.6');
+    expect(wrapper.html()).toContain('href="/admin/dashboard/general"');
   });
 
   it('updates query params when sorting the channel health table', async () => {

--- a/pages/admin/dashboard/[channelUniqueName].vue
+++ b/pages/admin/dashboard/[channelUniqueName].vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import ChannelHealthDetailView from '@/components/dashboard/ChannelHealthDetailView.vue';
+
+const route = useRoute();
+
+const channelUniqueName = computed(() => {
+  const value = route.params.channelUniqueName;
+  return typeof value === 'string' ? value : '';
+});
+</script>
+
+<template>
+  <ChannelHealthDetailView
+    :channel-unique-name="channelUniqueName"
+    audience-label="Admin dashboard"
+    back-href="/admin/dashboard"
+    back-label="Back to server dashboard"
+  />
+</template>

--- a/pages/admin/dashboard/index.vue
+++ b/pages/admin/dashboard/index.vue
@@ -353,6 +353,7 @@ const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
           :loading="isChannelHealthLoading"
           :active-sort-by="activeSortBy"
           :active-sort-direction="activeSortDirection"
+          detail-route-base="/admin/dashboard"
           @sort="updateChannelSort"
         />
 

--- a/pages/admin/issues.spec.ts
+++ b/pages/admin/issues.spec.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 
+const h = vi.hoisted(() => ({
+  routeName: 'admin-issues',
+  query: {
+    showOnlyServerRuleViolations: '',
+    searchInput: '',
+  } as Record<string, string>,
+}));
+
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({ name: 'admin-issues' }),
+  useRoute: () => ({ name: h.routeName, query: h.query }),
   useRouter: () => ({ push: vi.fn() }),
 }));
 
@@ -42,7 +50,45 @@ const mountPage = async (open: number, closed: number) => {
   });
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.routeName = 'admin-issues';
+  h.query.showOnlyServerRuleViolations = '';
+  h.query.searchInput = '';
+  delete h.query.startDate;
+  delete h.query.endDate;
+  delete h.query.channels;
+});
+
 describe('admin issues layout page', () => {
+  it('passes the current date filters into the open count query', async () => {
+    h.query.startDate = '2026-05-01';
+    h.query.endDate = '2026-07-01';
+
+    await mountPage(5, 3);
+
+    expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).toMatchObject({
+      isOpen: true,
+      flaggedServerRuleViolation: true,
+      createdAt_GTE: '2026-05-01T00:00:00.000Z',
+      createdAt_LTE: '2026-07-01T23:59:59.999Z',
+    });
+  });
+
+  it('omits date bounds from the count query when no dates are set', async () => {
+    delete h.query.startDate;
+    delete h.query.endDate;
+
+    await mountPage(5, 3);
+
+    expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).not.toHaveProperty(
+      'createdAt_GTE'
+    );
+    expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).not.toHaveProperty(
+      'createdAt_LTE'
+    );
+  });
+
   it('shows the open issue count from the aggregate', async () => {
     const wrapper = await mountPage(5, 3);
     expect(wrapper.text()).toContain('5 Open');

--- a/pages/admin/issues.vue
+++ b/pages/admin/issues.vue
@@ -8,20 +8,40 @@ import {
 } from '@/graphQLData/mod/queries';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import PrimaryButton from '@/components/PrimaryButton.vue';
+import { buildServerIssueWhere } from '@/utils/serverIssueFilters';
+import { getServerIssueFilterValuesFromParams } from '@/utils/getServerIssueFilterValuesFromParams';
 
 const route = useRoute();
 const router = useRouter();
+const filterValues = computed(() =>
+  getServerIssueFilterValuesFromParams({ route })
+);
+
+const openCountVariables = computed(() => ({
+  issueWhere: buildServerIssueWhere({
+    ...filterValues.value,
+    isOpen: true,
+  }),
+}));
+
+const closedCountVariables = computed(() => ({
+  issueWhere: buildServerIssueWhere({
+    ...filterValues.value,
+    isOpen: false,
+  }),
+}));
+
 const {
   result: issuesResult,
   error: issuesError,
   loading: issuesLoading,
-} = useQuery(SERVER_SCOPED_ISSUE_COUNT);
+} = useQuery(SERVER_SCOPED_ISSUE_COUNT, openCountVariables);
 
 const {
   result: closedIssuesResult,
   error: closedIssuesError,
   loading: closedIssuesLoading,
-} = useQuery(SERVER_SCOPED_CLOSED_ISSUE_COUNT);
+} = useQuery(SERVER_SCOPED_CLOSED_ISSUE_COUNT, closedCountVariables);
 
 const openCount = computed(() => {
   if (issuesLoading.value || issuesError.value) {

--- a/pages/admin/issues/index.spec.ts
+++ b/pages/admin/issues/index.spec.ts
@@ -3,6 +3,7 @@ import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
+import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
 
 const h = vi.hoisted(() => ({
   query: {
@@ -64,11 +65,24 @@ const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
   return shallowMount(Page, {
     global: {
       stubs: {
-        SearchBar: {
-          name: 'SearchBar',
-          emits: ['update-search-input'],
-          template:
-            '<button class="search-bar" @click="$emit(\'update-search-input\', \'needle\')" />',
+        IssueFilterBar: {
+          name: 'IssueFilterBar',
+          props: [
+            'searchInput',
+            'selectedChannels',
+            'channelLabel',
+            'startDate',
+            'endDate',
+            'showOnlyServerRuleViolations',
+          ],
+          emits: [
+            'update-search-input',
+            'toggle-selected-channel',
+            'update:startDate',
+            'update:endDate',
+            'update:showOnlyServerRuleViolations',
+          ],
+          template: '<div class="issue-filter-bar" />',
         },
         ModIssueListItem: {
           name: 'ModIssueListItem',
@@ -93,32 +107,26 @@ beforeEach(() => {
 });
 
 describe('admin server issues index page', () => {
-  it('defaults the server-rule-violations checkbox to checked', async () => {
+  it('passes the default server-rule-violations state to the filter bar', async () => {
     const wrapper = await mountWith({ issues: [] });
     expect(
-      (
-        wrapper.get('[data-testid="show-only-server-rule-violations"]')
-          .element as HTMLInputElement
-      ).checked
+      wrapper.getComponent(IssueFilterBar).props('showOnlyServerRuleViolations')
     ).toBe(true);
   });
 
-  it('unchecks the filter when the query opts out', async () => {
+  it('passes the opt-out server-rule-violations state to the filter bar', async () => {
     h.query.showOnlyServerRuleViolations = 'false';
     const wrapper = await mountWith({ issues: [] });
     expect(
-      (
-        wrapper.get('[data-testid="show-only-server-rule-violations"]')
-          .element as HTMLInputElement
-      ).checked
+      wrapper.getComponent(IssueFilterBar).props('showOnlyServerRuleViolations')
     ).toBe(false);
   });
 
-  it('updates the filters when the checkbox changes', async () => {
+  it('updates the filters when the checkbox value changes', async () => {
     const wrapper = await mountWith({ issues: [] });
     await wrapper
-      .get('[data-testid="show-only-server-rule-violations"]')
-      .setValue(false);
+      .getComponent(IssueFilterBar)
+      .vm.$emit('update:showOnlyServerRuleViolations', false);
     expect(h.updateFilters).toHaveBeenCalledWith({
       router: { push: h.routerPush, replace: h.routerReplace },
       route: { params: { forumId: '' }, path: '/admin/issues', query: h.query },
@@ -128,7 +136,9 @@ describe('admin server issues index page', () => {
 
   it('updates the filters when the search bar emits a new value', async () => {
     const wrapper = await mountWith({ issues: [] });
-    await wrapper.get('.search-bar').trigger('click');
+    await wrapper
+      .getComponent(IssueFilterBar)
+      .vm.$emit('update-search-input', 'needle');
     expect(h.updateFilters).toHaveBeenCalledWith({
       router: { push: h.routerPush, replace: h.routerReplace },
       route: { params: { forumId: '' }, path: '/admin/issues', query: h.query },
@@ -182,5 +192,25 @@ describe('admin server issues index page', () => {
     expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).not.toHaveProperty(
       'createdAt_LTE'
     );
+  });
+
+  it('updates the route filters when the start and end dates change', async () => {
+    const wrapper = await mountWith({ issues: [] });
+
+    await wrapper
+      .getComponent(IssueFilterBar)
+      .vm.$emit('update:startDate', '2026-05-01');
+    await wrapper
+      .getComponent(IssueFilterBar)
+      .vm.$emit('update:endDate', '2026-07-01');
+
+    expect(h.updateFilters).toHaveBeenLastCalledWith({
+      router: { push: h.routerPush, replace: h.routerReplace },
+      route: { params: { forumId: '' }, path: '/admin/issues', query: h.query },
+      params: {
+        startDate: '2026-05-01',
+        endDate: '2026-07-01',
+      },
+    });
   });
 });

--- a/pages/admin/issues/index.spec.ts
+++ b/pages/admin/issues/index.spec.ts
@@ -8,8 +8,6 @@ const h = vi.hoisted(() => ({
   query: {
     showOnlyServerRuleViolations: '',
     searchInput: '',
-    startDate: '2026-05-27',
-    endDate: '2026-06-26',
   } as Record<string, string>,
   routerPush: vi.fn(),
   routerReplace: vi.fn(),
@@ -88,8 +86,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.query.showOnlyServerRuleViolations = '';
   h.query.searchInput = '';
-  h.query.startDate = '2026-05-27';
-  h.query.endDate = '2026-06-26';
+  delete h.query.startDate;
+  delete h.query.endDate;
   delete h.query.channels;
   h.selectedIssueNumber.value = null;
 });
@@ -167,10 +165,22 @@ describe('admin server issues index page', () => {
   });
 
   it('passes the selected date range into the issues query variables', async () => {
+    h.query.startDate = '2026-05-27';
+    h.query.endDate = '2026-06-26';
     await mountWith({ issues: [] });
     expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).toMatchObject({
       createdAt_GTE: '2026-05-27T00:00:00.000Z',
       createdAt_LTE: '2026-06-26T23:59:59.999Z',
     });
+  });
+
+  it('omits date bounds when no date filters are set', async () => {
+    await mountWith({ issues: [] });
+    expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).not.toHaveProperty(
+      'createdAt_GTE'
+    );
+    expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).not.toHaveProperty(
+      'createdAt_LTE'
+    );
   });
 });

--- a/pages/admin/issues/index.spec.ts
+++ b/pages/admin/issues/index.spec.ts
@@ -4,11 +4,13 @@ import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
 import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
+import { issueSortValues } from '@/utils/issueSortOptions';
 
 const h = vi.hoisted(() => ({
   query: {
     showOnlyServerRuleViolations: '',
     searchInput: '',
+    sort: '',
   } as Record<string, string>,
   routerPush: vi.fn(),
   routerReplace: vi.fn(),
@@ -74,6 +76,8 @@ const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
             'startDate',
             'endDate',
             'showOnlyServerRuleViolations',
+            'selectedSort',
+            'selectedSortLabel',
           ],
           emits: [
             'update-search-input',
@@ -81,6 +85,7 @@ const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
             'update:startDate',
             'update:endDate',
             'update:showOnlyServerRuleViolations',
+            'update:sort',
           ],
           template: '<div class="issue-filter-bar" />',
         },
@@ -100,6 +105,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.query.showOnlyServerRuleViolations = '';
   h.query.searchInput = '';
+  h.query.sort = '';
   delete h.query.startDate;
   delete h.query.endDate;
   delete h.query.channels;
@@ -146,6 +152,28 @@ describe('admin server issues index page', () => {
     });
   });
 
+  it('passes the default sort state to the filter bar', async () => {
+    const wrapper = await mountWith({ issues: [] });
+    expect(wrapper.getComponent(IssueFilterBar).props('selectedSort')).toBe(
+      issueSortValues.NEWEST
+    );
+    expect(wrapper.getComponent(IssueFilterBar).props('selectedSortLabel')).toBe(
+      'Newest'
+    );
+  });
+
+  it('updates the route filters when the sort changes', async () => {
+    const wrapper = await mountWith({ issues: [] });
+    await wrapper
+      .getComponent(IssueFilterBar)
+      .vm.$emit('update:sort', issueSortValues.OLDEST);
+    expect(h.updateFilters).toHaveBeenCalledWith({
+      router: { push: h.routerPush, replace: h.routerReplace },
+      route: { params: { forumId: '' }, path: '/admin/issues', query: h.query },
+      params: { sort: issueSortValues.OLDEST },
+    });
+  });
+
   it('renders an item per issue', async () => {
     const wrapper = await mountWith({ issues: [{ id: 'i1' }, { id: 'i2' }] });
     expect(wrapper.findAllComponents(ModIssueListItem)).toHaveLength(2);
@@ -184,6 +212,14 @@ describe('admin server issues index page', () => {
     });
   });
 
+  it('passes the selected sort into the issues query variables', async () => {
+    h.query.sort = issueSortValues.OLDEST;
+    await mountWith({ issues: [] });
+    expect(mockedUseQuery.mock.calls[0][1].value.issueSort).toEqual([
+      { createdAt: 'ASC' },
+    ]);
+  });
+
   it('omits date bounds when no date filters are set', async () => {
     await mountWith({ issues: [] });
     expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).not.toHaveProperty(
@@ -212,5 +248,29 @@ describe('admin server issues index page', () => {
         endDate: '2026-07-01',
       },
     });
+  });
+
+  it('sorts issues by most reports when selected', async () => {
+    h.query.sort = issueSortValues.MOST_REPORTS;
+    const wrapper = await mountWith({
+      issues: [
+        {
+          id: 'a',
+          ActivityFeedAggregate: { count: 1 },
+          createdAt: '2026-06-01T00:00:00.000Z',
+        },
+        {
+          id: 'b',
+          ActivityFeedAggregate: { count: 3 },
+          createdAt: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(
+      wrapper
+        .findAllComponents(ModIssueListItem)
+        .map((item) => item.props('issue').id)
+    ).toEqual(['b', 'a']);
   });
 });

--- a/pages/admin/issues/index.spec.ts
+++ b/pages/admin/issues/index.spec.ts
@@ -58,7 +58,7 @@ const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
   const { loading = false, issues = [] } = opts;
   mockedUseQuery.mockReturnValue({
-    result: ref({ issues }),
+    result: ref({ getSiteWideIssueList: { issues } }),
     error: ref(null),
     loading: ref(loading),
     refetch: h.refetch,
@@ -197,37 +197,31 @@ describe('admin server issues index page', () => {
   it('passes the selected channel filter into the issues query variables', async () => {
     h.query.channels = 'announcements';
     await mountWith({ issues: [] });
-    expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).toMatchObject({
-      channelUniqueName_IN: ['announcements'],
-    });
+    expect(mockedUseQuery.mock.calls[0][1].value.selectedChannels).toEqual([
+      'announcements',
+    ]);
   });
 
   it('passes the selected date range into the issues query variables', async () => {
     h.query.startDate = '2026-05-27';
     h.query.endDate = '2026-06-26';
     await mountWith({ issues: [] });
-    expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).toMatchObject({
-      createdAt_GTE: '2026-05-27T00:00:00.000Z',
-      createdAt_LTE: '2026-06-26T23:59:59.999Z',
-    });
+    expect(mockedUseQuery.mock.calls[0][1].value.startDate).toBe('2026-05-27');
+    expect(mockedUseQuery.mock.calls[0][1].value.endDate).toBe('2026-06-26');
   });
 
   it('passes the selected sort into the issues query variables', async () => {
     h.query.sort = issueSortValues.OLDEST;
     await mountWith({ issues: [] });
-    expect(mockedUseQuery.mock.calls[0][1].value.issueSort).toEqual([
-      { createdAt: 'ASC' },
-    ]);
+    expect(mockedUseQuery.mock.calls[0][1].value.options).toEqual({
+      sort: issueSortValues.OLDEST,
+    });
   });
 
   it('omits date bounds when no date filters are set', async () => {
     await mountWith({ issues: [] });
-    expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).not.toHaveProperty(
-      'createdAt_GTE'
-    );
-    expect(mockedUseQuery.mock.calls[0][1].value.issueWhere).not.toHaveProperty(
-      'createdAt_LTE'
-    );
+    expect(mockedUseQuery.mock.calls[0][1].value.startDate).toBe(null);
+    expect(mockedUseQuery.mock.calls[0][1].value.endDate).toBe(null);
   });
 
   it('updates the route filters when the start and end dates change', async () => {
@@ -250,27 +244,12 @@ describe('admin server issues index page', () => {
     });
   });
 
-  it('sorts issues by most reports when selected', async () => {
+  it('passes most reports through to the backend sort option', async () => {
     h.query.sort = issueSortValues.MOST_REPORTS;
-    const wrapper = await mountWith({
-      issues: [
-        {
-          id: 'a',
-          ActivityFeedAggregate: { count: 1 },
-          createdAt: '2026-06-01T00:00:00.000Z',
-        },
-        {
-          id: 'b',
-          ActivityFeedAggregate: { count: 3 },
-          createdAt: '2026-05-01T00:00:00.000Z',
-        },
-      ],
-    });
+    await mountWith({ issues: [] });
 
-    expect(
-      wrapper
-        .findAllComponents(ModIssueListItem)
-        .map((item) => item.props('issue').id)
-    ).toEqual(['b', 'a']);
+    expect(mockedUseQuery.mock.calls[0][1].value.options).toEqual({
+      sort: issueSortValues.MOST_REPORTS,
+    });
   });
 });

--- a/pages/admin/issues/index.vue
+++ b/pages/admin/issues/index.vue
@@ -12,11 +12,9 @@ import SearchableForumList from '@/components/channel/SearchableForumList.vue';
 import { getChannelLabel } from '@/utils';
 import { updateFilters } from '@/utils/routerUtils';
 import {
-  getDefaultServerRuleViolationsFilter,
   buildServerIssuesWhere,
-  isDateInputValue,
 } from '@/utils/serverIssueFilters';
-import { useSelectedChannelsFromQuery } from '@/composables/useSelectedChannelsFromQuery';
+import { getServerIssueFilterValuesFromParams } from '@/utils/getServerIssueFilterValuesFromParams';
 import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
 
@@ -24,17 +22,7 @@ const route = useRoute();
 const router = useRouter();
 const uiStore = useUIStore();
 const { selectedIssueNumber } = storeToRefs(uiStore);
-const { selectedChannels } = useSelectedChannelsFromQuery();
-const toDateInputValue = (date: Date) =>
-  date.toISOString().split('T')[0] || '';
-const getQueryString = (value: unknown) => {
-  return typeof value === 'string' && value ? value : null;
-};
-const today = new Date();
-const defaultStart = new Date(today);
-defaultStart.setDate(today.getDate() - 30);
-const defaultStartDate = toDateInputValue(defaultStart);
-const defaultEndDate = toDateInputValue(today);
+const initialFilterValues = getServerIssueFilterValuesFromParams({ route });
 
 const channelId = computed(() => {
   if (typeof route.params.forumId !== 'string') {
@@ -43,22 +31,13 @@ const channelId = computed(() => {
   return route.params.forumId;
 });
 
+const selectedChannels = ref(initialFilterValues.selectedChannels);
 const showOnlyServerRuleViolations = ref(
-  getDefaultServerRuleViolationsFilter(route.query.showOnlyServerRuleViolations)
+  initialFilterValues.showOnlyServerRuleViolations
 );
-const searchInput = ref(
-  typeof route.query.searchInput === 'string' ? route.query.searchInput : ''
-);
-const startDate = ref(
-  isDateInputValue(getQueryString(route.query.startDate))
-    ? getQueryString(route.query.startDate) || defaultStartDate
-    : defaultStartDate
-);
-const endDate = ref(
-  isDateInputValue(getQueryString(route.query.endDate))
-    ? getQueryString(route.query.endDate) || defaultEndDate
-    : defaultEndDate
-);
+const searchInput = ref(initialFilterValues.searchInput);
+const startDate = ref(initialFilterValues.startDate);
+const endDate = ref(initialFilterValues.endDate);
 const channelLabel = computed(() => getChannelLabel(selectedChannels.value));
 
 const variables = computed(() =>
@@ -137,26 +116,20 @@ const handleSelectIssue = (payload: {
 watch(
   () => route.query,
   () => {
-    if (route.query) {
-      const nextStartDate = getQueryString(route.query.startDate);
-      const nextEndDate = getQueryString(route.query.endDate);
+    const nextFilterValues = getServerIssueFilterValuesFromParams({ route });
 
-      showOnlyServerRuleViolations.value =
-        getDefaultServerRuleViolationsFilter(
-          route.query.showOnlyServerRuleViolations
-        );
-      searchInput.value =
-        typeof route.query.searchInput === 'string'
-          ? route.query.searchInput
-          : '';
-      if (isDateInputValue(nextStartDate) && nextStartDate !== startDate.value) {
-        startDate.value = nextStartDate;
-      }
-      if (isDateInputValue(nextEndDate) && nextEndDate !== endDate.value) {
-        endDate.value = nextEndDate;
-      }
-      refetch(variables.value);
+    selectedChannels.value = nextFilterValues.selectedChannels;
+    showOnlyServerRuleViolations.value =
+      nextFilterValues.showOnlyServerRuleViolations;
+    searchInput.value = nextFilterValues.searchInput;
+
+    if (nextFilterValues.startDate !== startDate.value) {
+      startDate.value = nextFilterValues.startDate;
     }
+    if (nextFilterValues.endDate !== endDate.value) {
+      endDate.value = nextFilterValues.endDate;
+    }
+    refetch(variables.value);
   }
 );
 
@@ -181,7 +154,7 @@ watch([startDate, endDate], ([nextStartDate, nextEndDate]) => {
 
 <template>
   <div>
-    <div class="flex flex-col gap-3 pb-4">
+    <div class="flex flex-col gap-3 px-4 pb-4">
       <SearchBar
         :initial-value="searchInput"
         :search-placeholder="'Search issues'"

--- a/pages/admin/issues/index.vue
+++ b/pages/admin/issues/index.vue
@@ -5,10 +5,7 @@ import { GET_ISSUES } from '@/graphQLData/issue/queries';
 import { useQuery } from '@vue/apollo-composable';
 import { useRoute, useRouter } from 'nuxt/app';
 import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
-import SearchBar from '@/components/SearchBar.vue';
-import FilterChip from '@/components/FilterChip.vue';
-import ChannelIcon from '@/components/icons/ChannelIcon.vue';
-import SearchableForumList from '@/components/channel/SearchableForumList.vue';
+import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
 import { getChannelLabel } from '@/utils';
 import { updateFilters } from '@/utils/routerUtils';
 import {
@@ -66,13 +63,13 @@ const issues = computed<Issue[]>(() => {
   return getIssuesResult.value?.issues || [];
 });
 
-const toggleShowOnlyServerRuleViolations = () => {
-  showOnlyServerRuleViolations.value = !showOnlyServerRuleViolations.value;
+const updateShowOnlyServerRuleViolations = (value: boolean) => {
+  showOnlyServerRuleViolations.value = value;
   updateFilters({
     router,
     route,
     params: {
-      showOnlyServerRuleViolations: showOnlyServerRuleViolations.value,
+      showOnlyServerRuleViolations: value,
     },
   });
 };
@@ -154,69 +151,21 @@ watch([startDate, endDate], ([nextStartDate, nextEndDate]) => {
 
 <template>
   <div>
-    <div class="flex flex-col gap-3 px-4 pb-4">
-      <SearchBar
-        :initial-value="searchInput"
-        :search-placeholder="'Search issues'"
-        :test-id="'server-issue-search-input'"
-        :debounce-ms="500"
-        @update-search-input="updateSearchInput"
-      />
-      <div class="flex flex-wrap items-end gap-3">
-        <label
-          class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300"
-        >
-          Start
-          <input
-            v-model="startDate"
-            type="date"
-            data-testid="admin-issues-start-date"
-            class="rounded-md border-gray-300 px-2 py-1 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
-          >
-        </label>
-        <label
-          class="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-gray-300"
-        >
-          End
-          <input
-            v-model="endDate"
-            type="date"
-            data-testid="admin-issues-end-date"
-            class="rounded-md border-gray-300 px-2 py-1 text-sm text-gray-900 [color-scheme:light] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:[color-scheme:dark]"
-          >
-        </label>
-      </div>
-      <div class="flex flex-wrap items-center justify-end gap-2">
-        <FilterChip
-          :label="channelLabel"
-          :highlighted="selectedChannels.length > 0"
-          data-testid="admin-issues-channel-filter"
-        >
-          <template #icon>
-            <ChannelIcon class="-ml-0.5 mr-2 h-4 w-4" />
-          </template>
-          <template #content>
-            <div class="relative w-96">
-              <SearchableForumList
-                :selected-channels="selectedChannels"
-                @toggle-selection="toggleSelectedChannel"
-              />
-            </div>
-          </template>
-        </FilterChip>
-        <input
-          id="show-only-server-rule-violations"
-          type="checkbox"
-          :checked="showOnlyServerRuleViolations"
-          class="mr-2"
-          data-testid="show-only-server-rule-violations"
-          @change="toggleShowOnlyServerRuleViolations"
-        >
-        <label for="show-only-server-rule-violations" class="mr-2"
-          >Show only server rule violations</label
-        >
-      </div>
-    </div>
+    <IssueFilterBar
+      :search-input="searchInput"
+      :selected-channels="selectedChannels"
+      :channel-label="channelLabel"
+      :start-date="startDate"
+      :end-date="endDate"
+      :show-only-server-rule-violations="showOnlyServerRuleViolations"
+      @update-search-input="updateSearchInput"
+      @toggle-selected-channel="toggleSelectedChannel"
+      @update:start-date="startDate = $event"
+      @update:end-date="endDate = $event"
+      @update:show-only-server-rule-violations="
+        updateShowOnlyServerRuleViolations
+      "
+    />
     <ul
       class="divide-y border-t border-gray-200 dark:border-gray-800 dark:text-white"
       data-testid="issue-list"

--- a/pages/admin/issues/index.vue
+++ b/pages/admin/issues/index.vue
@@ -14,6 +14,11 @@ import {
 import { getServerIssueFilterValuesFromParams } from '@/utils/getServerIssueFilterValuesFromParams';
 import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
+import {
+  getIssueGraphqlSort,
+  getIssueSortLabel,
+  sortIssuesBySelection,
+} from '@/utils/issueSortOptions';
 
 const route = useRoute();
 const router = useRouter();
@@ -35,17 +40,20 @@ const showOnlyServerRuleViolations = ref(
 const searchInput = ref(initialFilterValues.searchInput);
 const startDate = ref(initialFilterValues.startDate);
 const endDate = ref(initialFilterValues.endDate);
+const selectedSort = ref(initialFilterValues.sort);
 const channelLabel = computed(() => getChannelLabel(selectedChannels.value));
+const selectedSortLabel = computed(() => getIssueSortLabel(selectedSort.value));
 
-const variables = computed(() =>
-  buildServerIssuesWhere({
+const variables = computed(() => ({
+  ...buildServerIssuesWhere({
     searchInput: searchInput.value,
     selectedChannels: selectedChannels.value,
     startDate: startDate.value,
     endDate: endDate.value,
     showOnlyServerRuleViolations: showOnlyServerRuleViolations.value,
-  })
-);
+  }),
+  issueSort: getIssueGraphqlSort(selectedSort.value),
+}));
 
 const {
   result: getIssuesResult,
@@ -60,7 +68,10 @@ const issues = computed<Issue[]>(() => {
   if (getIssuesLoading.value || getIssuesError.value) {
     return [];
   }
-  return getIssuesResult.value?.issues || [];
+  return sortIssuesBySelection(
+    getIssuesResult.value?.issues || [],
+    selectedSort.value
+  );
 });
 
 const updateShowOnlyServerRuleViolations = (value: boolean) => {
@@ -79,6 +90,14 @@ const updateSearchInput = (value: string) => {
     router,
     route,
     params: { searchInput: value },
+  });
+};
+
+const updateSort = (value: string) => {
+  updateFilters({
+    router,
+    route,
+    params: { sort: value },
   });
 };
 
@@ -119,6 +138,7 @@ watch(
     showOnlyServerRuleViolations.value =
       nextFilterValues.showOnlyServerRuleViolations;
     searchInput.value = nextFilterValues.searchInput;
+    selectedSort.value = nextFilterValues.sort;
 
     if (nextFilterValues.startDate !== startDate.value) {
       startDate.value = nextFilterValues.startDate;
@@ -158,8 +178,11 @@ watch([startDate, endDate], ([nextStartDate, nextEndDate]) => {
       :start-date="startDate"
       :end-date="endDate"
       :show-only-server-rule-violations="showOnlyServerRuleViolations"
+      :selected-sort="selectedSort"
+      :selected-sort-label="selectedSortLabel"
       @update-search-input="updateSearchInput"
       @toggle-selected-channel="toggleSelectedChannel"
+      @update:sort="updateSort"
       @update:start-date="startDate = $event"
       @update:end-date="endDate = $event"
       @update:show-only-server-rule-violations="

--- a/pages/admin/issues/index.vue
+++ b/pages/admin/issues/index.vue
@@ -1,24 +1,17 @@
 <script lang="ts" setup>
 import { computed, ref, watch } from 'vue';
 import type { Issue } from '@/__generated__/graphql';
-import { GET_ISSUES } from '@/graphQLData/issue/queries';
+import { GET_SITE_WIDE_ISSUE_LIST } from '@/graphQLData/issue/queries';
 import { useQuery } from '@vue/apollo-composable';
 import { useRoute, useRouter } from 'nuxt/app';
 import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
 import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
 import { getChannelLabel } from '@/utils';
 import { updateFilters } from '@/utils/routerUtils';
-import {
-  buildServerIssuesWhere,
-} from '@/utils/serverIssueFilters';
 import { getServerIssueFilterValuesFromParams } from '@/utils/getServerIssueFilterValuesFromParams';
 import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
-import {
-  getIssueGraphqlSort,
-  getIssueSortLabel,
-  sortIssuesBySelection,
-} from '@/utils/issueSortOptions';
+import { getIssueSortLabel } from '@/utils/issueSortOptions';
 
 const route = useRoute();
 const router = useRouter();
@@ -45,14 +38,15 @@ const channelLabel = computed(() => getChannelLabel(selectedChannels.value));
 const selectedSortLabel = computed(() => getIssueSortLabel(selectedSort.value));
 
 const variables = computed(() => ({
-  ...buildServerIssuesWhere({
-    searchInput: searchInput.value,
-    selectedChannels: selectedChannels.value,
-    startDate: startDate.value,
-    endDate: endDate.value,
-    showOnlyServerRuleViolations: showOnlyServerRuleViolations.value,
-  }),
-  issueSort: getIssueGraphqlSort(selectedSort.value),
+  searchInput: searchInput.value,
+  selectedChannels: selectedChannels.value,
+  startDate: startDate.value || null,
+  endDate: endDate.value || null,
+  showOnlyServerRuleViolations: showOnlyServerRuleViolations.value,
+  isOpen: true,
+  options: {
+    sort: selectedSort.value,
+  },
 }));
 
 const {
@@ -60,18 +54,22 @@ const {
   error: getIssuesError,
   loading: getIssuesLoading,
   refetch,
-} = useQuery(GET_ISSUES, variables, {
+} = useQuery(GET_SITE_WIDE_ISSUE_LIST, variables, {
   fetchPolicy: 'cache-first',
 });
 
-const issues = computed<Issue[]>(() => {
+type SiteWideIssueListItem = Issue & {
+  channelUniqueName?: string | null;
+  channelIconURL?: string | null;
+  authorName?: string | null;
+  reportCount?: number | null;
+};
+
+const issues = computed<SiteWideIssueListItem[]>(() => {
   if (getIssuesLoading.value || getIssuesError.value) {
     return [];
   }
-  return sortIssuesBySelection(
-    getIssuesResult.value?.issues || [],
-    selectedSort.value
-  );
+  return getIssuesResult.value?.getSiteWideIssueList?.issues || [];
 });
 
 const updateShowOnlyServerRuleViolations = (value: boolean) => {

--- a/utils/getServerIssueFilterValuesFromParams.spec.ts
+++ b/utils/getServerIssueFilterValuesFromParams.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { getServerIssueFilterValuesFromParams } from '@/utils/getServerIssueFilterValuesFromParams';
+import type { RouteLocationNormalized } from 'vue-router';
+
+function createMockRoute(
+  query: Record<string, unknown> = {}
+): Pick<RouteLocationNormalized, 'query'> {
+  return { query };
+}
+
+describe('getServerIssueFilterValuesFromParams', () => {
+  it('returns default values when route has no query parameters', () => {
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute(),
+      })
+    ).toEqual({
+      selectedChannels: [],
+      searchInput: '',
+      startDate: '',
+      endDate: '',
+      showOnlyServerRuleViolations: true,
+    });
+  });
+
+  it('parses selected channels from a string', () => {
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute({ channels: 'announcements' }),
+      }).selectedChannels
+    ).toEqual(['announcements']);
+  });
+
+  it('parses selected channels from an array', () => {
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute({
+          channels: ['announcements', 'support', 3],
+        }),
+      }).selectedChannels
+    ).toEqual(['announcements', 'support']);
+  });
+
+  it('parses search input and valid date bounds', () => {
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute({
+          searchInput: 'spam',
+          startDate: '2026-05-01',
+          endDate: '2026-07-01',
+        }),
+      })
+    ).toMatchObject({
+      searchInput: 'spam',
+      startDate: '2026-05-01',
+      endDate: '2026-07-01',
+    });
+  });
+
+  it('drops invalid date values', () => {
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute({
+          startDate: '2026-5-1',
+          endDate: 'not-a-date',
+        }),
+      })
+    ).toMatchObject({
+      startDate: '',
+      endDate: '',
+    });
+  });
+
+  it('defaults server-rule violations filter to true unless explicitly false', () => {
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute({
+          showOnlyServerRuleViolations: 'false',
+        }),
+      }).showOnlyServerRuleViolations
+    ).toBe(false);
+
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute({
+          showOnlyServerRuleViolations: 'true',
+        }),
+      }).showOnlyServerRuleViolations
+    ).toBe(true);
+  });
+});

--- a/utils/getServerIssueFilterValuesFromParams.spec.ts
+++ b/utils/getServerIssueFilterValuesFromParams.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { getServerIssueFilterValuesFromParams } from '@/utils/getServerIssueFilterValuesFromParams';
 import type { RouteLocationNormalized } from 'vue-router';
+import { issueSortValues } from '@/utils/issueSortOptions';
 
 function createMockRoute(
   query: Record<string, unknown> = {}
@@ -20,6 +21,7 @@ describe('getServerIssueFilterValuesFromParams', () => {
       startDate: '',
       endDate: '',
       showOnlyServerRuleViolations: true,
+      sort: issueSortValues.NEWEST,
     });
   });
 
@@ -87,5 +89,15 @@ describe('getServerIssueFilterValuesFromParams', () => {
         }),
       }).showOnlyServerRuleViolations
     ).toBe(true);
+  });
+
+  it('parses the sort value from query params', () => {
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute({
+          sort: issueSortValues.OLDEST,
+        }),
+      }).sort
+    ).toBe(issueSortValues.OLDEST);
   });
 });

--- a/utils/getServerIssueFilterValuesFromParams.ts
+++ b/utils/getServerIssueFilterValuesFromParams.ts
@@ -3,6 +3,11 @@ import {
   getDefaultServerRuleViolationsFilter,
   isDateInputValue,
 } from '@/utils/serverIssueFilters';
+import {
+  defaultIssueSort,
+  getIssueSortFromQuery,
+  type IssueSortValue,
+} from '@/utils/issueSortOptions';
 
 type GetServerIssueFilterValuesInput = {
   route: Pick<RouteLocationNormalized, 'query'>;
@@ -14,6 +19,7 @@ export type ServerIssueFilterValues = {
   startDate: string;
   endDate: string;
   showOnlyServerRuleViolations: boolean;
+  sort: IssueSortValue;
 };
 
 const getQueryString = (value: unknown) => {
@@ -29,6 +35,7 @@ export const getServerIssueFilterValuesFromParams = (
     startDate: '',
     endDate: '',
     showOnlyServerRuleViolations: true,
+    sort: defaultIssueSort,
   };
 
   for (const key in input.route?.query || {}) {
@@ -63,6 +70,9 @@ export const getServerIssueFilterValuesFromParams = (
       case 'showOnlyServerRuleViolations':
         cleanedValues.showOnlyServerRuleViolations =
           getDefaultServerRuleViolationsFilter(val);
+        break;
+      case 'sort':
+        cleanedValues.sort = getIssueSortFromQuery(input.route.query);
         break;
     }
   }

--- a/utils/getServerIssueFilterValuesFromParams.ts
+++ b/utils/getServerIssueFilterValuesFromParams.ts
@@ -1,0 +1,71 @@
+import type { RouteLocationNormalized } from 'vue-router';
+import {
+  getDefaultServerRuleViolationsFilter,
+  isDateInputValue,
+} from '@/utils/serverIssueFilters';
+
+type GetServerIssueFilterValuesInput = {
+  route: Pick<RouteLocationNormalized, 'query'>;
+};
+
+export type ServerIssueFilterValues = {
+  selectedChannels: string[];
+  searchInput: string;
+  startDate: string;
+  endDate: string;
+  showOnlyServerRuleViolations: boolean;
+};
+
+const getQueryString = (value: unknown) => {
+  return typeof value === 'string' && value ? value : null;
+};
+
+export const getServerIssueFilterValuesFromParams = (
+  input: GetServerIssueFilterValuesInput
+): ServerIssueFilterValues => {
+  const cleanedValues: ServerIssueFilterValues = {
+    selectedChannels: [],
+    searchInput: '',
+    startDate: '',
+    endDate: '',
+    showOnlyServerRuleViolations: true,
+  };
+
+  for (const key in input.route?.query || {}) {
+    const val = input.route.query[key];
+
+    switch (key) {
+      case 'channels':
+        if (typeof val === 'string') {
+          cleanedValues.selectedChannels = val ? [val] : [];
+        }
+        if (Array.isArray(val)) {
+          cleanedValues.selectedChannels = val.filter(
+            (value): value is string => typeof value === 'string' && !!value
+          );
+        }
+        break;
+      case 'searchInput':
+        if (typeof val === 'string') {
+          cleanedValues.searchInput = val;
+        }
+        break;
+      case 'startDate': {
+        const startDate = getQueryString(val);
+        cleanedValues.startDate = isDateInputValue(startDate) ? startDate : '';
+        break;
+      }
+      case 'endDate': {
+        const endDate = getQueryString(val);
+        cleanedValues.endDate = isDateInputValue(endDate) ? endDate : '';
+        break;
+      }
+      case 'showOnlyServerRuleViolations':
+        cleanedValues.showOnlyServerRuleViolations =
+          getDefaultServerRuleViolationsFilter(val);
+        break;
+    }
+  }
+
+  return cleanedValues;
+};

--- a/utils/issueSortOptions.spec.ts
+++ b/utils/issueSortOptions.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defaultIssueSort,
+  getIssueGraphqlSort,
+  getIssueSortFromQuery,
+  getIssueSortLabel,
+  issueSortValues,
+  sortIssuesBySelection,
+} from '@/utils/issueSortOptions';
+
+describe('issueSortOptions', () => {
+  it('defaults to newest when query sort is missing or invalid', () => {
+    expect(getIssueSortFromQuery({})).toBe(defaultIssueSort);
+    expect(getIssueSortFromQuery({ sort: 'invalid' })).toBe(defaultIssueSort);
+  });
+
+  it('parses a valid sort from the query', () => {
+    expect(getIssueSortFromQuery({ sort: issueSortValues.OLDEST })).toBe(
+      issueSortValues.OLDEST
+    );
+  });
+
+  it('returns labels for the configured sorts', () => {
+    expect(getIssueSortLabel(issueSortValues.NEWEST)).toBe('Newest');
+    expect(getIssueSortLabel(issueSortValues.OLDEST)).toBe('Oldest');
+    expect(getIssueSortLabel(issueSortValues.MOST_REPORTS)).toBe(
+      'Most reports'
+    );
+  });
+
+  it('maps server-supported sorts to graphql sort inputs', () => {
+    expect(getIssueGraphqlSort(issueSortValues.NEWEST)).toEqual([
+      { createdAt: 'DESC' },
+    ]);
+    expect(getIssueGraphqlSort(issueSortValues.OLDEST)).toEqual([
+      { createdAt: 'ASC' },
+    ]);
+    expect(getIssueGraphqlSort(issueSortValues.MOST_REPORTS)).toEqual([
+      { createdAt: 'DESC' },
+    ]);
+  });
+
+  it('sorts most reports by report count descending with newest tie-breaker', () => {
+    const sorted = sortIssuesBySelection(
+      [
+        {
+          id: '1',
+          createdAt: '2026-05-01T00:00:00.000Z',
+          ActivityFeedAggregate: { count: 2 },
+        },
+        {
+          id: '2',
+          createdAt: '2026-06-01T00:00:00.000Z',
+          ActivityFeedAggregate: { count: 4 },
+        },
+        {
+          id: '3',
+          createdAt: '2026-07-01T00:00:00.000Z',
+          ActivityFeedAggregate: { count: 2 },
+        },
+      ] as never,
+      issueSortValues.MOST_REPORTS
+    );
+
+    expect(sorted.map((issue) => issue.id)).toEqual(['2', '3', '1']);
+  });
+});

--- a/utils/issueSortOptions.spec.ts
+++ b/utils/issueSortOptions.spec.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   defaultIssueSort,
-  getIssueGraphqlSort,
   getIssueSortFromQuery,
   getIssueSortLabel,
   issueSortValues,
-  sortIssuesBySelection,
 } from '@/utils/issueSortOptions';
 
 describe('issueSortOptions', () => {
@@ -28,40 +26,9 @@ describe('issueSortOptions', () => {
     );
   });
 
-  it('maps server-supported sorts to graphql sort inputs', () => {
-    expect(getIssueGraphqlSort(issueSortValues.NEWEST)).toEqual([
-      { createdAt: 'DESC' },
-    ]);
-    expect(getIssueGraphqlSort(issueSortValues.OLDEST)).toEqual([
-      { createdAt: 'ASC' },
-    ]);
-    expect(getIssueGraphqlSort(issueSortValues.MOST_REPORTS)).toEqual([
-      { createdAt: 'DESC' },
-    ]);
-  });
-
-  it('sorts most reports by report count descending with newest tie-breaker', () => {
-    const sorted = sortIssuesBySelection(
-      [
-        {
-          id: '1',
-          createdAt: '2026-05-01T00:00:00.000Z',
-          ActivityFeedAggregate: { count: 2 },
-        },
-        {
-          id: '2',
-          createdAt: '2026-06-01T00:00:00.000Z',
-          ActivityFeedAggregate: { count: 4 },
-        },
-        {
-          id: '3',
-          createdAt: '2026-07-01T00:00:00.000Z',
-          ActivityFeedAggregate: { count: 2 },
-        },
-      ] as never,
-      issueSortValues.MOST_REPORTS
-    );
-
-    expect(sorted.map((issue) => issue.id)).toEqual(['2', '3', '1']);
+  it('includes most reports as a valid query sort', () => {
+    expect(
+      getIssueSortFromQuery({ sort: issueSortValues.MOST_REPORTS })
+    ).toBe(issueSortValues.MOST_REPORTS);
   });
 });

--- a/utils/issueSortOptions.ts
+++ b/utils/issueSortOptions.ts
@@ -1,0 +1,83 @@
+import type { Issue } from '@/__generated__/graphql';
+import type { LocationQuery } from 'vue-router';
+
+export const issueSortValues = {
+  NEWEST: 'newest',
+  OLDEST: 'oldest',
+  MOST_REPORTS: 'mostReports',
+} as const;
+
+export type IssueSortValue =
+  (typeof issueSortValues)[keyof typeof issueSortValues];
+
+export const defaultIssueSort = issueSortValues.NEWEST;
+
+export const issueSortOptions = [
+  {
+    label: 'Newest',
+    value: issueSortValues.NEWEST,
+  },
+  {
+    label: 'Oldest',
+    value: issueSortValues.OLDEST,
+  },
+  {
+    label: 'Most reports',
+    value: issueSortValues.MOST_REPORTS,
+  },
+];
+
+const validIssueSorts = new Set<IssueSortValue>(Object.values(issueSortValues));
+
+export const getIssueSortFromQuery = (query: LocationQuery): IssueSortValue => {
+  if (
+    typeof query.sort === 'string' &&
+    validIssueSorts.has(query.sort as IssueSortValue)
+  ) {
+    return query.sort as IssueSortValue;
+  }
+  return defaultIssueSort;
+};
+
+export const getIssueSortLabel = (value: IssueSortValue): string => {
+  const match = issueSortOptions.find((option) => option.value === value);
+  return match?.label || 'Newest';
+};
+
+export const getIssueGraphqlSort = (value: IssueSortValue) => {
+  if (value === issueSortValues.OLDEST) {
+    return [{ createdAt: 'ASC' }];
+  }
+
+  return [{ createdAt: 'DESC' }];
+};
+
+const getReportCount = (issue: Pick<Issue, 'ActivityFeedAggregate'>) => {
+  return issue.ActivityFeedAggregate?.count || 0;
+};
+
+const getCreatedAtTimestamp = (issue: Pick<Issue, 'createdAt'>) => {
+  if (!issue.createdAt) {
+    return 0;
+  }
+  const timestamp = new Date(issue.createdAt).getTime();
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
+export const sortIssuesBySelection = (
+  issues: Issue[],
+  selectedSort: IssueSortValue
+) => {
+  if (selectedSort !== issueSortValues.MOST_REPORTS) {
+    return issues;
+  }
+
+  return [...issues].sort((left, right) => {
+    const reportCountDelta = getReportCount(right) - getReportCount(left);
+    if (reportCountDelta !== 0) {
+      return reportCountDelta;
+    }
+
+    return getCreatedAtTimestamp(right) - getCreatedAtTimestamp(left);
+  });
+};

--- a/utils/issueSortOptions.ts
+++ b/utils/issueSortOptions.ts
@@ -1,4 +1,3 @@
-import type { Issue } from '@/__generated__/graphql';
 import type { LocationQuery } from 'vue-router';
 
 export const issueSortValues = {
@@ -42,42 +41,4 @@ export const getIssueSortFromQuery = (query: LocationQuery): IssueSortValue => {
 export const getIssueSortLabel = (value: IssueSortValue): string => {
   const match = issueSortOptions.find((option) => option.value === value);
   return match?.label || 'Newest';
-};
-
-export const getIssueGraphqlSort = (value: IssueSortValue) => {
-  if (value === issueSortValues.OLDEST) {
-    return [{ createdAt: 'ASC' }];
-  }
-
-  return [{ createdAt: 'DESC' }];
-};
-
-const getReportCount = (issue: Pick<Issue, 'ActivityFeedAggregate'>) => {
-  return issue.ActivityFeedAggregate?.count || 0;
-};
-
-const getCreatedAtTimestamp = (issue: Pick<Issue, 'createdAt'>) => {
-  if (!issue.createdAt) {
-    return 0;
-  }
-  const timestamp = new Date(issue.createdAt).getTime();
-  return Number.isNaN(timestamp) ? 0 : timestamp;
-};
-
-export const sortIssuesBySelection = (
-  issues: Issue[],
-  selectedSort: IssueSortValue
-) => {
-  if (selectedSort !== issueSortValues.MOST_REPORTS) {
-    return issues;
-  }
-
-  return [...issues].sort((left, right) => {
-    const reportCountDelta = getReportCount(right) - getReportCount(left);
-    if (reportCountDelta !== 0) {
-      return reportCountDelta;
-    }
-
-    return getCreatedAtTimestamp(right) - getCreatedAtTimestamp(left);
-  });
 };

--- a/utils/routerUtils.ts
+++ b/utils/routerUtils.ts
@@ -157,6 +157,7 @@ export type UpdateStateInput = {
   channels?: string[];
   tags?: string[];
   searchInput?: string;
+  sort?: string;
   startDate?: string;
   endDate?: string;
   searchOpen?: string;

--- a/utils/serverIssueFilters.ts
+++ b/utils/serverIssueFilters.ts
@@ -25,6 +25,7 @@ export type ServerIssuesWhereParams = {
   startDate: string;
   endDate: string;
   showOnlyServerRuleViolations: boolean;
+  isOpen?: boolean;
 };
 
 export const isDateInputValue = (value: string | null): value is string => {
@@ -67,15 +68,16 @@ const buildCreatedAtRange = (
  * optionally restricted to flagged server-rule violations, and optionally
  * matched against a case-insensitive title/body search.
  */
-export function buildServerIssuesWhere(
+export function buildServerIssueWhere(
   params: ServerIssuesWhereParams
-): { issueWhere: Record<string, unknown> } {
+): Record<string, unknown> {
   const {
     searchInput,
     selectedChannels,
     startDate,
     endDate,
     showOnlyServerRuleViolations,
+    isOpen = true,
   } =
     params;
   const searchPattern = createCaseInsensitivePattern(searchInput);
@@ -88,14 +90,20 @@ export function buildServerIssuesWhere(
       : {};
 
   return {
-    issueWhere: {
-      isOpen: true,
-      ...(showOnlyServerRuleViolations
-        ? { flaggedServerRuleViolation: true }
-        : {}),
-      ...buildCreatedAtRange(startDate, endDate),
-      ...channelFilter,
-      ...searchFilter,
-    },
+    isOpen,
+    ...(showOnlyServerRuleViolations
+      ? { flaggedServerRuleViolation: true }
+      : {}),
+    ...buildCreatedAtRange(startDate, endDate),
+    ...channelFilter,
+    ...searchFilter,
+  };
+}
+
+export function buildServerIssuesWhere(
+  params: ServerIssuesWhereParams
+): { issueWhere: Record<string, unknown> } {
+  return {
+    issueWhere: buildServerIssueWhere(params),
   };
 }


### PR DESCRIPTION
## Summary
- add admin channel detail drilldown UI
- refactor admin issue filtering into IssueFilterBar and route-driven sort/filter state
- switch admin issues to the custom sitewide issue list query and compact the issue scope filter

## Testing
- npx vitest run pages/admin/issues/index.spec.ts components/mod/ModIssueListItem.spec.ts utils/issueSortOptions.spec.ts utils/getServerIssueFilterValuesFromParams.spec.ts components/admin/IssueFilterBar.spec.ts
- npx vitest run components/admin/IssueFilterBar.spec.ts