### PR TITLE
Add collection ordering controls

### DIFF
--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -69,20 +69,20 @@ Notes:
 - Backend validation middleware now rejects invalid generated filter-group mutation payloads before writes run, including invalid keys/modes, empty new groups, duplicate group keys, and duplicate option values.
 - Frontend form/YAML validation now catches invalid or duplicate filter configuration earlier and uses explicit "must include" / "must exclude" copy with remove confirmations.
 
-### 5. Collection ordering `[partial]`
+### 5. Collection ordering `[done]`
 
-- [ ] Add or confirm the stable ordering model for collection membership.
-- [ ] Preserve order correctly when adding and removing items.
-- [ ] Define behavior when an item in the stored order no longer exists.
-- [ ] Add a reorder mutation with ownership checks.
-- [ ] Add reorder tests for success, non-owner rejection, missing-item behavior, and order preservation after add/remove.
-- [ ] Add reorder controls in the collection UI.
-- [ ] Persist reordering through the new mutation.
-- [ ] Keep keyboard-accessible move up/down controls even if drag-and-drop is added later.
+- [x] Add or confirm the stable ordering model for collection membership.
+- [x] Preserve order correctly when adding and removing items.
+- [x] Define behavior when an item in the stored order no longer exists.
+- [x] Add a reorder mutation with ownership checks.
+- [x] Add reorder tests for success, non-owner rejection, missing-item behavior, and order preservation after add/remove.
+- [x] Add reorder controls in the collection UI.
+- [x] Persist reordering through the new mutation.
+- [x] Keep keyboard-accessible move up/down controls.
 
 Notes:
 - Collections already have an `itemOrder` field and add-to-collection mutations push into it.
-- No reorder mutation or reorder UI was found.
+- Custom add/remove/reorder mutations now keep `itemOrder` deduplicated, prune removed items, normalize stale stored IDs, and append items missing from stored order.
 
 ### 6. Share public collections to a forum discussion `[not started]`
 

--- a/graphQLData/collection/mutations.ts
+++ b/graphQLData/collection/mutations.ts
@@ -38,181 +38,91 @@ export const CREATE_COLLECTION = gql`
 
 export const ADD_DISCUSSION_TO_COLLECTION = gql`
   mutation AddDiscussionToCollection($collectionId: ID!, $itemId: ID!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: {
-        itemOrder_PUSH: [$itemId]
-        Discussions: { connect: { where: { node: { id: $itemId } } } }
-      }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+    addToCollection(
+      input: { collectionId: $collectionId, itemId: $itemId, itemType: DISCUSSION }
+    )
   }
 `;
 
 export const ADD_COMMENT_TO_COLLECTION = gql`
   mutation AddCommentToCollection($collectionId: ID!, $itemId: ID!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: {
-        itemOrder_PUSH: [$itemId]
-        Comments: { connect: { where: { node: { id: $itemId } } } }
-      }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+    addToCollection(
+      input: { collectionId: $collectionId, itemId: $itemId, itemType: COMMENT }
+    )
   }
 `;
 
 export const ADD_IMAGE_TO_COLLECTION = gql`
   mutation AddImageToCollection($collectionId: ID!, $itemId: ID!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: {
-        itemOrder_PUSH: [$itemId]
-        Images: { connect: { where: { node: { id: $itemId } } } }
-      }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+    addToCollection(
+      input: { collectionId: $collectionId, itemId: $itemId, itemType: IMAGE }
+    )
   }
 `;
 
 export const ADD_CHANNEL_TO_COLLECTION = gql`
