### PR TITLE
Add profile and banner permanent delete UI

### DIFF
--- a/components/user/EditAccountSettingsFields.spec.ts
+++ b/components/user/EditAccountSettingsFields.spec.ts
@@ -7,11 +7,22 @@ import EditAccountSettingsFields from '@/components/user/EditAccountSettingsFiel
 const h = vi.hoisted(() => ({
   username: null as unknown,
   createSignedStorageUrl: vi.fn(),
+  permanentlyDeleteProfileImage: vi.fn(),
   uploadLink: vi.fn(),
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
-  useMutation: () => ({ mutate: h.createSignedStorageUrl }),
+  useMutation: (operation: unknown) => ({
+    mutate:
+      operation === 'PERMANENTLY_DELETE_PROFILE_IMAGE'
+        ? h.permanentlyDeleteProfileImage
+        : h.createSignedStorageUrl,
+    loading: ref(false),
+    error: ref(null),
+  }),
+}));
+vi.mock('@/graphQLData/user/mutations', () => ({
+  PERMANENTLY_DELETE_PROFILE_IMAGE: 'PERMANENTLY_DELETE_PROFILE_IMAGE',
 }));
 vi.mock('@/composables/useAuthState', () => ({ useUsername: () => h.username }));
 vi.mock('@/utils', async (orig) => {
@@ -51,6 +62,11 @@ const mountFields = (props: Record<string, unknown> = {}) =>
         },
         TextEditor: stub('TextEditor', ['initialValue'], ['update']),
         AddImage: stub('AddImage', ['fieldName'], ['file-change']),
+        WarningModal: stub(
+          'WarningModal',
+          ['open', 'loading', 'error'],
+          ['primary-button-click', 'close']
+        ),
         CharCounter: stub('CharCounter', ['current', 'max']),
         AvatarComponent: true,
       },
@@ -72,6 +88,14 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.username = ref('alice');
   vi.stubGlobal('alert', vi.fn());
+  h.permanentlyDeleteProfileImage.mockResolvedValue({
+    data: {
+      permanentlyDeleteProfileImage: {
+        username: 'alice',
+        profilePicURL: null,
+      },
+    },
+  });
   h.createSignedStorageUrl.mockResolvedValue({
     data: { createSignedStorageURL: { url: 'https://signed' } },
   });
@@ -168,5 +192,46 @@ describe('EditAccountSettingsFields profile picture upload', () => {
     await changeProfilePic(wrapper, big);
 
     expect(h.createSignedStorageUrl).not.toHaveBeenCalled();
+  });
+
+  it('permanently deletes the current profile picture URL', async () => {
+    const wrapper = mountFields({
+      formValues: {
+        displayName: 'Alice',
+        bio: 'hi',
+        profilePicURL: 'https://cdn.example.com/pic.png',
+      },
+    });
+
+    await wrapper.get('[data-testid="delete-profile-image-button"]').trigger('click');
+    await wrapper
+      .getComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(h.permanentlyDeleteProfileImage).toHaveBeenCalledWith({
+      username: 'alice',
+      imageUrl: 'https://cdn.example.com/pic.png',
+    });
+  });
+
+  it('clears the profile picture field after permanent delete succeeds', async () => {
+    const wrapper = mountFields({
+      formValues: {
+        displayName: 'Alice',
+        bio: 'hi',
+        profilePicURL: 'https://cdn.example.com/pic.png',
+      },
+    });
+
+    await wrapper.get('[data-testid="delete-profile-image-button"]').trigger('click');
+    await wrapper
+      .getComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(wrapper.emitted('updateFormValues')?.at(-1)?.[0]).toEqual({
+      profilePicURL: '',
+    });
   });
 });

--- a/components/user/EditAccountSettingsFields.vue
+++ b/components/user/EditAccountSettingsFields.vue
@@ -7,6 +7,7 @@ import TextInput from '@/components/TextInput.vue';
 import FormRow from '@/components/FormRow.vue';
 import TextEditor from '@/components/TextEditor.vue';
 import AddImage from '@/components/AddImage.vue';
