### PR TITLE
Add uploaded file management page

### DIFF
--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -41,12 +41,13 @@ Notes:
 - [x] Show the destructive action only to authorized users in the existing download edit surface.
 - [x] Add a confirmation dialog that clearly says the file is permanently removed. `[in draft PR]`
 - [x] Refresh download detail and list views after deletion by filtering permanently removed downloadable files out of discussion queries. `[in draft PR]`
-- [ ] Add uploader-facing file management so users can see their downloadable files grouped by linked discussion on profile/library pages and delete them from there when authorized.
+- [x] Add uploader-facing file management so users can see their downloadable files grouped by linked discussion on profile/library pages and delete them from there when authorized. `[in draft PR]`
 - [ ] Add tests for OP allowed, unrelated user rejected, permitted moderator allowed, and moderator without permission rejected across backend and frontend surfaces.
 
 Notes:
 - Delete confirmation copy exists for individual downloadable files in the edit form in the current frontend draft slice.
 - Backend PR gennit-project/multiforum-backend#118 added `permanentlyDeleteDownloadableFile` on top of the shared storage deletion utility.
+- The current draft slice adds an owner-scoped backend query and `/library/uploads` management page for uploaded downloadable files.
 - Backend draft PR gennit-project/multiforum-backend#116 and frontend draft PR gennit-project/multiforum-nuxt#266 add verified upload storage metadata for new downloadable files, including `storageObjectName` and `storageUrl`.
 
 ### 4. Download filters: review and finish include/exclude semantics `[partial]`
@@ -129,6 +130,7 @@ Notes:
 - [x] Add shared backend storage deletion utility for image/downloadable-file objects.
 - [x] Add backend permanent-delete mutations for uploaded images and downloadable files.
 - [x] Add the first frontend permanent-delete flow for downloadable files in the download edit form. `[in draft PR]`
+- [x] Add an owner-facing uploaded downloadable-file management page with storage-backed permanent delete. `[in draft PR]`
 - [ ] Let authorized users delete album images permanently and remove the backing object from GCP/storage.
 - [ ] Let authorized users delete profile images permanently and remove the backing object from GCP/storage.
 - [ ] Add permanent delete support for forum banners, including storage cleanup.

--- a/graphQLData/user/queries.js
+++ b/graphQLData/user/queries.js
@@ -284,6 +284,29 @@ export const GET_USER_OWNED_DOWNLOADS_COUNT = gql`
   }
 `;
 
