### PR TITLE
Clean stale download filter URL state

### DIFF
--- a/components/channel/DownloadList.spec.ts
+++ b/components/channel/DownloadList.spec.ts
@@ -12,16 +12,20 @@ const h = vi.hoisted(() => ({
   refetch: vi.fn(),
   fetchMore: vi.fn(),
   route: null as unknown,
+  useQueryCalls: [] as Array<{ variables: Record<string, unknown> }>,
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
-  useQuery: () => ({
-    result: h.result,
-    error: h.error,
-    loading: h.loading,
-    refetch: h.refetch,
-    fetchMore: h.fetchMore,
-  }),
+  useQuery: (_query: unknown, variables: Record<string, unknown>) => {
+    h.useQueryCalls.push({ variables });
+    return {
+      result: h.result,
+      error: h.error,
+      loading: h.loading,
+      refetch: h.refetch,
+      fetchMore: h.fetchMore,
+    };
+  },
 }));
 vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
 vi.mock('@/composables/useAuthState', () => ({ useUsername: () => ref('') }));
@@ -39,8 +43,9 @@ const resultWith = (channels: unknown[], aggregate = channels.length) => ({
   },
 });
 
-const mountList = () =>
+const mountList = (props: Record<string, unknown> = {}) =>
   mount(DownloadList, {
+    props,
     global: {
       plugins: [createTestingPinia({ createSpy: vi.fn })],
       stubs: {
@@ -76,6 +81,7 @@ beforeEach(() => {
   h.error = ref(null);
   h.loading = ref(false);
   h.route = { params: { forumId: 'cats' }, query: {} };
+  h.useQueryCalls = [];
 });
 
 describe('DownloadList states', () => {
@@ -149,6 +155,34 @@ describe('DownloadList filter events', () => {
       .vm.$emit('filter-by-channel', 'cats');
 
     expect(wrapper.emitted('filterByChannel')?.[0]).toEqual(['cats']);
+  });
+});
+
+describe('DownloadList label filters', () => {
+  it('passes only current filter-group values to the query variables', () => {
+    h.route = {
+      params: { forumId: 'cats' },
+      query: { filter_type: 'pdf,stale', filter_old: 'gone' },
+    };
+    mountList({
+      filterGroups: [
+        {
+          key: 'type',
+          options: [{ value: 'pdf', displayName: 'PDF' }],
+        },
+      ],
+    });
+    const downloadListQueryCall = h.useQueryCalls.find(
+      (call) => 'labelFilters' in call.variables
+    );
+
+    expect(
+      (
+        downloadListQueryCall?.variables.labelFilters as {
+          value: Array<{ groupKey: string; values: string[] }>;
+        }
+      ).value
+    ).toEqual([{ groupKey: 'type', values: ['pdf'] }]);
   });
 });
 

--- a/components/channel/DownloadList.vue
+++ b/components/channel/DownloadList.vue
@@ -25,8 +25,7 @@ const usernameVar = useUsername();
 
 const DOWNLOAD_PAGE_LIMIT = 25;
 
-// Props used in template
-defineProps({
+const props = defineProps({
   filterGroups: {
     type: Array as () => FilterGroup[],
     default: () => [],
@@ -79,7 +78,7 @@ const showArchived = computed(() => {
 });
 
 const labelFilters = computed(() => {
-  return convertUrlParamsToLabelFilters(route);
+  return convertUrlParamsToLabelFilters(route, props.filterGroups);
 });
 
 const {

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -53,15 +53,18 @@ Notes:
 
 ### 4. Download filters: review and finish include/exclude semantics `[partial]`
 
-- [ ] Confirm current exclude behavior in the actual download-list query path.
+- [x] Confirm current exclude behavior in the actual download-list query path.
 - [ ] Make filter-group create/update/delete operations atomic and validated end-to-end.
-- [ ] Ensure deleting a filter group does not leave stale selected filters in URLs or saved settings.
-- [ ] Add tests for include-only, exclude-only, combined include/exclude, deleted-group cleanup, and invalid filter-group input.
+- [x] Ensure deleting a filter group does not leave stale selected filters in URLs or saved settings.
+- [ ] Add remaining tests for filter-group mutation validation, including invalid filter-group input.
 - [ ] Review UX details: empty-group validation, delete confirmation/reversal, clear "must include" vs "must exclude" labels, and readable/shareable URL state.
 
 Notes:
 - Channel admin UI for filter groups already exists.
 - Include/exclude modes, ordering, YAML editing, and validation are already present in the frontend.
+- This slice fixes channel download-list query semantics so `INCLUDE` groups require selected labels and `EXCLUDE` groups reject selected labels.
+- This slice also ignores stale/deleted filter groups in download queries and removes stale `filter_*` URL params after the channel filter groups load.
+- Focused tests now cover include/exclude query semantics and stale filter cleanup; atomic mutation validation remains.
 
 ### 5. Collection ordering `[partial]`
 

--- a/pages/forums/[forumId]/downloads/index.spec.ts
+++ b/pages/forums/[forumId]/downloads/index.spec.ts
@@ -1,10 +1,21 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 
+const h = vi.hoisted(() => ({
+  route: {
+    params: { forumId: 'cats' },
+    query: {} as Record<string, unknown>,
+  },
+  router: {
+    replace: vi.fn(),
+  },
+}));
+
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({ params: { forumId: 'cats' } }),
+  useRoute: () => h.route,
+  useRouter: () => h.router,
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
@@ -17,7 +28,10 @@ const mountWith = async (opts: {
   channelDownloadsEnabled?: boolean;
   serverDownloadsEnabled?: boolean;
 }) => {
-  const channel = { downloadsEnabled: opts.channelDownloadsEnabled ?? true };
+  const channel = {
+    downloadsEnabled: opts.channelDownloadsEnabled ?? true,
+    FilterGroups: [{ key: 'type' }],
+  };
   const serverConfig = { enableDownloads: opts.serverDownloadsEnabled ?? true };
   mockedUseQuery
     .mockReturnValueOnce({
@@ -35,6 +49,11 @@ const mountWith = async (opts: {
 };
 
 describe('downloads index page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.route.query = {};
+  });
+
   it('shows the not-available message when downloads are disabled for the forum', async () => {
     const wrapper = await mountWith({ channelDownloadsEnabled: false });
     expect(wrapper.text()).toContain('Downloads Not Available');
@@ -43,5 +62,15 @@ describe('downloads index page', () => {
   it('hides the not-available message when downloads are enabled', async () => {
     const wrapper = await mountWith({});
     expect(wrapper.text()).not.toContain('Downloads Not Available');
+  });
+
+  it('removes stale download filter params after channel filters load', async () => {
+    h.route.query = { filter_old: 'x', filter_type: 'pdf' };
+    await mountWith({});
+    expect(h.router.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.not.objectContaining({ filter_old: expect.anything() }),
+      })
+    );
   });
 });

--- a/pages/forums/[forumId]/downloads/index.vue
+++ b/pages/forums/[forumId]/downloads/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import { useRoute } from 'nuxt/app';
+import { computed, watch } from 'vue';
+import { useRoute, useRouter } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import DownloadList from '@/components/channel/DownloadList.vue';
 import DownloadFilterBar from '@/components/download/DownloadFilterBar.vue';
@@ -11,8 +11,11 @@ import type { FilterGroup } from '@/__generated__/graphql';
 import { config } from '@/config';
 import { DateTime } from 'luxon';
 import { evaluateForumFeatureGate } from '@/utils/forumFeatureGate';
+import { getStaleDownloadFilterQueryKeys } from '@/utils/downloadFilters';
+import { updateFilters } from '@/utils/routerUtils';
 
 const route = useRoute();
+const router = useRouter();
 
 const channelId = computed(() => {
   return typeof route.params.forumId === 'string' ? route.params.forumId : '';
@@ -95,6 +98,30 @@ const errorMessage = computed(() => downloadsGate.value.errorMessage);
 const filterGroups = computed<FilterGroup[]>(() => {
   return channel.value?.FilterGroups || [];
 });
+
+const staleDownloadFilterQueryKeys = computed(() => {
+  if (!channel.value) {
+    return [];
+  }
+
+  return getStaleDownloadFilterQueryKeys(route, filterGroups.value);
+});
+
+watch(
+  staleDownloadFilterQueryKeys,
+  (staleKeys) => {
+    if (!staleKeys.length) {
+      return;
+    }
+
+    updateFilters({
+      router,
+      route,
+      params: Object.fromEntries(staleKeys.map((key) => [key, undefined])),
+    });
+  },
+  { immediate: true }
+);
 </script>
 
 <template>

--- a/utils/downloadFilters.spec.ts
+++ b/utils/downloadFilters.spec.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect } from 'vitest';
 import type { RouteLocationNormalizedLoaded } from 'vue-router';
-import { convertUrlParamsToLabelFilters } from './downloadFilters';
+import { FilterMode, type FilterGroup } from '@/__generated__/graphql';
+import {
+  convertUrlParamsToLabelFilters,
+  getStaleDownloadFilterQueryKeys,
+} from './downloadFilters';
 
 const routeWithQuery = (query: Record<string, unknown>) =>
   ({ query } as unknown as RouteLocationNormalizedLoaded);
+
+const filterGroup = (
+  key: string,
+  optionValues: string[] = ['a']
+): Pick<FilterGroup, 'key' | 'options'> =>
+  ({
+    key,
+    mode: FilterMode.Include,
+    options: optionValues.map((value) => ({
+      value,
+      displayName: value,
+    })),
+  }) as unknown as Pick<FilterGroup, 'key' | 'options'>;
 
 describe('convertUrlParamsToLabelFilters', () => {
   it('converts a filter_ param into a label filter', () => {
@@ -34,5 +51,34 @@ describe('convertUrlParamsToLabelFilters', () => {
         routeWithQuery({ filter_tag: ['a', null, 'b'] })
       )[0].values
     ).toEqual(['a', 'b']);
+  });
+
+  it('ignores stale filter params when current filter groups are provided', () => {
+    expect(
+      convertUrlParamsToLabelFilters(
+        routeWithQuery({ filter_old: 'x', filter_type: 'pdf' }),
+        [filterGroup('type', ['pdf'])]
+      )
+    ).toEqual([{ groupKey: 'type', values: ['pdf'] }]);
+  });
+
+  it('drops option values that no longer exist in the current group', () => {
+    expect(
+      convertUrlParamsToLabelFilters(
+        routeWithQuery({ filter_type: 'pdf,stale' }),
+        [filterGroup('type', ['pdf'])]
+      )[0].values
+    ).toEqual(['pdf']);
+  });
+});
+
+describe('getStaleDownloadFilterQueryKeys', () => {
+  it('returns filter query keys that do not match current filter groups', () => {
+    expect(
+      getStaleDownloadFilterQueryKeys(
+        routeWithQuery({ filter_old: 'x', filter_type: 'pdf', page: '2' }),
+        [filterGroup('type')]
+      )
+    ).toEqual(['filter_old']);
   });
 });

--- a/utils/downloadFilters.ts
+++ b/utils/downloadFilters.ts
@@ -1,4 +1,5 @@
 import type { RouteLocationNormalizedLoaded } from 'vue-router';
+import type { FilterGroup } from '@/__generated__/graphql';
 
 export type LabelFilterInput = {
   groupKey: string;
@@ -11,13 +12,28 @@ export type LabelFilterInput = {
  * into [{ groupKey: "lot_type", values: ["residential"] }, { groupKey: "style", values: ["modern", "contemporary"] }]
  */
 export function convertUrlParamsToLabelFilters(
-  route: RouteLocationNormalizedLoaded
+  route: RouteLocationNormalizedLoaded,
+  filterGroups?: Pick<FilterGroup, 'key' | 'options'>[]
 ): LabelFilterInput[] {
   const labelFilters: LabelFilterInput[] = [];
+  const allowedFilters = filterGroups
+    ? new Map(
+        filterGroups.map((group) => [
+          group.key,
+          new Set((group.options || []).map((option) => option.value)),
+        ])
+      )
+    : null;
 
   Object.keys(route.query).forEach((key) => {
     if (key.startsWith('filter_')) {
       const groupKey = key.replace('filter_', '');
+      const allowedValues = allowedFilters?.get(groupKey);
+
+      if (allowedFilters && !allowedValues) {
+        return;
+      }
+
       const value = route.query[key];
 
       let values: string[] = [];
@@ -26,6 +42,12 @@ export function convertUrlParamsToLabelFilters(
         values = value.split(',');
       } else if (Array.isArray(value)) {
         values = value.filter((v): v is string => typeof v === 'string');
+      }
+
+      if (allowedValues) {
+        values = values.filter((selectedValue) =>
+          allowedValues.has(selectedValue)
+        );
       }
 
       if (values.length > 0) {
@@ -38,4 +60,17 @@ export function convertUrlParamsToLabelFilters(
   });
 
   return labelFilters;
+}
+
+export function getStaleDownloadFilterQueryKeys(
+  route: RouteLocationNormalizedLoaded,
+  filterGroups: Pick<FilterGroup, 'key'>[]
+): string[] {
+  const allowedQueryKeys = new Set(
+    filterGroups.map((group) => `filter_${group.key}`)
+  );
+
+  return Object.keys(route.query).filter(
+    (key) => key.startsWith('filter_') && !allowedQueryKeys.has(key)
+  );
 }


### PR DESCRIPTION
## Summary
- Ignore stale/deleted download filter groups and stale option values before sending label filters to GraphQL.
- Remove stale `filter_*` query params after the channel's current filter groups load.
- Update the feature roadmap for the completed download-filter semantics slice.
- Add unit coverage for stale filter cleanup and query variable sanitization.

## Backend pair
- gennit-project/multiforum-backend#122

## Validation
- `npm run test:unit:run -- utils/downloadFilters.spec.ts components/channel/DownloadList.spec.ts 'pages/forums/[forumId]/downloads/index.spec.ts'`
- `npm run tsc`
- Commit hook also ran `vue-tsc --noEmit` and full `eslint`; lint completed with existing warnings only.