### PR TITLE
[codex] Default new collections to private

### DIFF
--- a/components/collection/AddToListPopover.spec.ts
+++ b/components/collection/AddToListPopover.spec.ts
@@ -61,6 +61,18 @@ const mountPopover = (props: Record<string, unknown> = {}) =>
 const rows = (wrapper: ReturnType<typeof mount>) =>
   wrapper.findAll('.cursor-pointer');
 
+const clickNewListButton = async (wrapper: ReturnType<typeof mount>) => {
+  const newListButton = wrapper
+    .findAll('button')
+    .find((button) => button.text().includes('New List'));
+
+  if (!newListButton) {
+    throw new Error('New List button not found');
+  }
+
+  await newListButton.trigger('click');
+};
+
 beforeEach(() => {
   h.username.value = 'alice';
   h.collectionsResult = ref({
@@ -222,6 +234,53 @@ describe('AddToListPopover collection toggle', () => {
       collectionId: 'c1',
       itemId: 'item-1',
     });
+  });
+});
+
+describe('AddToListPopover collection creation', () => {
+  it('creates new collections as private by default', async () => {
+    (h.createCollection as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        createCollections: { collections: [{ id: 'new1', name: 'New List' }] },
+      },
+    });
+
+    const wrapper = mountPopover();
+
+    await clickNewListButton(wrapper);
+    await wrapper.get('input[aria-label="New list name"]').setValue('New List');
+    await wrapper.get('button[class*="bg-blue-600"]').trigger('click');
+    await flushPromises();
+
+    expect(h.createCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'New List',
+        visibility: 'PRIVATE',
+      })
+    );
+  });
+
+  it('lets the user explicitly create a public collection', async () => {
+    (h.createCollection as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        createCollections: { collections: [{ id: 'new1', name: 'Shared List' }] },
+      },
+    });
+
+    const wrapper = mountPopover();
+
+    await clickNewListButton(wrapper);
+    await wrapper.get('input[aria-label="New list name"]').setValue('Shared List');
+    await wrapper.get('select[aria-label="New list visibility"]').setValue('PUBLIC');
+    await wrapper.get('button[class*="bg-blue-600"]').trigger('click');
+    await flushPromises();
+
+    expect(h.createCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Shared List',
+        visibility: 'PUBLIC',
+      })
+    );
   });
 });
 

--- a/components/collection/AddToListPopover.vue
+++ b/components/collection/AddToListPopover.vue
@@ -64,6 +64,7 @@ const popoverRef = ref<HTMLElement | null>(null);
 const searchTerm = ref('');
 const isCreatingNew = ref(false);
 const newCollectionName = ref('');