+import WarningModal from '@/components/WarningModal.vue';
 import {
   getUploadFileName,
   uploadAndGetEmbeddedLink,
@@ -17,6 +18,7 @@ import type { EditAccountSettingsFormValues } from '@/types/User';
 import FormComponent from '../FormComponent.vue';
 import { MAX_CHARS_IN_USER_BIO } from '@/utils/constants';
 import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
+import { PERMANENTLY_DELETE_PROFILE_IMAGE } from '@/graphQLData/user/mutations';
 import { isFileSizeValid } from '@/utils/index';
 
 type FileChangeInput = {
@@ -59,10 +61,18 @@ const usernameVar = useUsername();
 // Data and Setup
 const titleInputRef = ref<InstanceType<typeof TextInput> | null>(null);
 const touched = ref(false);
+const showDeleteProfileImageModal = ref(false);
+const deleteProfileImageError = ref('');
 
 const { mutate: createSignedStorageUrl } = useMutation(
   CREATE_SIGNED_STORAGE_URL
 );
+
+const {
+  mutate: permanentlyDeleteProfileImage,
+  loading: permanentlyDeleteProfileImageLoading,
+  error: permanentlyDeleteProfileImageError,
+} = useMutation(PERMANENTLY_DELETE_PROFILE_IMAGE);
 
 // Methods
 const upload = async (file: File) => {
@@ -117,6 +127,33 @@ const handleProfilePicChange = async (input: FileChangeInput) => {
 
     emit('updateFormValues', { profilePicURL: embeddedLink });
     emit('submit');
+  }
+};
+
+const closeDeleteProfileImageModal = () => {
+  if (permanentlyDeleteProfileImageLoading.value) return;
+  showDeleteProfileImageModal.value = false;
+  deleteProfileImageError.value = '';
+};
+
+const confirmDeleteProfileImage = async () => {
+  if (!usernameVar.value || !props.formValues?.profilePicURL) return;
+
+  deleteProfileImageError.value = '';
+
+  try {
+    await permanentlyDeleteProfileImage({
+      username: usernameVar.value,
+      imageUrl: props.formValues.profilePicURL,
+    });
+    emit('updateFormValues', { profilePicURL: '' });
+    emit('submit');
+    showDeleteProfileImageModal.value = false;
+  } catch (error) {
+    deleteProfileImageError.value =
+      error instanceof Error
+        ? error.message
+        : 'Failed to permanently delete profile image.';
   }
 };
 
@@ -219,6 +256,22 @@ const needsChanges = computed(() => {
                   }
                 "
               />
+              <button
+                v-if="formValues.profilePicURL"
+                type="button"
+                data-testid="delete-profile-image-button"
+                class="mt-3 rounded-md border border-red-300 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-700 dark:text-red-300 dark:hover:bg-red-950"
+                :disabled="permanentlyDeleteProfileImageLoading"
+                @click="showDeleteProfileImageModal = true"
+              >
+                Delete profile image
+              </button>
+              <p
+                v-if="permanentlyDeleteProfileImageError"
+                class="mt-2 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ permanentlyDeleteProfileImageError.message }}
+              </p>
             </template>
           </FormRow>
         </div>
@@ -230,5 +283,18 @@ const needsChanges = computed(() => {
     <div v-for="(error, i) of updateUserError?.graphQLErrors" :key="i">
       {{ error.message }}
     </div>
+    <WarningModal
+      :open="showDeleteProfileImageModal"
+      title="Delete profile image?"
+      body="This permanently deletes the stored profile image file and clears it from your profile. This cannot be undone."
+      primary-button-text="Delete Image"
+      secondary-button-text="Cancel"
+      icon="trash"
+      data-testid="permanently-delete-profile-image-modal"
+      :loading="permanentlyDeleteProfileImageLoading"
+      :error="deleteProfileImageError"
+      @primary-button-click="confirmDeleteProfileImage"
+      @close="closeDeleteProfileImageModal"
+    />
   </div>
 </template>

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -143,14 +143,15 @@ Notes:
 - [x] Add backend permanent-delete mutations for uploaded images and downloadable files.
 - [x] Add the first frontend permanent-delete flow for downloadable files in the download edit form. `[in draft PR]`
 - [x] Add an owner-facing uploaded downloadable-file management page with storage-backed permanent delete. `[in draft PR]`
-- [ ] Let authorized users delete profile images permanently and remove the backing object from GCP/storage.
-- [ ] Add permanent delete support for forum banners, including storage cleanup.
-- [ ] Make storage cleanup behavior explicit and tested so database deletion and blob deletion stay in sync.
-- [ ] Define permissions separately for uploader/owner actions versus moderator/admin actions across these media types.
-- [ ] Add tests covering successful delete, unauthorized rejection, missing-file cleanup behavior, and stale-reference cleanup.
+- [x] Let authorized users delete profile images permanently and remove the backing object from GCP/storage. `[in this slice]`
+- [x] Add permanent delete support for forum banners, including storage cleanup. `[in this slice]`
+- [x] Make storage cleanup behavior explicit and tested so database deletion and blob deletion stay in sync. `[in this slice]`
+- [x] Define permissions separately for uploader/owner actions versus moderator/admin actions across these media types. `[in this slice]`
+- [x] Add tests covering successful delete, unauthorized rejection, missing-file cleanup behavior, and stale-reference cleanup. `[in this slice]`
 
 Notes:
-- Album edit deletion now confirms and calls the backend permanent-delete mutation before removing the image from the album UI; remaining media deletion work is profile images, forum banners, and broader permission/error coverage.
+- Album edit deletion now confirms and calls the backend permanent-delete mutation before removing the image from the album UI.
+- This slice adds storage-backed permanent delete for URL-backed profile images and forum banners by resolving active URLs through upload audit metadata before clearing the owning profile/forum field.
 
 ### 11. Wiki: pinned sidebar pages `[not started]`
 

--- a/graphQLData/channel/mutations.js
+++ b/graphQLData/channel/mutations.js
@@ -72,6 +72,21 @@ export const UPDATE_CHANNEL = gql`
   }
 `;
 
+export const PERMANENTLY_DELETE_CHANNEL_BANNER = gql`
+  mutation permanentlyDeleteChannelBanner(
+    $channelUniqueName: String!
+    $imageUrl: String!
+  ) {
+    permanentlyDeleteChannelBanner(
+      channelUniqueName: $channelUniqueName
+      imageUrl: $imageUrl
+    ) {
+      uniqueName
+      channelBannerURL
+    }
+  }
+`;
+
 export const CREATE_WIKI_PAGE = gql`
   mutation createWikiPage($where: ChannelWhere!, $update: ChannelUpdateInput!) {
     updateChannels(where: $where, update: $update) {

--- a/graphQLData/user/mutations.js
+++ b/graphQLData/user/mutations.js
@@ -23,6 +23,15 @@ export const UPDATE_USER = gql`
   }
 `;
 
+export const PERMANENTLY_DELETE_PROFILE_IMAGE = gql`
+  mutation permanentlyDeleteProfileImage($username: String!, $imageUrl: String!) {
+    permanentlyDeleteProfileImage(username: $username, imageUrl: $imageUrl) {
+      username
+      profilePicURL
+    }
+  }
+`;
+
 export const MARK_NOTIFICATIONS_AS_READ = gql`
   mutation markNotificationsAsRead($username: String!) {
     updateUsers(

--- a/pages/forums/[forumId]/edit/basic.spec.ts
+++ b/pages/forums/[forumId]/edit/basic.spec.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
-import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
 import { ref } from 'vue';
 import TextInput from '@/components/TextInput.vue';
+
+const h = vi.hoisted(() => ({
+  createSignedStorageUrl: vi.fn(),
+  removeForumOwner: vi.fn(),
+  permanentlyDeleteChannelBanner: vi.fn(),
+}));
 
 vi.mock('nuxt/app', async () => {
   const { ref: vref } = await import('vue');
@@ -14,13 +20,26 @@ vi.mock('nuxt/app', async () => {
 });
 
 vi.mock('@vue/apollo-composable', () => ({
-  useMutation: () => ({
-    mutate: vi.fn(),
+  useMutation: (operation: unknown) => ({
+    mutate:
+      operation === 'PERMANENTLY_DELETE_CHANNEL_BANNER'
+        ? h.permanentlyDeleteChannelBanner
+        : operation === 'REMOVE_FORUM_OWNER'
+          ? h.removeForumOwner
+          : h.createSignedStorageUrl,
     loading: ref(false),
     error: ref(null),
     onDone: vi.fn(),
     onError: vi.fn(),
   }),
+}));
+
+vi.mock('@/graphQLData/channel/mutations', () => ({
+  PERMANENTLY_DELETE_CHANNEL_BANNER: 'PERMANENTLY_DELETE_CHANNEL_BANNER',
+}));
+
+vi.mock('@/graphQLData/mod/mutations', () => ({
+  REMOVE_FORUM_OWNER: 'REMOVE_FORUM_OWNER',
 }));
 
 const FormRowStub = { template: '<div><slot name="content" /></div>' };
@@ -31,23 +50,90 @@ const TextInputStub = {
   methods: { focus() {} },
 };
 
+const WarningModalStub = {
+  name: 'WarningModal',
+  props: ['open', 'loading', 'error'],
+  emits: ['primary-button-click', 'close'],
+  template: '<div />',
+};
+
+const buildWrapper = async (formValues: Record<string, unknown>) => {
+  const Page = (await import('./basic.vue')).default;
+  return shallowMount(Page, {
+    props: {
+      editMode: true,
+      touched: false,
+      titleIsInvalid: false,
+      ownerList: ['alice'],
+      formValues: {
+        uniqueName: 'cats',
+        displayName: 'Cats',
+        description: '',
+        selectedTags: [],
+        channelIconURL: '',
+        channelBannerURL: '',
+        ...formValues,
+      },
+    },
+    global: {
+      stubs: {
+        FormRow: FormRowStub,
+        TextInput: TextInputStub,
+        WarningModal: WarningModalStub,
+      },
+    },
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.permanentlyDeleteChannelBanner.mockResolvedValue({
+    data: {
+      permanentlyDeleteChannelBanner: {
+        uniqueName: 'cats',
+        channelBannerURL: null,
+      },
+    },
+  });
+});
+
 describe('forum basic settings page', () => {
   it('renders the editable channel text fields', async () => {
-    const Page = (await import('./basic.vue')).default;
-    const wrapper = shallowMount(Page, {
-      props: {
-        editMode: true,
-        formValues: {
-          uniqueName: 'cats',
-          displayName: 'Cats',
-          description: '',
-          selectedTags: [],
-          channelIconURL: '',
-          channelBannerURL: '',
-        },
-      },
-      global: { stubs: { FormRow: FormRowStub, TextInput: TextInputStub } },
-    });
+    const wrapper = await buildWrapper({});
+
     expect(wrapper.findComponent(TextInput).exists()).toBe(true);
+  });
+
+  it('permanently deletes the current forum banner URL', async () => {
+    const wrapper = await buildWrapper({
+      channelBannerURL: 'https://cdn.example.com/banner.png',
+    });
+
+    await wrapper.get('[data-testid="delete-channel-banner-button"]').trigger('click');
+    await wrapper
+      .getComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(h.permanentlyDeleteChannelBanner).toHaveBeenCalledWith({
+      channelUniqueName: 'cats',
+      imageUrl: 'https://cdn.example.com/banner.png',
+    });
+  });
+
+  it('clears the banner field after permanent delete succeeds', async () => {
+    const wrapper = await buildWrapper({
+      channelBannerURL: 'https://cdn.example.com/banner.png',
+    });
+
+    await wrapper.get('[data-testid="delete-channel-banner-button"]').trigger('click');
+    await wrapper
+      .getComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+
+    expect(wrapper.emitted('updateFormValues')?.at(-1)?.[0]).toEqual({
+      channelBannerURL: '',
+    });
   });
 });

--- a/pages/forums/[forumId]/edit/basic.vue
+++ b/pages/forums/[forumId]/edit/basic.vue
@@ -8,6 +8,7 @@ import TextInput from '@/components/TextInput.vue';
 import TextEditor from '@/components/TextEditor.vue';
 import AddImage from '@/components/AddImage.vue';
 import RemoveOwnerModal from '@/components/channel/RemoveOwnerModal.vue';
+import WarningModal from '@/components/WarningModal.vue';
 import {
   getUploadFileName,
   uploadAndGetEmbeddedLink,
@@ -16,6 +17,7 @@ import {
 import { useUsername } from '@/composables/useAuthState';
 import { ref, nextTick, computed } from 'vue';
 import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
+import { PERMANENTLY_DELETE_CHANNEL_BANNER } from '@/graphQLData/channel/mutations';
 import { REMOVE_FORUM_OWNER } from '@/graphQLData/mod/mutations';
 import { useMutation } from '@vue/apollo-composable';
 import { isFileSizeValid } from '@/utils/index';
@@ -73,6 +75,8 @@ const forumId = computed(() => {
 });
 
 const showRemoveOwnerModal = ref(false);
+const showDeleteBannerModal = ref(false);
+const deleteBannerError = ref('');
 
 const canRemoveOwner = computed(() => {
   const currentUser = usernameVar.value;
@@ -83,6 +87,12 @@ const canRemoveOwner = computed(() => {
 const { mutate: createSignedStorageUrl } = useMutation(
   CREATE_SIGNED_STORAGE_URL
 );
+
+const {
+  mutate: permanentlyDeleteChannelBanner,
+  loading: permanentlyDeleteChannelBannerLoading,
+  error: permanentlyDeleteChannelBannerError,
+} = useMutation(PERMANENTLY_DELETE_CHANNEL_BANNER);
 
 const {
   mutate: removeForumOwner,
@@ -162,6 +172,34 @@ const handleImageChange = async (input: FileChangeInput) => {
 
     emit('updateFormValues', { [fieldName]: embeddedLink });
     emit('submit');
+  }
+};
+
+const closeDeleteBannerModal = () => {
+  if (permanentlyDeleteChannelBannerLoading.value) return;
+  showDeleteBannerModal.value = false;
+  deleteBannerError.value = '';
+};
+
+const confirmDeleteBanner = async () => {
+  const imageUrl = props.formValues.channelBannerURL;
+  if (!forumId.value || !imageUrl) return;
+
+  deleteBannerError.value = '';
+
+  try {
+    await permanentlyDeleteChannelBanner({
+      channelUniqueName: forumId.value,
+      imageUrl,
+    });
+    emit('updateFormValues', { channelBannerURL: '' });
+    emit('submit');
+    showDeleteBannerModal.value = false;
+  } catch (error) {
+    deleteBannerError.value =
+      error instanceof Error
+        ? error.message
+        : 'Failed to permanently delete forum banner.';
   }
 };
 </script>
@@ -267,6 +305,22 @@ const handleImageChange = async (input: FileChangeInput) => {
               }
             "
           />
+          <button
+            v-if="formValues.channelBannerURL"
+            type="button"
+            data-testid="delete-channel-banner-button"
+            class="mt-3 rounded-md border border-red-300 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-700 dark:text-red-300 dark:hover:bg-red-950"
+            :disabled="permanentlyDeleteChannelBannerLoading"
+            @click="showDeleteBannerModal = true"
+          >
+            Delete forum banner
+          </button>
+          <p
+            v-if="permanentlyDeleteChannelBannerError"
+            class="mt-2 text-sm text-red-600 dark:text-red-400"
+          >
+            {{ permanentlyDeleteChannelBannerError.message }}
+          </p>
         </template>
       </FormRow>
       <FormRow>
@@ -317,6 +371,19 @@ const handleImageChange = async (input: FileChangeInput) => {
       :error="removeForumOwnerError?.message || ''"
       @close="showRemoveOwnerModal = false"
       @confirm="handleRemoveOwner"
+    />
+    <WarningModal
+      :open="showDeleteBannerModal"
+      title="Delete forum banner?"
+      body="This permanently deletes the stored forum banner file and clears it from the forum. This cannot be undone."
+      primary-button-text="Delete Banner"
+      secondary-button-text="Cancel"
+      icon="trash"
+      data-testid="permanently-delete-channel-banner-modal"
+      :loading="permanentlyDeleteChannelBannerLoading"
+      :error="deleteBannerError"
+      @primary-button-click="confirmDeleteBanner"
+      @close="closeDeleteBannerModal"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Add profile image permanent-delete controls with confirmation copy in account settings.
- Add forum banner permanent-delete controls with confirmation copy in forum basic settings.
- Add GraphQL mutation documents for the new backend mutations.
- Update `docs/FEATURE_ROADMAP.md` for the permanent media deletion slice.

## Dependency
- Depends on backend PR https://github.com/gennit-project/multiforum-backend/pull/124 for `permanentlyDeleteProfileImage` and `permanentlyDeleteChannelBanner`.

## Validation
- `npx nuxi prepare`
- `npm run test:unit:run -- components/user/EditAccountSettingsFields.spec.ts 'pages/forums/[forumId]/edit/basic.spec.ts'`
- `npm run tsc`