### PR TITLE
[codex] Fix dark hover styling for text dropdown

### DIFF
--- a/components/TextButtonDropdown.spec.ts
+++ b/components/TextButtonDropdown.spec.ts
@@ -37,6 +37,14 @@ describe('TextButtonDropdown', () => {
     expect(wrapper.find('sort-icon-stub').exists()).toBe(true);
   });
 
+  it('uses the dark hover background variant on the trigger button', () => {
+    const wrapper = mountDropdown({ label: 'Sort' });
+
+    expect(wrapper.find('.menu-button').attributes('class')).toContain(
+      'dark:hover:bg-gray-800'
+    );
+  });
+
   it('emits clickedItem with the value', async () => {
     const wrapper = mountDropdown({ items: [{ value: 'top', label: 'Top' }] });
 

--- a/components/TextButtonDropdown.vue
+++ b/components/TextButtonDropdown.vue
@@ -39,7 +39,7 @@ function handleClick(item: MenuItemType) {
       <div>
         <MenuButton
           :data-testid="`text-dropdown-${label}`"
-          class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-100 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
+          class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-100 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800"
         >
           <SortIcon v-if="showSortIcon" class="h-4 w-4" aria-hidden="true" />
           {{ label }}
@@ -87,7 +87,7 @@ function handleClick(item: MenuItemType) {
     <template #fallback>
       <button
         :data-testid="`text-dropdown-${label}`"
-        class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-200 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
+        class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-200 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800"
       >
         <SortIcon v-if="showSortIcon" class="h-4 w-4" aria-hidden="true" />
         {{ label }}


### PR DESCRIPTION
## Summary
Fix the dark-mode hover styling on the shared text dropdown trigger used by the discussion filter bar and related controls.

## What Changed
- replaced the invalid Tailwind variant order `hover:dark:bg-gray-800` with `dark:hover:bg-gray-800` in `TextButtonDropdown`
- added a regression test to assert the trigger button includes the correct dark hover class

## Root Cause
A recent styling change used an invalid Tailwind variant ordering, so the dark hover background class never applied. In dark mode that allowed the light hover background to win while the trigger text stayed white.

## Impact
Dropdown buttons used in the discussion filter bar and reused components now keep a dark hover background in dark mode instead of rendering white text on a light background.

## Validation
- `npx vitest run components/TextButtonDropdown.spec.ts`