### PR TITLE
[codex] Polish shared filter bar surfaces

### DIFF
--- a/components/FilterChip.vue
+++ b/components/FilterChip.vue
@@ -40,22 +40,22 @@ const handleClick = () => {
             :data-testid="dataTestid"
             :class="[
               highlighted
-                ? 'border-gray-500 ring-1 ring-gray-400 dark:border-gray-400 dark:ring-gray-500'
+                ? 'border-gray-400 ring-1 ring-gray-300 dark:border-slate-500 dark:ring-slate-500'
                 : '',
             ]"
-            class="font-small align-items flex whitespace-nowrap rounded-md border bg-white px-3 py-2 text-xs text-gray-700 hover:bg-gray-200 focus:border-gray-500 focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus:border-gray-400 dark:focus:ring-gray-400"
+            class="align-items flex h-10 items-center gap-2 whitespace-nowrap rounded-lg border border-gray-200 bg-gradient-to-b from-white to-gray-50 px-3.5 text-sm font-medium text-gray-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] transition-colors hover:border-gray-300 hover:bg-gray-100 focus:border-gray-300 focus:ring-1 focus:ring-gray-300 dark:border-slate-600 dark:bg-none dark:bg-slate-900 dark:text-gray-200 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:border-slate-500 dark:hover:bg-slate-800 dark:focus:border-slate-500 dark:focus:ring-slate-500"
             @click="handleClick"
           >
             <slot name="icon" />
             {{ label }}
             <ChevronDownIcon
-              class="-mr-1 ml-1 mt-0.5 h-3 w-3"
+              class="h-3.5 w-3.5 shrink-0"
               aria-hidden="true"
             />
           </button>
         </template>
         <template #content>
-          <div class="rounded-md border bg-white dark:border-gray-700 dark:bg-gray-900">
+          <div class="rounded-lg border border-gray-200 bg-white/95 shadow-lg shadow-black/10 backdrop-blur-sm dark:border-slate-600 dark:bg-slate-900/95">
             <slot name="content" />
           </div>
         </template>
@@ -65,15 +65,15 @@ const handleClick = () => {
           :data-testid="dataTestid"
           :class="[
             highlighted
-              ? 'border-gray-500 ring-1 ring-gray-400 dark:border-gray-400 dark:ring-gray-500'
+              ? 'border-gray-400 ring-1 ring-gray-300 dark:border-slate-500 dark:ring-slate-500'
               : '',
           ]"
-          class="max-height-3 font-small mr-2 inline-flex whitespace-nowrap rounded-md border bg-white px-3 py-2.5 text-xs text-gray-700 hover:bg-gray-200 focus:border-gray-500 focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus:border-gray-400 dark:focus:ring-gray-400"
+          class="max-height-3 inline-flex h-10 items-center gap-2 whitespace-nowrap rounded-lg border border-gray-200 bg-gradient-to-b from-white to-gray-50 px-3.5 text-sm font-medium text-gray-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] transition-colors hover:border-gray-300 hover:bg-gray-100 focus:border-gray-300 focus:ring-1 focus:ring-gray-300 dark:border-slate-600 dark:bg-none dark:bg-slate-900 dark:text-gray-200 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:border-slate-500 dark:hover:bg-slate-800 dark:focus:border-slate-500 dark:focus:ring-slate-500"
         >
           <slot name="icon" />
           {{ label }}
           <ChevronDownIcon
-            class="-mr-1 ml-1 mt-0.5 h-3 w-3"
+            class="h-3.5 w-3.5 shrink-0"
             aria-hidden="true"
           />
         </button>

--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -111,7 +111,7 @@ defineExpose({ focus, getValue });
         class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400 dark:text-gray-300"
         aria-hidden="true"
       >
-        <SearchIcon />
+        <SearchIcon class="h-4 w-4" />
       </div>
       <input
         ref="searchInputRef"
@@ -119,25 +119,25 @@ defineExpose({ focus, getValue });
         name="search"
         :data-testid="testId"
         :class="[
-          leftSideIsRounded ? 'rounded-l-md' : '',
-          rightSideIsRounded ? 'rounded-r-md' : '',
-          small ? 'h-9' : 'h-10',
+          leftSideIsRounded ? 'rounded-l-lg' : '',
+          rightSideIsRounded ? 'rounded-r-lg' : '',
+          small ? 'h-10' : 'h-10',
         ]"
