### PR TITLE
Add album image permanent deletion

### DIFF
--- a/components/discussion/form/AlbumEditor.spec.ts
+++ b/components/discussion/form/AlbumEditor.spec.ts
@@ -7,14 +7,23 @@ import AlbumEditor from '@/components/discussion/form/AlbumEditor.vue';
 
 // Hoisted, controllable test seams: username (for the no-username branch) and
 // the URL-image creation spy (for the submit success/failure branches).
-const { usernameRef, createImageFromUrl } = vi.hoisted(() => ({
-  usernameRef: { value: 'alice' as string },
-  createImageFromUrl: vi.fn(),
-}));
+const { usernameRef, createImageFromUrl, permanentlyDeleteImage } = vi.hoisted(
+  () => ({
+    usernameRef: { value: 'alice' as string },
+    createImageFromUrl: vi.fn(),
+    permanentlyDeleteImage: vi.fn(),
+  })
+);
 
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => usernameRef,
   setUsername: vi.fn(),
+}));
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({
+    mutate: permanentlyDeleteImage,
+    loading: { value: false },
+  }),
 }));
 vi.mock('@/composables/useAlbumImageUpload', () => ({
   useAlbumImageUpload: () => ({
@@ -59,10 +68,18 @@ const AlbumUrlInputFormStub = {
   template: '<div class="url-input-stub" />',
 };
 
+const WarningModalStub = {
+  name: 'WarningModal',
+  props: ['open', 'title', 'body', 'loading', 'error'],
+  emits: ['primary-button-click', 'close'],
+  template: '<div class="warning-modal-stub" />',
+};
+
 const stubs = {
   AlbumImageItem: AlbumImageItemStub,
   AlbumDropZone: AlbumDropZoneStub,
   AlbumUrlInputForm: AlbumUrlInputFormStub,
+  WarningModal: WarningModalStub,
   ErrorBanner: { props: ['text'], template: '<div />' },
   LoadingSpinner: { template: '<div />' },
 };
@@ -89,10 +106,17 @@ const lastEmit = (wrapper: ReturnType<typeof mountEditor>) => {
   return (calls?.[calls.length - 1]?.[0] as { album: { images: { id: string }[]; imageOrder: string[] } }).album;
 };
 
+const warningModal = (wrapper: ReturnType<typeof mountEditor>) =>
+  wrapper.getComponent(WarningModalStub);
+
 describe('AlbumEditor', () => {
   beforeEach(() => {
     usernameRef.value = 'alice';
     createImageFromUrl.mockReset();
+    permanentlyDeleteImage.mockReset();
+    permanentlyDeleteImage.mockResolvedValue({
+      data: { permanentlyDeleteImage: { id: 'a' } },
+    });
   });
 
   it('renders one image item per ordered image', () => {
@@ -103,7 +127,35 @@ describe('AlbumEditor', () => {
   it('emits the album without the deleted image', async () => {
     const wrapper = mountEditor();
     wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('delete');
+    warningModal(wrapper).vm.$emit('primary-button-click');
+    await flushPromises();
     expect(lastEmit(wrapper).images.map((i) => i.id)).toEqual(['b', 'c']);
+  });
+
+  it('opens a confirmation modal before deleting an image', async () => {
+    const wrapper = mountEditor();
+    wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('delete');
+    await wrapper.vm.$nextTick();
+    expect(warningModal(wrapper).props('open')).toBe(true);
+  });
+
+  it('calls the permanent-delete mutation for the selected image', async () => {
+    const wrapper = mountEditor();
+    wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('delete');
+    warningModal(wrapper).vm.$emit('primary-button-click');
+    await flushPromises();
+    expect(permanentlyDeleteImage).toHaveBeenCalledWith({ imageId: 'a' });
+  });
+
+  it('keeps the image in the album when permanent delete fails', async () => {
+    permanentlyDeleteImage.mockRejectedValue(
+      new Error('backend rejected delete')
+    );
+    const wrapper = mountEditor();
+    wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('delete');
+    warningModal(wrapper).vm.$emit('primary-button-click');
+    await flushPromises();
+    expect(wrapper.emitted('updateFormValues')).toBeUndefined();
   });
 
   it('reorders imageOrder when an image moves up', () => {

--- a/components/discussion/form/AlbumEditor.vue
+++ b/components/discussion/form/AlbumEditor.vue
@@ -8,6 +8,9 @@ import AlbumDropZone from './AlbumDropZone.vue';
 import AlbumUrlInputForm from './AlbumUrlInputForm.vue';
 import { useAlbumImageUpload } from '@/composables/useAlbumImageUpload';
 import { useAlbumAutoSave } from '@/composables/useAlbumAutoSave';
+import { useMutation } from '@vue/apollo-composable';
+import WarningModal from '@/components/WarningModal.vue';
+import { PERMANENTLY_DELETE_IMAGE } from '@/graphQLData/discussion/mutations';
 import {
   orderImagesByOrder,
   getImageIdOrder,
@@ -126,6 +129,11 @@ const {
 const showUrlInput = ref(false);
 const isCreatingImageFromUrl = ref(false);
 const urlInputFormRef = ref<InstanceType<typeof AlbumUrlInputForm> | null>(null);
+const pendingDeleteImageIndex = ref<number | null>(null);
+const permanentDeleteImageError = ref('');
+
+const { mutate: permanentlyDeleteImage, loading: permanentlyDeleteImageLoading } =
+  useMutation(PERMANENTLY_DELETE_IMAGE);
 
 // Image field update handler
 const updateImageField = (
@@ -160,8 +168,7 @@ const updateImageField = (
   debouncedAutoSave();
 };
 
-// Delete image handler
-const deleteImage = (index: number) => {
+const removeImageFromAlbum = (index: number) => {
   const orderedImage = orderedImages.value[index];
   if (!orderedImage || !orderedImage.id) return;
 
@@ -183,6 +190,41 @@ const deleteImage = (index: number) => {
   });
 
   debouncedAutoSave();
+};
+
+// Delete image handler
+const requestDeleteImage = (index: number) => {
+  pendingDeleteImageIndex.value = index;
+  permanentDeleteImageError.value = '';
+};
+
+const closeDeleteImageModal = () => {
+  if (permanentlyDeleteImageLoading.value) return;
+  pendingDeleteImageIndex.value = null;
+  permanentDeleteImageError.value = '';
+};
+
+const confirmDeleteImage = async () => {
+  if (pendingDeleteImageIndex.value === null) return;
+
+  const deleteIndex = pendingDeleteImageIndex.value;
+  const orderedImage = orderedImages.value[deleteIndex];
+  if (!orderedImage?.id) {
+    removeImageFromAlbum(deleteIndex);
+    closeDeleteImageModal();
+    return;
+  }
+
+  permanentDeleteImageError.value = '';
+
+  try {
+    await permanentlyDeleteImage({ imageId: orderedImage.id });
+    removeImageFromAlbum(deleteIndex);
+    pendingDeleteImageIndex.value = null;
+  } catch (error) {
+    permanentDeleteImageError.value =
+      error instanceof Error ? error.message : 'Failed to delete image.';
+  }
 };
 
 // Move image up handler
@@ -319,7 +361,7 @@ const handleUrlCancel = () => {
       :is-last="index === orderedImages.length - 1"
       :is-loading="loadingStates[index] ?? false"
       @update-field="(field, value) => updateImageField(index, field, value)"
-      @delete="deleteImage(index)"
+      @delete="requestDeleteImage(index)"
       @move-up="moveImageUp(index)"
       @move-down="moveImageDown(index)"
     />
@@ -340,6 +382,20 @@ const handleUrlCancel = () => {
       :is-creating="isCreatingImageFromUrl"
       @submit="handleUrlSubmit"
       @cancel="handleUrlCancel"
+    />
+
+    <WarningModal
+      :open="pendingDeleteImageIndex !== null"
+      title="Delete this image?"
+      body="This permanently deletes the image and removes the stored file. This cannot be undone."
+      primary-button-text="Delete Image"
+      secondary-button-text="Cancel"
+      icon="trash"
+      data-testid="permanently-delete-album-image-modal"
+      :loading="permanentlyDeleteImageLoading"
+      :error="permanentDeleteImageError"
+      @primary-button-click="confirmDeleteImage"
+      @close="closeDeleteImageModal"
     />
   </div>
 </template>

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -131,7 +131,7 @@ Notes:
 
 ### 10. Permanent media deletion and storage cleanup `[partial]`
 
-- [ ] Let authorized users delete album images permanently and remove the backing object from GCP/storage.
+- [x] Let authorized users delete album images permanently and remove the backing object from GCP/storage. `[in this PR]`
 - [ ] Let authorized users delete profile images permanently and remove the backing object from GCP/storage.
 - [ ] Add permanent delete support for forum banners, including storage cleanup.
 - [ ] Make storage cleanup behavior explicit and tested so database deletion and blob deletion stay in sync.
@@ -139,7 +139,7 @@ Notes:
 - [ ] Add tests covering successful delete, unauthorized rejection, missing-file cleanup behavior, and stale-reference cleanup.
 
 Notes:
-- The repo has album/image editing and removal-from-local-state flows, but that is not the same as permanent backend deletion plus cloud-storage cleanup.
+- Album edit deletion now confirms and calls the backend permanent-delete mutation before removing the image from the album UI; remaining media deletion work is profile images, forum banners, and broader permission/error coverage.
 
 ### 11. Wiki: pinned sidebar pages `[not started]`
 

--- a/graphQLData/discussion/mutations.js
+++ b/graphQLData/discussion/mutations.js
@@ -101,6 +101,16 @@ export const TRACK_DOWNLOAD = gql`
   }
 `;
 
+export const PERMANENTLY_DELETE_IMAGE = gql`
+  mutation permanentlyDeleteImage($imageId: ID!) {
+    permanentlyDeleteImage(imageId: $imageId) {
+      id
+      permanentlyRemoved
+      permanentlyRemovedAt
+    }
+  }
+`;
+
 export const UPDATE_DOWNLOADABLE_FILE_SUPPORT_SETTINGS = gql`
   mutation updateDownloadableFileSupportSettings(
     $downloadableFileId: ID!


### PR DESCRIPTION
## Summary
- Add the `permanentlyDeleteImage` GraphQL mutation document.
- Require confirmation before deleting an album image, call the backend permanent-delete mutation, and only remove the image from local album state after success.
- Update `docs/FEATURE_ROADMAP.md` to mark album-image permanent deletion as covered by this PR.

## Validation
- `npm run test:unit:run -- components/discussion/form/AlbumEditor.spec.ts`
- `npm run tsc`
- Commit hook also ran `vue-tsc --noEmit` and full `eslint`; lint completed with existing warnings only.