### PR TITLE
Fix vertical alignment of site name, separator, and channel in TopNav

### DIFF
--- a/components/nav/TopNav.spec.ts
+++ b/components/nav/TopNav.spec.ts
@@ -86,18 +86,32 @@ describe('TopNav route label', () => {
     expect(wrapper.text()).toContain(label);
   });
 
-  it('falls back to getLabel for a search preview route', () => {
+  it('labels a search preview route', () => {
     h.route = { params: {}, name: 'SitewideSearchDiscussionPreview' };
     const wrapper = mountNav();
 
-    expect(wrapper.text()).toContain('• discussions');
+    expect(wrapper.text()).toContain('discussions');
   });
 
   it('labels admin routes', () => {
     h.route = { params: {}, name: 'admin-dashboard' };
     const wrapper = mountNav();
 
-    expect(wrapper.text()).toContain('• admin dashboard');
+    expect(wrapper.text()).toContain('admin dashboard');
+  });
+
+  it('separates the label with a geometric dot, not a bullet glyph', () => {
+    h.route = { params: {}, name: 'admin-dashboard' };
+    const wrapper = mountNav();
+
+    expect(wrapper.text()).not.toContain('•');
+  });
+
+  it('renders a rounded-full dot separator before the label', () => {
+    h.route = { params: {}, name: 'discussions' };
+    const wrapper = mountNav();
+
+    expect(wrapper.find('span.rounded-full').exists()).toBe(true);
   });
 });
 