+const newCollectionVisibility = ref<CollectionVisibility>('PRIVATE' as CollectionVisibility);
 const isLoading = ref(false);
 const toastStore = useToastStore();
 const popoverIdBase = `add-to-list-popover-${props.itemType}-${props.itemId.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
@@ -193,6 +194,12 @@ const { adjustedPosition } = usePopoverPositioning({
 
 const isModal = computed(() => props.variant === 'modal');
 
+const resetCreateCollectionForm = () => {
+  isCreatingNew.value = false;
+  newCollectionName.value = '';
+  newCollectionVisibility.value = 'PRIVATE' as CollectionVisibility;
+};
+
 // Search functionality
 watch(searchTerm, () => {
   if (usernameVar.value && props.isVisible) {
@@ -211,7 +218,7 @@ const handleCreateNewCollection = async () => {
     const result = await createCollection({
       name: newCollectionName.value.trim(),
       collectionType,
-      visibility: 'PUBLIC' as CollectionVisibility,
+      visibility: newCollectionVisibility.value,
       updatedAt: now,
       username: usernameVar.value,
     });
@@ -229,8 +236,7 @@ const handleCreateNewCollection = async () => {
       toastStore.showToast(`Added to "${newCollection.name}"`);
       refetchCollections();
       refetchItemInCollections();
-      newCollectionName.value = '';
-      isCreatingNew.value = false;
+      resetCreateCollectionForm();
     }
   } catch (error) {
     console.error('Error creating collection:', error);
@@ -431,7 +437,7 @@ const popoverStyles = computed(() => {
           <div v-if="!isCreatingNew">
             <button
               class="hover:bg-blue-50 flex w-full items-center rounded-md px-3 py-2 text-sm text-blue-600 transition-colors dark:text-blue-400 dark:hover:bg-blue-900/20"
-              @click="isCreatingNew = true"
+              @click="resetCreateCollectionForm(); isCreatingNew = true"
             >
               <span class="mr-2">+</span>
               New List
@@ -445,8 +451,22 @@ const popoverStyles = computed(() => {
               aria-label="New list name"
               class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
               @keyup.enter="handleCreateNewCollection"
-              @keyup.escape="isCreatingNew = false"
+              @keyup.escape="resetCreateCollectionForm"
             >
+            <label class="block text-xs font-medium text-gray-600 dark:text-gray-300">
+              Visibility
+            </label>
+            <select
+              v-model="newCollectionVisibility"
+              aria-label="New list visibility"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            >
+              <option value="PRIVATE">Private (default)</option>
+              <option value="PUBLIC">Public</option>
+            </select>
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              New lists start private unless you explicitly make them public.
+            </p>
             <div class="flex gap-2">
               <button
                 class="flex-1 rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
@@ -457,10 +477,7 @@ const popoverStyles = computed(() => {
               </button>
               <button
                 class="hover:bg-gray-50 flex-1 rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
-                @click="
-                  isCreatingNew = false;
-                  newCollectionName = '';
-                "
+                @click="resetCreateCollectionForm"
               >
                 Cancel
               </button>
@@ -612,7 +629,7 @@ const popoverStyles = computed(() => {
         <div v-if="!isCreatingNew">
           <button
             class="hover:bg-blue-50 flex w-full items-center rounded-md px-3 py-2 text-sm text-blue-600 transition-colors dark:text-blue-400 dark:hover:bg-blue-900/20"
-            @click="isCreatingNew = true"
+            @click="resetCreateCollectionForm(); isCreatingNew = true"
           >
             <span class="mr-2">+</span>
             New List
@@ -626,8 +643,22 @@ const popoverStyles = computed(() => {
             aria-label="New list name"
             class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
             @keyup.enter="handleCreateNewCollection"
-            @keyup.escape="isCreatingNew = false"
+            @keyup.escape="resetCreateCollectionForm"
           >
+          <label class="block text-xs font-medium text-gray-600 dark:text-gray-300">
+            Visibility
+          </label>
+          <select
+            v-model="newCollectionVisibility"
+            aria-label="New list visibility"
+            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+          >
+            <option value="PRIVATE">Private (default)</option>
+            <option value="PUBLIC">Public</option>
+          </select>
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            New lists start private unless you explicitly make them public.
+          </p>
           <div class="flex gap-2">
             <button
               class="flex-1 rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
@@ -638,10 +669,7 @@ const popoverStyles = computed(() => {
             </button>
             <button
               class="hover:bg-gray-50 flex-1 rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
-              @click="
-                isCreatingNew = false;
-                newCollectionName = '';
-              "
+              @click="resetCreateCollectionForm"
             >
               Cancel
             </button>

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -1,281 +1,200 @@
 # Feature Roadmap
 
-## Remaining Implementation Work
+## Prioritized Checklist
+
+Status labels:
+- `[complete]` The roadmap item is implemented and covered by targeted tests.
+- `[partial]` Some frontend and/or schema groundwork exists, but the feature is not complete.
+- `[not started]` No meaningful implementation was found in this frontend repo.
+
+### 1. Downloads: auto-save downloaded items into the user's library `[complete]`
+
+- [x] Confirm the download tracking model records the downloaded file/item and authenticated user while still supporting anonymous total counts.
+- [x] Add or reuse a dedicated private system collection/list for downloaded items, such as `Downloaded Items` or `Downloads`.
+- [x] On successful authenticated download, upsert the item into that private collection without duplicates.
+- [x] Keep download activity separate from collection membership so repeat downloads increase totals without creating duplicate library entries.
+- [x] Show the auto-saved download collection in the library with copy explaining why items appear there.
+- [x] Add tests for anonymous download, first authenticated download, repeat authenticated download, and second-user download.
+- [x] Ensure the special auto-saved downloads collection is private by default and cannot be accidentally exposed.
+
+Notes:
+- Completed by the merged downloads backend and frontend PRs.
+
+### 2. Collections default to private on creation `[complete]`
+
+- [x] Make newly created user collections private by default unless the user explicitly chooses another visibility.
+- [x] Audit every collection-creation entry point so they behave consistently.
+- [x] Add tests covering default-private creation and explicit visibility overrides.
+
+Notes:
+- The add-to-list creation flow now defaults to `PRIVATE` and includes an explicit public visibility override.
+- The backend collection-create sanitizer also defaults missing visibility to `PRIVATE` while preserving explicit overrides.
+
+### 3. Downloadable file permanent delete permission flow `[partial]`
+
+- [ ] Define the exact moderator permission using the existing moderation permission model.
+- [ ] Decide whether OP/uploader self-delete is allowed and under what product rules.
+- [ ] Decide whether deletion hard-deletes the blob, detaches it, marks it deleted, or combines those steps.
+- [ ] Preserve enough metadata for moderation and audit history.
+- [ ] Show the destructive action only to authorized users.
+- [ ] Add a confirmation dialog that clearly says the file is permanently removed.
+- [ ] Refresh download detail and list views after deletion.
+- [ ] Add uploader-facing file management so users can see their downloadable files grouped by linked discussion on profile/library pages and delete them from there when authorized.
+- [ ] Add tests for OP allowed, unrelated user rejected, permitted moderator allowed, and moderator without permission rejected.
+
+Notes:
+- Delete confirmation copy exists in the discussion/download header UI, but the roadmap-level permission flow is not complete.
+- One known permission asymmetry around permanent-remove behavior was documented separately and should be resolved as part of this work rather than preserved indefinitely.
+
+### 4. Download filters: review and finish include/exclude semantics `[partial]`
+
+- [ ] Confirm current exclude behavior in the actual download-list query path.
+- [ ] Make filter-group create/update/delete operations atomic and validated end-to-end.
+- [ ] Ensure deleting a filter group does not leave stale selected filters in URLs or saved settings.
+- [ ] Add tests for include-only, exclude-only, combined include/exclude, deleted-group cleanup, and invalid filter-group input.
+- [ ] Review UX details: empty-group validation, delete confirmation/reversal, clear "must include" vs "must exclude" labels, and readable/shareable URL state.
+
+Notes:
+- Channel admin UI for filter groups already exists.
+- Include/exclude modes, ordering, YAML editing, and validation are already present in the frontend.
+
+### 5. Collection ordering `[partial]`
 
-### Downloads and Collections
+- [ ] Add or confirm the stable ordering model for collection membership.
+- [ ] Preserve order correctly when adding and removing items.
+- [ ] Define behavior when an item in the stored order no longer exists.
+- [ ] Add a reorder mutation with ownership checks.
+- [ ] Add reorder tests for success, non-owner rejection, missing-item behavior, and order preservation after add/remove.
+- [ ] Add reorder controls in the collection UI.
+- [ ] Persist reordering through the new mutation.
+- [ ] Keep keyboard-accessible move up/down controls even if drag-and-drop is added later.
 
-#### 1. Normalize Download Tracking and Library Auto-Save
+Notes:
+- Collections already have an `itemOrder` field and add-to-collection mutations push into it.
+- No reorder mutation or reorder UI was found.
 
-**Goal:** Every successful download should have a durable record that can power download counts and the user's library.
+### 6. Share public collections to a forum discussion `[not started]`
 
-**Backend work:**
+- [ ] Require collection visibility to be public before it can be shared to a discussion.
+- [ ] Add mutation input / relationships for attaching a collection to a new or existing discussion.
+- [ ] Enforce forum posting permissions plus collection ownership/visibility rules.
+- [ ] Add tests for public allowed, private rejected, non-owner rejected, and missing forum permission rejected.
+- [ ] Add a `Share to forum` action on public collection detail pages.
+- [ ] Let the user choose a forum and create or attach to a discussion.
+- [ ] Hide or explain the action for private collections.
 
-- Confirm the existing download tracking model records both the downloaded file/item and the authenticated user, while still supporting anonymous total counts.
-- Add or reuse a dedicated private system collection/list for each user's downloaded items, for example `Downloaded Items` or `Downloads`.
-- On successful download, upsert the downloaded item into that private collection without duplicating entries when the same user downloads the same item multiple times.
-- Keep download activity separate from collection membership so repeat downloads can increment total counts without creating duplicate library entries.
-- Add tests for anonymous downloads, first authenticated download, repeat authenticated download, and download by a second user.
+### 7. Submission UI for channels that do not allow the current post type `[partial]`
 
-**Frontend work:**
+- [ ] Review every channel/forum picker used for discussions, downloads, events, and similar flows.
+- [ ] Decide whether unsupported channels should remain visible but disabled, or be filtered with clear explanatory copy.
+- [ ] If disabled options are shown, include a reason such as `Does not allow downloads` or `Does not allow events`.
+- [ ] If unsupported channels are filtered out, show explicit helper text explaining that some channels were removed because they do not allow the current post type.
+- [ ] Add tests for both search results and selection behavior so users are not left guessing why a channel is unavailable.
 
-- Show the auto-saved download collection in the user's library.
-- Ensure the collection is private by default and cannot be accidentally shared unless the user explicitly changes visibility, if that is supported.
-- Add copy explaining why a downloaded item appeared there, without treating it as a manually curated collection.
+Notes:
+- Existing picker logic already filters channels by required flags in some flows, especially events.
+- That filtering currently hides unsupported channels instead of clearly explaining why they are unavailable.
 
-**Manual validation:**
+### 8. User profile pinned posts `[not started]`
 
-- Download an item while logged out and verify only total count changes.
-- Download an item while logged in and verify it appears in the user's library.
-- Download the same item twice and verify the library has one entry but total downloads increase.
-- Log in as a second user and verify unique download count increases.
+- [ ] Define eligible pinned content types.
+- [ ] Add a profile-level ordered relationship or ordered ID list with a max of four items.
+- [ ] Add mutations to pin, unpin, and reorder pinned posts with ownership checks.
+- [ ] Add tests for pin limit, owner-only updates, reorder, and deleted/archived content behavior.
+- [ ] Render pinned posts on profile pages.
+- [ ] Show edit controls only to the profile owner.
+- [ ] Add clear empty states and limit messaging.
 
-#### 2. Add Download Counts to Download Detail Pages
+### 9. Images in multiple albums and fuller image-usage display `[partial]`
 
-**Goal:** Download detail pages should show both unique downloader count and total download count.
+- [ ] Change album-image modeling so one image can belong to multiple albums without re-uploading.
+- [ ] Preserve uploader/original attribution on the image node anywhere it is reused.
+- [ ] Define permissions for adding someone else's image to a collection or album.
+- [ ] Add image-detail query support for albums containing the image, grouped into original-poster-owned albums vs other users' albums.
+- [ ] Add tests for multi-album membership, attribution preservation, permission enforcement, and grouped album results.
+- [ ] Update album add/remove flows to link existing images instead of requiring re-upload.
+- [ ] Let users save permitted images from someone else's album to their own library/collection.
+- [ ] On image detail pages, show grouped image usage by original poster vs others.
 
-**Backend work:**
+Notes:
+- The frontend already shows some cross-album/image-usage behavior.
+- The current image detail page still appears centered on a single `Album`, not the full grouped usage model in this roadmap item.
 
-- Add query fields or resolver output for `uniqueDownloadCount` and `totalDownloadCount`.
-- Count anonymous downloads only toward total downloads unless there is a stable anonymous identity model.
-- Count each authenticated user once for unique downloads, regardless of repeat downloads.
-- Add resolver tests for anonymous, repeat, and multi-user download scenarios.
+### 10. Permanent media deletion and storage cleanup `[partial]`
 
-**Frontend work:**
+- [ ] Let authorized users delete album images permanently and remove the backing object from GCP/storage.
+- [ ] Let authorized users delete profile images permanently and remove the backing object from GCP/storage.
+- [ ] Add permanent delete support for forum banners, including storage cleanup.
+- [ ] Make storage cleanup behavior explicit and tested so database deletion and blob deletion stay in sync.
+- [ ] Define permissions separately for uploader/owner actions versus moderator/admin actions across these media types.
+- [ ] Add tests covering successful delete, unauthorized rejection, missing-file cleanup behavior, and stale-reference cleanup.
 
-- Add both counts to the download detail page near existing download metadata.
-- Use labels that distinguish "downloads" from "downloaders" clearly.
-- Keep count display resilient when the backend returns zero or null during rollout.
+Notes:
+- The repo has album/image editing and removal-from-local-state flows, but that is not the same as permanent backend deletion plus cloud-storage cleanup.
 
-#### 3. Clean Up and Extend Download Share/Attribution UX
+### 11. Wiki: pinned sidebar pages `[not started]`
 
-**Goal:** Modernize the post-download/share flow and let uploaders configure appropriate attribution/support links.
+- [ ] Add channel-sidebar support for pinned wiki pages.
+- [ ] Let channel owners and authorized moderators pin an existing wiki page from channel UI.
+- [ ] Add a matching action from wiki detail pages.
 
-**Frontend work:**
+### 12. Wiki: lock wiki pages to owners `[not started]`
 
-- Remove the X/Twitter link from the existing "share this download" component.
-- Audit the modal that appears after clicking download and identify the source of its attribution text.
-- Add uploader-controlled attribution text if the schema already supports it; otherwise add backend fields first.
-- Add optional support links for Patreon, Buy Me a Coffee, Ko-fi, and PayPal.me.
-- Validate link format on write and render only configured links in the post-download modal.
-- Avoid showing empty sections when the uploader has not configured support links.
+- [ ] Add a lock state for wiki pages.
+- [ ] Restrict editing of locked wiki pages to channel owners per product rules.
 
-**Backend work:**
+### 13. Moderation: sticky comment on discussion or event `[not started]`
 
-- Add structured fields for attribution/support links if they do not already exist.
-- Validate allowed support-link domains or URL patterns server-side, not just in the form.
-- Ensure only the uploader or an authorized moderator can update this configuration.
+- [ ] Let moderators sticky a comment so it appears at the top of a discussion or event comment list.
+- [ ] Define ordering, permissions, and unsticky behavior.
 
-**Manual validation:**
+### 14. Wiki search: featured wiki pages from server settings `[not started]`
 
-- Download an item with no support links and verify the modal remains clean.
-- Configure each supported link type and verify it appears after download.
-- Try an invalid support URL and verify it is rejected.
-- Verify the X/Twitter share option no longer appears.
+- [ ] Add server-admin configuration for featured wiki pages.
+- [ ] Surface featured pages in `/wiki/search`.
 
-#### 4. Add Permanent Delete Permission Flow for Downloadable Files
+### 15. Favorites API optimization `[partial]`
 
-**Goal:** OPs and moderators with sufficient permissions can permanently delete downloadable files through explicit backend permission checks.
+- [ ] Update image and channel list queries to include computed favorite state where missing.
+- [ ] Pass `initialIsFavorited` from parent list components consistently.
+- [ ] Add an equivalent optimized path for comments instead of relying on a per-item lookup.
 
-**Backend work:**
+Notes:
+- Discussions are already optimized.
+- Image and channel favorite buttons now accept `initialIsFavorited`.
+- Comments still appear to use a separate lookup path.
 
-- Define the exact permission required for moderators, using the existing moderation permission pattern rather than an ad hoc mod check.
-- Allow the uploader/OP to permanently delete their own downloadable file unless product rules require moderator-only deletion after publication.
-- Decide whether permanent deletion removes the file blob, detaches it from content, marks it as deleted, or combines these steps.
-- Preserve enough metadata for moderation/audit history if hard-deleting the file blob.
-- Add tests for OP allowed, unrelated user rejected, permitted moderator allowed, and moderator without permission rejected.
+### 16. Auto-save for server settings and channel admin settings `[not started]`
 
-**Frontend work:**
+- [ ] Replace explicit save-button flows where appropriate with autosave behavior.
+- [ ] Start with plugins/settings areas called out in the original note.
 
-- Add a destructive action only where the current user is authorized.
-- Use a confirmation dialog that clearly says the file will be permanently removed.
-- Refresh download detail and list views after deletion.
+### 17. Event edit history: title and description revisions `[partial]`
 
-#### 5. Review Download List Filtering and Filter Group Configuration
+- [ ] Add event version-history schema fields for title and description revisions plus `DescriptionLastEditedBy`.
+- [ ] Add backend middleware/hook logic to snapshot prior values on update.
+- [ ] Add query support for event revision history.
+- [ ] Add frontend activity-feed components similar to discussion edit history.
+- [ ] Add moderator redaction/delete support for event description revisions if required.
 
-**Goal:** Filtering downloads should support excluding packs/items, and channel admins should be able to maintain filter groups reliably.
+Notes:
+- Discussions already have full version history.
+- The roadmap notes indicate events still do not.
 
-**Investigation first:**
+### 18. Channel deprecation flow `[not started]`
 
-- Confirm whether excluding packs/items when filtering download lists is already partially implemented.
-- Review the existing channel settings UI for adding, updating, and deleting download filter groups.
-- Identify whether filter group state is stored in channel config, server config, or a dedicated model.
+- [ ] Add a way to deprecate or lock a channel for reasons other than sitewide-rule enforcement.
+- [ ] Define moderation/admin permissions and user-facing messaging.
 
-**Implementation work:**
+## Removed From This Roadmap As Completed
 
-- Add explicit include/exclude semantics to the filter query model if missing.
-- Make filter group create/update/delete operations atomic and validated.
-- Ensure deleting a filter group does not leave stale selected filters in download list URLs or saved channel settings.
-- Add tests for include-only, exclude-only, combined include/exclude, deleted group cleanup, and invalid filter group input.
+The following items were removed because they appear complete in this frontend repo:
 
-**UX review checklist:**
-
-- Empty filter groups have a clear disabled or validation state.
-- Delete actions are reversible or require confirmation.
-- Labels distinguish "must include" from "must exclude."
-- The downloads list URL/query state stays readable and shareable.
-
-#### 6. Add Collection Ordering
-
-**Goal:** Users can change the order of items in a collection in their library.
-
-**Backend work:**
-
-- Add a stable ordering field to collection membership. Prefer ordered membership metadata over a raw array of IDs if the graph model supports relationship properties; otherwise use a separate ordered ID array.
-- Preserve order when adding/removing items.
-- Define behavior when an item in the ordered array no longer exists.
-- Add mutations for reordering a collection with ownership checks.
-- Add tests for reorder success, non-owner rejected, missing item rejected or ignored by defined policy, and order preservation after add/remove.
-
-**Frontend work:**
-
-- Add reorder controls to collection detail/edit UI.
-- Persist the new order through the reorder mutation.
-- Keep keyboard-accessible controls for moving items up/down even if drag-and-drop is added.
-
-#### 7. Share Public Collections to a Forum Discussion
-
-**Goal:** A public collection can be shared to a forum by attaching it to a new or existing discussion.
-
-**Backend work:**
-
-- Require collection visibility to be public before it can be attached to a forum discussion.
-- Add relationship fields or mutation input for attaching a collection to a discussion.
-- Enforce forum posting permissions and collection ownership/visibility.
-- Add tests for public collection allowed, private collection rejected, non-owner rejected unless product allows sharing any public collection, and missing forum permission rejected.
-
-**Frontend work:**
-
-- Add a "Share to forum" action on public collection detail pages.
-- Let the user choose a forum and create a discussion with the collection attached.
-- Hide or explain the action for private collections.
-
-#### 8. Add User Profile Pinned Posts
-
-**Goal:** Users can pin up to four posts on their profile and edit that list themselves.
-
-**Backend work:**
-
-- Define eligible pinned content types, likely discussions first unless comments/downloads are explicitly in scope.
-- Add a profile-level ordered relationship or ordered ID list with a maximum of four entries.
-- Add mutations to pin, unpin, and reorder pinned posts with user ownership checks.
-- Add tests for pin limit, owner-only updates, reorder, and deleted/archived content behavior.
-
-**Frontend work:**
-
-- Add pinned posts to the user profile page.
-- Add edit controls visible only to the profile owner.
-- Provide clear empty states and limit messaging.
-
-#### 9. Allow Images in Multiple Albums and Show Image Usage
-
-**Goal:** Images should be reusable across albums/collections without re-uploading, preserving original attribution.
-
-**Backend work:**
-
-- Change album-image modeling so the same image node can belong to multiple albums.
-- Preserve uploader/original attribution on the image node and avoid copying image blobs when a user saves an image into their own collection or album.
-- Define permissions for adding someone else's image to a collection or album based on image visibility.
-- Add image detail queries for albums containing the image, grouped by albums owned by the original poster and albums owned by others.
-- Add tests for adding one image to multiple albums, attribution preservation, permission enforcement, and grouped album query results.
-
-**Frontend work:**
-
-- Update album add/remove flows to link existing images rather than requiring re-upload.
-- Let users save an image from someone else's album to their own library/collection when permitted.
-- On image detail pages, show albums containing this image by the original poster and by other users in separate sections.
-- Make attribution visible anywhere the reused image appears.
-
-#### Recommended Slice Order
-
-1. Download tracking and library auto-save, because it creates the data foundation for counts and library behavior.
-2. Download detail counts, because it can reuse the tracking data from slice 1.
-3. Share modal cleanup plus attribution/support links, because it is mostly isolated UI/configuration.
-4. Permanent delete permissions, because it needs careful backend authorization and destructive-action UX.
-5. Download filter group review and exclude semantics.
-6. Collection ordering.
-7. Share public collections to forum discussions.
-8. Profile pinned posts.
-9. Multi-album image reuse and image usage display, because it has the broadest modeling impact.
-
----
-
-### Wiki
-
-| Task                                                                                                                                 | Type    |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| Channel sidebar has pinned wiki pages                                                                                                | Feature |
-| Channel owners and mods with appropriate permissions see "pin wiki page here" button to attach existing wiki page to channel sidebar | Feature |
-| Can also pin a wiki page to channel sidebar as an action menu item on wiki detail page                                               | Feature |
-| Can lock a wiki page so only channel owners can edit it                                                                              | Feature |
-| Mod can sticky a comment on a discussion or event, making it appear at the top of comments list                                      | Feature |
-| Server admins can add featured wiki pages (via server settings) that show up at /wiki/search                                         | Feature |
-
----
-
-### Misc
-
-| Task                                                                                                                            | Type        | Status |
-| ------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------ |
-| Adding emoji to comment should not update last updated date; need new field `textLastEdited`                                    | Bug         | ✅     |
-| In comment section, can search comments by text to find specific comments                                                       | Feature     | ✅     |
-| Album image and detail page has share button (copy link, crosspost)                                                             | Feature     | ✅     |
-| Discussion detail page comments have less left side padding at mobile width                                                     | UI          | ✅     |
-| In comment search results page, each result list item should be a permalink                                                     | Feature     | ✅     |
-| Well-tested function for making accurate permalink to comment on event, discussion, feedback, issue (both frontend and backend) | Feature     | ✅     |
-| Reduce API calls on favorites lists - include whether user has favorited each item in fetch-list API call (see notes below)     | Performance | ⏳     |
-| Auto-save for server settings and channel admin settings (at least for plugins; should not have two save buttons)               | UX          |        |
-| Activity feed shows title edit history of an event (similar to discussion detail pages) (see notes below)                       | Feature     | ⏳     |
-| Can see description edits of event (see notes below)                                                                            | Feature     | ⏳     |
-| Add a way to deprecate a channel - lock for reasons unrelated to sitewide rule violations                                       | Feature     |        |
-
-#### Notes on Favorites API Optimization
-
-**Current state (April 2026):**
-
-- **Discussions:** Already optimized. `getSiteWideDiscussionList` and `getDiscussionsInChannel` include `isFavorited` in results. `AddToDiscussionFavorites` accepts `initialIsFavorited` prop to skip refetch.
-- **Comments:** Have `isFavoritedByUser` in queries but `AddToCommentFavorites` lacks `initialIsFavorited` prop.
-- **Images:** `AddToImageFavorites` makes separate API call per image. Needs `initialIsFavorited` prop and backend query changes.
-- **Channels:** `AddToChannelFavorites` makes separate API call per channel. Needs similar optimization.
-
-**Work required:**
-
-1. Add `initialIsFavorited` prop to `AddToImageFavorites`, `AddToCommentFavorites`, `AddToChannelFavorites`
-2. Update image/channel list queries to include `isFavorited` computed field
-3. Update parent list components to pass `initialIsFavorited` prop
-
-#### Notes on Event Edit History
-
-**Current state:** Events have `editReason` field but NO version history tracking. Discussions already have full version history with `PastTitleVersions`, `PastBodyVersions`, and `BodyLastEditedBy`.
-
-**Backend work required:**
-
-1. **Schema update** (`typeDefs.ts`) - Add to Event type:
-
-   ```graphql
-   PastTitleVersions: [TextVersion!]! @relationship(type: "HAS_EVENT_TITLE_VERSION", direction: OUT)
-   PastDescriptionVersions: [TextVersion!]! @relationship(type: "HAS_EVENT_DESCRIPTION_VERSION", direction: OUT)
-   DescriptionLastEditedBy: User @relationship(type: "EVENT_DESCRIPTION_LAST_EDITED_BY", direction: OUT)
-   ```
-
-2. **Middleware** - Create `eventVersionHistoryMiddleware.ts`:
-   - Hook into `updateEventWithChannelConnections` mutation
-   - Snapshot old title/description before update
-
-3. **Hook** - Create `eventVersionHistoryHook.ts`:
-   - Mirror `discussionVersionHistoryHook.ts` logic
-   - Create TextVersion records for old title/description
-   - Track `DescriptionLastEditedBy`
-
-**Frontend work required:**
-
-1. **Query update** - Add version fields to `GET_EVENT` query
-2. **Components** - Create `EventEditsDropdown.vue` and `EventTitleVersions.vue` (can reuse `RevisionDiffContent.vue`)
-3. **Mutation** - Add `deleteEventDescriptionRevision` for moderator redaction
-
-**Reference files:**
-
-- `hooks/discussionVersionHistoryHook.ts` - Pattern to follow
-- `middleware/discussionVersionHistoryMiddleware.ts` - Middleware pattern
-- `components/discussion/detail/activityFeed/EditsDropdown.vue` - UI component to adapt
-
----
+- Download detail page download counts
+- Download share/attribution/support-link UX cleanup
+- `textLastEdited` comment-edit timestamp fix
+- Comment search by text
+- Comment search result permalinks
+- Shared permalink utility for comments across supported content types
+- Album image/detail share button
+- Discussion mobile comment-padding adjustment


### PR DESCRIPTION
## What changed
- default new collections created from the Add to List popover to `PRIVATE`
- add an explicit visibility picker so users can intentionally create a public collection
- update the feature roadmap using the newer prioritized checklist as the base, marking the merged downloads slice and this collections-private slice complete
- add unit coverage for default-private creation and explicit-public override

## Why
Collections should not be exposed publicly by default. Users now have to explicitly choose public visibility when creating a new collection from the primary frontend creation flow.

## Backend dependency
- pairs with `gennit-project/multiforum-backend` branch `codex/collections-private-backend`, which adds a server-side private default when visibility is omitted

## Validation
- `npm run tsc`
- `npx vitest run components/collection/AddToListPopover.spec.ts`