### PR TITLE
[codex] Refine library mobile navigation and collection layout

### DIFF
--- a/components/GenericModal.vue
+++ b/components/GenericModal.vue
@@ -126,7 +126,7 @@ const dangerButtonClasses = computed(() => {
 
         <div class="fixed inset-0 z-10 overflow-y-auto">
           <div
-            class="flex min-h-full items-end justify-center text-center sm:items-center sm:p-0 md:p-4"
+            class="flex min-h-full items-start justify-center px-3 pb-6 pt-8 text-center sm:items-center sm:px-0 sm:pb-0 sm:pt-0 md:p-4"
           >
             <TransitionChild
               as="template"
@@ -138,7 +138,7 @@ const dangerButtonClasses = computed(() => {
               leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
               <DialogPanel
-                class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all dark:bg-gray-800 sm:my-8 sm:w-full sm:p-6"
+                class="relative w-full max-w-lg transform overflow-hidden rounded-2xl bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all dark:bg-gray-800 sm:my-8 sm:p-6"
               >
                 <!-- Header Area with fixed height -->
                 <div class="flex-none px-2 pb-2 pt-5 md:px-4">

--- a/components/album/AlbumThumbnailGrid.vue
+++ b/components/album/AlbumThumbnailGrid.vue
@@ -46,7 +46,7 @@ defineProps({
       <img
         :src="image.url || ''"
         :alt="image.alt || image.caption || 'Album image'"
-        class="h-full w-full object-cover transition-transform group-hover:scale-105"
+        class="h-full w-full object-cover"
       >
       <div
         v-if="showCaptions && image.caption"

--- a/components/collection/CollectionDownloadListItem.vue
+++ b/components/collection/CollectionDownloadListItem.vue
@@ -50,7 +50,7 @@ const createdAgo = computed(() => {
 
 <template>
   <li
-    class="w-48 flex-shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
+    class="w-48 flex-shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
   >
     <nuxt-link :to="linkTarget" class="block">
       <div

--- a/components/collection/PublicCollectionListItem.vue
+++ b/components/collection/PublicCollectionListItem.vue
@@ -27,7 +27,7 @@ const creatorLabel = computed(() => {
 
 <template>
   <div
-    class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-orange-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-orange-400"
+    class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition hover:border-orange-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-orange-400"
   >
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">

--- a/components/library/LibraryChannelCard.vue
+++ b/components/library/LibraryChannelCard.vue
@@ -28,7 +28,7 @@ withDefaults(
 
 <template>
   <article
-    class="rounded-2xl border border-slate-200/80 bg-white p-5 shadow-[0_18px_45px_-28px_rgba(15,23,42,0.45)] transition-all hover:-translate-y-0.5 hover:shadow-[0_24px_60px_-30px_rgba(15,23,42,0.55)] dark:border-gray-700 dark:bg-gray-800"
+    class="rounded-2xl border border-slate-200/80 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
   >
     <div class="flex items-start justify-between gap-4">
       <NuxtLink

--- a/components/library/LibraryCommentCard.vue
+++ b/components/library/LibraryCommentCard.vue
@@ -95,14 +95,14 @@ withDefaults(
       </div>
     </div>
 
-    <div class="mt-5 flex items-end justify-between gap-4">
+    <div class="mt-5 flex flex-wrap items-end justify-between gap-4">
       <div class="min-w-0 text-sm text-gray-500 dark:text-gray-400">
         <NuxtLink
           :to="contextPermalink"
-          class="inline-flex min-w-0 items-center gap-1 rounded-full bg-orange-50 px-3 py-1.5 font-medium text-orange-700 transition-colors hover:bg-orange-100 dark:bg-orange-500/10 dark:text-orange-300 dark:hover:bg-orange-500/20"
+          class="flex max-w-full flex-wrap items-center gap-x-1 gap-y-0.5 rounded-2xl bg-orange-50 px-3 py-1.5 font-medium text-orange-700 transition-colors hover:bg-orange-100 dark:bg-orange-500/10 dark:text-orange-300 dark:hover:bg-orange-500/20"
         >
           <span class="opacity-75">Post from</span>
-          <span class="truncate">{{ contextTitle }}</span>
+          <span class="min-w-0 break-words">{{ contextTitle }}</span>
         </NuxtLink>
       </div>
 

--- a/components/library/LibraryCommentCard.vue
+++ b/components/library/LibraryCommentCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import AvatarComponent from '@/components/AvatarComponent.vue';
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import AddToCommentFavorites from '@/components/favorites/AddToCommentFavorites.vue';
 import MarkdownPreview from '@/components/MarkdownPreview.vue';
@@ -44,66 +45,83 @@ withDefaults(
 
 <template>
   <article
-    class="rounded-2xl border border-slate-200/80 bg-white p-5 shadow-[0_18px_45px_-28px_rgba(15,23,42,0.45)] transition-all hover:-translate-y-0.5 hover:shadow-[0_24px_60px_-30px_rgba(15,23,42,0.55)] dark:border-gray-700 dark:bg-gray-800"
+    class="rounded-[1.6rem] border border-gray-200/80 bg-white/92 p-5 shadow-[0_18px_45px_-28px_rgba(38,38,38,0.24)] dark:border-gray-700 dark:bg-gray-800"
   >
-    <div class="mb-4 flex items-start justify-between gap-3">
+    <div class="mb-4 flex items-start justify-between gap-4">
+      <div class="flex min-w-0 items-center gap-3">
+        <AvatarComponent
+          :text="authorInfo?.displayName || authorInfo?.username || 'Deleted'"
+          :src="authorInfo?.profilePicURL || ''"
+          :is-small="true"
+        />
+        <div class="min-w-0">
+          <div class="min-w-0 text-sm text-gray-900 dark:text-white">
+            <UsernameWithTooltip
+              v-if="authorInfo && !authorInfo.isModerationProfile"
+              :username="authorInfo.username"
+              :display-name="authorInfo.displayName"
+              :src="authorInfo.profilePicURL"
+              :is-server-admin="authorInfo.isAdmin"
+              :comment-karma="authorInfo.commentKarma"
+              :discussion-karma="authorInfo.discussionKarma"
+              :account-created="authorInfo.createdAt"
+            />
+            <span
+              v-else-if="authorInfo?.isModerationProfile"
+              class="font-semibold text-orange-600 dark:text-orange-400"
+            >
+              {{ authorInfo.displayName }} (Moderator)
+            </span>
+            <span v-else class="font-semibold">Deleted</span>
+          </div>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {{ relativeTime(comment.createdAt) }}
+          </p>
+        </div>
+      </div>
+
       <NuxtLink
-        :to="contextPermalink"
-        class="inline-flex min-w-0 items-center gap-2 rounded-full bg-orange-50 px-3 py-1 text-sm font-medium text-orange-700 transition-colors hover:bg-orange-100 dark:bg-orange-500/10 dark:text-orange-300 dark:hover:bg-orange-500/20"
+        :to="permalink"
+        aria-label="Open comment"
+        class="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-gray-200 bg-gray-50 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
       >
-        <span class="opacity-80">{{ contextType }}</span>
-        <span class="truncate">{{ contextTitle }}</span>
+        <i class="fa-solid fa-ellipsis" />
       </NuxtLink>
-      <span class="flex-shrink-0 text-sm text-gray-500 dark:text-gray-400">
-        {{ relativeTime(comment.createdAt) }}
-      </span>
     </div>
 
-    <div class="rounded-xl bg-slate-50/80 px-4 py-3 dark:bg-gray-900/45">
-      <div class="prose prose-sm max-w-none dark:prose-invert">
+    <div class="rounded-[1.2rem] border border-gray-200/80 bg-gray-50/85 px-4 py-4 dark:border-gray-700 dark:bg-gray-900">
+      <div class="prose prose-sm max-w-none leading-[1.6] dark:prose-invert">
         <MarkdownPreview :text="comment.text" :disable-gallery="false" />
       </div>
     </div>
 
-    <div class="mt-4 flex items-center justify-between gap-3">
-      <div class="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-500 dark:text-gray-400">
-        <div class="flex min-w-0 items-center">
-          <span class="mr-1">by</span>
-          <UsernameWithTooltip
-            v-if="authorInfo && !authorInfo.isModerationProfile"
-            :username="authorInfo.username"
-            :display-name="authorInfo.displayName"
-            :src="authorInfo.profilePicURL"
-            :is-server-admin="authorInfo.isAdmin"
-            :comment-karma="authorInfo.commentKarma"
-            :discussion-karma="authorInfo.discussionKarma"
-            :account-created="authorInfo.createdAt"
-          />
-          <span
-            v-else-if="authorInfo?.isModerationProfile"
-            class="text-orange-600 dark:text-orange-400"
-          >
-            {{ authorInfo.displayName }} (Moderator)
-          </span>
-          <span v-else>Deleted</span>
-        </div>
-
+    <div class="mt-5 flex items-end justify-between gap-4">
+      <div class="min-w-0 text-sm text-gray-500 dark:text-gray-400">
         <NuxtLink
-          :to="permalink"
-          class="inline-flex items-center gap-1 transition-colors hover:text-gray-700 dark:hover:text-gray-300"
+          :to="contextPermalink"
+          class="inline-flex min-w-0 items-center gap-1 rounded-full bg-orange-50 px-3 py-1.5 font-medium text-orange-700 transition-colors hover:bg-orange-100 dark:bg-orange-500/10 dark:text-orange-300 dark:hover:bg-orange-500/20"
         >
-          <i class="fa-regular fa-comment" />
-          View Comment
+          <span class="opacity-75">Post from</span>
+          <span class="truncate">{{ contextTitle }}</span>
         </NuxtLink>
       </div>
 
-      <div v-if="showFavoriteButton" class="flex-shrink-0">
-        <AddToCommentFavorites
-          :allow-add-to-list="allowAddToList"
-          :comment-id="comment.id"
-          :is-favorited="isFavorited"
-          size="medium"
-        />
+      <div class="flex flex-shrink-0 items-center gap-2">
+        <NuxtLink
+          :to="permalink"
+          class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-gray-50 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white"
+          aria-label="View comment thread"
+        >
+          <i class="fa-solid fa-arrow-up-right-from-square text-sm" />
+        </NuxtLink>
+        <div v-if="showFavoriteButton" class="flex-shrink-0">
+          <AddToCommentFavorites
+            :allow-add-to-list="allowAddToList"
+            :comment-id="comment.id"
+            :is-favorited="isFavorited"
+            size="medium"
+          />
+        </div>
       </div>
     </div>
   </article>

--- a/components/library/LibraryDiscussionCard.vue
+++ b/components/library/LibraryDiscussionCard.vue
@@ -69,7 +69,7 @@ const albumForDisplay = computed(() => props.discussion.Album as Album | null);
 
 <template>
   <article
-    class="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_18px_45px_-28px_rgba(15,23,42,0.45)] transition-all hover:-translate-y-0.5 hover:shadow-[0_24px_60px_-30px_rgba(15,23,42,0.55)] dark:border-gray-700 dark:bg-gray-800"
+    class="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_18px_45px_-28px_rgba(15,23,42,0.45)] dark:border-gray-700 dark:bg-gray-800"
   >
     <div class="border-b border-slate-200/70 bg-slate-50/85 px-5 py-3 dark:border-gray-700 dark:bg-gray-900/40">
       <div class="flex items-center justify-between gap-3">

--- a/components/library/LibraryDownloadCard.vue
+++ b/components/library/LibraryDownloadCard.vue
@@ -47,7 +47,7 @@ withDefaults(
 
 <template>
   <article
-    class="group overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_18px_45px_-28px_rgba(15,23,42,0.45)] transition-all hover:-translate-y-0.5 hover:shadow-[0_24px_60px_-30px_rgba(15,23,42,0.55)] dark:border-gray-700 dark:bg-gray-800"
+    class="group overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_18px_45px_-28px_rgba(15,23,42,0.45)] dark:border-gray-700 dark:bg-gray-800"
   >
     <NuxtLink
       :to="downloadLink"
@@ -57,7 +57,7 @@ withDefaults(
         v-if="previewImageUrl"
         :src="previewImageUrl"
         :alt="download.title"
-        class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+        class="h-full w-full object-cover"
       >
       <div
         v-else

--- a/components/nav/Breadcrumbs.spec.ts
+++ b/components/nav/Breadcrumbs.spec.ts
@@ -31,9 +31,28 @@ describe('Breadcrumbs', () => {
     expect(wrapper.text()).toContain('Forums');
   });
 
+  it('includes dark-mode link styling for breadcrumb links', () => {
+    const wrapper = mountCrumbs([{ path: 'forums', label: 'Forums' }]);
+    expect(wrapper.get('a').attributes('class')).toContain('dark:text-gray-300');
+  });
+
   it('builds the link href from the path', () => {
     const wrapper = mountCrumbs([{ path: 'forums/cats', label: 'Cats' }]);
     expect(wrapper.get('a').attributes('href')).toBe('/forums/cats/');
+  });
+
+  it('renders root links without adding an extra slash', () => {
+    const wrapper = mountCrumbs([{ path: '/', label: 'Home' }]);
+    expect(wrapper.get('a').attributes('href')).toBe('/');
+  });
+
+  it('renders the current crumb as plain text', () => {
+    const wrapper = mountCrumbs([
+      { path: 'library', label: 'Library' },
+      { label: 'Saved Comments', current: true },
+    ]);
+    expect(wrapper.text()).toContain('Saved Comments');
+    expect(wrapper.findAll('a')).toHaveLength(1);
   });
 
   it('does not render a chevron before the first crumb', () => {

--- a/components/nav/Breadcrumbs.vue
+++ b/components/nav/Breadcrumbs.vue
@@ -24,12 +24,12 @@ const buildTarget = (link: Link) => {
 
 <template>
   <nav class="mb-1 mt-2 flex" aria-label="Breadcrumb">
-    <ol role="list" class="flex items-center space-x-4">
+    <ol role="list" class="flex flex-wrap items-center gap-x-4 gap-y-2">
       <li
         v-for="(link, i) in props.links"
         :key="`${link.path || 'current'}-${link.label}`"
       >
-        <div class="flex items-center">
+        <div class="flex items-center whitespace-nowrap">
           <!-- Heroicon name: solid/chevron-right -->
           <svg
             v-if="i !== 0"

--- a/components/nav/Breadcrumbs.vue
+++ b/components/nav/Breadcrumbs.vue
@@ -1,18 +1,34 @@
 <script setup lang="ts">
 interface Link {
-  path: string;
+  path?: string;
   label: string;
+  current?: boolean;
 }
 
-defineProps<{
+const props = defineProps<{
   links: Link[];
 }>();
+
+const buildTarget = (link: Link) => {
+  if (!link.path || link.current) {
+    return null;
+  }
+
+  if (link.path === '/') {
+    return '/';
+  }
+
+  return link.path.startsWith('/') ? link.path : `/${link.path}/`;
+};
 </script>
 
 <template>
   <nav class="mb-1 mt-2 flex" aria-label="Breadcrumb">
     <ol role="list" class="flex items-center space-x-4">
-      <li v-for="(link, i) in links" :key="link.path">
+      <li
+        v-for="(link, i) in props.links"
+        :key="`${link.path || 'current'}-${link.label}`"
+      >
         <div class="flex items-center">
           <!-- Heroicon name: solid/chevron-right -->
           <svg
@@ -30,13 +46,19 @@ defineProps<{
             />
           </svg>
           <nuxt-link
-            v-if="link.path"
-            :to="`/${link.path}/`"
-            class="text-xs text-gray-500 underline hover:text-gray-700"
-            active-class="text-gray-700"
+            v-if="buildTarget(link)"
+            :to="buildTarget(link)"
+            class="text-xs text-gray-500 underline hover:text-gray-700 dark:text-gray-300 dark:hover:text-white"
+            active-class="text-gray-700 dark:text-white"
           >
             {{ link.label }}
           </nuxt-link>
+          <span
+            v-else
+            class="text-xs font-medium text-gray-700 dark:text-gray-300"
+          >
+            {{ link.label }}
+          </span>
         </div>
       </li>
     </ol>

--- a/components/nav/LoginButton.vue
+++ b/components/nav/LoginButton.vue
@@ -11,7 +11,7 @@ const { logout: handleLogout } = useServerLogout();
     <template #has-auth>
       <button
         data-testid="logout-button"
-        class="mr-2 inline-flex items-center rounded-full px-1 py-1 text-base leading-none font-medium tracking-[-0.02em] text-gray-300 transition-colors hover:text-white"
+        class="mr-2 inline-flex items-center rounded-full px-1 py-1 text-base leading-none font-medium tracking-[-0.02em] text-gray-700 transition-colors hover:text-gray-950 dark:text-gray-300 dark:hover:text-white"
         @click="handleLogout"
       >
         Log Out
@@ -20,7 +20,7 @@ const { logout: handleLogout } = useServerLogout();
     <template #does-not-have-auth>
       <button
         data-testid="login-button"
-        class="mr-2 inline-flex items-center rounded-full px-1 py-1 text-base leading-none font-medium tracking-[-0.02em] text-gray-300 transition-colors hover:text-white"
+        class="mr-2 inline-flex items-center rounded-full px-1 py-1 text-base leading-none font-medium tracking-[-0.02em] text-gray-700 transition-colors hover:text-gray-950 dark:text-gray-300 dark:hover:text-white"
       >
         Log In
       </button>

--- a/components/nav/TopNav.spec.ts
+++ b/components/nav/TopNav.spec.ts
@@ -8,9 +8,10 @@ const h = vi.hoisted(() => ({
   route: null as unknown,
   username: null as unknown,
   notificationCount: null as unknown,
+  smAndDown: null as unknown,
 }));
 
-vi.mock('vuetify', () => ({ useDisplay: () => ({ smAndDown: ref(false) }) }));
+vi.mock('vuetify', () => ({ useDisplay: () => ({ smAndDown: h.smAndDown }) }));
 vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
 vi.mock('@/cache', () => ({ sideNavIsOpenVar: false }));
 vi.mock('@/composables/useAuthState', () => ({
@@ -43,6 +44,7 @@ beforeEach(() => {
   h.route = { params: {}, name: 'home' };
   h.username = ref('');
   h.notificationCount = ref(0);
+  h.smAndDown = ref(false);
 });
 
 describe('TopNav branding', () => {
@@ -120,6 +122,14 @@ describe('TopNav actions', () => {
     const wrapper = mountNav();
 
     expect(wrapper.find('.profile').exists()).toBe(true);
+  });
+
+  it('does not render the profile menu on mobile widths', () => {
+    h.username = ref('alice');
+    h.smAndDown = ref(true);
+    const wrapper = mountNav();
+
+    expect(wrapper.find('.profile').exists()).toBe(false);
   });
 
   it('hides the profile menu when logged out', () => {

--- a/components/nav/TopNav.vue
+++ b/components/nav/TopNav.vue
@@ -90,7 +90,7 @@ const isOnMapPage = computed(() => {
         <div class="ml-2 flex h-full min-w-0 items-center gap-2 text-sm lg:gap-3">
           <nuxt-link to="/" class="flex h-full items-center gap-1.5">
             <h1
-              class="logo-font text-[1.2rem] font-semibold leading-none tracking-[-0.04em] text-white lg:text-[1.3rem]"
+              class="logo-font text-[1.2rem] font-semibold leading-none tracking-[-0.04em] text-gray-900 dark:text-white lg:text-[1.3rem]"
             >
               {{ config.serverDisplayName }}
             </h1>
@@ -98,12 +98,12 @@ const isOnMapPage = computed(() => {
 
           <div
             v-if="shouldShowChannelId"
-            class="hidden h-full items-center gap-2 text-base leading-none tracking-[-0.02em] text-gray-300 sm:flex"
+            class="hidden h-full items-center gap-2 text-base leading-none tracking-[-0.02em] text-gray-700 sm:flex dark:text-gray-300"
           >
-            <span class="inline-flex h-5 items-center self-center text-lg leading-none text-gray-400">•</span>
+            <span class="inline-flex h-5 items-center self-center text-lg leading-none text-gray-500 dark:text-gray-400">•</span>
             <nuxt-link
               :to="`/forums/${channelId}`"
-              class="inline-flex h-5 -translate-y-px items-center self-center max-w-[8rem] truncate leading-none text-gray-300 transition-colors hover:text-white sm:max-w-[12rem] lg:max-w-[16rem]"
+              class="inline-flex h-5 -translate-y-px items-center self-center max-w-[8rem] truncate leading-none text-gray-700 transition-colors hover:text-gray-950 sm:max-w-[12rem] lg:max-w-[16rem] dark:text-gray-300 dark:hover:text-white"
             >
               {{ channelId }}
             </nuxt-link>
@@ -116,16 +116,16 @@ const isOnMapPage = computed(() => {
           </div>
           <div
             v-else-if="routeInfoLabel"
-            class="hidden h-full items-center gap-2 truncate text-base leading-none tracking-[-0.02em] text-gray-300 sm:flex"
+            class="hidden h-full items-center gap-2 truncate text-base leading-none tracking-[-0.02em] text-gray-700 sm:flex dark:text-gray-300"
           >
-            <span class="inline-flex h-5 items-center self-center text-lg leading-none text-gray-400">•</span>
+            <span class="inline-flex h-5 items-center self-center text-lg leading-none text-gray-500 dark:text-gray-400">•</span>
             <span class="inline-flex h-5 -translate-y-px items-center self-center leading-none">
               {{ routeInfoLabel }}
             </span>
           </div>
           <div
             v-else
-            class="hidden h-full items-center gap-1 truncate text-base leading-none tracking-[-0.02em] text-gray-300 sm:flex"
+            class="hidden h-full items-center gap-1 truncate text-base leading-none tracking-[-0.02em] text-gray-700 sm:flex dark:text-gray-300"
           >
             <span class="inline-flex h-5 items-center self-center leading-none">
               {{ getLabel() }}
@@ -153,7 +153,7 @@ const isOnMapPage = computed(() => {
         <div class="hidden items-center justify-end gap-7 lg:flex">
           <nuxt-link
             to="/about"
-            class="inline-flex items-center px-1 py-1 text-base leading-none font-medium tracking-[-0.02em] text-gray-300 transition-colors hover:text-white"
+            class="inline-flex items-center px-1 py-1 text-base leading-none font-medium tracking-[-0.02em] text-gray-700 transition-colors hover:text-gray-950 dark:text-gray-300 dark:hover:text-white"
           >
             About
           </nuxt-link>
@@ -178,7 +178,7 @@ const isOnMapPage = computed(() => {
             data-testid="notification-bell"
             to="/notifications"
             :aria-label="notificationCountVar > 0 ? `${notificationCountVar} new notifications` : 'Notifications'"
-            class="relative inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-300 transition-colors hover:bg-white/5 hover:text-white focus:outline-none"
+            class="relative inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-200 hover:text-gray-950 focus:outline-none dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white"
           >
             <i class="fa-regular fa-bell text-lg" aria-hidden="true" />
             <span

--- a/components/nav/TopNav.vue
+++ b/components/nav/TopNav.vue
@@ -190,7 +190,7 @@ const isOnMapPage = computed(() => {
             </span>
           </nuxt-link>
           <ThemeSwitcher />
-          <div v-if="usernameVar" class="block">
+          <div v-if="usernameVar && !smAndDown" class="hidden md:block">
             <div class="flex items-center">
               <div class="relative flex-shrink-0">
                 <UserProfileDropdownMenu

--- a/components/nav/VerticalIconNav.vue
+++ b/components/nav/VerticalIconNav.vue
@@ -184,7 +184,7 @@ watch(
 );
 
 const ACTIVE_NAV_ITEM =
-  'bg-orange-100 text-orange-600 ring-1 ring-inset ring-orange-300 dark:bg-orange-500/20 dark:text-orange-400 dark:ring-orange-500/40';
+  'bg-orange-100 text-orange-700 ring-1 ring-inset ring-orange-300 dark:bg-orange-950/70 dark:text-orange-200 dark:ring-orange-700/70';
 
 const getNavItemClasses = (isActive: boolean) => {
   const baseClasses =
@@ -194,12 +194,12 @@ const getNavItemClasses = (isActive: boolean) => {
 
 const getNavIconClasses = (isActive: boolean) =>
   isActive
-    ? 'h-6 w-6 text-orange-600 dark:text-orange-400'
+    ? 'h-6 w-6 text-orange-700 dark:text-orange-200'
     : 'h-6 w-6 text-gray-500 dark:text-gray-300';
 
 const getNavLabelClasses = (isActive: boolean) =>
   isActive
-    ? 'w-full text-center text-[10px] leading-[10px] font-medium text-orange-600 dark:text-orange-400'
+    ? 'w-full text-center text-[10px] leading-[10px] font-medium text-orange-700 dark:text-orange-200'
     : 'w-full text-center text-[10px] leading-[10px] text-gray-600 dark:text-gray-300';
 </script>
 

--- a/pages/library.spec.ts
+++ b/pages/library.spec.ts
@@ -45,13 +45,24 @@ const RequireAuthUnauth = defineComponent({
   },
 });
 
+const PopperStub = defineComponent({
+  name: 'Popper',
+  setup(_p, { slots }) {
+    return () =>
+      createEl('div', [
+        slots.default?.(),
+        createEl('div', slots.content?.()),
+      ]);
+  },
+});
+
 const mountLibrary = (extraStubs: Record<string, unknown> = {}) =>
   mountWithDefaults(LibraryPage, {
     global: {
       mocks: {
         $route: { query: {}, params: {}, path: '/library', fullPath: '/library' },
       },
-      stubs: { NuxtPage: true, ...extraStubs },
+      stubs: { NuxtPage: true, Popper: PopperStub, ...extraStubs },
     },
   });
 
@@ -183,5 +194,64 @@ describe('Library page', () => {
       .find((link) => link.attributes('href') === '/library/favorite-channels');
 
     expect(favoriteForumsLink?.classes().join(' ')).toContain('bg-orange-100');
+  });
+
+  it('renders the active library item label in the mobile dropdown', () => {
+    setCounts(3, 1, 2);
+    h.route.path = '/library/favorite-discussions';
+
+    const wrapper = mountLibrary();
+    expect(wrapper.get('[data-testid="mobile-library-nav-dropdown"]').text()).toContain(
+      'Favorite Discussions'
+    );
+  });
+
+  it('renders collection links inside the mobile dropdown', async () => {
+    setCounts(3, 1, 2);
+    h.collections.value = {
+      users: [
+        {
+          Collections: [
+            {
+              id: 'c1',
+              name: 'My Reading List',
+              description: 'stuff to read',
+              collectionType: 'DISCUSSIONS',
+              visibility: 'PRIVATE',
+              itemCount: 4,
+            },
+          ],
+        },
+      ],
+    };
+
+    const wrapper = mountLibrary();
+    await wrapper.get('[data-testid="mobile-library-nav-dropdown"]').trigger('click');
+    expect(
+      wrapper.get('[data-testid="mobile-library-item-favorite-channels"]').attributes(
+        'href'
+      )
+    ).toBe('/library/favorite-channels');
+    expect(wrapper.get('[data-testid="mobile-library-item-c1"]').text()).toContain(
+      'My Reading List'
+    );
+  });
+
+  it('opens the mobile library navigation when the dropdown is clicked', async () => {
+    setCounts(3, 1, 2);
+    const wrapper = mountLibrary();
+
+    expect(wrapper.find('[data-testid="mobile-library-item-favorite-channels"]').exists()).toBe(
+      false
+    );
+
+    await wrapper.get('[data-testid="mobile-library-nav-dropdown"]').trigger('click');
+
+    expect(wrapper.get('[data-testid="mobile-library-nav-dropdown"]').attributes('aria-expanded')).toBe(
+      'true'
+    );
+    expect(wrapper.get('[data-testid="mobile-library-item-favorite-channels"]').exists()).toBe(
+      true
+    );
   });
 });

--- a/pages/library.spec.ts
+++ b/pages/library.spec.ts
@@ -9,10 +9,14 @@ const h = vi.hoisted(() => ({
   downloads: null as unknown as { value: unknown },
   owned: null as unknown as { value: unknown },
   collections: null as unknown as { value: unknown },
+  route: { path: '/library', params: {} as Record<string, unknown> },
   qi: 0,
 }));
 
-vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
+vi.mock('nuxt/app', () => ({
+  useHead: vi.fn(),
+  useRoute: () => h.route,
+}));
 
 vi.mock('@vue/apollo-composable', async () => {
   const { ref } = await import('vue');
@@ -70,6 +74,8 @@ const setCounts = (channels: number, discussions: number, images: number) => {
 beforeEach(() => {
   vi.clearAllMocks();
   h.qi = 0;
+  h.route.path = '/library';
+  h.route.params = {};
   h.counts.value = null;
   h.downloads.value = null;
   h.owned.value = null;
@@ -111,6 +117,16 @@ describe('Library page', () => {
     expect(mountLibrary().text()).toContain('My Reading List');
   });
 
+  it('renders the collection search input', () => {
+    setCounts(0, 0, 0);
+    const wrapper = mountLibrary();
+    expect(
+      wrapper.get('input[aria-label="Search library collections"]').attributes(
+        'placeholder'
+      )
+    ).toBe('Search collections');
+  });
+
   it('filters collections by type', async () => {
     setCounts(3, 1, 2);
     const wrapper = mountLibrary();
@@ -124,5 +140,48 @@ describe('Library page', () => {
     // Only the images favorite remains; the forums card (3) is filtered out.
     expect(wrapper.text()).toContain('(2)');
     expect(wrapper.text()).not.toContain('(3)');
+  });
+
+  it('filters collections by search term', async () => {
+    setCounts(0, 0, 0);
+    h.collections.value = {
+      users: [
+        {
+          Collections: [
+            {
+              id: 'c1',
+              name: 'My Reading List',
+              description: 'stuff to read',
+              collectionType: 'DISCUSSIONS',
+              visibility: 'PRIVATE',
+              itemCount: 4,
+            },
+          ],
+        },
+      ],
+    };
+
+    const wrapper = mountLibrary();
+    await wrapper
+      .get('input[aria-label="Search library collections"]')
+      .setValue('reading');
+
+    expect(wrapper.text()).toContain('My Reading List');
+    await wrapper
+      .get('input[aria-label="Search library collections"]')
+      .setValue('missing');
+    expect(wrapper.text()).toContain('No collections match "missing".');
+  });
+
+  it('marks a favorite collection route as active in the sidebar', () => {
+    setCounts(3, 1, 2);
+    h.route.path = '/library/favorite-channels';
+
+    const wrapper = mountLibrary();
+    const favoriteForumsLink = wrapper
+      .findAll('a')
+      .find((link) => link.attributes('href') === '/library/favorite-channels');
+
+    expect(favoriteForumsLink?.classes().join(' ')).toContain('bg-orange-100');
   });
 });

--- a/pages/library.vue
+++ b/pages/library.vue
@@ -22,6 +22,7 @@ useHead({
 // Filter state
 const activeFilter = ref('all');
 const searchTerm = ref('');
+const isMobileNavOpen = ref(false);
 
 // Filter options
 const filterOptions = [
@@ -96,6 +97,13 @@ watch(
       refetchOwnedDownloads();
       refetchCustomCollections();
     }
+  }
+);
+
+watch(
+  () => route.path,
+  () => {
+    isMobileNavOpen.value = false;
   }
 );
 
@@ -255,6 +263,31 @@ const filteredCustom = computed(() => {
   return filteredCollections.value.filter((c) => !c.id.startsWith('favorite-'));
 });
 
+const allMobileCollections = computed(() => [
+  {
+    id: 'my-downloads',
+    name: 'My Downloads',
+    itemCount: ownedDownloadsCount.value,
+    visibility: 'PRIVATE',
+    collectionType: 'DOWNLOADS',
+  },
+  ...filteredFavorites.value,
+  ...filteredCustom.value,
+]);
+
+const activeLibraryItem = computed(() => {
+  return (
+    allMobileCollections.value.find(
+      (collection) => collection.id === activeLibraryItemId.value
+    ) ?? null
+  );
+});
+
+const getLibraryItemRoute = (collectionId: string) =>
+  collectionId === 'my-downloads'
+    ? '/library/my-downloads'
+    : `/library/${collectionId}`;
+
 // Get color for collection type
 const getCollectionTypeInfo = (collectionType: string, isActive = false) => {
   if (isActive) {
@@ -314,13 +347,224 @@ const isMyDownloadsActive = computed(
       <RequireAuth>
         <template #has-auth>
           <div class="flex flex-col gap-4 px-3 py-4 md:flex-row md:gap-6 md:px-4">
-            <!-- Sidebar - hidden on mobile when viewing collection detail -->
-            <div
-              :class="[
-                'w-72 md:w-[24rem] md:flex-shrink-0',
-                activeLibraryItemId ? 'hidden md:block' : 'block',
-              ]"
-            >
+            <div class="md:hidden">
+              <button
+                class="flex w-full items-center justify-between rounded-[1.5rem] border border-gray-200 bg-white px-4 py-3 text-left text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+                data-testid="mobile-library-nav-dropdown"
+                type="button"
+                :aria-expanded="isMobileNavOpen ? 'true' : 'false'"
+                @click="isMobileNavOpen = !isMobileNavOpen"
+              >
+                <div class="min-w-0">
+                  <p class="truncate text-xs font-semibold uppercase tracking-[0.2em] text-gray-400 dark:text-gray-500">
+                    Library
+                  </p>
+                  <p class="mt-1 truncate text-base font-semibold text-gray-900 dark:text-white">
+                    {{ activeLibraryItem?.name ?? 'Browse collections' }}
+                  </p>
+                </div>
+                <i
+                  class="fa-solid ml-3 h-4 w-4 flex-shrink-0 text-gray-500 transition-transform dark:text-gray-400"
+                  :class="isMobileNavOpen ? 'fa-chevron-up' : 'fa-chevron-down'"
+                />
+              </button>
+
+              <div
+                v-if="isMobileNavOpen"
+                class="mt-2 rounded-[1.5rem] border border-gray-200 bg-white p-4 shadow-xl ring-1 ring-black/5 dark:border-gray-700 dark:bg-gray-900 dark:ring-white/10"
+              >
+                <div class="relative">
+                  <span
+                    class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400 dark:text-gray-500"
+                  >
+                    <i class="fa-solid fa-magnifying-glass text-sm" />
+                  </span>
+                  <input
+                    v-model="searchTerm"
+                    type="search"
+                    placeholder="Search collections"
+                    aria-label="Search library collections"
+                    class="w-full rounded-2xl border border-gray-200 bg-gray-50/90 py-3 pl-10 pr-4 text-sm text-gray-900 outline-none transition focus:border-orange-400 focus:bg-white focus:ring-2 focus:ring-orange-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-orange-400 dark:focus:bg-gray-800 dark:focus:ring-orange-500/20"
+                  >
+                </div>
+
+                <div class="mt-4 flex flex-wrap gap-2">
+                  <button
+                    v-for="filter in filterOptions"
+                    :key="`mobile-${filter.key}`"
+                    type="button"
+                    :class="[
+                      'rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
+                      activeFilter === filter.key
+                        ? 'bg-gray-900 text-white ring-1 ring-inset ring-gray-800 dark:bg-gray-700 dark:text-gray-50 dark:ring-gray-600'
+                        : 'bg-gray-200/80 text-gray-700 hover:bg-gray-300/80 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:hover:text-white',
+                    ]"
+                    @click="activeFilter = filter.key"
+                  >
+                    {{ filter.label }}
+                  </button>
+                </div>
+
+                <nav class="mt-4 space-y-2">
+                  <NuxtLink
+                    :to="getLibraryItemRoute('my-downloads')"
+                    data-testid="mobile-library-item-my-downloads"
+                    :class="[
+                      'block rounded-2xl border px-4 py-3 text-sm transition-all',
+                      getSidebarItemClasses(isMyDownloadsActive),
+                    ]"
+                  >
+                    <div class="flex items-center justify-between gap-3">
+                      <div class="min-w-0">
+                        <p
+                          :class="
+                            isMyDownloadsActive
+                              ? 'font-semibold text-gray-900 dark:text-white'
+                              : 'font-semibold'
+                          "
+                        >
+                          My Downloads
+                        </p>
+                        <p
+                          :class="
+                            isMyDownloadsActive
+                              ? 'mt-1 text-xs text-gray-700 dark:text-white'
+                              : 'mt-1 text-xs text-gray-500 dark:text-gray-400'
+                          "
+                        >
+                          Files you uploaded across the site
+                        </p>
+                      </div>
+                      <span
+                        :class="
+                          isMyDownloadsActive
+                            ? 'text-gray-700 dark:text-white'
+                            : 'text-gray-500 dark:text-gray-400'
+                        "
+                      >
+                        ({{ ownedDownloadsCount }})
+                      </span>
+                    </div>
+                  </NuxtLink>
+
+                  <NuxtLink
+                    v-for="collection in filteredFavorites"
+                    :key="`mobile-favorite-${collection.id}`"
+                    :to="getLibraryItemRoute(collection.id)"
+                    :data-testid="`mobile-library-item-${collection.id}`"
+                    :class="[
+                      'block rounded-2xl border px-4 py-3 text-sm transition-all',
+                      getSidebarItemClasses(activeLibraryItemId === collection.id),
+                    ]"
+                  >
+                    <div class="flex items-start justify-between gap-3">
+                      <div class="min-w-0">
+                        <p class="font-semibold">
+                          {{ collection.name.replace('Favorite ', '') }}
+                          <span
+                            :class="
+                              activeLibraryItemId === collection.id
+                                ? 'text-gray-700 dark:text-white'
+                                : 'text-gray-500 dark:text-gray-400'
+                            "
+                          >
+                            ({{ collection.itemCount }})</span
+                          >
+                        </p>
+                        <p
+                          :class="
+                            activeLibraryItemId === collection.id
+                              ? 'mt-1 text-xs capitalize text-gray-700 dark:text-white'
+                              : 'mt-1 text-xs capitalize text-gray-500 dark:text-gray-400'
+                          "
+                        >
+                          {{ collection.visibility.toLowerCase() }}
+                        </p>
+                      </div>
+                      <span
+                        :class="
+                          activeLibraryItemId === collection.id
+                            ? 'text-xs font-medium uppercase tracking-[0.18em] text-gray-700 dark:text-white'
+                            : 'text-xs font-medium uppercase tracking-[0.18em] text-gray-400 dark:text-gray-500'
+                        "
+                      >
+                        Fav
+                      </span>
+                    </div>
+                  </NuxtLink>
+
+                  <NuxtLink
+                    v-for="collection in filteredCustom"
+                    :key="`mobile-custom-${collection.id}`"
+                    :to="getLibraryItemRoute(collection.id)"
+                    :data-testid="`mobile-library-item-${collection.id}`"
+                    :class="[
+                      'block rounded-2xl border px-4 py-3 text-sm transition-all',
+                      getSidebarItemClasses(activeLibraryItemId === collection.id),
+                    ]"
+                  >
+                    <div class="flex items-start justify-between gap-3">
+                      <div class="min-w-0">
+                        <p class="font-semibold">
+                          {{ collection.name }}
+                          <span
+                            :class="
+                              activeLibraryItemId === collection.id
+                                ? 'text-gray-700 dark:text-white'
+                                : 'text-gray-500 dark:text-gray-400'
+                            "
+                          >
+                            ({{ collection.itemCount }})</span
+                          >
+                        </p>
+                        <div class="mt-2 flex flex-wrap items-center gap-2">
+                          <span
+                            :class="[
+                              'rounded-full px-2 py-0.5 text-[11px] font-medium',
+                              getCollectionTypeInfo(
+                                collection.collectionType,
+                                activeLibraryItemId === collection.id
+                              ).color,
+                            ]"
+                          >
+                            {{
+                              collection.collectionType
+                                .toLowerCase()
+                                .replace('_', ' ')
+                            }}
+                          </span>
+                          <span
+                            :class="
+                              activeLibraryItemId === collection.id
+                                ? 'text-xs capitalize text-gray-700 dark:text-white'
+                                : 'text-xs capitalize text-gray-500 dark:text-gray-400'
+                            "
+                          >
+                            {{ collection.visibility.toLowerCase() }}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </NuxtLink>
+
+                  <div
+                    v-if="
+                      filteredFavorites.length === 0 &&
+                      filteredCustom.length === 0
+                    "
+                    class="rounded-2xl border border-dashed border-gray-300/80 px-3 py-6 text-center text-sm text-gray-500 dark:border-white/10 dark:text-gray-400"
+                  >
+                    {{
+                      searchTerm
+                        ? `No collections match "${searchTerm}".`
+                        : 'No collections yet. Start adding items to create your first collection!'
+                    }}
+                  </div>
+                </nav>
+              </div>
+            </div>
+
+            <div class="hidden w-72 md:block md:w-[24rem] md:flex-shrink-0">
               <div class="rounded-[2rem] border border-gray-200/80 bg-white/95 p-5 shadow-[0_25px_70px_-38px_rgba(38,38,38,0.22)] backdrop-blur dark:border-gray-700 dark:bg-gray-900 dark:shadow-[0_32px_80px_-45px_rgba(0,0,0,0.78)]">
                 <!-- Header -->
                 <h1

--- a/pages/library.vue
+++ b/pages/library.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { useHead } from 'nuxt/app';
+import { useHead, useRoute } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import {
@@ -13,6 +13,7 @@ import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
 
 const usernameVar = useUsername();
 const isAuthenticatedVar = useIsAuthenticated();
+const route = useRoute();
 
 useHead({
   title: 'Library',
@@ -20,6 +21,7 @@ useHead({
 
 // Filter state
 const activeFilter = ref('all');
+const searchTerm = ref('');
 
 // Filter options
 const filterOptions = [
@@ -142,6 +144,26 @@ const ownedDownloadsCount = computed(() => {
   );
 });
 
+const activeLibraryItemId = computed(() => {
+  if (route.path === '/library/my-downloads') {
+    return 'my-downloads';
+  }
+
+  const matchingDefaultCollection = defaultCollections.value.find(
+    (collection) => route.path === `/library/${collection.id}`
+  );
+
+  if (matchingDefaultCollection) {
+    return matchingDefaultCollection.id;
+  }
+
+  return typeof route.params.collectionId === 'string'
+    ? route.params.collectionId
+    : '';
+});
+
+const normalizedSearchTerm = computed(() => searchTerm.value.trim().toLowerCase());
+
 // Collections with real counts
 const defaultCollections = computed(() => [
   {
@@ -198,11 +220,29 @@ const allCollections = computed(() => {
 
 // Filtered collections based on active filter
 const filteredCollections = computed(() => {
-  if (activeFilter.value === 'all') {
-    return allCollections.value;
+  let collections = allCollections.value;
+
+  if (activeFilter.value !== 'all') {
+    collections = collections.filter(
+      (collection) => collection.collectionType === activeFilter.value
+    );
   }
-  return allCollections.value.filter(
-    (collection) => collection.collectionType === activeFilter.value
+
+  if (!normalizedSearchTerm.value) {
+    return collections;
+  }
+
+  return collections.filter((collection) =>
+    [
+      collection.name,
+      collection.description,
+      collection.collectionType,
+      collection.visibility,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+      .includes(normalizedSearchTerm.value)
   );
 });
 
@@ -216,7 +256,14 @@ const filteredCustom = computed(() => {
 });
 
 // Get color for collection type
-const getCollectionTypeInfo = (collectionType: string) => {
+const getCollectionTypeInfo = (collectionType: string, isActive = false) => {
+  if (isActive) {
+    return {
+      color:
+        'border border-orange-300/80 bg-orange-50/90 text-orange-950 dark:border-white/15 dark:bg-white/10 dark:text-white',
+    };
+  }
+
   switch (collectionType) {
     case 'DISCUSSIONS':
       return {
@@ -250,41 +297,64 @@ const getCollectionTypeInfo = (collectionType: string) => {
       };
   }
 };
+
+const getSidebarItemClasses = (isActive: boolean) =>
+  isActive
+    ? 'border-orange-300 bg-orange-100 text-gray-900 shadow-[0_18px_40px_-32px_rgba(249,115,22,0.45)] ring-1 ring-orange-200 dark:border-orange-800/80 dark:bg-orange-950/75 dark:text-white dark:ring-orange-800/70'
+    : 'border-gray-200/90 bg-white/92 text-gray-700 hover:border-gray-300 hover:bg-white hover:text-gray-950 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:hover:text-white';
+
+const isMyDownloadsActive = computed(
+  () => activeLibraryItemId.value === 'my-downloads'
+);
 </script>
 
 <template>
   <NuxtLayout>
-    <div class="min-h-screen bg-white dark:bg-black dark:text-white">
+    <div class="min-h-screen bg-gray-200 text-gray-900 dark:bg-gray-900 dark:text-white">
       <RequireAuth>
         <template #has-auth>
-          <div class="flex flex-col px-3 md:flex-row">
+          <div class="flex flex-col gap-4 px-3 py-4 md:flex-row md:gap-6 md:px-4">
             <!-- Sidebar - hidden on mobile when viewing collection detail -->
             <div
               :class="[
-                'md:w-100 w-72 md:flex-shrink-0',
-                $route.params.collectionId ? 'hidden md:block' : 'block',
+                'w-72 md:w-[24rem] md:flex-shrink-0',
+                activeLibraryItemId ? 'hidden md:block' : 'block',
               ]"
             >
-              <div class="py-8">
+              <div class="rounded-[2rem] border border-gray-200/80 bg-white/95 p-5 shadow-[0_25px_70px_-38px_rgba(38,38,38,0.22)] backdrop-blur dark:border-gray-700 dark:bg-gray-900 dark:shadow-[0_32px_80px_-45px_rgba(0,0,0,0.78)]">
                 <!-- Header -->
                 <h1
-                  class="mb-2 text-xl font-bold text-gray-900 dark:text-white"
+                  class="text-2xl font-semibold tracking-[-0.04em] text-gray-950 dark:text-gray-50"
                 >
                   Library
                 </h1>
+                <div class="relative mt-4">
+                  <span
+                    class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400 dark:text-gray-500"
+                  >
+                    <i class="fa-solid fa-magnifying-glass text-sm" />
+                  </span>
+                  <input
+                    v-model="searchTerm"
+                    type="search"
+                    placeholder="Search collections"
+                    aria-label="Search library collections"
+                    class="w-full rounded-2xl border border-gray-200 bg-gray-50/90 py-3 pl-10 pr-4 text-sm text-gray-900 outline-none transition focus:border-orange-400 focus:bg-white focus:ring-2 focus:ring-orange-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-orange-400 dark:focus:bg-gray-800 dark:focus:ring-orange-500/20"
+                  >
+                </div>
 
                 <!-- Filter Chips -->
-                <div class="mb-6">
+                <div class="mb-6 mt-5">
                   <div class="flex flex-wrap gap-2">
                     <button
                       v-for="filter in filterOptions"
                       :key="filter.key"
                       type="button"
                       :class="[
-                        'font-sm rounded-full px-3 py-1 text-sm transition-colors',
+                        'rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
                         activeFilter === filter.key
-                          ? 'bg-orange-500 text-black shadow-sm'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600',
+                          ? 'bg-gray-900 text-white ring-1 ring-inset ring-gray-800 dark:bg-gray-700 dark:text-gray-50 dark:ring-gray-600'
+                          : 'bg-gray-200/80 text-gray-700 hover:bg-gray-300/80 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:hover:text-white',
                       ]"
                       @click="activeFilter = filter.key"
                     >
@@ -296,18 +366,45 @@ const getCollectionTypeInfo = (collectionType: string) => {
                 <!-- My Downloads Section -->
                 <div class="mb-8">
                   <div
-                    class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                    class="mb-3 px-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-400 dark:text-gray-500"
                   >
                     My Downloads
                   </div>
                   <NuxtLink
                     to="/library/my-downloads"
-                    class="block rounded-md py-2 text-sm transition-colors"
-                    active-class="bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300 font-semibold"
+                    :class="[
+                      'block rounded-2xl border px-4 py-3 text-sm transition-all',
+                      getSidebarItemClasses(isMyDownloadsActive),
+                    ]"
                   >
-                    <div class="flex items-center justify-between">
-                      <span class="font-medium">My Downloads</span>
-                      <span class="text-gray-500 dark:text-gray-400">
+                    <div class="flex items-center justify-between gap-3">
+                      <div class="min-w-0">
+                        <p
+                          :class="
+                            isMyDownloadsActive
+                              ? 'font-semibold text-gray-900 dark:text-white'
+                              : 'font-semibold'
+                          "
+                        >
+                          My Downloads
+                        </p>
+                        <p
+                          :class="
+                            isMyDownloadsActive
+                              ? 'mt-1 text-xs text-gray-700 dark:text-white'
+                              : 'mt-1 text-xs text-gray-500 dark:text-gray-400'
+                          "
+                        >
+                          Files you uploaded across the site
+                        </p>
+                      </div>
+                      <span
+                        :class="
+                          isMyDownloadsActive
+                            ? 'text-gray-700 dark:text-white'
+                            : 'text-gray-500 dark:text-gray-400'
+                        "
+                      >
                         ({{ ownedDownloadsCount }})
                       </span>
                     </div>
@@ -318,7 +415,7 @@ const getCollectionTypeInfo = (collectionType: string) => {
                 <div class="mb-8">
                   <div class="mb-4 flex items-center justify-between">
                     <h2
-                      class="font-semibold text-xl text-gray-900 dark:text-white"
+                      class="text-lg font-semibold tracking-[-0.03em] text-gray-900 dark:text-gray-100"
                     >
                       Your Collections
                     </h2>
@@ -356,7 +453,7 @@ const getCollectionTypeInfo = (collectionType: string) => {
                       <!-- Favorites Section -->
                       <div v-if="filteredFavorites.length > 0">
                         <div
-                          class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                          class="mb-3 px-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-400 dark:text-gray-500"
                         >
                           Favorites
                         </div>
@@ -364,18 +461,43 @@ const getCollectionTypeInfo = (collectionType: string) => {
                           v-for="collection in filteredFavorites"
                           :key="collection.id"
                           :to="`/library/${collection.id}`"
-                          class="block rounded-md py-2 text-sm transition-colors"
-                          active-class="bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300 font-semibold"
+                          :class="[
+                            'mb-2 block rounded-2xl border px-4 py-3 text-sm transition-all',
+                            getSidebarItemClasses(activeLibraryItemId === collection.id),
+                          ]"
                         >
-                          <div class="flex flex-wrap items-center gap-2">
-                            <span class="font-medium">
-                              {{ collection.name.replace('Favorite ', '') }}
-                              <span class="text-gray-500 dark:text-gray-400"
-                                >({{ collection.itemCount }})</span
+                          <div class="flex items-start justify-between gap-3">
+                            <div class="min-w-0">
+                              <p class="font-semibold">
+                                {{ collection.name.replace('Favorite ', '') }}
+                                <span
+                                  :class="
+                                    activeLibraryItemId === collection.id
+                                      ? 'text-gray-700 dark:text-white'
+                                      : 'text-gray-500 dark:text-gray-400'
+                                  "
+                                >
+                                  ({{ collection.itemCount }})</span
+                                >
+                              </p>
+                              <p
+                                :class="
+                                  activeLibraryItemId === collection.id
+                                    ? 'mt-1 text-xs capitalize text-gray-700 dark:text-white'
+                                    : 'mt-1 text-xs capitalize text-gray-500 dark:text-gray-400'
+                                "
                               >
-                            </span>
-                            <span class="text-xs capitalize text-gray-400">
-                              · {{ collection.visibility.toLowerCase() }}
+                                {{ collection.visibility.toLowerCase() }}
+                              </p>
+                            </div>
+                            <span
+                              :class="
+                                activeLibraryItemId === collection.id
+                                  ? 'text-xs font-medium uppercase tracking-[0.18em] text-gray-700 dark:text-white'
+                                  : 'text-xs font-medium uppercase tracking-[0.18em] text-gray-400 dark:text-gray-500'
+                              "
+                            >
+                              Fav
                             </span>
                           </div>
                         </NuxtLink>
@@ -387,7 +509,7 @@ const getCollectionTypeInfo = (collectionType: string) => {
                         :class="{ 'mt-6': filteredFavorites.length > 0 }"
                       >
                         <div
-                          class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                          class="mb-3 px-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-400 dark:text-gray-500"
                         >
                           Custom Collections
                         </div>
@@ -395,32 +517,52 @@ const getCollectionTypeInfo = (collectionType: string) => {
                           v-for="collection in filteredCustom"
                           :key="collection.id"
                           :to="`/library/${collection.id}`"
-                          class="block rounded-md py-2 text-sm transition-colors"
-                          active-class="bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300 font-semibold"
+                          :class="[
+                            'mb-2 block rounded-2xl border px-4 py-3 text-sm transition-all',
+                            getSidebarItemClasses(activeLibraryItemId === collection.id),
+                          ]"
                         >
-                          <div class="flex flex-wrap items-center gap-2">
-                            <span class="font-medium">
-                              {{ collection.name }}
-                              <span class="text-gray-500 dark:text-gray-400"
-                                >({{ collection.itemCount }})</span
-                              >
-                            </span>
-                            <span
-                              :class="[
-                                'rounded-full px-2 py-0.5 text-xs font-medium',
-                                getCollectionTypeInfo(collection.collectionType)
-                                  .color,
-                              ]"
-                            >
-                              {{
-                                collection.collectionType
-                                  .toLowerCase()
-                                  .replace('_', ' ')
-                              }}
-                            </span>
-                            <span class="text-xs capitalize text-gray-400">
-                              · {{ collection.visibility.toLowerCase() }}
-                            </span>
+                          <div class="flex items-start justify-between gap-3">
+                            <div class="min-w-0">
+                              <p class="font-semibold">
+                                {{ collection.name }}
+                                <span
+                                  :class="
+                                    activeLibraryItemId === collection.id
+                                      ? 'text-gray-700 dark:text-white'
+                                      : 'text-gray-500 dark:text-gray-400'
+                                  "
+                                >
+                                  ({{ collection.itemCount }})</span
+                                >
+                              </p>
+                              <div class="mt-2 flex flex-wrap items-center gap-2">
+                                <span
+                                  :class="[
+                                    'rounded-full px-2 py-0.5 text-[11px] font-medium',
+                                    getCollectionTypeInfo(
+                                      collection.collectionType,
+                                      activeLibraryItemId === collection.id
+                                    ).color,
+                                  ]"
+                                >
+                                  {{
+                                    collection.collectionType
+                                      .toLowerCase()
+                                      .replace('_', ' ')
+                                  }}
+                                </span>
+                                <span
+                                  :class="
+                                    activeLibraryItemId === collection.id
+                                      ? 'text-xs capitalize text-gray-700 dark:text-white'
+                                      : 'text-xs capitalize text-gray-500 dark:text-gray-400'
+                                  "
+                                >
+                                  {{ collection.visibility.toLowerCase() }}
+                                </span>
+                              </div>
+                            </div>
                           </div>
                         </NuxtLink>
                       </div>
@@ -431,10 +573,13 @@ const getCollectionTypeInfo = (collectionType: string) => {
                           filteredFavorites.length === 0 &&
                           filteredCustom.length === 0
                         "
-                        class="px-3 py-8 text-center text-sm text-gray-500 dark:text-gray-400"
+                        class="rounded-2xl border border-dashed border-gray-300/80 px-3 py-8 text-center text-sm text-gray-500 dark:border-white/10 dark:text-gray-400"
                       >
-                        No collections yet. Start adding items to create your
-                        first collection!
+                        {{
+                          searchTerm
+                            ? `No collections match "${searchTerm}".`
+                            : 'No collections yet. Start adding items to create your first collection!'
+                        }}
                       </div>
                     </template>
                   </nav>
@@ -443,7 +588,7 @@ const getCollectionTypeInfo = (collectionType: string) => {
             </div>
             <!-- Main content area -->
             <div
-              class="w-full flex-1 md:border-l md:border-gray-200 md:dark:border-gray-700"
+              class="w-full flex-1 overflow-hidden rounded-[2rem] border border-gray-300/80 bg-white shadow-[0_30px_90px_-50px_rgba(38,38,38,0.26)] backdrop-blur dark:border-gray-700 dark:bg-gray-900 dark:shadow-[0_36px_100px_-56px_rgba(0,0,0,0.78)]"
             >
               <NuxtPage />
             </div>

--- a/pages/library/[collectionId].spec.ts
+++ b/pages/library/[collectionId].spec.ts
@@ -69,6 +69,10 @@ const mountWith = async (collection: unknown) => {
         LibraryChannelCard: true,
         LibraryCommentCard: LibraryCommentCardStub,
         ImageListItem: true,
+        Breadcrumbs: {
+          props: ['links'],
+          template: '<nav>{{ links.map((link) => link.label).join(" > ") }}</nav>',
+        },
       },
     },
   });
@@ -84,6 +88,20 @@ describe('library collection detail page', () => {
       Discussions: [],
       itemCount: 0,
     });
+    expect(wrapper.text()).toContain('Cat GIFs');
+  });
+
+  it('renders the library breadcrumb trail', async () => {
+    const wrapper = await mountWith({
+      id: 'col-1',
+      name: 'Cat GIFs',
+      collectionType: 'DISCUSSIONS',
+      visibility: 'PUBLIC',
+      Discussions: [],
+      itemCount: 0,
+    });
+
+    expect(wrapper.text()).toContain('Custom Collections');
     expect(wrapper.text()).toContain('Cat GIFs');
   });
 

--- a/pages/library/[collectionId].vue
+++ b/pages/library/[collectionId].vue
@@ -285,7 +285,7 @@ const handleDelete = async () => {
                 </NuxtLink>
 
                 <!-- Title and actions -->
-                <div class="flex items-start justify-between gap-4">
+                <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                   <div class="flex-1">
                     <h1
                       class="text-3xl font-semibold tracking-[-0.04em] text-gray-950 dark:text-white md:text-4xl"
@@ -324,15 +324,17 @@ const handleDelete = async () => {
                   </div>
 
                   <!-- Action buttons -->
-                  <div class="ml-4 flex flex-shrink-0 items-center gap-2">
+                  <div
+                    class="flex w-full flex-wrap items-center gap-2 lg:ml-4 lg:w-auto lg:flex-shrink-0 lg:flex-nowrap"
+                  >
                     <button
                       type="button"
-                      class="inline-flex items-center rounded-full border border-gray-300 bg-gray-100 px-3 py-2 text-sm font-medium text-gray-800 shadow-sm transition hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-70 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                      class="inline-flex items-center rounded-full border border-gray-300 bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-800 shadow-sm transition hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-70 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 lg:px-3 lg:py-2 lg:text-sm"
                       :disabled="visibilityUpdating || updateLoading"
                       @click="handleToggleVisibility"
                     >
                       <svg
-                        class="mr-1.5 h-4 w-4"
+                        class="mr-1.5 h-3.5 w-3.5 lg:h-4 lg:w-4"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
@@ -354,11 +356,11 @@ const handleDelete = async () => {
                       type="button"
                       aria-label="Edit collection"
                       title="Edit collection"
-                      class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-800 shadow-sm transition hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                      class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-800 shadow-sm transition hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 lg:h-11 lg:w-11"
                       @click="openRenameModal"
                     >
                       <svg
-                        class="h-4 w-4"
+                        class="h-3.5 w-3.5 lg:h-4 lg:w-4"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
@@ -375,11 +377,11 @@ const handleDelete = async () => {
                       type="button"
                       aria-label="Delete collection"
                       title="Delete collection"
-                      class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-red-300 bg-white text-red-600 shadow-sm transition hover:bg-red-50 dark:border-red-500/40 dark:bg-gray-800 dark:text-red-300 dark:hover:bg-red-500/12"
+                      class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-red-300 bg-white text-red-600 shadow-sm transition hover:bg-red-50 dark:border-red-500/40 dark:bg-gray-800 dark:text-red-300 dark:hover:bg-red-500/12 lg:h-11 lg:w-11"
                       @click="showDeleteModal = true"
                     >
                       <svg
-                        class="h-4 w-4"
+                        class="h-3.5 w-3.5 lg:h-4 lg:w-4"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"

--- a/pages/library/[collectionId].vue
+++ b/pages/library/[collectionId].vue
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from '@vue/apollo-composable';
 import { useHead } from 'nuxt/app';
 import { useRoute, useRouter } from 'vue-router';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
+import Breadcrumbs from '@/components/nav/Breadcrumbs.vue';
 import {
   GET_COLLECTION_ITEMS,
   GET_ALL_USER_COLLECTIONS,
@@ -104,6 +105,13 @@ const items = computed(() => getCollectionItems(collection.value));
 const collectionTypeLabel = computed(() =>
   getCollectionTypeLabel(collection.value?.collectionType)
 );
+
+const breadcrumbLinks = computed(() => [
+  { label: 'Home', path: '/' },
+  { label: 'Library', path: 'library' },
+  { label: 'Custom Collections', path: 'library' },
+  { label: collectionName.value, current: true },
+]);
 
 // Rename modal state
 const showRenameModal = ref(false);
@@ -206,11 +214,13 @@ const handleDelete = async () => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-white dark:bg-black dark:text-white">
+  <div class="min-h-screen bg-transparent dark:text-white">
     <RequireAuth>
       <template #has-auth>
         <div class="w-full px-4 sm:px-6 lg:px-8">
           <div class="py-6 md:py-8">
+            <Breadcrumbs :links="breadcrumbLinks" />
+
             <!-- Loading state -->
             <div v-if="loading" class="py-8 text-center">
               <div
@@ -252,7 +262,7 @@ const handleDelete = async () => {
             <!-- Collection content -->
             <template v-else>
               <!-- Header -->
-              <div class="mb-8">
+              <div class="mb-8 rounded-[1.75rem] border border-gray-200/80 bg-white/82 p-6 shadow-[0_24px_70px_-42px_rgba(38,38,38,0.26)] backdrop-blur dark:border-gray-700 dark:bg-gray-900 dark:shadow-[0_24px_70px_-48px_rgba(0,0,0,0.82)]">
                 <!-- Back button for mobile -->
                 <NuxtLink
                   to="/library"
@@ -275,29 +285,35 @@ const handleDelete = async () => {
                 </NuxtLink>
 
                 <!-- Title and actions -->
-                <div class="flex items-start justify-between">
+                <div class="flex items-start justify-between gap-4">
                   <div class="flex-1">
                     <h1
-                      class="text-2xl font-bold text-gray-900 dark:text-white md:text-3xl"
+                      class="text-3xl font-semibold tracking-[-0.04em] text-gray-950 dark:text-white md:text-4xl"
                     >
                       {{ collection.name }}
+                      <span class="font-semibold text-gray-500 dark:text-gray-300"
+                        >({{ collection.itemCount }})</span
+                      >
                     </h1>
                     <p
                       v-if="collection.description"
-                      class="mt-2 text-gray-600 dark:text-gray-300"
+                      class="mt-3 max-w-3xl text-base leading-7 text-gray-600 dark:text-gray-300"
                     >
                       {{ collection.description }}
                     </p>
                     <div
-                      class="mt-2 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400"
+                      class="mt-4 flex flex-wrap items-center gap-2 text-sm"
                     >
-                      <span class="capitalize">{{
-                        collection.visibility.toLowerCase()
-                      }}</span>
                       <span
-                        >{{ collection.itemCount }}
-                        {{ collectionTypeLabel.toLowerCase() }}</span
+                        class="rounded-full border border-emerald-300 bg-emerald-50 px-3 py-1 font-medium text-emerald-700 dark:border-emerald-500/35 dark:bg-emerald-500/12 dark:text-emerald-300"
                       >
+                        {{ collectionTypeLabel.toLowerCase() }}
+                      </span>
+                      <span
+                        class="rounded-full border border-gray-300 bg-gray-100 px-3 py-1 font-medium capitalize text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                      >
+                        {{ collection.visibility.toLowerCase() }}
+                      </span>
                     </div>
                     <p
                       v-if="visibilityError"
@@ -308,10 +324,10 @@ const handleDelete = async () => {
                   </div>
 
                   <!-- Action buttons -->
-                  <div class="ml-4 flex flex-shrink-0 gap-2">
+                  <div class="ml-4 flex flex-shrink-0 items-center gap-2">
                     <button
                       type="button"
-                      class="hover:bg-gray-50 inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm disabled:cursor-not-allowed disabled:opacity-70 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                      class="inline-flex items-center rounded-full border border-gray-300 bg-gray-100 px-3 py-2 text-sm font-medium text-gray-800 shadow-sm transition hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-70 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
                       :disabled="visibilityUpdating || updateLoading"
                       @click="handleToggleVisibility"
                     >
@@ -336,11 +352,13 @@ const handleDelete = async () => {
                     </button>
                     <button
                       type="button"
-                      class="hover:bg-gray-50 inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                      aria-label="Edit collection"
+                      title="Edit collection"
+                      class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-800 shadow-sm transition hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
                       @click="openRenameModal"
                     >
                       <svg
-                        class="mr-1.5 h-4 w-4"
+                        class="h-4 w-4"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
@@ -352,15 +370,16 @@ const handleDelete = async () => {
                           d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
                         />
                       </svg>
-                      Rename
                     </button>
                     <button
                       type="button"
-                      class="hover:bg-red-50 inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-600 shadow-sm dark:border-red-600 dark:bg-gray-700 dark:text-red-400 dark:hover:bg-red-900/20"
+                      aria-label="Delete collection"
+                      title="Delete collection"
+                      class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-red-300 bg-white text-red-600 shadow-sm transition hover:bg-red-50 dark:border-red-500/40 dark:bg-gray-800 dark:text-red-300 dark:hover:bg-red-500/12"
                       @click="showDeleteModal = true"
                     >
                       <svg
-                        class="mr-1.5 h-4 w-4"
+                        class="h-4 w-4"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
@@ -372,10 +391,10 @@ const handleDelete = async () => {
                           d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
                         />
                       </svg>
-                      Delete
                     </button>
                   </div>
                 </div>
+
               </div>
 
               <!-- Empty state -->

--- a/pages/u/[username]/albums/index.vue
+++ b/pages/u/[username]/albums/index.vue
@@ -149,7 +149,7 @@ const getAlbumThumbnail = (album: Album) => {
                 v-if="getAlbumThumbnail(album)"
                 :src="getAlbumThumbnail(album)"
                 alt="Album thumbnail"
-                class="h-full w-full object-cover transition-transform group-hover:scale-105"
+                class="h-full w-full object-cover"
               >
               <div
                 v-else
@@ -197,7 +197,7 @@ const getAlbumThumbnail = (album: Album) => {
                 v-if="getAlbumThumbnail(album)"
                 :src="getAlbumThumbnail(album)"
                 alt="Album thumbnail"
-                class="h-full w-full object-cover transition-transform group-hover:scale-105"
+                class="h-full w-full object-cover"
               >
               <div
                 v-else

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -380,7 +380,7 @@ onUnmounted(() => {
             v-else-if="image.url"
             :src="image.url"
             :alt="image.alt ?? 'Image'"
-            class="h-auto max-w-full cursor-pointer rounded-lg shadow-lg transition-transform hover:scale-105"
+            class="h-auto max-w-full cursor-pointer rounded-lg shadow-lg"
             title="Click to view in lightbox"
             @click="openLightbox"
           >


### PR DESCRIPTION
## Summary
Refines the library and related navigation UI with a focus on contrast, responsive behavior, and collection page usability.

## What changed
- fixes dark/light mode contrast issues across the library sidebar, chips, breadcrumbs, top nav, and active navigation states
- adds a mobile-friendly library navigation dropdown in place of the full sidebar
- improves custom collection detail layouts for medium and small screens
- improves favorite comment cards so the `Post from` context link wraps cleanly
- adjusts shared modal sizing/positioning so the collection rename modal works better on mobile
- hides the top-nav profile dropdown at mobile widths

## Validation
- `npm run tsc`
- `npx vitest run pages/library.spec.ts 'pages/library/[collectionId].spec.ts' pages/library/favorite-comments.spec.ts components/nav/TopNav.spec.ts components/GenericModal.spec.ts components/nav/Breadcrumbs.spec.ts`