--- a/components/nav/TopNav.vue
+++ b/components/nav/TopNav.vue
@@ -33,15 +33,18 @@ const channelId = computed(() =>
 
 const shouldShowChannelId = computed(() => channelId.value);
 
-const routeInfoLabel = computed(() => {
-  if (
-    typeof route.name === 'string' &&
-    route.name.indexOf('map-search') !== -1
-  ) {
+// The text label shown after the site name when we're not inside a channel.
+// Merges the former `routeInfoLabel` computed and `getLabel` function into one
+// source of truth. The separator is rendered as a geometric dot in the
+// template, so labels here are plain text (no baked-in "•").
+const secondaryLabel = computed(() => {
+  const name = route.name;
+
+  if (typeof name === 'string' && name.includes('map-search')) {
     return 'in-person events';
   }
 
-  switch (route.name) {
+  switch (name) {
     case 'discussions':
       return 'discussions';
     case 'downloads':
@@ -50,19 +53,22 @@ const routeInfoLabel = computed(() => {
       return 'online events';
     case 'forums':
       return 'forums';
+    case 'SitewideSearchDiscussionPreview':
+      return 'discussions';
+    case 'SearchEventsList':
+      return 'online events';
+    case 'MapEventPreview':
+      return 'in-person events';
     default:
-      return '';
+      break;
   }
-});
 
-function getLabel() {
-  if (route.name === 'SitewideSearchDiscussionPreview') return '• discussions';
-  if (route.name === 'SearchEventsList') return '• online events';
-  if (route.name === 'MapEventPreview') return '• in-person events';
-  if (typeof route.name === 'string' && route.name.includes('admin'))
-    return '• admin dashboard';
+  if (typeof name === 'string' && name.includes('admin')) {
+    return 'admin dashboard';
+  }
+
   return '';
-}
+});
 
 const isOnMapPage = computed(() => {
   if (route.name && typeof route.name === 'string') {
@@ -87,8 +93,8 @@ const isOnMapPage = computed(() => {
           @click="$emit('toggleDropdown')"
         />
 
-        <div class="ml-2 flex h-full min-w-0 items-center gap-2 text-sm lg:gap-3">
-          <nuxt-link to="/" class="flex h-full items-center gap-1.5">
+        <div class="ml-2 flex min-w-0 items-center gap-2 lg:gap-3">
+          <nuxt-link to="/" class="flex items-center">
             <h1
               class="logo-font text-[1.2rem] font-semibold leading-none tracking-[-0.04em] text-gray-900 dark:text-white lg:text-[1.3rem]"
             >
@@ -96,14 +102,18 @@ const isOnMapPage = computed(() => {
             </h1>
           </nuxt-link>
 
+          <!-- Channel context: separator dot + channel link + favorite star -->
           <div
             v-if="shouldShowChannelId"
-            class="hidden h-full items-center gap-2 text-base leading-none tracking-[-0.02em] text-gray-700 sm:flex dark:text-gray-300"
+            class="hidden min-w-0 items-center gap-2 text-base leading-none tracking-[-0.02em] sm:flex"
           >
-            <span class="inline-flex h-5 items-center self-center text-lg leading-none text-gray-500 dark:text-gray-400">•</span>
+            <span
+              class="h-1.5 w-1.5 shrink-0 rounded-full bg-gray-400 dark:bg-gray-500"
+              aria-hidden="true"
+            />
             <nuxt-link
               :to="`/forums/${channelId}`"
-              class="inline-flex h-5 -translate-y-px items-center self-center max-w-[8rem] truncate leading-none text-gray-700 transition-colors hover:text-gray-950 sm:max-w-[12rem] lg:max-w-[16rem] dark:text-gray-300 dark:hover:text-white"
+              class="max-w-[8rem] truncate text-gray-700 transition-colors hover:text-gray-950 sm:max-w-[12rem] lg:max-w-[16rem] dark:text-gray-300 dark:hover:text-white"
             >
               {{ channelId }}
             </nuxt-link>
@@ -111,25 +121,19 @@ const isOnMapPage = computed(() => {
               :channel-unique-name="channelId"
               :allow-add-to-list="true"
               size="small"
-              class="ml-1"
             />
           </div>
+
+          <!-- Section label: separator dot + label text -->
           <div
-            v-else-if="routeInfoLabel"
-            class="hidden h-full items-center gap-2 truncate text-base leading-none tracking-[-0.02em] text-gray-700 sm:flex dark:text-gray-300"
+            v-else-if="secondaryLabel"
+            class="hidden min-w-0 items-center gap-2 text-base leading-none tracking-[-0.02em] text-gray-700 sm:flex dark:text-gray-300"
           >
-            <span class="inline-flex h-5 items-center self-center text-lg leading-none text-gray-500 dark:text-gray-400">•</span>
-            <span class="inline-flex h-5 -translate-y-px items-center self-center leading-none">
-              {{ routeInfoLabel }}
-            </span>
-          </div>
-          <div
-            v-else
-            class="hidden h-full items-center gap-1 truncate text-base leading-none tracking-[-0.02em] text-gray-700 sm:flex dark:text-gray-300"
-          >
-            <span class="inline-flex h-5 items-center self-center leading-none">
-              {{ getLabel() }}
-            </span>
+            <span
+              class="h-1.5 w-1.5 shrink-0 rounded-full bg-gray-400 dark:bg-gray-500"
+              aria-hidden="true"
+            />
+            <span class="truncate">{{ secondaryLabel }}</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## The problem

In `TopNav.vue`, the site name, the `•` separator, and the channel/section label never lined up vertically — it looked visually broken. Prior attempts to patch it didn't hold.

## Why it was misaligned

Three compounding causes:

1. **Three different font sizes on one row** — site name `1.2–1.3rem`, bullet `text-lg` (1.125rem), label `text-base` (1rem).
2. **The `•` text glyph** doesn't sit at the vertical center of its em box, so it always rode high relative to the text next to it.
3. **A stack of compensating hacks** piled on to fight #2 — per-item `-translate-y-px` nudges, fixed `h-5` boxes, `self-center`, `inline-flex`, `leading-none` — none of which actually resolved it, and which fought each other across the three font sizes.

## The fix

- Reconstruct the cluster as a **single flat `items-center` flex row**.
- Replace the text-glyph bullet with a **geometric dot** (a small `rounded-full` span), which centers perfectly regardless of surrounding font sizes — no glyph-metric guesswork, no nudges.
- Remove all the `-translate-y-px` / `h-5` / `self-center` / per-item `inline-flex` hacks.
- Unify the two duplicate label code paths (`routeInfoLabel` computed + `getLabel` function, which even baked `• ` into its strings) into one `secondaryLabel` computed, so the separator is rendered one way in every state.

## Verification

Ran the app (mocked dev) on a forum route and **measured the rendered geometry** — all three elements now share the exact same vertical center:

| Element | height | center Y |
| --- | --- | --- |
| Site name (`Topical`) | 19.2px | **28.00** |
| Dot separator | 6px | **28.00** |
| Channel (`cats`) | 16px | **28.00** |

- `npm run tsc` — clean
- `TopNav.spec.ts` — 18 passing (updated the two assertions that expected the old baked-in `• ` prefix; added a regression guard that the `•` glyph is gone and a geometric dot is present)
- Full pre-commit suite (tsc + unit tests) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)