-        class="w-full border border-gray-200 pl-10 pr-12 text-sm leading-5 text-gray-900 placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder-gray-400"
+        class="search-bar-input w-full border border-gray-200 bg-gradient-to-b from-white to-gray-50 pl-10 pr-12 text-sm leading-5 text-gray-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] placeholder-gray-400 focus:border-gray-300 focus:outline-none focus:ring-1 focus:ring-gray-300 dark:border-slate-600 dark:text-white dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:placeholder-gray-400 dark:focus:border-slate-500 dark:focus:ring-slate-500"
         :placeholder="searchPlaceholder"
         type="text"
         @input="updateSearchInput"
         @keydown.enter.prevent="submit"
       >
       <button
-        v-if="initialValue"
+        v-if="input"
         type="button"
         aria-label="Clear search"
-        class="bg-transparent absolute inset-y-0 right-12 z-10 flex cursor-pointer items-center border-none"
+        class="absolute inset-y-0 right-12 z-10 flex cursor-pointer items-center border-none bg-transparent text-gray-400 transition-colors hover:text-gray-600 dark:text-gray-300 dark:hover:text-gray-100"
         @click="clear"
       >
         <i
-          class="fa-solid fa-xmark h-4 w-4 text-gray-400 dark:text-gray-300"
+          class="fa-solid fa-xmark h-4 w-4"
           aria-hidden="true"
         />
       </button>
@@ -146,3 +146,10 @@ defineExpose({ focus, getValue });
     </div>
   </div>
 </template>
+
+<style>
+html.dark .search-bar-input {
+  background-color: rgb(15 23 42) !important;
+  background-image: none !important;
+}
+</style>

