### PR TITLE
Harden download filter group settings

### DIFF
--- a/components/filter/FilterGroupManager.vue
+++ b/components/filter/FilterGroupManager.vue
@@ -49,13 +49,16 @@ const yamlError = ref('');
 const filterModeOptions = [
   {
     value: FilterMode.Include,
-    label: 'Inclusion (show downloads with these labels)',
+    label: 'Must include selected labels',
   },
   {
     value: FilterMode.Exclude,
-    label: 'Exclusion (hide downloads with these labels)',
+    label: 'Must exclude selected labels',
   },
 ];
+
+const createLocalId = (kind: 'group' | 'option', index: number) =>
+  `local-filter-${kind}-${Date.now()}-${index}`;
 
 const convertFilterGroupsToYaml = (filterGroups: FilterGroup[]): string =>
   serializeFilterGroupsToYaml(filterGroups);
@@ -70,13 +73,13 @@ const convertYamlToFilterGroups = (
 
   // Map the validated plain groups onto full GraphQL FilterGroup objects.
   const filterGroups: FilterGroup[] = result.groups.map((group, index) => ({
-    id: '', // Empty ID for new/edited groups - server will handle
+    id: createLocalId('group', index),
     key: group.key,
     displayName: group.displayName,
     mode: group.mode as FilterMode,
     order: group.order ?? index,
     options: (group.options || []).map((option, optionIndex) => ({
-      id: '', // Empty ID for new/edited options - server will handle
+      id: createLocalId('option', optionIndex),
       value: option.value,
       displayName: option.displayName,
       order: option.order ?? optionIndex,
@@ -104,7 +107,7 @@ const addNewGroup = () => {
   }
 
   const newGroup: FilterGroup = {
-    id: '', // Empty ID for new groups - server will generate
+    id: createLocalId('group', props.filterGroups.length),
     key: newGroupForm.value.key,
     displayName: newGroupForm.value.displayName,
     mode: newGroupForm.value.mode,
@@ -235,7 +238,8 @@ watch(
           </h3>
           <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
             Configure filter groups that will appear in the downloads sidebar.
-            Users can filter downloads by selecting options within these groups.
+            Include groups require selected labels; exclude groups hide downloads
+            with selected labels.
           </p>
         </div>
 

--- a/components/filter/FilterOptionManager.spec.ts
+++ b/components/filter/FilterOptionManager.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { FilterMode } from '@/__generated__/graphql';
 import type { FilterGroup, FilterOption } from '@/__generated__/graphql';
@@ -36,6 +36,14 @@ const byText = (wrapper: ReturnType<typeof mountOM>, text: string) =>
   wrapper.findAll('button').find((b) => b.text() === text)!;
 
 describe('FilterOptionManager', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'confirm', {
+      configurable: true,
+      value: vi.fn(() => true),
+    });
+  });
+
   it('renders the group index in the header', () => {
     const wrapper = mountOM({ groupIndex: 3 });
     expect(wrapper.text()).toContain('Group #3');
@@ -43,7 +51,7 @@ describe('FilterOptionManager', () => {
 
   it('shows the mode label in read mode', () => {
     const wrapper = mountOM({ filterGroup: makeGroup({ mode: FilterMode.Exclude }) });
-    expect(wrapper.text()).toContain('Exclusion');
+    expect(wrapper.text()).toContain('Must exclude selected labels');
   });
 
   it('emits moveGroup up when Move Up is clicked', async () => {
@@ -61,6 +69,13 @@ describe('FilterOptionManager', () => {
     const wrapper = mountOM();
     await byText(wrapper, 'Remove Group').trigger('click');
     expect(wrapper.emitted('removeGroup')?.[0]).toEqual(['g1']);
+  });
+
+  it('does not emit removeGroup when removal is cancelled', async () => {
+    vi.mocked(window.confirm).mockReturnValueOnce(false);
+    const wrapper = mountOM();
+    await byText(wrapper, 'Remove Group').trigger('click');
+    expect(wrapper.emitted('removeGroup')).toBeUndefined();
   });
 
   it('reveals the edit form when Edit Group Settings is clicked', async () => {
@@ -93,7 +108,7 @@ describe('FilterOptionManager', () => {
 
   it('shows the empty-options state when there are no options', () => {
     const wrapper = mountOM();
-    expect(wrapper.text()).toContain('No options configured. Add an option above.');
+    expect(wrapper.text()).toContain('No options configured. Add at least one option before saving this group.');
   });
 
   it('emits updateGroup with the new option when added', async () => {
@@ -113,6 +128,14 @@ describe('FilterOptionManager', () => {
     expect(wrapper.text()).toContain('This value already exists in this group.');
   });
 
+  it('flags an option value with invalid characters', async () => {
+    const wrapper = mountOM();
+    await byText(wrapper, '+ Add New Option').trigger('click');
+    await wrapper.get('input[placeholder="e.g. 10x20"]').setValue('bad value');
+    expect(wrapper.text()).toContain('Value can only contain letters, numbers, underscores, and hyphens.');
+    expect(byText(wrapper, 'Add Option').attributes('disabled')).toBeDefined();
+  });
+
   it('emits updateGroup with the option removed', async () => {
     const wrapper = mountOM({
       filterGroup: makeGroup({ options: [makeOption({ id: 'o1' }), makeOption({ id: 'o2', value: 'x' })] }),
@@ -120,6 +143,15 @@ describe('FilterOptionManager', () => {
     await byText(wrapper, 'Remove').trigger('click');
     const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as { options: FilterOption[] };
     expect(payload.options.map((o) => o.id)).toEqual(['o2']);
+  });
+
+  it('does not remove an option when removal is cancelled', async () => {
+    vi.mocked(window.confirm).mockReturnValueOnce(false);
+    const wrapper = mountOM({
+      filterGroup: makeGroup({ options: [makeOption({ id: 'o1' })] }),
+    });
+    await byText(wrapper, 'Remove').trigger('click');
+    expect(wrapper.emitted('updateGroup')).toBeUndefined();
   });
 
   it('reorders options when moved down', async () => {

--- a/components/filter/FilterOptionManager.vue
+++ b/components/filter/FilterOptionManager.vue
@@ -46,12 +46,24 @@ const newOptionForm = ref({
   displayName: '',
 });
 
+const createLocalOptionId = () =>
+  `local-filter-option-${Date.now()}-${props.filterGroup.options?.length || 0}`;
+
 const filterModeOptions = [
-  { value: FilterMode.Include, label: 'Inclusion' },
-  { value: FilterMode.Exclude, label: 'Exclusion' },
+  {
+    value: FilterMode.Include,
+    label: 'Must include selected labels',
+    description: 'Downloads must have at least one selected option from this group.',
+  },
+  {
+    value: FilterMode.Exclude,
+    label: 'Must exclude selected labels',
+    description: 'Downloads with selected options from this group are hidden.',
+  },
 ];
 
 const isValidKey = (key: string) => /^[a-zA-Z0-9_]+$/.test(key);
+const isValidOptionValue = (value: string) => /^[a-zA-Z0-9_-]+$/.test(value);
 
 const isKeyUnique = (key: string) => {
   return !props.existingKeys.includes(key);
@@ -71,6 +83,7 @@ const canAddOption = computed(() => {
   return (
     newOptionForm.value.value &&
     newOptionForm.value.displayName &&
+    isValidOptionValue(newOptionForm.value.value) &&
     !props.filterGroup.options?.some(
       (option) => option.value === newOptionForm.value.value
     )
@@ -110,7 +123,7 @@ const addOption = () => {
   if (!canAddOption.value) return;
 
   const newOption: FilterOption = {
-    id: '', // Empty ID for new options - server will generate
+    id: createLocalOptionId(),
     value: newOptionForm.value.value,
     displayName: newOptionForm.value.displayName,
     order: props.filterGroup.options?.length || 0,
@@ -138,9 +151,27 @@ const addOption = () => {
 };
 
 const removeOption = (optionId: string) => {
+  if (
+    !window.confirm(
+      'Remove this filter option? Downloads using this option will no longer be matched by it after you save.'
+    )
+  ) {
+    return;
+  }
   const updatedOptions =
     props.filterGroup.options?.filter((option) => option.id !== optionId) || [];
   emit('updateGroup', props.filterGroup.id, { options: updatedOptions });
+};
+
+const removeGroup = () => {
+  if (
+    !window.confirm(
+      'Remove this filter group? Its options will be removed from the download filter settings after you save.'
+    )
+  ) {
+    return;
+  }
+  emit('removeGroup', props.filterGroup.id);
 };
 
 const moveOption = (optionId: string, direction: 'up' | 'down') => {
@@ -195,7 +226,7 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
           type="button"
           class="rounded border border-red-300 bg-red-100 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:border-red-700 dark:bg-red-900 dark:text-red-300 dark:hover:bg-red-800"
           :disabled="disabled"
-          @click="$emit('removeGroup', filterGroup.id)"
+          @click="removeGroup"
         >
           Remove Group
         </button>
@@ -214,6 +245,12 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
           {{
             filterModeOptions.find((opt) => opt.value === filterGroup.mode)
               ?.label
+          }}
+        </p>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          {{
+            filterModeOptions.find((opt) => opt.value === filterGroup.mode)
+              ?.description
           }}
         </p>
       </div>
@@ -260,6 +297,12 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
               {{ option.label }}
             </option>
           </select>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {{
+              filterModeOptions.find((option) => option.value === editForm.mode)
+                ?.description
+            }}
+          </p>
         </div>
         <div>
           <label
@@ -378,14 +421,22 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
               :class="{
                 'border-red-500':
                   newOptionForm.value &&
-                  filterGroup.options?.some(
-                    (option) => option.value === newOptionForm.value
-                  ),
+                  (!isValidOptionValue(newOptionForm.value) ||
+                    filterGroup.options?.some(
+                      (option) => option.value === newOptionForm.value
+                    )),
               }"
             >
             <p
+              v-if="newOptionForm.value && !isValidOptionValue(newOptionForm.value)"
+              class="mt-1 text-xs text-red-500"
+            >
+              Value can only contain letters, numbers, underscores, and hyphens.
+            </p>
+            <p
               v-if="
                 newOptionForm.value &&
+                isValidOptionValue(newOptionForm.value) &&
                 filterGroup.options?.some(
                   (option) => option.value === newOptionForm.value
                 )
@@ -495,7 +546,7 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
         v-else-if="!showNewOptionForm"
         class="py-4 text-center text-sm text-gray-500 dark:text-gray-400"
       >
-        No options configured. Add an option above.
+        No options configured. Add at least one option before saving this group.
       </div>
     </div>
   </div>

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -51,20 +51,23 @@ Notes:
 - This slice adds scalar permanent-removal audit fields and focused authorization/storage-failure tests for downloadable-file deletion.
 - Backend draft PR gennit-project/multiforum-backend#116 and frontend draft PR gennit-project/multiforum-nuxt#266 add verified upload storage metadata for new downloadable files, including `storageObjectName` and `storageUrl`.
 
-### 4. Download filters: review and finish include/exclude semantics `[partial]`
+### 4. Download filters: review and finish include/exclude semantics `[complete]`
 
 - [x] Confirm current exclude behavior in the actual download-list query path.
-- [ ] Make filter-group create/update/delete operations atomic and validated end-to-end.
+- [x] Make filter-group create/update/delete operations atomic and validated end-to-end.
 - [x] Ensure deleting a filter group does not leave stale selected filters in URLs or saved settings.
-- [ ] Add remaining tests for filter-group mutation validation, including invalid filter-group input.
-- [ ] Review UX details: empty-group validation, delete confirmation/reversal, clear "must include" vs "must exclude" labels, and readable/shareable URL state.
+- [x] Add remaining tests for filter-group mutation validation, including invalid filter-group input.
+- [x] Review UX details: empty-group validation, delete confirmation/reversal, clear "must include" vs "must exclude" labels, and readable/shareable URL state.
 
 Notes:
 - Channel admin UI for filter groups already exists.
 - Include/exclude modes, ordering, YAML editing, and validation are already present in the frontend.
 - This slice fixes channel download-list query semantics so `INCLUDE` groups require selected labels and `EXCLUDE` groups reject selected labels.
 - This slice also ignores stale/deleted filter groups in download queries and removes stale `filter_*` URL params after the channel filter groups load.
-- Focused tests now cover include/exclude query semantics and stale filter cleanup; atomic mutation validation remains.
+- Focused tests now cover include/exclude query semantics, stale filter cleanup, mutation validation, and settings payload persistence.
+- This slice fixes the channel settings save payload so existing filter groups/options are updated, new groups/options are created, and removed groups/options are deleted in the generated channel update mutation.
+- Backend validation middleware now rejects invalid generated filter-group mutation payloads before writes run, including invalid keys/modes, empty new groups, duplicate group keys, and duplicate option values.
+- Frontend form/YAML validation now catches invalid or duplicate filter configuration earlier and uses explicit "must include" / "must exclude" copy with remove confirmations.
 
 ### 5. Collection ordering `[partial]`
 

--- a/pages/forums/[forumId]/edit.spec.ts
+++ b/pages/forums/[forumId]/edit.spec.ts
@@ -3,6 +3,11 @@ import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import CreateEditChannelFields from '@/components/channel/form/CreateEditChannelFields.vue';
+import { FilterMode } from '@/__generated__/graphql';
+
+const h = vi.hoisted(() => ({
+  mutate: vi.fn(),
+}));
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({
@@ -16,7 +21,7 @@ vi.mock('nuxt/app', () => ({
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
   useMutation: () => ({
-    mutate: vi.fn(),
+    mutate: h.mutate,
     loading: ref(false),
     error: ref(null),
     onDone: vi.fn(),
@@ -31,6 +36,63 @@ vi.mock('@/composables/useAuthState', () => ({
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
 describe('forum settings edit page', () => {
+  const channelData = {
+    uniqueName: 'cats',
+    displayName: 'Cats',
+    description: 'Cat forum',
+    channelIconURL: '',
+    channelBannerURL: '',
+    wikiEnabled: true,
+    eventsEnabled: true,
+    feedbackEnabled: true,
+    imageUploadsEnabled: true,
+    markdownImagesEnabled: true,
+    emojiEnabled: true,
+    downloadsEnabled: true,
+    allowedFileTypes: ['zip'],
+    Tags: [],
+    Admins: [{ username: 'alice' }],
+    rules: '[]',
+    FilterGroups: [
+      {
+        id: 'group-1',
+        key: 'game_packs',
+        displayName: 'Game Packs',
+        mode: FilterMode.Include,
+        order: 0,
+        options: [
+          {
+            id: 'option-1',
+            value: 'vampires',
+            displayName: 'Vampires',
+            order: 0,
+          },
+          {
+            id: 'option-2',
+            value: 'dine_out',
+            displayName: 'Dine Out',
+            order: 1,
+          },
+        ],
+      },
+      {
+        id: 'group-2',
+        key: 'lot_type',
+        displayName: 'Lot Type',
+        mode: FilterMode.Include,
+        order: 1,
+        options: [
+          {
+            id: 'option-3',
+            value: 'residential',
+            displayName: 'Residential',
+            order: 0,
+          },
+        ],
+      },
+    ],
+  };
+
   it('renders the channel edit fields', async () => {
     mockedUseQuery.mockReturnValue({
       result: ref({
@@ -45,5 +107,96 @@ describe('forum settings edit page', () => {
       global: { mocks: { $route: { fullPath: '/forums/cats/edit' } } },
     });
     expect(wrapper.findComponent(CreateEditChannelFields).exists()).toBe(true);
+  });
+
+  it('persists existing filter group edits and deletes removed groups/options', async () => {
+    h.mutate.mockClear();
+    mockedUseQuery.mockReturnValue({
+      result: ref({
+        channels: [channelData],
+      }),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    });
+    const Page = (await import('./edit.vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: { mocks: { $route: { fullPath: '/forums/cats/edit' } } },
+    });
+
+    wrapper.findComponent(CreateEditChannelFields).vm.$emit('updateFormValues', {
+      downloadFilterGroups: [
+        {
+          ...channelData.FilterGroups[0],
+          displayName: 'Required Game Packs',
+          mode: FilterMode.Exclude,
+          options: [
+            {
+              id: 'option-1',
+              value: 'vampires',
+              displayName: 'Vampires Updated',
+              order: 0,
+            },
+            {
+              id: 'local-filter-option-1',
+              value: 'werewolves',
+              displayName: 'Werewolves',
+              order: 1,
+            },
+          ],
+        },
+      ],
+    });
+    wrapper.findComponent(CreateEditChannelFields).vm.$emit('submit');
+
+    const update = h.mutate.mock.calls[0][0].update;
+    expect(update.FilterGroups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          where: { node: { id: 'group-1' } },
+          update: expect.objectContaining({
+            node: expect.objectContaining({
+              displayName: 'Required Game Packs',
+              mode: FilterMode.Exclude,
+              options: expect.arrayContaining([
+                expect.objectContaining({
+                  where: { node: { id: 'option-1' } },
+                  update: {
+                    node: {
+                      value: 'vampires',
+                      displayName: 'Vampires Updated',
+                      order: 0,
+                    },
+                  },
+                }),
+                expect.objectContaining({
+                  create: [
+                    {
+                      node: {
+                        id: '',
+                        value: 'werewolves',
+                        displayName: 'Werewolves',
+                        order: 1,
+                      },
+                    },
+                  ],
+                }),
+                expect.objectContaining({
+                  delete: [{ where: { node: { id: 'option-2' } } }],
+                }),
+              ]),
+            }),
+          }),
+        }),
+        {
+          delete: [
+            {
+              where: { node: { id: 'group-2' } },
+              delete: { options: [{}] },
+            },
+          ],
+        },
+      ])
+    );
   });
 });

--- a/pages/forums/[forumId]/edit.vue
+++ b/pages/forums/[forumId]/edit.vue
@@ -10,6 +10,7 @@ import { useUsername } from '@/composables/useAuthState';
 import type {
   ChannelUpdateInput,
   FilterGroup,
+  FilterOption,
   Tag as TagData,
 } from '@/__generated__/graphql';
 import { useRoute } from 'nuxt/app';
@@ -108,6 +109,65 @@ const existingFilterGroups = computed(() => {
   return channel.value?.FilterGroups || [];
 });
 
+const isPersistedId = (id: unknown): id is string =>
+  typeof id === 'string' && id.length > 0 && !id.startsWith('local-');
+
+const toFilterOptionCreate = (option: FilterOption, optionIndex: number) => ({
+  node: {
+    id: '',
+    value: option.value,
+    displayName: option.displayName,
+    order: optionIndex,
+  },
+});
+
+const toFilterOptionUpdate = (option: FilterOption, optionIndex: number) => ({
+  where: { node: { id: option.id } },
+  update: {
+    node: {
+      value: option.value,
+      displayName: option.displayName,
+      order: optionIndex,
+    },
+  },
+});
+
+const buildFilterOptionUpdates = (
+  currentGroup: FilterGroup,
+  existingGroup?: FilterGroup
+) => {
+  const currentOptions = currentGroup.options || [];
+  const existingOptions = existingGroup?.options || [];
+  const currentExistingOptionIds = currentOptions
+    .map((option: FilterOption) => option.id)
+    .filter(isPersistedId);
+  const createdOptions = currentOptions
+    .flatMap((option: FilterOption, optionIndex: number) =>
+      !isPersistedId(option.id)
+        ? [toFilterOptionCreate(option, optionIndex)]
+        : []
+    );
+  const updatedOptions = currentOptions
+    .flatMap((option: FilterOption, optionIndex: number) =>
+      isPersistedId(option.id)
+        ? [toFilterOptionUpdate(option, optionIndex)]
+        : []
+    );
+  const deletedOptions = existingOptions
+    .filter((option: FilterOption) =>
+      !currentExistingOptionIds.includes(option.id)
+    )
+    .map((option: FilterOption) => ({
+      where: { node: { id: option.id } },
+    }));
+
+  return [
+    ...(updatedOptions.length > 0 ? updatedOptions : []),
+    ...(createdOptions.length > 0 ? [{ create: createdOptions }] : []),
+    ...(deletedOptions.length > 0 ? [{ delete: deletedOptions }] : []),
+  ];
+};
+
 const channelUpdateInput = computed<ChannelUpdateInput>(() => {
   const tagConnections = formValues.value.selectedTags.map((tag: string) => ({
     onCreate: { node: { text: tag } },
@@ -120,25 +180,39 @@ const channelUpdateInput = computed<ChannelUpdateInput>(() => {
       where: { node: { text: tag } },
     }));
 
-  // Handle FilterGroups using connect/create/disconnect pattern (like Tags)
+  // Keep filter groups atomic inside the channel update: create new groups,
+  // update existing groups/options, and delete removed groups/options.
   const existingFilterGroupIds = existingFilterGroups.value.map(
     (group: FilterGroup) => group.id
   );
   const currentFilterGroupIds = formValues.value.downloadFilterGroups
     .map((group: FilterGroup) => group.id)
-    .filter(Boolean); // Only existing groups have IDs
+    .filter(isPersistedId);
 
-  // Connect to existing groups that are still selected
-  const filterGroupConnections = formValues.value.downloadFilterGroups
-    .filter((group: FilterGroup) => group.id) // Only existing groups
-    .map((group, _index) => ({
-      where: { node: { id: group.id } },
-      // Note: We might need to handle updates here if group properties changed
-    }));
+  const filterGroupUpdates = formValues.value.downloadFilterGroups
+    .filter((group: FilterGroup) => isPersistedId(group.id))
+    .map((group, index) => {
+      const existingGroup = existingFilterGroups.value.find(
+        (existingGroup: FilterGroup) => existingGroup.id === group.id
+      );
+      const optionUpdates = buildFilterOptionUpdates(group, existingGroup);
+      return {
+        where: { node: { id: group.id } },
+        update: {
+          node: {
+            key: group.key,
+            displayName: group.displayName,
+            mode: group.mode,
+            order: index,
+            ...(optionUpdates.length > 0 ? { options: optionUpdates } : {}),
+          },
+        },
+      };
+    });
 
   // Create new groups (those without IDs)
   const filterGroupCreations = formValues.value.downloadFilterGroups
-    .filter((group: FilterGroup) => !group.id) // Only new groups
+    .filter((group: FilterGroup) => !isPersistedId(group.id))
     .map((group, _index) => ({
       node: {
         id: '', // Empty ID for new groups - server will generate
@@ -148,24 +222,18 @@ const channelUpdateInput = computed<ChannelUpdateInput>(() => {
         order: formValues.value.downloadFilterGroups.indexOf(group),
         options: group.options
           ? {
-              create: group.options.map((option, optionIndex) => ({
-                node: {
-                  id: '', // Empty ID for new options - server will generate
-                  value: option.value,
-                  displayName: option.displayName,
-                  order: optionIndex,
-                },
-              })),
+              create: group.options.map(toFilterOptionCreate),
             }
           : undefined,
       },
     }));
 
-  // Disconnect groups that were removed
-  const filterGroupDisconnections = existingFilterGroupIds
+  // Delete groups that were removed from the settings form.
+  const filterGroupDeletions = existingFilterGroupIds
     .filter((id: string) => !currentFilterGroupIds.includes(id))
     .map((id: string) => ({
       where: { node: { id } },
+      delete: { options: [{}] },
     }));
 
   return {
@@ -184,14 +252,14 @@ const channelUpdateInput = computed<ChannelUpdateInput>(() => {
     allowedFileTypes: formValues.value.allowedFileTypes,
     Tags: [{ connectOrCreate: tagConnections, disconnect: tagDisconnections }],
     FilterGroups: [
-      ...(filterGroupConnections.length > 0
-        ? [{ connect: filterGroupConnections }]
+      ...(filterGroupUpdates.length > 0
+        ? filterGroupUpdates
         : []),
       ...(filterGroupCreations.length > 0
         ? [{ create: filterGroupCreations }]
         : []),
-      ...(filterGroupDisconnections.length > 0
-        ? [{ disconnect: filterGroupDisconnections }]
+      ...(filterGroupDeletions.length > 0
+        ? [{ delete: filterGroupDeletions }]
         : []),
     ],
     Admins: [

--- a/tests/unit/utils/filterGroupYaml.spec.ts
+++ b/tests/unit/utils/filterGroupYaml.spec.ts
@@ -56,9 +56,37 @@ describe('parseFilterGroupsYaml', () => {
 
   it('defaults missing order values to the index', () => {
     const result = parseFilterGroupsYaml(
-      '- key: a\n  displayName: A\n  mode: INCLUDE\n- key: b\n  displayName: B\n  mode: EXCLUDE'
+      '- key: a\n  displayName: A\n  mode: INCLUDE\n  options:\n    - value: one\n      displayName: One\n- key: b\n  displayName: B\n  mode: EXCLUDE\n  options:\n    - value: two\n      displayName: Two'
     );
     expect(result.groups?.map((g) => g.order)).toEqual([0, 1]);
+  });
+
+  it('fails when a group key is duplicated', () => {
+    const result = parseFilterGroupsYaml(
+      '- key: packs\n  displayName: Packs\n  mode: INCLUDE\n  options:\n    - value: vampires\n      displayName: Vampires\n- key: PACKS\n  displayName: Packs Again\n  mode: EXCLUDE\n  options:\n    - value: dine_out\n      displayName: Dine Out'
+    );
+    expect(result.error).toContain('Duplicate filter group key');
+  });
+
+  it('fails when a group has no options', () => {
+    const result = parseFilterGroupsYaml(
+      '- key: packs\n  displayName: Packs\n  mode: INCLUDE\n  options: []'
+    );
+    expect(result.error).toContain('must include at least one option');
+  });
+
+  it('fails when an option value is duplicated within a group', () => {
+    const result = parseFilterGroupsYaml(
+      '- key: packs\n  displayName: Packs\n  mode: INCLUDE\n  options:\n    - value: vampires\n      displayName: Vampires\n    - value: VAMPIRES\n      displayName: Vampires Duplicate'
+    );
+    expect(result.error).toContain('duplicate option value');
+  });
+
+  it('fails when an option value has invalid characters', () => {
+    const result = parseFilterGroupsYaml(
+      '- key: packs\n  displayName: Packs\n  mode: INCLUDE\n  options:\n    - value: bad value\n      displayName: Bad Value'
+    );
+    expect(result.error).toContain('invalid value');
   });
 
   it('returns an error for malformed YAML', () => {

--- a/utils/filterGroupYaml.spec.ts
+++ b/utils/filterGroupYaml.spec.ts
@@ -37,13 +37,19 @@ describe('parseFilterGroupsYaml', () => {
 
   it('fails on an invalid mode', () => {
     expect(
-      parseFilterGroupsYaml('- key: k\n  displayName: D\n  mode: MAYBE').error
+      parseFilterGroupsYaml('- key: k\n  displayName: D\n  mode: MAYBE\n  options:\n    - value: v\n      displayName: V').error
     ).toContain('invalid mode');
   });
 
   it('defaults order to the index when omitted', () => {
-    const result = parseFilterGroupsYaml('- key: k\n  displayName: D\n  mode: INCLUDE');
+    const result = parseFilterGroupsYaml('- key: k\n  displayName: D\n  mode: INCLUDE\n  options:\n    - value: v\n      displayName: V');
     expect(result.groups?.[0].order).toBe(0);
+  });
+
+  it('fails when a group has no options', () => {
+    expect(
+      parseFilterGroupsYaml('- key: k\n  displayName: D\n  mode: INCLUDE\n  options: []').error
+    ).toContain('must include at least one option');
   });
 
   it('returns an error string for malformed YAML', () => {

--- a/utils/filterGroupYaml.ts
+++ b/utils/filterGroupYaml.ts
@@ -25,6 +25,11 @@ export type ParseFilterGroupsResult = {
   error?: string;
 };
 
+const validKeyPattern = /^[a-zA-Z0-9_]+$/;
+const validOptionValuePattern = /^[a-zA-Z0-9_-]+$/;
+
+const normalizeKey = (value: string) => value.trim().toLowerCase();
+
 /** Serialize filter groups to YAML, picking only the persisted fields. */
 export function serializeFilterGroupsToYaml(
   filterGroups: PlainFilterGroup[]
@@ -68,27 +73,61 @@ export function parseFilterGroupsYaml(
       };
     }
 
+    const seenGroupKeys = new Set<string>();
     const groups: PlainFilterGroup[] = parsed.map((group, index) => {
       if (!group.key || !group.displayName) {
         throw new Error(
           `Group at index ${index} is missing required fields (key, displayName)`
         );
       }
+      if (!validKeyPattern.test(group.key)) {
+        throw new Error(
+          `Group "${group.key}" has an invalid key. Use only letters, numbers, and underscores`
+        );
+      }
+      const normalizedGroupKey = normalizeKey(group.key);
+      if (seenGroupKeys.has(normalizedGroupKey)) {
+        throw new Error(`Duplicate filter group key "${group.key}"`);
+      }
+      seenGroupKeys.add(normalizedGroupKey);
       if (!['INCLUDE', 'EXCLUDE'].includes(group.mode)) {
         throw new Error(
           `Group "${group.key}" has invalid mode. Must be INCLUDE or EXCLUDE`
         );
       }
+      if (!Array.isArray(group.options) || group.options.length === 0) {
+        throw new Error(`Group "${group.key}" must include at least one option`);
+      }
+      const seenOptionValues = new Set<string>();
       return {
         key: group.key,
         displayName: group.displayName,
         mode: group.mode,
         order: group.order ?? index,
-        options: (group.options || []).map((option, optionIndex) => ({
-          value: option.value,
-          displayName: option.displayName,
-          order: option.order ?? optionIndex,
-        })),
+        options: group.options.map((option, optionIndex) => {
+          if (!option.value || !option.displayName) {
+            throw new Error(
+              `Option at index ${optionIndex} in group "${group.key}" is missing required fields (value, displayName)`
+            );
+          }
+          if (!validOptionValuePattern.test(option.value)) {
+            throw new Error(
+              `Option "${option.value}" in group "${group.key}" has an invalid value. Use only letters, numbers, underscores, and hyphens`
+            );
+          }
+          const normalizedOptionValue = normalizeKey(option.value);
+          if (seenOptionValues.has(normalizedOptionValue)) {
+            throw new Error(
+              `Group "${group.key}" has duplicate option value "${option.value}"`
+            );
+          }
+          seenOptionValues.add(normalizedOptionValue);
+          return {
+            value: option.value,
+            displayName: option.displayName,
+            order: option.order ?? optionIndex,
+          };
+        }),
       };
     });
 


### PR DESCRIPTION
## Summary
- fix forum download settings so existing filter groups/options are updated instead of only reconnected
- delete removed groups/options through the generated channel update mutation and use local IDs for unsaved rows
- tighten YAML/form validation for duplicate keys/options, empty groups, invalid values, and clearer include/exclude copy
- update FEATURE_ROADMAP.md to mark the download filter slice complete

## Verification
- npx vitest run utils/filterGroupYaml.spec.ts tests/unit/utils/filterGroupYaml.spec.ts components/filter/FilterGroupManager.spec.ts components/filter/FilterOptionManager.spec.ts 'pages/forums/[forumId]/edit.spec.ts'
- npm run tsc
- commit hook lint-staged, vue-tsc, and full eslint completed; eslint reported existing warnings only

## Related
- Backend validation PR: gennit-project/multiforum-backend#126