### PR TITLE
[codex] Fix wiki edits profile and related UI bugs

### DIFF
--- a/components/discussion/list/SitewideDiscussionListItem.spec.ts
+++ b/components/discussion/list/SitewideDiscussionListItem.spec.ts
@@ -122,6 +122,16 @@ describe('SitewideDiscussionListItem channel icons', () => {
     );
     expect(wrapper.find('[class*="group-hover/chicon"]').text()).toBe('cats');
   });
+
+  it('positions channel icon tooltips away from the left nav rail', () => {
+    const wrapper = mountItem(
+      discussion({ DiscussionChannels: [channel('cats')] })
+    );
+
+    expect(wrapper.find('[class*="group-hover/chicon"]').classes()).toEqual(
+      expect.arrayContaining(['left-0', 'z-30'])
+    );
+  });
 });
 
 describe('SitewideDiscussionListItem thumbnail', () => {

--- a/components/discussion/list/SitewideDiscussionListItem.vue
+++ b/components/discussion/list/SitewideDiscussionListItem.vue
@@ -258,7 +258,10 @@ const revealSensitiveContent = () => {
       <!-- Discussion row -->
       <div class="flex items-start gap-3">
         <div class="flex flex-shrink-0 flex-col items-center gap-1">
-          <ChannelIconStack :channels="channelIcons" />
+          <ChannelIconStack
+            :channels="channelIcons"
+            tooltip-position-class="pointer-events-none absolute -top-8 left-0 z-30 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 shadow-lg transition-opacity duration-200 group-hover/chicon:opacity-100 dark:bg-gray-700"
+          />
           <AddToDiscussionFavorites
             v-if="discussion"
             :allow-add-to-list="true"

--- a/components/icons/MoreIcon.vue
+++ b/components/icons/MoreIcon.vue
@@ -1,15 +1,12 @@
 <template>
   <svg
-    class="h-6 w-6 text-gray-300"
-    fill="none"
-    stroke="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
     viewBox="0 0 24 24"
+    aria-hidden="true"
   >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"
-    />
+    <circle cx="5" cy="12" r="1.75" />
+    <circle cx="12" cy="12" r="1.75" />
+    <circle cx="19" cy="12" r="1.75" />
   </svg>
 </template>

--- a/components/nav/VerticalIconNav.vue
+++ b/components/nav/VerticalIconNav.vue
@@ -264,7 +264,7 @@ const getNavLabelClasses = (isActive: boolean) =>
       <ClientOnly>
         <div
           v-if="recentForums.length > 0 && !isVerticallyShort"
-          class="flex flex-col space-y-1"
+          class="recent-forums-rail flex w-full flex-col items-center space-y-1"
         >
           <!-- Limited Recent Forums -->
           <IconTooltip
@@ -303,7 +303,7 @@ const getNavLabelClasses = (isActive: boolean) =>
 
           <!-- More Button -->
           <div v-if="hasMoreForums" class="w-full px-2">
-            <IconTooltip text="More Forums">
+            <IconTooltip text="More Forums" class="!block w-full">
               <button
                 type="button"
                 :class="getNavItemClasses(false)"
@@ -311,7 +311,7 @@ const getNavLabelClasses = (isActive: boolean) =>
                 title="More forums"
                 @click="isDrawerOpen = true"
               >
-                <MoreIcon />
+                <MoreIcon :class="getNavIconClasses(false)" />
                 <span
                   class="w-full text-center text-[10px] leading-[10px] text-gray-600 dark:text-gray-300"
                   >More</span

--- a/components/user/UserProfileTabs.spec.ts
+++ b/components/user/UserProfileTabs.spec.ts
@@ -49,6 +49,17 @@ describe('UserProfileTabs', () => {
     expect(tabs(wrapper)[0].props('count')).toBe(4);
   });
 
+  it('prefers the dedicated wiki edits count for the wiki tab', () => {
+    const wrapper = mountTabs({
+      user: user({
+        wikiEditsCount: 7,
+        AuthoredWikiPageVersionsAggregate: { count: 11 },
+      }),
+    });
+
+    expect(tabs(wrapper)[4].props('count')).toBe(7);
+  });
+
   it('marks the tab matching the route as active', () => {
     const wrapper = mountTabs();
 

--- a/components/user/UserProfileTabs.vue
+++ b/components/user/UserProfileTabs.vue
@@ -23,6 +23,7 @@ type UserProfileCounts = User & {
   AlbumsAggregate?: {
     count?: number | null;
   } | null;
+  wikiEditsCount?: number | null;
   AuthoredWikiPageVersionsAggregate?: {
     count?: number | null;
   } | null;
@@ -116,7 +117,9 @@ const tabs = computed(() => {
       path: `/u/${usernameInParams.value}/wiki-edits`,
       to: getTabTo(`/u/${usernameInParams.value}/wiki-edits`),
       current: false,
-      count: props.user?.AuthoredWikiPageVersionsAggregate?.count,
+      count:
+        props.user?.wikiEditsCount ??
+        props.user?.AuthoredWikiPageVersionsAggregate?.count,
     },
     {
       name: 'Images',

--- a/graphQLData/user/queries.js
+++ b/graphQLData/user/queries.js
@@ -2,6 +2,7 @@ import { gql } from '@apollo/client/core';
 
 export const GET_USER = gql`
   query getBasicUserInfo($username: String!) {
+    getUserWikiEditsCount(username: $username)
     users(where: { username: $username }) {
       username
       commentKarma
@@ -329,8 +330,17 @@ export const GET_USER_WIKI_EDITS = gql`
     wikiPages(where: $where, options: { sort: [{ updatedAt: DESC }] }) {
       id
       title
+      body
+      editReason
       slug
+      createdAt
+      updatedAt
       channelUniqueName
+      VersionAuthor {
+        username
+        displayName
+        profilePicURL
+      }
       PastVersions(
         where: $versionWhere
         options: { sort: [{ createdAt: DESC }] }

--- a/pages/u/[username].spec.ts
+++ b/pages/u/[username].spec.ts
@@ -161,4 +161,16 @@ describe('User profile container', () => {
       wrapper.findComponent({ name: 'UserProfileSidebar' }).props('serverRoleBadge')
     ).toBeNull();
   });
+
+  it('passes the dedicated wiki edits count through to the tabs', async () => {
+    h.resultRef.value = {
+      getUserWikiEditsCount: 3,
+      users: [makeUser({ AuthoredWikiPageVersionsAggregate: { count: 11 } })],
+    };
+
+    const wrapper = await mountContainer();
+
+    expect(wrapper.findComponent({ name: 'UserProfileTabs' }).props('user'))
+      .toMatchObject({ wikiEditsCount: 3 });
+  });
 });

--- a/pages/u/[username].vue
+++ b/pages/u/[username].vue
@@ -41,7 +41,13 @@ const {
 const user = computed(() => {
   if (userError.value) return null;
   if (userResult.value && userResult.value.users.length > 0) {
-    return userResult.value.users[0];
+    return {
+      ...userResult.value.users[0],
+      wikiEditsCount:
+        userResult.value.getUserWikiEditsCount ??
+        userResult.value.users[0].AuthoredWikiPageVersionsAggregate?.count ??
+        0,
+    };
   }
   // Return a placeholder user object while loading so tabs can render
   if (userLoading.value && username.value) {
@@ -51,6 +57,7 @@ const user = computed(() => {
       DiscussionsAggregate: { count: 0 },
       DownloadsAggregate: { count: 0 },
       EventsAggregate: { count: 0 },
+      wikiEditsCount: 0,
       AuthoredWikiPageVersionsAggregate: { count: 0 },
       ImagesAggregate: { count: 0 },
       AlbumsAggregate: { count: 0 },

--- a/pages/u/[username]/wiki-edits.spec.ts
+++ b/pages/u/[username]/wiki-edits.spec.ts
@@ -45,8 +45,13 @@ const SAMPLE = [
   {
     id: 'w1',
     title: 'Cat Care',
+    body: 'Current body',
+    editReason: 'Current revision',
     slug: 'cat-care',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-02-01T00:00:00Z',
     channelUniqueName: 'cats',
+    VersionAuthor: { username: 'alice' },
     PastVersions: [
       { id: 'v1', createdAt: '2024-02-01T00:00:00Z', editReason: 'Tidied up' },
     ],
@@ -69,15 +74,20 @@ describe('user wiki edits page', () => {
       {
         id: 'w1',
         title: 'Page 1',
+        body: 'Current body',
+        editReason: 'Current revision',
         slug: 'page-1',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-02-02T00:00:00Z',
         channelUniqueName: 'cats',
+        VersionAuthor: { username: 'alice' },
         PastVersions: [
           { id: 'v1', createdAt: '2024-01-01T00:00:00Z' },
           { id: 'v2', createdAt: '2024-02-01T00:00:00Z' },
         ],
       },
     ]);
-    expect(wrapper.findAll('li')).toHaveLength(2);
+    expect(wrapper.findAll('li')).toHaveLength(3);
   });
 
   it('orders edits newest first', async () => {
@@ -85,15 +95,25 @@ describe('user wiki edits page', () => {
       {
         id: 'w1',
         title: 'OLDER',
+        body: 'Older current body',
+        editReason: 'Older current revision',
         slug: 'older',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
         channelUniqueName: 'cats',
+        VersionAuthor: { username: 'bob' },
         PastVersions: [{ id: 'v1', createdAt: '2024-01-01T00:00:00Z' }],
       },
       {
         id: 'w2',
         title: 'NEWER',
+        body: 'Newer current body',
+        editReason: 'Newer current revision',
         slug: 'newer',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-02-02T00:00:00Z',
         channelUniqueName: 'cats',
+        VersionAuthor: { username: 'alice' },
         PastVersions: [{ id: 'v2', createdAt: '2024-02-01T00:00:00Z' }],
       },
     ]);
@@ -118,6 +138,9 @@ describe('user wiki edits page', () => {
     expect(targets).toContain(
       '/forums/cats/wiki/revisions/diff/cat-care/v1'
     );
+    expect(targets).toContain(
+      '/forums/cats/wiki/revisions/diff/cat-care/current'
+    );
   });
 
   it('narrows the query to the selected channels when filtering', async () => {
@@ -131,5 +154,24 @@ describe('user wiki edits page', () => {
     };
     const where = variablesGetter().where;
     expect(where.AND?.[1]?.channelUniqueName_IN).toEqual(['cats']);
+  });
+
+  it('includes the current wiki version when the profile user authored it', async () => {
+    const wrapper = await mountWith([
+      {
+        id: 'w1',
+        title: 'Current Only',
+        body: 'Current wiki body',
+        editReason: 'Most recent update',
+        slug: 'current-only',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-02-01T00:00:00Z',
+        channelUniqueName: 'cats',
+        VersionAuthor: { username: 'alice' },
+        PastVersions: [],
+      },
+    ]);
+
+    expect(wrapper.text()).toContain('Current Only');
   });
 });

--- a/pages/u/[username]/wiki-edits.vue
+++ b/pages/u/[username]/wiki-edits.vue
@@ -9,12 +9,21 @@ import type { TextVersion, WikiPage } from '@/__generated__/graphql';
 
 type WikiEditPage = Pick<
   WikiPage,
-  'id' | 'title' | 'slug' | 'channelUniqueName'
+  | 'id'
+  | 'title'
+  | 'body'
+  | 'editReason'
+  | 'slug'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'channelUniqueName'
+  | 'VersionAuthor'
 > & {
   PastVersions?: TextVersion[] | null;
 };
 
 type WikiEdit = TextVersion & {
+  listKey: string;
   wikiPage: Pick<WikiPage, 'id' | 'title' | 'slug' | 'channelUniqueName'>;
 };
 
@@ -33,7 +42,16 @@ const versionWhere = computed(() => ({
 
 const wikiPagesWhere = computed(() => {
   const baseWhere = {
-    PastVersions_SOME: versionWhere.value,
+    OR: [
+      {
+        PastVersions_SOME: versionWhere.value,
+      },
+      {
+        VersionAuthor: {
+          username: username.value,
+        },
+      },
+    ],
   };
 
   if (!hasSelectedChannels.value) {
@@ -73,10 +91,30 @@ const wikiEdits = computed<WikiEdit[]>(() => {
         channelUniqueName: wikiPage.channelUniqueName,
       };
 
-      return (wikiPage.PastVersions || []).map((version) => ({
+      const edits = (wikiPage.PastVersions || []).map((version) => ({
         ...version,
+        listKey: `${wikiPage.id}:${version.id}`,
         wikiPage: page,
       }));
+
+      if (wikiPage.VersionAuthor?.username === username.value) {
+        edits.push({
+          id: 'current',
+          body: wikiPage.body,
+          editReason: wikiPage.editReason,
+          createdAt: wikiPage.updatedAt || wikiPage.createdAt,
+          Author: wikiPage.VersionAuthor,
+          AuthorConnection: {
+            edges: [],
+            pageInfo: { hasNextPage: false, hasPreviousPage: false },
+            totalCount: 0,
+          },
+          listKey: `${wikiPage.id}:current`,
+          wikiPage: page,
+        });
+      }
+
+      return edits;
     })
     .sort((a, b) => {
       return (
@@ -102,7 +140,7 @@ const getWikiRevisionPath = (edit: WikiEdit) => {
     <ul v-else class="flex flex-col gap-3">
       <li
         v-for="edit in wikiEdits"
-        :key="edit.id"
+        :key="edit.listKey"
         class="rounded-md border border-gray-200 p-3 dark:border-gray-700"
       >
         <div class="flex flex-col gap-1">


### PR DESCRIPTION
## What changed
This PR fixes the user-profile wiki-edits experience by:
- using the new backend wiki-edits count for the profile badge
- including the current wiki version in the wiki-edits list when the profile user is the current wiki author
- keeping the sitewide discussion forum-icon tooltip fixes and vertical nav alignment fixes that were completed in this work slice

## Why
The wiki-edits badge and list disagreed badly. The list could only show wiki-linked edits, while the old badge was driven by an overbroad aggregate. This PR switches the badge to the dedicated backend count and makes the list include the current wiki version so users are not left with an empty or misleading tab.

## Dependency
Depends on backend PR #120:
https://github.com/gennit-project/multiforum-backend/pull/120

## Validation
- `npx vitest run components/user/UserProfileTabs.spec.ts 'pages/u/[username].spec.ts' 'pages/u/[username]/wiki-edits.spec.ts'`
- verified against the updated local backend serving `getUserWikiEditsCount`