--- a/components/SortButtons.vue
+++ b/components/SortButtons.vue
@@ -91,7 +91,7 @@ function handleTopSort(value: string) {
 </script>
 
 <template>
-  <div class="flex items-center space-x-2">
+  <div class="flex items-center gap-2">
     <TextButtonDropdown
       :label="capitalizeCase(activeSortQuery)"
       :items="sortOptions"

--- a/components/TextButtonDropdown.vue
+++ b/components/TextButtonDropdown.vue
@@ -39,12 +39,12 @@ function handleClick(item: MenuItemType) {
       <div>
         <MenuButton
           :data-testid="`text-dropdown-${label}`"
-          class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-100 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
+          class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg border border-gray-200 bg-gradient-to-b from-white to-gray-50 px-3.5 text-sm font-medium text-gray-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] transition-colors duration-200 hover:border-gray-300 hover:bg-gray-100 focus:outline-none focus:ring-1 focus:ring-gray-300 dark:border-slate-600 dark:bg-none dark:bg-slate-900 dark:text-gray-100 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:border-slate-500 dark:hover:bg-slate-800 dark:focus:ring-slate-500"
         >
           <SortIcon v-if="showSortIcon" class="h-4 w-4" aria-hidden="true" />
           {{ label }}
           <ChevronDownIcon
-            class="-mr-1 ml-1 mt-0.5 h-3 w-3"
+            class="h-3.5 w-3.5 shrink-0"
             aria-hidden="true"
           />
         </MenuButton>
@@ -58,22 +58,22 @@ function handleClick(item: MenuItemType) {
         leave-to-class="transform opacity-0 scale-95"
       >
         <MenuItems
-          class="top absolute right-0 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-700 dark:text-gray-200"
+          class="top absolute right-0 mt-2 w-56 origin-top-right rounded-lg border border-gray-200 bg-white/95 shadow-lg shadow-black/10 ring-1 ring-black/5 backdrop-blur-sm focus:outline-none dark:border-slate-600 dark:bg-slate-900/95 dark:text-gray-200 dark:ring-white/10"
         >
           <div class="py-1">
             <MenuItem
               v-for="(item, i) in items"
               :key="i"
               v-slot="{ active }"
-              class="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600"
+              class="cursor-pointer"
               @click="handleClick(item)"
             >
               <span
                 :class="[
                   active
-                    ? 'bg-white text-gray-900 dark:bg-gray-800 dark:hover:bg-gray-500 dark:hover:text-gray-100'
+                    ? 'bg-gray-100 text-gray-900 dark:bg-slate-800 dark:text-gray-100'
                     : 'text-gray-700 dark:text-gray-200',
-                  'block px-4 py-2 text-sm',
+                  'block rounded-md px-4 py-2 text-sm',
                 ]"
               >
                 {{ item.label }}
@@ -84,16 +84,16 @@ function handleClick(item: MenuItemType) {
       </transition>
     </Menu>
 
-    <template #fallback>
-      <button
-        :data-testid="`text-dropdown-${label}`"
-        class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-200 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
-      >
-        <SortIcon v-if="showSortIcon" class="h-4 w-4" aria-hidden="true" />
-        {{ label }}
-        <ChevronDownIcon class="-mr-1 ml-1 mt-0.5 h-3 w-3" aria-hidden="true" />
-      </button>
-    </template>
+      <template #fallback>
+        <button
+          :data-testid="`text-dropdown-${label}`"
+          class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg border border-gray-200 bg-gradient-to-b from-white to-gray-50 px-3.5 text-sm font-medium text-gray-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] transition-colors duration-200 hover:border-gray-300 hover:bg-gray-100 focus:outline-none focus:ring-1 focus:ring-gray-300 dark:border-slate-600 dark:bg-none dark:bg-slate-900 dark:text-gray-100 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:border-slate-500 dark:hover:bg-slate-800 dark:focus:ring-slate-500"
+        >
+          <SortIcon v-if="showSortIcon" class="h-4 w-4" aria-hidden="true" />
+          {{ label }}
+          <ChevronDownIcon class="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        </button>
+      </template>
   </client-only>
 </template>
 

--- a/components/discussion/list/DiscussionFilterBar.vue
+++ b/components/discussion/list/DiscussionFilterBar.vue
@@ -130,8 +130,8 @@ const isExpanded = computed(() => {
 </script>
 
 <template>
-  <div class="pb-2 pt-2">
-    <div class="flex flex-wrap items-center justify-between gap-2">
+  <div class="pb-3 pt-3">
+    <div class="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
       <h1
         class="font-semibold h-9 px-4 text-xl leading-9 dark:text-white lg:px-0"
       >
@@ -147,61 +147,57 @@ const isExpanded = computed(() => {
           About
         </button>
       </div>
-      <div class="flex flex-wrap items-center justify-end gap-1">
-        <FilterChip
-          v-if="!isForumScoped"
-          class="align-middle"
-          :data-testid="'forum-filter-button'"
-          :label="channelLabel"
-          :highlighted="
-            filterValues.channels && filterValues.channels.length > 0
-          "
-        >
-          <template #icon>
-            <ChannelIcon class="-ml-0.5 mr-2 h-4 w-4" />
-          </template>
-          <template #content>
-            <div class="relative w-96">
-              <SearchableForumList
-                :selected-channels="filterValues.channels"
-                @toggle-selection="toggleSelectedChannel"
-              />
-            </div>
-          </template>
-        </FilterChip>
-        <!-- Expand/Collapse Button Group (hidden in download mode) -->
+      <div class="flex flex-wrap items-center justify-end gap-3">
+        <div v-if="!isForumScoped" class="flex items-center">
+          <FilterChip
+            class="align-middle"
+            :data-testid="'forum-filter-button'"
+            :label="channelLabel"
+            :highlighted="
+              filterValues.channels && filterValues.channels.length > 0
+            "
+          >
+            <template #icon>
+              <ChannelIcon class="h-4 w-4" />
+            </template>
+            <template #content>
+              <div class="relative w-96">
+                <SearchableForumList
+                  :selected-channels="filterValues.channels"
+                  @toggle-selection="toggleSelectedChannel"
+                />
+              </div>
+            </template>
+          </FilterChip>
+        </div>
         <div
           v-if="!isDownloadPage"
-          class="flex overflow-hidden rounded-md border border-gray-300 dark:border-gray-600"
+          class="flex overflow-hidden rounded-lg border border-gray-200 bg-gradient-to-b from-white to-gray-50 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] dark:border-slate-600 dark:bg-none dark:bg-slate-900 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
         >
           <button
             data-testid="expand-all-button"
             aria-label="Expand all discussions"
             :aria-pressed="isExpanded"
             :class="[
-              // layout
-              'flex h-9 items-center border-l px-2 transition-colors first:border-none',
-              // base (non‑active) colours
-              !isExpanded
-                ? 'bg-gray-50 text-gray-800 dark:bg-gray-800 dark:text-gray-300'
-                : 'bg-gray-800 text-white dark:bg-gray-700 dark:text-white',
-              // hover shade (one step darker) – always present
-              'hover:bg-gray-700 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white',
+              'flex h-10 w-10 items-center justify-center transition-colors',
+              isExpanded
+                ? 'bg-gray-900 text-white dark:bg-slate-700 dark:text-white'
+                : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-800',
             ]"
             title="Expand all discussions"
             @click="expandAll"
           >
             <i class="fa-solid fa-expand text-xs" />
           </button>
+          <div class="w-px bg-gray-200 dark:bg-slate-600" />
           <button
             aria-label="Collapse all discussions"
             :aria-pressed="!isExpanded"
             :class="[
-              'flex h-9 items-center border-l px-2 transition-colors',
-              isExpanded
-                ? 'bg-gray-50 text-gray-800 dark:bg-gray-800 dark:text-gray-300'
-                : 'bg-gray-800 text-white dark:bg-gray-700 dark:text-white',
-              'hover:bg-gray-700 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white',
+              'flex h-10 w-10 items-center justify-center transition-colors',
+              !isExpanded
+                ? 'bg-gray-900 text-white dark:bg-slate-700 dark:text-white'
+                : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-800',
             ]"
             title="Collapse all discussions"
             @click="collapseAll"
@@ -209,49 +205,54 @@ const isExpanded = computed(() => {
             <i class="fa-solid fa-compress text-xs" />
           </button>
         </div>
-        <button
-          data-testid="discussion-filter-button"
-          :aria-label="showFilters ? 'Hide filters' : 'Show filters'"
-          :title="showFilters ? 'Hide filters' : 'Show filters'"
-          :class="
-            showFilters
-              ? 'border-gray-500 bg-gray-100 text-gray-900 dark:border-gray-400 dark:bg-gray-800 dark:text-white'
-              : 'border-gray-300 text-gray-800 dark:border-gray-600 dark:text-gray-300'
-          "
-          class="flex h-9 items-center gap-1 rounded-md border px-2 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-900 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-          @click="
-            (event) => {
-              event.preventDefault();
-              toggleShowFilters();
-            }
-          "
-        >
-          <FilterIcon />
-        </button>
-        <button
-          data-testid="discussion-search-button"
-          :aria-label="showSearch ? 'Hide search' : 'Show search'"
-          :title="showSearch ? 'Hide search' : 'Show search'"
-          :class="
-            showSearch
-              ? 'border-gray-500 bg-gray-100 text-gray-900 dark:border-gray-400 dark:bg-gray-800 dark:text-white'
-              : 'border-gray-300 text-gray-800 dark:border-gray-600 dark:text-gray-300'
-          "
-          class="flex h-9 items-center gap-1 rounded-md border px-2 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-900 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-          @click="
-            (event) => {
-              event.preventDefault();
-              toggleShowSearch();
-            }
-          "
-        >
-          <SearchIcon />
-        </button>
-        <SortButtons />
-        <div v-if="!isDownloadPage">
+        <div class="flex items-center gap-2">
+          <button
+            data-testid="discussion-filter-button"
+            :aria-label="showFilters ? 'Hide filters' : 'Show filters'"
+            :title="showFilters ? 'Hide filters' : 'Show filters'"
+            :class="
+              showFilters
+                ? 'border-gray-400 bg-gray-100 text-gray-900 dark:border-slate-500 dark:bg-slate-800 dark:text-white'
+                : 'border-gray-200 text-gray-700 dark:border-slate-600 dark:text-gray-300'
+            "
+            class="flex h-10 w-10 items-center justify-center rounded-lg border bg-gradient-to-b from-white to-gray-50 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] transition-colors hover:border-gray-300 hover:bg-gray-100 hover:text-gray-900 dark:bg-none dark:bg-slate-900 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:border-slate-500 dark:hover:bg-slate-800 dark:hover:text-white"
+            @click="
+              (event) => {
+                event.preventDefault();
+                toggleShowFilters();
+              }
+            "
+          >
+            <FilterIcon class="h-4 w-4" />
+          </button>
+          <button
+            data-testid="discussion-search-button"
+            :aria-label="showSearch ? 'Hide search' : 'Show search'"
+            :title="showSearch ? 'Hide search' : 'Show search'"
+            :class="
+              showSearch
+                ? 'border-gray-400 bg-gray-100 text-gray-900 dark:border-slate-500 dark:bg-slate-800 dark:text-white'
+                : 'border-gray-200 text-gray-700 dark:border-slate-600 dark:text-gray-300'
+            "
+            class="flex h-10 w-10 items-center justify-center rounded-lg border bg-gradient-to-b from-white to-gray-50 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] transition-colors hover:border-gray-300 hover:bg-gray-100 hover:text-gray-900 dark:bg-none dark:bg-slate-900 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:border-slate-500 dark:hover:bg-slate-800 dark:hover:text-white"
+            @click="
+              (event) => {
+                event.preventDefault();
+                toggleShowSearch();
+              }
+            "
+          >
+            <SearchIcon class="h-4 w-4" />
+          </button>
+        </div>
+        <div class="flex items-center">
+          <SortButtons />
+        </div>
+        <div v-if="!isDownloadPage" class="flex items-center">
           <RequireAuth :full-width="false">
             <template #has-auth>
               <PrimaryButton
+                class="h-10 rounded-lg border-gray-400 bg-gradient-to-b from-gray-700 to-gray-800 px-4 font-semibold text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:from-gray-600 hover:to-gray-700 dark:border-slate-500 dark:from-slate-700 dark:to-slate-800 dark:hover:from-slate-600 dark:hover:to-slate-700"
                 :label="isDownloadPage ? 'New Upload' : 'New Post'"
                 @click="
                   $router.push(
@@ -266,6 +267,7 @@ const isExpanded = computed(() => {
             </template>
             <template #does-not-have-auth>
               <PrimaryButton
+                class="h-10 rounded-lg border-gray-400 bg-gradient-to-b from-gray-700 to-gray-800 px-4 font-semibold text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:from-gray-600 hover:to-gray-700 dark:border-slate-500 dark:from-slate-700 dark:to-slate-800 dark:hover:from-slate-600 dark:hover:to-slate-700"
                 :label="isDownloadPage ? 'New Upload' : 'New Post'"
               />
             </template>
@@ -273,10 +275,10 @@ const isExpanded = computed(() => {
         </div>
       </div>
     </div>
-    <hr class="mt-2 border border-t-gray-500 dark:border-t-gray-600" >
+    <hr class="mt-3 border-t border-gray-200 dark:border-slate-700" >
     <div
       v-if="showSearch"
-      class="flex flex-col gap-2 bg-gray-100 py-2 dark:bg-gray-900 dark:text-gray-300"
+      class="mt-3 flex flex-col gap-2 rounded-xl border border-gray-200 bg-gray-100/80 px-3 py-3 dark:border-slate-700 dark:bg-slate-900/80 dark:text-gray-300"
     >
       <SearchBar
         data-testid="discussion-filter-search-bar"
@@ -291,7 +293,7 @@ const isExpanded = computed(() => {
     </div>
     <div
       v-if="showFilters"
-      class="flex justify-end gap-2 bg-gray-100 py-2 dark:bg-gray-900 dark:text-gray-300"
+      class="mt-3 flex flex-wrap justify-end gap-2 rounded-xl border border-gray-200 bg-gray-100/80 px-3 py-3 dark:border-slate-700 dark:bg-slate-900/80 dark:text-gray-300"
     >
       <FilterChip
         class="align-middle"
@@ -300,7 +302,7 @@ const isExpanded = computed(() => {
         :highlighted="tagLabel !== defaultFilterLabels.tags"
       >
         <template #icon>
-          <TagIcon class="-ml-0.5 mr-2 h-4 w-4" />
+          <TagIcon class="h-4 w-4" />
         </template>
         <template #content>
           <div class="relative w-96">

--- a/components/download/DownloadFilterBar.vue
+++ b/components/download/DownloadFilterBar.vue
@@ -130,9 +130,9 @@ const hasActiveDownloadFilters = computed(() => {
 </script>
 
 <template>
-  <div class="pb-2 pt-2">
+  <div class="pb-3 pt-3">
     <div>
-      <div class="flex flex-wrap items-center justify-end space-x-2">
+      <div class="flex flex-wrap items-center justify-end gap-3">
         <!-- Download Filters Button (mobile only) -->
         <button
           v-if="filterGroups.length > 0"
@@ -140,15 +140,15 @@ const hasActiveDownloadFilters = computed(() => {
           :aria-label="showFilters ? 'Hide filters' : 'Show filters'"
           :title="showFilters ? 'Hide filters' : 'Show filters'"
           :class="[
-            'flex h-9 items-center gap-1 rounded-md border px-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 lg:hidden',
+            'flex h-10 min-w-10 items-center justify-center gap-1.5 rounded-lg border bg-gradient-to-b from-white to-gray-50 px-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] transition-colors hover:border-gray-300 hover:bg-gray-100 dark:bg-none dark:bg-slate-900 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:border-slate-500 dark:hover:bg-slate-800 lg:hidden',
             hasActiveDownloadFilters || showFilters
-              ? 'border-orange-500 text-orange-600 dark:text-orange-400'
-              : 'border-gray-800 text-gray-800 dark:border-gray-600 dark:text-gray-300',
+              ? 'border-gray-400 bg-gray-100 text-gray-900 dark:border-slate-500 dark:bg-slate-800 dark:text-white'
+              : 'border-gray-200 text-gray-700 dark:border-slate-600 dark:text-gray-300',
           ]"
           @click="toggleShowFilters"
         >
-          <FilterIcon />
-          <span v-if="hasActiveDownloadFilters" class="ml-1 text-xs">
+          <FilterIcon class="h-4 w-4" />
+          <span v-if="hasActiveDownloadFilters" class="text-xs font-medium">
             {{ getActiveDownloadFilterCount }}
           </span>
         </button>
@@ -159,35 +159,38 @@ const hasActiveDownloadFilters = computed(() => {
           :title="showSearch ? 'Hide search' : 'Show search'"
           :class="
             showSearch
-              ? 'border-orange-500'
-              : 'border-gray-800 text-gray-800 dark:border-gray-600 dark:text-gray-300'
+              ? 'border-gray-400 bg-gray-100 text-gray-900 dark:border-slate-500 dark:bg-slate-800 dark:text-white'
+              : 'border-gray-200 text-gray-700 dark:border-slate-600 dark:text-gray-300'
           "
-          class="flex h-9 items-center gap-1 rounded-md border px-1.5 text-gray-800 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          class="flex h-10 w-10 items-center justify-center rounded-lg border bg-gradient-to-b from-white to-gray-50 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] transition-colors hover:border-gray-300 hover:bg-gray-100 hover:text-gray-900 dark:bg-none dark:bg-slate-900 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:border-slate-500 dark:hover:bg-slate-800 dark:hover:text-white"
           @click="toggleShowSearch"
         >
-          <SearchIcon />
+          <SearchIcon class="h-4 w-4" />
         </button>
         <SortButtons />
         <RequireAuth :full-width="false">
           <template #has-auth>
             <PrimaryButton
-              class="mx-2"
+              class="h-10 rounded-lg border-gray-400 bg-gradient-to-b from-gray-700 to-gray-800 px-4 font-semibold text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:from-gray-600 hover:to-gray-700 dark:border-slate-500 dark:from-slate-700 dark:to-slate-800 dark:hover:from-slate-600 dark:hover:to-slate-700"
               label="New Upload"
               @click="$router.push(`/forums/${channelId}/downloads/create`)"
             />
           </template>
           <template #does-not-have-auth>
-            <PrimaryButton class="mx-2" label="New Upload" />
+            <PrimaryButton
+              class="h-10 rounded-lg border-gray-400 bg-gradient-to-b from-gray-700 to-gray-800 px-4 font-semibold text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:from-gray-600 hover:to-gray-700 dark:border-slate-500 dark:from-slate-700 dark:to-slate-800 dark:hover:from-slate-600 dark:hover:to-slate-700"
+              label="New Upload"
+            />
           </template>
         </RequireAuth>
       </div>
     </div>
-    <hr class="mt-2 border border-t-gray-500 dark:border-t-gray-600" >
+    <hr class="mt-3 border-t border-gray-200 dark:border-slate-700" >
 
     <!-- Search Panel -->
     <div
       v-if="showSearch"
-      class="flex flex-col gap-2 bg-gray-100 py-2 dark:bg-gray-700 dark:text-gray-300"
+      class="mt-3 flex flex-col gap-2 rounded-xl border border-gray-200 bg-gray-100/80 px-3 py-3 dark:border-slate-700 dark:bg-slate-900/80 dark:text-gray-300"
     >
       <SearchBar
         data-testid="download-filter-search-bar"
@@ -204,7 +207,7 @@ const hasActiveDownloadFilters = computed(() => {
     <!-- Mobile Filter Panel -->
     <div
       v-if="showFilters && filterGroups.length > 0"
-      class="flex flex-col gap-4 bg-gray-100 px-2 py-4 dark:bg-gray-800 dark:text-gray-300 lg:hidden"
+      class="mt-3 flex flex-col gap-4 rounded-xl border border-gray-200 bg-gray-100/80 px-3 py-4 dark:border-slate-700 dark:bg-slate-900/80 dark:text-gray-300 lg:hidden"
     >
       <DownloadFilters :filter-groups="filterGroups" />
 
@@ -243,7 +246,7 @@ const hasActiveDownloadFilters = computed(() => {
     <!-- Desktop Filter Panel (for tags/archived only) -->
     <div
       v-if="showFilters && !filterGroups.length"
-      class="hidden justify-end gap-2 bg-gray-100 py-2 dark:bg-gray-700 dark:text-gray-300 lg:flex"
+      class="mt-3 hidden flex-wrap justify-end gap-2 rounded-xl border border-gray-200 bg-gray-100/80 px-3 py-3 dark:border-slate-700 dark:bg-slate-900/80 dark:text-gray-300 lg:flex"
     >
       <FilterChip
         class="align-middle"
@@ -252,7 +255,7 @@ const hasActiveDownloadFilters = computed(() => {
         :highlighted="tagLabel !== 'Tags'"
       >
         <template #icon>
-          <TagIcon class="-ml-0.5 mr-2 h-4 w-4" />
+          <TagIcon class="h-4 w-4" />
         </template>
         <template #content>
           <div class="relative w-96">

--- a/components/event/list/filters/EventFilterBar.vue
+++ b/components/event/list/filters/EventFilterBar.vue
@@ -473,14 +473,14 @@ const IN_PERSON_FEATURED_FORUMS: ChannelOption[] = [
           <RequireAuth v-if="showNewEventNextToSearchBar" :full-width="false">
             <template #has-auth>
               <PrimaryButton
-                class="h-9 whitespace-nowrap"
+                class="h-10 whitespace-nowrap rounded-lg border-gray-400 bg-gradient-to-b from-gray-700 to-gray-800 px-4 font-semibold text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:from-gray-600 hover:to-gray-700 dark:border-slate-500 dark:from-slate-700 dark:to-slate-800 dark:hover:from-slate-600 dark:hover:to-slate-700"
                 :label="'New Event'"
                 @click="$router.push(createEventLink)"
               />
             </template>
             <template #does-not-have-auth>
               <PrimaryButton
-                class="h-9 whitespace-nowrap"
+                class="h-10 whitespace-nowrap rounded-lg border-gray-400 bg-gradient-to-b from-gray-700 to-gray-800 px-4 font-semibold text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:from-gray-600 hover:to-gray-700 dark:border-slate-500 dark:from-slate-700 dark:to-slate-800 dark:hover:from-slate-600 dark:hover:to-slate-700"
                 :label="'New Event'"
               />
             </template>

--- a/components/icons/SearchIcon.vue
+++ b/components/icons/SearchIcon.vue
@@ -6,7 +6,7 @@
     viewBox="0 0 20 20"
     fill="none"
     stroke="currentColor"
-    stroke-width="1.2"
+    stroke-width="1.5"
     aria-hidden="true"
   >
     <circle cx="8" cy="8" r="5" />


### PR DESCRIPTION
## What changed
This refines the shared filter bar surfaces used across discussions, downloads, and related toolbar controls.

## Why it changed
The existing filter bars were visually inconsistent across controls and still had several dark-mode issues, especially around search inputs and button surfaces.

## User impact
The filter bars now feel more consistent and polished: controls share a common height, radius, spacing, and icon alignment, and dark mode no longer shows unintended light search backgrounds or light gradients on toolbar buttons.

## Root cause
The filter bar UI relied on a mix of one-off classes across shared controls, and the search input was still inheriting a light forms background in dark mode even when dark utility classes were present.

## Validation
- `npm run tsc`

## Notes
This PR is limited to the shared filter bar primitives and the bars that consume them, including discussions and downloads.