### PR TITLE
Harden downloadable file delete UI

### DIFF
--- a/components/discussion/form/DownloadEditForm.spec.ts
+++ b/components/discussion/form/DownloadEditForm.spec.ts
@@ -84,7 +84,7 @@ const stubs = {
   },
   WarningModal: {
     name: 'WarningModal',
-    props: ['open', 'title', 'body', 'loading'],
+    props: ['open', 'title', 'body', 'loading', 'error'],
     emits: ['close', 'primary-button-click'],
     template: '<div data-testid="warning-modal" :data-open="open" />',
   },
@@ -247,6 +247,42 @@ describe('DownloadEditForm file editing', () => {
     expect(h.permanentlyDeleteDownloadableFile).toHaveBeenCalledWith({
       downloadableFileId: 'f1',
     });
+  });
+
+  it('keeps the file in the form when permanent delete fails', async () => {
+    (h.permanentlyDeleteDownloadableFile as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('Not authorized'));
+    const wrapper = mountForm({
+      discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),
+    });
+    await flushPromises();
+
+    await wrapper.get('button[title="Delete this file"]').trigger('click');
+    await wrapper
+      .getComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(wrapper.emitted('updateFormValues')).toBeUndefined();
+  });
+
+  it('shows the backend delete error when permanent delete fails', async () => {
+    (h.permanentlyDeleteDownloadableFile as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('Not authorized'));
+    const wrapper = mountForm({
+      discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),
+    });
+    await flushPromises();
+
+    await wrapper.get('button[title="Delete this file"]').trigger('click');
+    await wrapper
+      .getComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(wrapper.getComponent({ name: 'WarningModal' }).props('error')).toBe(
+      'Not authorized'
+    );
   });
 
   it('updates a file license and emits the change', async () => {

--- a/components/discussion/form/DownloadEditForm.vue
+++ b/components/discussion/form/DownloadEditForm.vue
@@ -160,6 +160,7 @@ const formValues = ref({
 const uploadingFile = ref(false);
 const uploadError = ref('');
 const pendingDeleteFileIndex = ref<number | null>(null);
+const permanentDeleteFileError = ref('');
 
 // Notification state
 const savedSuccessfully = ref(false);
@@ -394,6 +395,7 @@ const removeFileFromForm = (index: number) => {
 
 const requestRemoveFile = (index: number) => {
   const file = formValues.value.downloadableFiles[index];
+  permanentDeleteFileError.value = '';
 
   if (!file?.id) {
     removeFileFromForm(index);
@@ -409,12 +411,14 @@ const closePermanentDeleteModal = () => {
   }
 
   pendingDeleteFileIndex.value = null;
+  permanentDeleteFileError.value = '';
 };
 
 const permanentlyDeleteSelectedFile = async () => {
   if (pendingDeleteFileIndex.value === null) {
     return;
   }
+  permanentDeleteFileError.value = '';
 
   const index = pendingDeleteFileIndex.value;
   const file = formValues.value.downloadableFiles[index];
@@ -433,6 +437,10 @@ const permanentlyDeleteSelectedFile = async () => {
     pendingDeleteFileIndex.value = null;
   } catch (error) {
     console.error('Error permanently deleting downloadable file:', error);
+    permanentDeleteFileError.value =
+      error instanceof Error
+        ? error.message
+        : 'Failed to permanently delete this file.';
   }
 };
 
@@ -505,8 +513,12 @@ function handleSave() {
       />
 
       <ErrorBanner
-        v-else-if="permanentlyDeleteDownloadableFileError"
-        :text="permanentlyDeleteDownloadableFileError.message"
+        v-else-if="permanentDeleteFileError || permanentlyDeleteDownloadableFileError"
+        :text="
+          permanentDeleteFileError ||
+          permanentlyDeleteDownloadableFileError?.message ||
+          ''
+        "
         class="mb-4"
       />
 
@@ -758,6 +770,7 @@ function handleSave() {
       icon="trash"
       primary-button-text="Permanently delete"
       :loading="permanentlyDeleteDownloadableFileLoading"
+      :error="permanentDeleteFileError"
       data-testid="permanent-download-file-delete-modal"
       @close="closePermanentDeleteModal"
       @primary-button-click="permanentlyDeleteSelectedFile"

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -37,17 +37,18 @@ Notes:
 - [x] Decide whether deletion hard-deletes the blob, detaches it, marks it deleted, or combines those steps.
 - [x] Preserve upload/storage metadata for new downloadable-file uploads so deletion/audit flows do not reconstruct storage paths later. `[in draft PR]`
 - [x] Add backend permanent-delete mutation support for downloadable files that deletes the storage object before marking the database node removed.
-- [ ] Preserve any additional deletion-specific metadata needed for moderation and audit history.
+- [x] Preserve additional deletion-specific metadata needed for moderation and audit history. `[in backend draft PR]`
 - [x] Show the destructive action only to authorized users in the existing download edit surface.
 - [x] Add a confirmation dialog that clearly says the file is permanently removed. `[in draft PR]`
 - [x] Refresh download detail and list views after deletion by filtering permanently removed downloadable files out of discussion queries. `[in draft PR]`
 - [x] Add uploader-facing file management so users can see their downloadable files grouped by linked discussion on profile/library pages and delete them from there when authorized. `[in draft PR]`
-- [ ] Add tests for OP allowed, unrelated user rejected, permitted moderator allowed, and moderator without permission rejected across backend and frontend surfaces.
+- [x] Add tests for OP allowed, unrelated user rejected, permitted moderator allowed, and moderator without permission rejected across backend and frontend surfaces. `[in this slice]`
 
 Notes:
 - Delete confirmation copy exists for individual downloadable files in the edit form in the current frontend draft slice.
 - Backend PR gennit-project/multiforum-backend#118 added `permanentlyDeleteDownloadableFile` on top of the shared storage deletion utility.
 - The current draft slice adds an owner-scoped backend query and `/library/uploads` management page for uploaded downloadable files.
+- This slice adds scalar permanent-removal audit fields and focused authorization/storage-failure tests for downloadable-file deletion.
 - Backend draft PR gennit-project/multiforum-backend#116 and frontend draft PR gennit-project/multiforum-nuxt#266 add verified upload storage metadata for new downloadable files, including `storageObjectName` and `storageUrl`.
 
 ### 4. Download filters: review and finish include/exclude semantics `[partial]`

--- a/pages/library/uploads.spec.ts
+++ b/pages/library/uploads.spec.ts
@@ -22,7 +22,7 @@ const RequireAuthStub = defineComponent({
 
 const WarningModalStub = defineComponent({
   name: 'WarningModal',
-  props: ['open', 'title'],
+  props: ['open', 'title', 'error'],
   emits: ['close', 'primary-button-click'],
   template: '<div data-testid="warning-modal" :data-open="open" />',
 });
@@ -127,5 +127,33 @@ describe('uploaded files library page', () => {
     await flushPromises();
 
     expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refetch uploaded files when delete fails', async () => {
+    deleteMutation.mockRejectedValueOnce(new Error('Not authorized'));
+    const wrapper = await mountPage();
+
+    await wrapper.get('button').trigger('click');
+    await wrapper
+      .getComponent(WarningModalStub)
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it('shows the backend delete error when delete fails', async () => {
+    deleteMutation.mockRejectedValueOnce(new Error('Not authorized'));
+    const wrapper = await mountPage();
+
+    await wrapper.get('button').trigger('click');
+    await wrapper
+      .getComponent(WarningModalStub)
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(wrapper.getComponent(WarningModalStub).props('error')).toBe(
+      'Not authorized'
+    );
   });
 });

--- a/pages/library/uploads.vue
+++ b/pages/library/uploads.vue
@@ -30,6 +30,7 @@ type UploadedDownloadGroup = {
 
 const usernameVar = useUsername();
 const pendingDeleteFile = ref<UploadedFile | null>(null);
+const deleteErrorMessage = ref('');
 
 useHead({
   title: 'Uploaded Files - Library',
@@ -84,6 +85,7 @@ const getDiscussionPath = (group: UploadedDownloadGroup) => {
 };
 
 const confirmDelete = (file: UploadedFile) => {
+  deleteErrorMessage.value = '';
   pendingDeleteFile.value = file;
 };
 
@@ -93,12 +95,14 @@ const closeDeleteModal = () => {
   }
 
   pendingDeleteFile.value = null;
+  deleteErrorMessage.value = '';
 };
 
 const deleteSelectedFile = async () => {
   if (!pendingDeleteFile.value) {
     return;
   }
+  deleteErrorMessage.value = '';
 
   try {
     await permanentlyDeleteDownloadableFile({
@@ -108,6 +112,10 @@ const deleteSelectedFile = async () => {
     await refetch();
   } catch (err) {
     console.error('Error permanently deleting uploaded file:', err);
+    deleteErrorMessage.value =
+      err instanceof Error
+        ? err.message
+        : 'Failed to permanently delete this uploaded file.';
   }
 };
 </script>
@@ -200,9 +208,9 @@ const deleteSelectedFile = async () => {
           </div>
 
           <ErrorBanner
-            v-if="deleteError"
+            v-if="deleteErrorMessage || deleteError"
             class="mt-4"
-            :text="deleteError.message"
+            :text="deleteErrorMessage || deleteError?.message || ''"
           />
 
           <WarningModal
@@ -212,6 +220,7 @@ const deleteSelectedFile = async () => {
             icon="trash"
             primary-button-text="Permanently delete"
             :loading="deleteLoading"
+            :error="deleteErrorMessage"
             data-testid="uploaded-file-delete-modal"
             @close="closeDeleteModal"
             @primary-button-click="deleteSelectedFile"


### PR DESCRIPTION
## Summary
- Preserve pending delete state when `permanentlyDeleteDownloadableFile` fails in the download edit form and uploaded-files library page.
- Surface backend authorization/storage errors in the confirmation modal and error banner instead of only logging them.
- Add focused unit coverage for failed permanent-delete behavior and update `docs/FEATURE_ROADMAP.md` for the permission/audit hardening slice.

## Stack
- Base: `codex/upload-management-clean` / frontend PR #271
- Backend pair: gennit-project/multiforum-backend#121

## Validation
- `npm run test:unit:run -- components/discussion/form/DownloadEditForm.spec.ts pages/library/uploads.spec.ts`
- `npm run tsc`
- Commit hook also ran `vue-tsc --noEmit` and full `eslint`; lint completed with existing warnings only.