-  mutation AddChannelToCollection($collectionId: ID!, $itemId: String!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: {
-        Channels: { connect: { where: { node: { uniqueName: $itemId } } } }
-      }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+  mutation AddChannelToCollection($collectionId: ID!, $itemId: ID!) {
+    addToCollection(
+      input: { collectionId: $collectionId, itemId: $itemId, itemType: CHANNEL }
+    )
   }
 `;
 
 export const REMOVE_DISCUSSION_FROM_COLLECTION = gql`
   mutation RemoveDiscussionFromCollection($collectionId: ID!, $itemId: ID!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: {
-        Discussions: { disconnect: { where: { node: { id: $itemId } } } }
-      }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+    removeFromCollection(
+      collectionId: $collectionId
+      itemId: $itemId
+      itemType: DISCUSSION
+    )
   }
 `;
 
 export const REMOVE_COMMENT_FROM_COLLECTION = gql`
   mutation RemoveCommentFromCollection($collectionId: ID!, $itemId: ID!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: { Comments: { disconnect: { where: { node: { id: $itemId } } } } }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+    removeFromCollection(
+      collectionId: $collectionId
+      itemId: $itemId
+      itemType: COMMENT
+    )
   }
 `;
 
 export const REMOVE_IMAGE_FROM_COLLECTION = gql`
   mutation RemoveImageFromCollection($collectionId: ID!, $itemId: ID!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: { Images: { disconnect: { where: { node: { id: $itemId } } } } }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+    removeFromCollection(
+      collectionId: $collectionId
+      itemId: $itemId
+      itemType: IMAGE
+    )
   }
 `;
 
 export const REMOVE_CHANNEL_FROM_COLLECTION = gql`
-  mutation RemoveChannelFromCollection($collectionId: ID!, $itemId: String!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: {
-        Channels: { disconnect: { where: { node: { uniqueName: $itemId } } } }
-      }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+  mutation RemoveChannelFromCollection($collectionId: ID!, $itemId: ID!) {
+    removeFromCollection(
+      collectionId: $collectionId
+      itemId: $itemId
+      itemType: CHANNEL
+    )
   }
 `;
 
 export const ADD_DOWNLOAD_TO_COLLECTION = gql`
   mutation AddDownloadToCollection($collectionId: ID!, $itemId: ID!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: {
-        itemOrder_PUSH: [$itemId]
-        Downloads: { connect: { where: { node: { id: $itemId } } } }
-      }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+    addToCollection(
+      input: { collectionId: $collectionId, itemId: $itemId, itemType: DOWNLOAD }
+    )
   }
 `;
 
 export const REMOVE_DOWNLOAD_FROM_COLLECTION = gql`
   mutation RemoveDownloadFromCollection($collectionId: ID!, $itemId: ID!) {
-    updateCollections(
-      where: { id: $collectionId }
-      update: {
-        Downloads: { disconnect: { where: { node: { id: $itemId } } } }
-      }
-    ) {
-      collections {
-        id
-        name
-        itemCount
-        itemOrder
-      }
-    }
+    removeFromCollection(
+      collectionId: $collectionId
+      itemId: $itemId
+      itemType: DOWNLOAD
+    )
   }
 `;
 
@@ -247,5 +157,19 @@ export const DELETE_COLLECTION = gql`
     deleteCollections(where: { id: $collectionId }) {
       nodesDeleted
     }
+  }
+`;
+
+export const REORDER_COLLECTION_ITEM = gql`
+  mutation ReorderCollectionItem(
+    $collectionId: ID!
+    $itemId: ID!
+    $newPosition: Int!
+  ) {
+    reorderCollectionItem(
+      collectionId: $collectionId
+      itemId: $itemId
+      newPosition: $newPosition
+    )
   }
 `;

--- a/pages/library/[collectionId].spec.ts
+++ b/pages/library/[collectionId].spec.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref, defineComponent, h } from 'vue';
-import { useQuery } from '@vue/apollo-composable';
+import { useQuery, useMutation } from '@vue/apollo-composable';
 vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
 
 vi.mock('vue-router', () => ({
@@ -11,13 +11,7 @@ vi.mock('vue-router', () => ({
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
-  useMutation: () => ({
-    mutate: vi.fn(),
-    loading: ref(false),
-    error: ref(null),
-    onDone: vi.fn(),
-    onError: vi.fn(),
-  }),
+  useMutation: vi.fn(),
 }));
 
 vi.mock('@/composables/useAuthState', () => ({
@@ -49,14 +43,57 @@ const LibraryCommentCardStub = defineComponent({
   template: '<div>{{ comment.text }} {{ contextType }}</div>',
 });
 
+const LibraryDiscussionCardStub = defineComponent({
+  name: 'LibraryDiscussionCard',
+  props: {
+    discussion: {
+      type: Object,
+      required: true,
+    },
+  },
+  template:
+    '<article data-testid="discussion-card">{{ discussion.id }} {{ discussion.title }}</article>',
+});
+
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+const mockedUseMutation = useMutation as unknown as ReturnType<typeof vi.fn>;
+const mutationMocks = {
+  update: vi.fn(),
+  delete: vi.fn(),
+  reorder: vi.fn(),
+};
+let refetchCollection = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 const mountWith = async (collection: unknown) => {
+  refetchCollection = vi.fn();
+  mutationMocks.update.mockResolvedValue({});
+  mutationMocks.delete.mockResolvedValue({});
+  mutationMocks.reorder.mockResolvedValue({});
+  mockedUseMutation
+    .mockReturnValueOnce({
+      mutate: mutationMocks.update,
+      loading: ref(false),
+      error: ref(null),
+    })
+    .mockReturnValueOnce({
+      mutate: mutationMocks.delete,
+      loading: ref(false),
+      error: ref(null),
+    })
+    .mockReturnValueOnce({
+      mutate: mutationMocks.reorder,
+      loading: ref(false),
+      error: ref(null),
+    });
   mockedUseQuery.mockReturnValue({
     result: ref({ collections: collection ? [collection] : [] }),
     loading: ref(false),
     error: ref(null),
-    refetch: vi.fn(),
+    refetch: refetchCollection,
   });
   const Page = (await import('./[collectionId].vue')).default;
   return shallowMount(Page, {
@@ -65,7 +102,7 @@ const mountWith = async (collection: unknown) => {
         RequireAuth: RequireAuthStub,
         NuxtLink: { template: '<a><slot /></a>' },
         LibraryDownloadCard: true,
-        LibraryDiscussionCard: true,
+        LibraryDiscussionCard: LibraryDiscussionCardStub,
         LibraryChannelCard: true,
         LibraryCommentCard: LibraryCommentCardStub,
         ImageListItem: true,
@@ -119,6 +156,53 @@ describe('library collection detail page', () => {
     expect(wrapper.text()).toContain(
       'Downloads are added to this private collection automatically when you grab a file.'
     );
+  });
+
+  it('renders discussion collection items in stored order', async () => {
+    const wrapper = await mountWith({
+      id: 'col-1',
+      name: 'Ordered discussions',
+      collectionType: 'DISCUSSIONS',
+      visibility: 'PRIVATE',
+      itemCount: 2,
+      itemOrder: ['d2', 'd1'],
+      Discussions: [
+        { id: 'd1', title: 'First saved', DiscussionChannels: [] },
+        { id: 'd2', title: 'Second saved', DiscussionChannels: [] },
+      ],
+    });
+
+    const cards = wrapper.findAll('[data-testid="discussion-card"]');
+    expect(cards.map((card) => card.text().split(' ')[0])).toEqual([
+      'd2',
+      'd1',
+    ]);
+  });
+
+  it('persists move down through the reorder mutation', async () => {
+    const wrapper = await mountWith({
+      id: 'col-1',
+      name: 'Ordered discussions',
+      collectionType: 'DISCUSSIONS',
+      visibility: 'PRIVATE',
+      itemCount: 2,
+      itemOrder: ['d1', 'd2'],
+      Discussions: [
+        { id: 'd1', title: 'First saved', DiscussionChannels: [] },
+        { id: 'd2', title: 'Second saved', DiscussionChannels: [] },
+      ],
+    });
+
+    await wrapper
+      .find('button[aria-label="Move First saved down"]')
+      .trigger('click');
+
+    expect(mutationMocks.reorder).toHaveBeenCalledWith({
+      collectionId: 'col-1',
+      itemId: 'd1',
+      newPosition: 1,
+    });
+    expect(refetchCollection).toHaveBeenCalled();
   });
 
   const commentsCollection = {

--- a/pages/library/[collectionId].vue
+++ b/pages/library/[collectionId].vue
@@ -12,6 +12,7 @@ import {
 import {
   UPDATE_COLLECTION,
   DELETE_COLLECTION,
+  REORDER_COLLECTION_ITEM,
 } from '@/graphQLData/collection/mutations';
 import GenericModal from '@/components/GenericModal.vue';
 import WarningModal from '@/components/WarningModal.vue';
@@ -21,6 +22,7 @@ import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import {
   getCollectionTypeLabel,
   getCollectionItems,
+  getCollectionItemStableId,
   buildCollectionDiscussionLink,
   resolveCollectionItemAuthor,
 } from '@/utils/collectionItemUtils';
@@ -138,8 +140,27 @@ const {
   loading: deleteLoading,
   error: deleteError,
 } = useMutation(DELETE_COLLECTION);
+const {
+  mutate: reorderCollectionItem,
+  loading: reorderLoading,
+  error: reorderError,
+} = useMutation(REORDER_COLLECTION_ITEM);
 const visibilityUpdating = ref(false);
 const visibilityError = ref<string | null>(null);
+
+const getItemId = (item: unknown) => getCollectionItemStableId(item);
+
+const moveCollectionItem = async (item: unknown, newPosition: number) => {
+  const itemId = getItemId(item);
+  if (!itemId || newPosition < 0 || newPosition >= items.value.length) return;
+
+  await reorderCollectionItem({
+    collectionId: collectionId.value,
+    itemId,
+    newPosition,
+  });
+  await refetchCollection();
+};
 
 // Open rename modal with current values
 const openRenameModal = () => {
@@ -333,6 +354,12 @@ const handleDelete = async () => {
                     >
                       {{ visibilityError }}
                     </p>
+                    <p
+                      v-if="reorderError"
+                      class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
+                      Could not update collection order: {{ reorderError.message }}
+                    </p>
                   </div>
 
                   <!-- Action buttons -->
@@ -445,53 +472,75 @@ const handleDelete = async () => {
                 class="space-y-4"
               >
                 <template
-                  v-for="discussion in items"
-                  :key="discussion.id"
+                  v-for="(discussion, index) in items"
+                  :key="getItemId(discussion)"
                 >
-                  <LibraryDownloadCard
-                    v-if="collection.collectionType === 'DOWNLOADS'"
-                    :download="discussion"
-                    :download-link="getDiscussionLink(discussion)"
-                    :channel-link="
-                      discussion.DiscussionChannels?.[0]?.channelUniqueName
-                        ? `/forums/${discussion.DiscussionChannels[0].channelUniqueName}`
-                        : '/'
-                    "
-                    :channel-unique-name="
-                      discussion.DiscussionChannels?.[0]?.channelUniqueName || ''
-                    "
-                    :author-info="getAuthorInfo(discussion)"
-                    :preview-image-url="getPreviewImage(discussion)"
-                    :show-favorite-button="true"
-                    :allow-add-to-list="true"
-                    :is-favorited="Boolean(discussion.isFavorited)"
-                  />
-                  <LibraryDiscussionCard
-                    v-else
-                    :discussion="discussion"
-                    :discussion-link="getDiscussionLink(discussion)"
-                    :channel-link="
-                      discussion.DiscussionChannels?.[0]?.channelUniqueName
-                        ? `/forums/${discussion.DiscussionChannels[0].channelUniqueName}`
-                        : '/'
-                    "
-                    :channel-unique-name="
-                      discussion.DiscussionChannels?.[0]?.channelUniqueName || ''
-                    "
-                    :author-info="getAuthorInfo(discussion)"
-                    :comment-count="
-                      discussion.DiscussionChannels?.reduce(
-                        (
-                          total: number,
-                          item: CollectionDiscussionChannel
-                        ) => total + (item.CommentsAggregate?.count || 0),
-                        0
-                      ) || 0
-                    "
-                    :show-favorite-button="true"
-                    :allow-add-to-list="true"
-                    :is-favorited="Boolean(discussion.isFavorited)"
-                  />
+                  <div class="grid gap-3 md:grid-cols-[auto,minmax(0,1fr)] md:items-start">
+                    <div class="flex gap-2 md:flex-col">
+                      <button
+                        type="button"
+                        class="inline-flex items-center justify-center rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                        :disabled="index === 0 || reorderLoading"
+                        :aria-label="`Move ${discussion.title || 'item'} up`"
+                        @click="moveCollectionItem(discussion, index - 1)"
+                      >
+                        Up
+                      </button>
+                      <button
+                        type="button"
+                        class="inline-flex items-center justify-center rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                        :disabled="index === items.length - 1 || reorderLoading"
+                        :aria-label="`Move ${discussion.title || 'item'} down`"
+                        @click="moveCollectionItem(discussion, index + 1)"
+                      >
+                        Down
+                      </button>
+                    </div>
+                    <LibraryDownloadCard
+                      v-if="collection.collectionType === 'DOWNLOADS'"
+                      :download="discussion"
+                      :download-link="getDiscussionLink(discussion)"
+                      :channel-link="
+                        discussion.DiscussionChannels?.[0]?.channelUniqueName
+                          ? `/forums/${discussion.DiscussionChannels[0].channelUniqueName}`
+                          : '/'
+                      "
+                      :channel-unique-name="
+                        discussion.DiscussionChannels?.[0]?.channelUniqueName || ''
+                      "
+                      :author-info="getAuthorInfo(discussion)"
+                      :preview-image-url="getPreviewImage(discussion)"
+                      :show-favorite-button="true"
+                      :allow-add-to-list="true"
+                      :is-favorited="Boolean(discussion.isFavorited)"
+                    />
+                    <LibraryDiscussionCard
+                      v-else
+                      :discussion="discussion"
+                      :discussion-link="getDiscussionLink(discussion)"
+                      :channel-link="
+                        discussion.DiscussionChannels?.[0]?.channelUniqueName
+                          ? `/forums/${discussion.DiscussionChannels[0].channelUniqueName}`
+                          : '/'
+                      "
+                      :channel-unique-name="
+                        discussion.DiscussionChannels?.[0]?.channelUniqueName || ''
+                      "
+                      :author-info="getAuthorInfo(discussion)"
+                      :comment-count="
+                        discussion.DiscussionChannels?.reduce(
+                          (
+                            total: number,
+                            item: CollectionDiscussionChannel
+                          ) => total + (item.CommentsAggregate?.count || 0),
+                          0
+                        ) || 0
+                      "
+                      :show-favorite-button="true"
+                      :allow-add-to-list="true"
+                      :is-favorited="Boolean(discussion.isFavorited)"
+                    />
+                  </div>
                 </template>
               </div>
 
@@ -499,47 +548,119 @@ const handleDelete = async () => {
                 v-else-if="collection.collectionType === 'CHANNELS'"
                 class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
               >
-                <LibraryChannelCard
-                  v-for="channel in items"
-                  :key="channel.uniqueName"
-                  :channel="channel"
-                  :show-favorite-button="true"
-                  :allow-add-to-list="true"
-                  :is-favorited="Boolean(channel.isFavorited)"
-                />
+                <div
+                  v-for="(channel, index) in items"
+                  :key="getItemId(channel)"
+                  class="space-y-2"
+                >
+                  <div class="flex gap-2">
+                    <button
+                      type="button"
+                      class="rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                      :disabled="index === 0 || reorderLoading"
+                      :aria-label="`Move ${channel.displayName || channel.uniqueName || 'forum'} up`"
+                      @click="moveCollectionItem(channel, index - 1)"
+                    >
+                      Up
+                    </button>
+                    <button
+                      type="button"
+                      class="rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                      :disabled="index === items.length - 1 || reorderLoading"
+                      :aria-label="`Move ${channel.displayName || channel.uniqueName || 'forum'} down`"
+                      @click="moveCollectionItem(channel, index + 1)"
+                    >
+                      Down
+                    </button>
+                  </div>
+                  <LibraryChannelCard
+                    :channel="channel"
+                    :show-favorite-button="true"
+                    :allow-add-to-list="true"
+                    :is-favorited="Boolean(channel.isFavorited)"
+                  />
+                </div>
               </div>
 
               <div
                 v-else-if="collection.collectionType === 'COMMENTS'"
                 class="space-y-4"
               >
-                <LibraryCommentCard
-                  v-for="comment in items"
-                  :key="comment.id"
-                  :comment="comment"
-                  :author-info="getAuthorInfo(comment)"
-                  :context-type="getCommentContextType(comment)"
-                  :context-title="getCommentContextTitle(comment)"
-                  :context-permalink="getCommentContextPermalink(comment)"
-                  :permalink="getCommentPermalink(comment)"
-                  :show-favorite-button="true"
-                  :allow-add-to-list="true"
-                  :is-favorited="Boolean(comment.isFavorited)"
-                />
+                <div
+                  v-for="(comment, index) in items"
+                  :key="getItemId(comment)"
+                  class="grid gap-3 md:grid-cols-[auto,minmax(0,1fr)] md:items-start"
+                >
+                  <div class="flex gap-2 md:flex-col">
+                    <button
+                      type="button"
+                      class="inline-flex items-center justify-center rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                      :disabled="index === 0 || reorderLoading"
+                      aria-label="Move comment up"
+                      @click="moveCollectionItem(comment, index - 1)"
+                    >
+                      Up
+                    </button>
+                    <button
+                      type="button"
+                      class="inline-flex items-center justify-center rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                      :disabled="index === items.length - 1 || reorderLoading"
+                      aria-label="Move comment down"
+                      @click="moveCollectionItem(comment, index + 1)"
+                    >
+                      Down
+                    </button>
+                  </div>
+                  <LibraryCommentCard
+                    :comment="comment"
+                    :author-info="getAuthorInfo(comment)"
+                    :context-type="getCommentContextType(comment)"
+                    :context-title="getCommentContextTitle(comment)"
+                    :context-permalink="getCommentContextPermalink(comment)"
+                    :permalink="getCommentPermalink(comment)"
+                    :show-favorite-button="true"
+                    :allow-add-to-list="true"
+                    :is-favorited="Boolean(comment.isFavorited)"
+                  />
+                </div>
               </div>
 
               <div
                 v-else-if="collection.collectionType === 'IMAGES'"
                 class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
               >
-                <ImageListItem
-                  v-for="image in items"
-                  :key="image.id"
-                  :image="image"
-                  :username="image.Uploader?.username || ''"
-                  :show-favorite-button="false"
-                  :allow-add-to-list="true"
-                />
+                <div
+                  v-for="(image, index) in items"
+                  :key="getItemId(image)"
+                  class="space-y-2"
+                >
+                  <div class="flex gap-2">
+                    <button
+                      type="button"
+                      class="rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                      :disabled="index === 0 || reorderLoading"
+                      :aria-label="`Move ${image.alt || 'image'} up`"
+                      @click="moveCollectionItem(image, index - 1)"
+                    >
+                      Up
+                    </button>
+                    <button
+                      type="button"
+                      class="rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                      :disabled="index === items.length - 1 || reorderLoading"
+                      :aria-label="`Move ${image.alt || 'image'} down`"
+                      @click="moveCollectionItem(image, index + 1)"
+                    >
+                      Down
+                    </button>
+                  </div>
+                  <ImageListItem
+                    :image="image"
+                    :username="image.Uploader?.username || ''"
+                    :show-favorite-button="false"
+                    :allow-add-to-list="true"
+                  />
+                </div>
               </div>
             </template>
           </div>

--- a/utils/collectionItemUtils.spec.ts
+++ b/utils/collectionItemUtils.spec.ts
@@ -3,6 +3,8 @@ import type { Discussion, Comment } from '@/__generated__/graphql';
 import {
   getCollectionTypeLabel,
   getCollectionItems,
+  getCollectionItemStableId,
+  orderCollectionItems,
   buildCollectionDiscussionLink,
   resolveCollectionItemAuthor,
 } from './collectionItemUtils';
@@ -28,6 +30,7 @@ describe('getCollectionItems', () => {
     expect(
       getCollectionItems({
         collectionType: 'COMMENTS',
+        itemOrder: ['c1'],
         Comments: [{ id: 'c1' }],
         Discussions: [{ id: 'd1' }],
       })
@@ -40,6 +43,38 @@ describe('getCollectionItems', () => {
 
   it('returns an empty array for an unknown type', () => {
     expect(getCollectionItems({ collectionType: 'WIDGETS' })).toEqual([]);
+  });
+
+  it('sorts collection items by itemOrder and appends missing items', () => {
+    expect(
+      getCollectionItems({
+        collectionType: 'DOWNLOADS',
+        itemOrder: ['d2', 'stale-id'],
+        Downloads: [{ id: 'd1' }, { id: 'd2' }, { id: 'd3' }],
+      }).map((item) => item.id)
+    ).toEqual(['d2', 'd1', 'd3']);
+  });
+});
+
+describe('collection item ordering helpers', () => {
+  it('uses uniqueName as the stable ID for channel items', () => {
+    expect(getCollectionItemStableId({ uniqueName: 'sims4_builds' })).toBe(
+      'sims4_builds'
+    );
+  });
+
+  it('returns the original array when no order is stored', () => {
+    const items = [{ id: 'a' }, { id: 'b' }];
+    expect(orderCollectionItems(items, [])).toBe(items);
+  });
+
+  it('drops stale stored IDs and preserves unordered items', () => {
+    expect(
+      orderCollectionItems(
+        [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+        ['c', 'missing', 'a']
+      ).map((item) => item.id)
+    ).toEqual(['c', 'a', 'b']);
   });
 });
 

--- a/utils/collectionItemUtils.ts
+++ b/utils/collectionItemUtils.ts
@@ -47,6 +47,7 @@ export interface CollectionLike {
   Images?: unknown[];
   Channels?: unknown[];
   Downloads?: unknown[];
+  itemOrder?: string[] | null;
 }
 
 /**
@@ -59,20 +60,56 @@ export function getCollectionItems(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any[] {
   if (!collection) return [];
+  let items: unknown[];
   switch (collection.collectionType) {
     case 'DISCUSSIONS':
-      return collection.Discussions || [];
+      items = collection.Discussions || [];
+      break;
     case 'COMMENTS':
-      return collection.Comments || [];
+      items = collection.Comments || [];
+      break;
     case 'IMAGES':
-      return collection.Images || [];
+      items = collection.Images || [];
+      break;
     case 'CHANNELS':
-      return collection.Channels || [];
+      items = collection.Channels || [];
+      break;
     case 'DOWNLOADS':
-      return collection.Downloads || [];
+      items = collection.Downloads || [];
+      break;
     default:
       return [];
   }
+
+  return orderCollectionItems(items, collection.itemOrder);
+}
+
+export function getCollectionItemStableId(item: unknown): string {
+  if (!item || typeof item !== 'object') return '';
+  const record = item as { id?: string | null; uniqueName?: string | null };
+  return record.id || record.uniqueName || '';
+}
+
+export function orderCollectionItems<T>(
+  items: T[],
+  itemOrder: string[] | null | undefined
+): T[] {
+  if (!itemOrder?.length) return items;
+
+  const itemById = new Map(
+    items
+      .map((item) => [getCollectionItemStableId(item), item] as const)
+      .filter(([id]) => Boolean(id))
+  );
+  const orderedItems = itemOrder
+    .map((id) => itemById.get(id))
+    .filter((item): item is T => Boolean(item));
+  const orderedIds = new Set(itemOrder);
+  const unorderedItems = items.filter(
+    (item) => !orderedIds.has(getCollectionItemStableId(item))
+  );
+
+  return [...orderedItems, ...unorderedItems];
 }
 
 /**


### PR DESCRIPTION
## Summary
- switch collection add/remove GraphQL documents to the custom collection mutations
- render collection detail items in itemOrder order with stale IDs ignored and missing items appended
- add keyboard-accessible move up/down controls backed by reorderCollectionItem
- update FEATURE_ROADMAP.md and remove drag-and-drop from the collection ordering scope

Depends on backend PR: https://github.com/gennit-project/multiforum-backend/pull/127

## Tests
- npx vitest run utils/collectionItemUtils.spec.ts 'pages/library/[collectionId].spec.ts'
- npx vitest run components/collection/AddToListPopover.spec.ts components/collection/PublicCollectionListItem.spec.ts
- npm run tsc
- pre-commit eslint/tsc hook