### PR TITLE
[codex] Simplify robots.txt handling

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/server/robots.txt.ts
+++ b/server/robots.txt.ts
@@ -9,14 +9,12 @@ Disallow: /`;
   }
 
   return `User-agent: *
-Allow: /
-
-Disallow: /api/*
-Disallow: /admin/*
-Disallow: /mod/*
-Disallow: /auth/*
-Disallow: /_nuxt/*
-Disallow: /assets/*
-Disallow: /static/*
-Disallow: /issues/*`;
+Disallow: /api/
+Disallow: /admin/
+Disallow: /mod/
+Disallow: /auth/
+Disallow: /_nuxt/
+Disallow: /assets/
+Disallow: /static/
+Disallow: /issues/`;
 });

--- a/tests/unit/server/robots.spec.ts
+++ b/tests/unit/server/robots.spec.ts
@@ -30,15 +30,13 @@ describe('robots.txt', () => {
     const result = await runHandler();
 
     expect(result).toBe(`User-agent: *
-Allow: /
-
-Disallow: /api/*
-Disallow: /admin/*
-Disallow: /mod/*
-Disallow: /auth/*
-Disallow: /_nuxt/*
-Disallow: /assets/*
-Disallow: /static/*
-Disallow: /issues/*`);
+Disallow: /api/
+Disallow: /admin/
+Disallow: /mod/
+Disallow: /auth/
+Disallow: /_nuxt/
+Disallow: /assets/
+Disallow: /static/
+Disallow: /issues/`);
   });
 });


### PR DESCRIPTION
## What changed
- removes the redundant static `public/robots.txt`
- keeps a single dynamic `server/robots.txt.ts` source of truth
- simplifies production rules to a short, standard-looking set of prefix disallows

## Why
The previous setup had two different `robots.txt` sources that could drift out of sync, and the production rules were more complicated than they needed to be. This makes the behavior normal, simple, and easier to reason about.

## Validation
- `npx vitest run tests/unit/server/robots.spec.ts`