+export const GET_UPLOADED_DOWNLOADABLE_FILES = gql`
+  query getUploadedDownloadableFiles($username: String!) {
+    getUploadedDownloadableFiles(username: $username) {
+      discussion {
+        id
+        title
+        createdAt
+        updatedAt
+        channelUniqueNames
+      }
+      files {
+        id
+        fileName
+        kind
+        size
+        url
+        uploadedAt
+        createdAt
+      }
+    }
+  }
+`;
+
 export const GET_USER_EVENTS = gql`
   query getUserEvents($username: String!, $where: EventWhere) {
     users(where: { username: $username }) {

--- a/pages/library.spec.ts
+++ b/pages/library.spec.ts
@@ -8,6 +8,7 @@ const h = vi.hoisted(() => ({
   counts: null as unknown as { value: unknown },
   downloads: null as unknown as { value: unknown },
   owned: null as unknown as { value: unknown },
+  uploaded: null as unknown as { value: unknown },
   collections: null as unknown as { value: unknown },
   route: { path: '/library', params: {} as Record<string, unknown> },
   qi: 0,
@@ -23,8 +24,9 @@ vi.mock('@vue/apollo-composable', async () => {
   h.counts = ref(null);
   h.downloads = ref(null);
   h.owned = ref(null);
+  h.uploaded = ref(null);
   h.collections = ref(null);
-  const order = [h.counts, h.downloads, h.owned, h.collections];
+  const order = [h.counts, h.downloads, h.owned, h.uploaded, h.collections];
   return {
     useQuery: () => ({ result: order[h.qi++] ?? ref(null), refetch: vi.fn() }),
   };
@@ -79,6 +81,7 @@ const setCounts = (channels: number, discussions: number, images: number) => {
   };
   h.downloads.value = { users: [{ FavoriteDiscussionsAggregate: { count: 0 } }] };
   h.owned.value = { users: [{ OwnedDownloadsAggregate: { count: 0 } }] };
+  h.uploaded.value = { getUploadedDownloadableFiles: [] };
   h.collections.value = { users: [{ Collections: [] }] };
 };
 
@@ -90,6 +93,7 @@ beforeEach(() => {
   h.counts.value = null;
   h.downloads.value = null;
   h.owned.value = null;
+  h.uploaded.value = null;
   h.collections.value = null;
 });
 
@@ -261,6 +265,24 @@ describe('Library page', () => {
     ).toBe('/library/favorite-channels');
     expect(wrapper.get('[data-testid="mobile-library-item-c1"]').text()).toContain(
       'My Reading List'
+    );
+  });
+
+  it('links to uploaded files management from the sidebar', () => {
+    setCounts(0, 0, 0);
+    h.uploaded.value = {
+      getUploadedDownloadableFiles: [
+        {
+          discussion: { id: 'd1', title: 'Model' },
+          files: [{ id: 'f1', fileName: 'model.stl' }],
+        },
+      ],
+    };
+
+    const wrapper = mountLibrary();
+
+    expect(wrapper.get('[data-testid="library-item-uploaded-files"]').text()).toContain(
+      '(1)'
     );
   });
 

--- a/pages/library.vue
+++ b/pages/library.vue
@@ -8,6 +8,7 @@ import {
   GET_USER_FAVORITE_COUNTS,
   GET_USER_FAVORITE_DOWNLOADS_COUNT,
   GET_USER_OWNED_DOWNLOADS_COUNT,
+  GET_UPLOADED_DOWNLOADABLE_FILES,
 } from '@/graphQLData/user/queries';
 import { GET_ALL_USER_COLLECTIONS } from '@/graphQLData/collection/queries';
 import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
@@ -77,6 +78,20 @@ const {
   })
 );
 
+const {
+  result: uploadedFilesResult,
+  refetch: refetchUploadedFiles,
+} = useQuery(
+  GET_UPLOADED_DOWNLOADABLE_FILES,
+  () => ({
+    username: username.value,
+  }),
+  () => ({
+    enabled: !!username.value && isAuthenticated.value,
+    fetchPolicy: 'cache-and-network',
+  })
+);
+
 const { result: customCollectionsResult, refetch: refetchCustomCollections } =
   useQuery(
     GET_ALL_USER_COLLECTIONS,
@@ -97,6 +112,7 @@ watch(
       refetchCounts();
       refetchDownloads();
       refetchOwnedDownloads();
+      refetchUploadedFiles();
       refetchCustomCollections();
     }
   }
@@ -115,6 +131,7 @@ const isLoading = computed(() => {
     !favoriteCountsResult.value &&
     !favoriteDownloadsResult.value &&
     !ownedDownloadsCountResult.value &&
+    !uploadedFilesResult.value &&
     !customCollectionsResult.value &&
     isAuthenticated.value &&
     !!username.value
@@ -154,9 +171,22 @@ const ownedDownloadsCount = computed(() => {
   );
 });
 
+const uploadedFilesCount = computed(() => {
+  const groups = uploadedFilesResult.value?.getUploadedDownloadableFiles || [];
+  return groups.reduce(
+    (count: number, group: { files?: unknown[] }) =>
+      count + (group.files?.length || 0),
+    0
+  );
+});
+
 const activeLibraryItemId = computed(() => {
   if (route.path === '/library/my-downloads') {
     return 'my-downloads';
+  }
+
+  if (route.path === '/library/uploads') {
+    return 'uploaded-files';
   }
 
   const matchingDefaultCollection = defaultCollections.value.find(
@@ -289,6 +319,13 @@ const allMobileCollections = computed(() => [
     visibility: 'PRIVATE',
     collectionType: 'DOWNLOADS',
   },
+  {
+    id: 'uploaded-files',
+    name: 'Uploaded Files',
+    itemCount: uploadedFilesCount.value,
+    visibility: 'PRIVATE',
+    collectionType: 'DOWNLOADS',
+  },
   ...filteredFavorites.value,
   ...filteredCustom.value,
 ]);
@@ -310,7 +347,9 @@ const activeLibraryItem = computed(() => {
 const getLibraryItemRoute = (collectionId: string) =>
   collectionId === 'my-downloads'
     ? myDownloadsLink.value
-    : `/library/${collectionId}`;
+    : collectionId === 'uploaded-files'
+      ? '/library/uploads'
+      : `/library/${collectionId}`;
 
 // Get color for collection type
 const getCollectionTypeInfo = (collectionType: string, isActive = false) => {
@@ -364,6 +403,10 @@ const isMyDownloadsActive = computed(
   () =>
     activeLibraryItemId.value === 'my-downloads' ||
     activeLibraryItemId.value === autoSavedDownloadsCollection.value?.id
+);
+
+const isUploadedFilesActive = computed(
+  () => activeLibraryItemId.value === 'uploaded-files'
 );
 </script>
 
@@ -475,6 +518,47 @@ const isMyDownloadsActive = computed(
                   <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
                     Downloads are added here automatically when you grab a file.
                   </p>
+
+                  <NuxtLink
+                    :to="getLibraryItemRoute('uploaded-files')"
+                    data-testid="mobile-library-item-uploaded-files"
+                    :class="[
+                      'mt-3 block rounded-2xl border px-4 py-3 text-sm transition-all',
+                      getSidebarItemClasses(isUploadedFilesActive),
+                    ]"
+                  >
+                    <div class="flex items-center justify-between gap-3">
+                      <div class="min-w-0">
+                        <p
+                          :class="
+                            isUploadedFilesActive
+                              ? 'font-semibold text-gray-900 dark:text-white'
+                              : 'font-semibold'
+                          "
+                        >
+                          Uploaded Files
+                        </p>
+                        <p
+                          :class="
+                            isUploadedFilesActive
+                              ? 'mt-1 text-xs text-gray-700 dark:text-white'
+                              : 'mt-1 text-xs text-gray-500 dark:text-gray-400'
+                          "
+                        >
+                          Manage files you uploaded
+                        </p>
+                      </div>
+                      <span
+                        :class="
+                          isUploadedFilesActive
+                            ? 'text-gray-700 dark:text-white'
+                            : 'text-gray-500 dark:text-gray-400'
+                        "
+                      >
+                        ({{ uploadedFilesCount }})
+                      </span>
+                    </div>
+                  </NuxtLink>
 
                   <NuxtLink
                     v-for="collection in filteredFavorites"
@@ -676,6 +760,44 @@ const isMyDownloadsActive = computed(
                   <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
                     Downloads are added here automatically when you grab a file.
                   </p>
+                  <NuxtLink
+                    :to="getLibraryItemRoute('uploaded-files')"
+                    class="mt-3 block rounded-2xl border px-4 py-3 text-sm transition-all"
+                    :class="getSidebarItemClasses(isUploadedFilesActive)"
+                    data-testid="library-item-uploaded-files"
+                  >
+                    <div class="flex items-center justify-between gap-3">
+                      <div class="min-w-0">
+                        <p
+                          :class="
+                            isUploadedFilesActive
+                              ? 'font-semibold text-gray-900 dark:text-white'
+                              : 'font-semibold'
+                          "
+                        >
+                          Uploaded Files
+                        </p>
+                        <p
+                          :class="
+                            isUploadedFilesActive
+                              ? 'mt-1 text-xs text-gray-700 dark:text-white'
+                              : 'mt-1 text-xs text-gray-500 dark:text-gray-400'
+                          "
+                        >
+                          Manage files you uploaded
+                        </p>
+                      </div>
+                      <span
+                        :class="
+                          isUploadedFilesActive
+                            ? 'text-gray-700 dark:text-white'
+                            : 'text-gray-500 dark:text-gray-400'
+                        "
+                      >
+                        ({{ uploadedFilesCount }})
+                      </span>
+                    </div>
+                  </NuxtLink>
                 </div>
 
                 <!-- Collections Section -->

--- a/pages/library/uploads.spec.ts
+++ b/pages/library/uploads.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { defineComponent, h, ref } from 'vue';
+import { useMutation, useQuery } from '@vue/apollo-composable';
+
+vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+  useMutation: vi.fn(),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+const RequireAuthStub = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots['has-auth']?.());
+  },
+});
+
+const WarningModalStub = defineComponent({
+  name: 'WarningModal',
+  props: ['open', 'title'],
+  emits: ['close', 'primary-button-click'],
+  template: '<div data-testid="warning-modal" :data-open="open" />',
+});
+
+const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+const mockedUseMutation = useMutation as unknown as ReturnType<typeof vi.fn>;
+const deleteMutation = vi.fn();
+const refetch = vi.fn();
+
+const mountPage = async () => {
+  const Page = (await import('./uploads.vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        RequireAuth: RequireAuthStub,
+        WarningModal: WarningModalStub,
+        ErrorBanner: { props: ['text'], template: '<div>{{ text }}</div>' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  deleteMutation.mockResolvedValue({
+    data: {
+      permanentlyDeleteDownloadableFile: {
+        id: 'file-1',
+        permanentlyRemoved: true,
+      },
+    },
+  });
+  refetch.mockResolvedValue({});
+  mockedUseQuery.mockReturnValue({
+    result: ref({
+      getUploadedDownloadableFiles: [
+        {
+          discussion: {
+            id: 'discussion-1',
+            title: 'Printable model',
+            channelUniqueNames: ['models'],
+          },
+          files: [
+            {
+              id: 'file-1',
+              fileName: 'model.stl',
+              kind: 'STL',
+              size: 1048576,
+            },
+          ],
+        },
+      ],
+    }),
+    loading: ref(false),
+    error: ref(null),
+    refetch,
+  });
+  mockedUseMutation.mockReturnValue({
+    mutate: deleteMutation,
+    loading: ref(false),
+    error: ref(null),
+  });
+});
+
+describe('uploaded files library page', () => {
+  it('renders uploaded files grouped under their discussion', async () => {
+    const wrapper = await mountPage();
+
+    expect(wrapper.text()).toContain('Printable model');
+  });
+
+  it('opens a confirmation before deleting a file', async () => {
+    const wrapper = await mountPage();
+
+    await wrapper.get('button').trigger('click');
+
+    expect(wrapper.getComponent(WarningModalStub).props('open')).toBe(true);
+  });
+
+  it('passes the selected file id to the permanent delete mutation', async () => {
+    const wrapper = await mountPage();
+
+    await wrapper.get('button').trigger('click');
+    await wrapper
+      .getComponent(WarningModalStub)
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(deleteMutation).toHaveBeenCalledWith({
+      downloadableFileId: 'file-1',
+    });
+  });
+
+  it('refetches uploaded files after a successful delete', async () => {
+    const wrapper = await mountPage();
+
+    await wrapper.get('button').trigger('click');
+    await wrapper
+      .getComponent(WarningModalStub)
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pages/library/uploads.vue
+++ b/pages/library/uploads.vue
@@ -1,0 +1,233 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useMutation, useQuery } from '@vue/apollo-composable';
+import { useHead } from 'nuxt/app';
+import RequireAuth from '@/components/auth/RequireAuth.vue';
+import ErrorBanner from '@/components/ErrorBanner.vue';
+import WarningModal from '@/components/WarningModal.vue';
+import { useUsername } from '@/composables/useAuthState';
+import { GET_UPLOADED_DOWNLOADABLE_FILES } from '@/graphQLData/user/queries';
+import { PERMANENTLY_DELETE_DOWNLOADABLE_FILE } from '@/graphQLData/discussion/mutations';
+
+type UploadedFile = {
+  id: string;
+  fileName: string;
+  kind?: string | null;
+  size?: number | null;
+  url?: string | null;
+  uploadedAt?: string | null;
+  createdAt?: string | null;
+};
+
+type UploadedDownloadGroup = {
+  discussion: {
+    id: string;
+    title: string;
+    channelUniqueNames?: string[];
+  };
+  files: UploadedFile[];
+};
+
+const usernameVar = useUsername();
+const pendingDeleteFile = ref<UploadedFile | null>(null);
+
+useHead({
+  title: 'Uploaded Files - Library',
+});
+
+const {
+  result,
+  loading,
+  error,
+  refetch,
+} = useQuery(
+  GET_UPLOADED_DOWNLOADABLE_FILES,
+  () => ({
+    username: usernameVar.value,
+  }),
+  () => ({
+    enabled: !!usernameVar.value,
+    fetchPolicy: 'cache-and-network',
+  })
+);
+
+const {
+  mutate: permanentlyDeleteDownloadableFile,
+  loading: deleteLoading,
+  error: deleteError,
+} = useMutation(PERMANENTLY_DELETE_DOWNLOADABLE_FILE);
+
+const groups = computed<UploadedDownloadGroup[]>(() => {
+  return result.value?.getUploadedDownloadableFiles || [];
+});
+
+const totalFiles = computed(() =>
+  groups.value.reduce((count, group) => count + group.files.length, 0)
+);
+
+const formatFileSize = (size?: number | null) => {
+  if (!size) {
+    return '0 MB';
+  }
+
+  return `${(size / (1024 * 1024)).toFixed(2)} MB`;
+};
+
+const getDiscussionPath = (group: UploadedDownloadGroup) => {
+  const channelUniqueName = group.discussion.channelUniqueNames?.[0];
+
+  if (!channelUniqueName) {
+    return `/discussions/${group.discussion.id}`;
+  }
+
+  return `/forums/${channelUniqueName}/downloads/${group.discussion.id}`;
+};
+
+const confirmDelete = (file: UploadedFile) => {
+  pendingDeleteFile.value = file;
+};
+
+const closeDeleteModal = () => {
+  if (deleteLoading.value) {
+    return;
+  }
+
+  pendingDeleteFile.value = null;
+};
+
+const deleteSelectedFile = async () => {
+  if (!pendingDeleteFile.value) {
+    return;
+  }
+
+  try {
+    await permanentlyDeleteDownloadableFile({
+      downloadableFileId: pendingDeleteFile.value.id,
+    });
+    pendingDeleteFile.value = null;
+    await refetch();
+  } catch (err) {
+    console.error('Error permanently deleting uploaded file:', err);
+  }
+};
+</script>
+
+<template>
+  <div class="min-h-screen bg-white dark:bg-black dark:text-white">
+    <RequireAuth>
+      <template #has-auth>
+        <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+          <div class="mb-8">
+            <p class="text-xs font-semibold uppercase tracking-[0.24em] text-orange-600 dark:text-orange-300">
+              Data control
+            </p>
+            <h1 class="mt-2 text-3xl font-bold tracking-tight text-gray-950 dark:text-white">
+              Uploaded Files
+            </h1>
+            <p class="mt-2 max-w-2xl text-sm text-gray-600 dark:text-gray-300">
+              Files you uploaded to downloads, grouped by the discussion where they are attached.
+              Permanent delete removes the backing file from storage.
+            </p>
+          </div>
+
+          <div v-if="loading" class="py-10 text-center">
+            <div class="inline-block h-8 w-8 animate-spin rounded-full border-b-2 border-orange-500" />
+            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+              Loading uploaded files...
+            </p>
+          </div>
+
+          <ErrorBanner
+            v-else-if="error"
+            :text="`Error loading uploaded files: ${error.message}`"
+          />
+
+          <div
+            v-else-if="totalFiles === 0"
+            class="rounded-3xl border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center dark:border-gray-700 dark:bg-gray-900"
+          >
+            <i class="fa-regular fa-folder-open text-4xl text-gray-400" />
+            <h2 class="mt-4 text-lg font-semibold text-gray-950 dark:text-white">
+              No uploaded files yet
+            </h2>
+            <p class="mx-auto mt-2 max-w-md text-sm text-gray-600 dark:text-gray-300">
+              Files you upload to download posts will appear here so you can find and delete them later.
+            </p>
+          </div>
+
+          <div v-else class="space-y-5">
+            <article
+              v-for="group in groups"
+              :key="group.discussion.id"
+              class="overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900"
+            >
+              <div class="border-b border-gray-100 bg-gray-50 px-5 py-4 dark:border-gray-800 dark:bg-gray-950/60">
+                <NuxtLink
+                  :to="getDiscussionPath(group)"
+                  class="text-lg font-semibold text-gray-950 hover:text-orange-600 dark:text-white dark:hover:text-orange-300"
+                >
+                  {{ group.discussion.title }}
+                </NuxtLink>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {{ group.files.length }} uploaded file{{ group.files.length === 1 ? '' : 's' }}
+                </p>
+              </div>
+
+              <ul class="divide-y divide-gray-100 dark:divide-gray-800">
+                <li
+                  v-for="file in group.files"
+                  :key="file.id"
+                  class="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div class="min-w-0">
+                    <p class="truncate font-medium text-gray-900 dark:text-gray-100">
+                      {{ file.fileName }}
+                    </p>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                      {{ file.kind || 'File' }} · {{ formatFileSize(file.size) }}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    class="inline-flex items-center justify-center rounded-full border border-red-200 px-4 py-2 text-sm font-semibold text-red-700 transition hover:border-red-300 hover:bg-red-50 dark:border-red-900/70 dark:text-red-300 dark:hover:bg-red-950/40"
+                    @click="confirmDelete(file)"
+                  >
+                    Permanently delete
+                  </button>
+                </li>
+              </ul>
+            </article>
+          </div>
+
+          <ErrorBanner
+            v-if="deleteError"
+            class="mt-4"
+            :text="deleteError.message"
+          />
+
+          <WarningModal
+            :open="!!pendingDeleteFile"
+            title="Permanently delete this uploaded file?"
+            body="This removes the file from its download post and permanently deletes the backing file from storage. This cannot be undone."
+            icon="trash"
+            primary-button-text="Permanently delete"
+            :loading="deleteLoading"
+            data-testid="uploaded-file-delete-modal"
+            @close="closeDeleteModal"
+            @primary-button-click="deleteSelectedFile"
+          />
+        </div>
+      </template>
+      <template #does-not-have-auth>
+        <div class="mx-auto max-w-md py-12 text-center">
+          <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+            Sign In Required
+          </h1>
+          <p class="mt-4 text-gray-600 dark:text-gray-300">
+            Please sign in to manage uploaded files.
+          </p>
+        </div>
+      </template>
+    </RequireAuth>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add `/library/uploads` so users can find uploaded downloadable files grouped by discussion
- add permanent-delete confirmation and mutation wiring from the upload-management page
- add an Uploaded Files entry to the library navigation with a file count
- update `docs/FEATURE_ROADMAP.md` for the downloadable-file management slice
- add focused unit coverage for the page and library nav entry

Stacked on `codex/upload-storage-metadata-frontend`.

## Validation
- `npm run test:unit:run -- pages/library/uploads.spec.ts pages/library.spec.ts`
- `npm run tsc`
- pre-commit hook passed; repo-wide lint emitted existing warnings only