### PR TITLE
[codex] Add image save reuse UI

### DIFF
--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -121,16 +121,17 @@ Notes:
 
 - [x] Change album-image modeling so one image can belong to multiple albums without re-uploading. `[in backend PR]`
 - [x] Preserve uploader/original attribution on the image node anywhere it is reused by linking the same image node instead of creating a copy. `[in backend/frontend PRs]`
-- [ ] Define permissions for adding someone else's image to a collection or album.
+- [x] Define permissions for adding someone else's image to a collection or album: album owner may link active images into their own albums; existing collection ownership rules apply for image collections. `[in this slice]`
 - [x] Add image-detail query support for albums containing the image, grouped into original-poster-owned albums vs other users' albums. `[in backend PR]`
 - [x] Add tests for plural album membership during upload creation and grouped album results. `[in backend/frontend PRs]`
-- [ ] Add tests for permission enforcement and existing-image add/remove flows.
-- [ ] Update album add/remove flows to link existing images instead of requiring re-upload.
-- [ ] Let users save permitted images from someone else's album to their own library/collection.
+- [x] Add tests for permission enforcement and existing-image add/remove flows. `[in this slice]`
+- [x] Add backend album add/remove flows that link existing images instead of requiring re-upload. `[in this slice]`
+- [x] Let users save permitted images from image detail to their own album or image collection. `[in this slice]`
+- [ ] Add existing-image picker/search to album editor flows.
 - [x] On image detail pages, show grouped image usage by original poster vs others. `[in frontend PR]`
 
 Notes:
-- The remaining work in this section is the user-facing reuse flow: permissions, adding existing images to albums/collections, and tests around those actions.
+- The remaining work in this section is a fuller album-editor reuse flow, such as browsing/searching existing images while editing an album.
 
 ### 9. Permanent media deletion and storage cleanup `[partial]`
 

--- a/graphQLData/image/mutations.js
+++ b/graphQLData/image/mutations.js
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client/core';
+
+export const ADD_IMAGE_TO_ALBUM = gql`
+  mutation AddImageToAlbum($albumId: ID!, $imageId: ID!, $position: Int) {
+    addImageToAlbum(albumId: $albumId, imageId: $imageId, position: $position)
+  }
+`;
+
+export const REMOVE_IMAGE_FROM_ALBUM = gql`
+  mutation RemoveImageFromAlbum($albumId: ID!, $imageId: ID!) {
+    removeImageFromAlbum(albumId: $albumId, imageId: $imageId)
+  }
+`;

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -6,7 +6,9 @@ import { useRoute, useHead } from 'nuxt/app';
 import {
   GET_IMAGE_ALBUM_USAGE,
   GET_IMAGE_DETAILS,
+  GET_USER_ALBUMS,
 } from '@/graphQLData/image/queries';
+import { ADD_IMAGE_TO_ALBUM } from '@/graphQLData/image/mutations';
 import { UPDATE_IMAGE } from '@/graphQLData/discussion/mutations';
 import type { Image } from '@/__generated__/graphql';
 import { useCopyCurrentUrl } from '@/composables/useCopyCurrentUrl';
@@ -26,8 +28,11 @@ import CancelButton from '@/components/CancelButton.vue';
 import PencilIcon from '@/components/icons/PencilIcon.vue';
 import AlbumThumbnailGrid from '@/components/album/AlbumThumbnailGrid.vue';
 import { useImageZoomPan } from '@/composables/useImageZoomPan';
+import AddToListPopover from '@/components/collection/AddToListPopover.vue';
+import { useToastStore } from '@/stores/toastStore';
 
 const usernameVar = useUsername();
+const toastStore = useToastStore();
 
 type AlbumUsageDiscussion = {
   id: string;
@@ -75,6 +80,21 @@ type ImageAlbumUsageResult = {
   } | null;
 };
 
+type UserAlbumListItem = {
+  id: string;
+  imageOrder?: string[] | null;
+  Owner?: {
+    username?: string | null;
+    displayName?: string | null;
+  } | null;
+  ImagesAggregate?: {
+    count?: number | null;
+  } | null;
+  Discussions?: Array<{
+    title?: string | null;
+  }> | null;
+};
+
 // @ts-ignore - definePageMeta is auto-imported by Nuxt
 definePageMeta({
   ssr: false,
@@ -111,7 +131,8 @@ const {
   })
 );
 
-const { result: albumUsageResult } = useQuery<ImageAlbumUsageResult>(
+const { result: albumUsageResult, refetch: refetchAlbumUsage } =
+  useQuery<ImageAlbumUsageResult>(
   GET_IMAGE_ALBUM_USAGE,
   () => ({
     imageId: imageId.value,
@@ -121,6 +142,29 @@ const { result: albumUsageResult } = useQuery<ImageAlbumUsageResult>(
     fetchPolicy: 'network-only',
   })
 );
+
+const showAlbumSaveModal = ref(false);
+const showCollectionSaveModal = ref(false);
+const albumSaveError = ref('');
+
+const { mutate: addImageToAlbum, loading: addImageToAlbumLoading } =
+  useMutation(ADD_IMAGE_TO_ALBUM);
+
+const { result: userAlbumsResult, loading: userAlbumsLoading, refetch: refetchUserAlbums } =
+  useQuery(
+    GET_USER_ALBUMS,
+    () => ({
+      where: {
+        Owner: {
+          username: usernameVar.value,
+        },
+      },
+    }),
+    () => ({
+      enabled: showAlbumSaveModal.value && !!usernameVar.value,
+      fetchPolicy: 'network-only',
+    })
+  );
 
 const image = computed((): ImageWithAlbums | null => {
   if (imageError.value) return null;
@@ -216,6 +260,75 @@ const uploaderOwnedAlbums = computed(() => {
 const otherAlbums = computed(() => {
   return albumUsage.value?.otherAlbums || [];
 });
+
+const currentUserAlbumIdsContainingImage = computed(() => {
+  if (!usernameVar.value) return new Set<string>();
+
+  const allUsageAlbums = [
+    ...uploaderOwnedAlbums.value,
+    ...otherAlbums.value,
+  ];
+
+  return new Set(
+    allUsageAlbums
+      .filter((album) => album.Owner?.username === usernameVar.value)
+      .map((album) => album.id)
+  );
+});
+
+const userAlbums = computed<UserAlbumListItem[]>(() => {
+  return (userAlbumsResult.value?.albums || []) as UserAlbumListItem[];
+});
+
+const openAlbumSaveModal = () => {
+  albumSaveError.value = '';
+  showAlbumSaveModal.value = true;
+  refetchUserAlbums();
+};
+
+const closeAlbumSaveModal = () => {
+  showAlbumSaveModal.value = false;
+  albumSaveError.value = '';
+};
+
+const openCollectionSaveModal = () => {
+  showCollectionSaveModal.value = true;
+};
+
+const closeCollectionSaveModal = () => {
+  showCollectionSaveModal.value = false;
+};
+
+const getAlbumDisplayName = (album: UserAlbumListItem) => {
+  return album.Discussions?.[0]?.title || `Album ${album.id.slice(0, 8)}`;
+};
+
+const saveImageToAlbum = async (album: UserAlbumListItem) => {
+  if (!image.value?.id || !album.id) return;
+
+  if (currentUserAlbumIdsContainingImage.value.has(album.id)) {
+    albumSaveError.value = 'This image is already in that album.';
+    return;
+  }
+
+  albumSaveError.value = '';
+
+  try {
+    await addImageToAlbum({
+      albumId: album.id,
+      imageId: image.value.id,
+    });
+    toastStore.showToast('Image saved to album.');
+    await refetchAlbumUsage();
+    await refetchUserAlbums();
+    closeAlbumSaveModal();
+  } catch (error) {
+    console.error('Error saving image to album:', error);
+    albumSaveError.value =
+      error instanceof Error ? error.message : 'Could not save image to album.';
+    toastStore.showToast('Could not save image to album.', 'error');
+  }
+};
 
 const albumUsageSections = computed(() => {
   return [
@@ -430,6 +543,24 @@ onUnmounted(() => {
               :image-title="image.caption || image.alt || 'Image'"
               size="medium"
             />
+
+            <button
+              v-if="usernameVar"
+              type="button"
+              class="flex items-center gap-2 rounded border border-gray-300 bg-white px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              @click="openAlbumSaveModal"
+            >
+              Save to album
+            </button>
+
+            <button
+              v-if="usernameVar"
+              type="button"
+              class="flex items-center gap-2 rounded border border-gray-300 bg-white px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              @click="openCollectionSaveModal"
+            >
+              Save to collection
+            </button>
 
             <button
               type="button"
@@ -736,6 +867,107 @@ onUnmounted(() => {
           </div>
         </div>
       </div>
+
+      <div
+        v-if="showAlbumSaveModal"
+        class="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="save-to-album-title"
+      >
+        <div class="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl dark:bg-gray-900">
+          <div class="mb-4 flex items-start justify-between gap-4">
+            <div>
+              <h2
+                id="save-to-album-title"
+                class="text-xl font-semibold dark:text-white"
+              >
+                Save image to album
+              </h2>
+              <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                Add this image to one of your albums without re-uploading it.
+                The original uploader attribution stays with the image.
+              </p>
+            </div>
+            <button
+              type="button"
+              class="text-2xl leading-none text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
+              aria-label="Close save to album dialog"
+              @click="closeAlbumSaveModal"
+            >
+              ×
+            </button>
+          </div>
+
+          <p
+            v-if="albumSaveError"
+            class="mb-3 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300"
+          >
+            {{ albumSaveError }}
+          </p>
+
+          <div v-if="userAlbumsLoading" class="py-6 text-center text-gray-600 dark:text-gray-400">
+            Loading your albums...
+          </div>
+
+          <div
+            v-else-if="userAlbums.length === 0"
+            class="rounded border border-dashed border-gray-300 p-6 text-center dark:border-gray-700"
+          >
+            <p class="text-gray-700 dark:text-gray-300">
+              You do not have any albums yet.
+            </p>
+            <NuxtLink
+              :to="`/u/${usernameVar}/albums`"
+              class="mt-3 inline-block text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              @click="closeAlbumSaveModal"
+            >
+              Go to your albums
+            </NuxtLink>
+          </div>
+
+          <div v-else class="max-h-96 space-y-2 overflow-y-auto">
+            <button
+              v-for="album in userAlbums"
+              :key="album.id"
+              type="button"
+              class="flex w-full items-center justify-between gap-3 rounded border border-gray-200 p-3 text-left transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:hover:bg-gray-800"
+              :disabled="
+                addImageToAlbumLoading ||
+                currentUserAlbumIdsContainingImage.has(album.id)
+              "
+              @click="saveImageToAlbum(album)"
+            >
+              <span>
+                <span class="block font-medium text-gray-900 dark:text-gray-100">
+                  {{ getAlbumDisplayName(album) }}
+                </span>
+                <span class="block text-sm text-gray-600 dark:text-gray-400">
+                  {{ album.ImagesAggregate?.count || 0 }} images
+                </span>
+              </span>
+              <span
+                v-if="currentUserAlbumIdsContainingImage.has(album.id)"
+                class="text-sm text-gray-500 dark:text-gray-400"
+              >
+                Already saved
+              </span>
+              <span v-else class="text-sm text-blue-600 dark:text-blue-400">
+                Save
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <AddToListPopover
+        v-if="showCollectionSaveModal && imageId"
+        :item-id="imageId"
+        item-type="image"
+        :is-visible="showCollectionSaveModal"
+        variant="modal"
+        @close="closeCollectionSaveModal"
+      />
 
       <!-- Custom lightbox -->
       <div

--- a/tests/playwright/mocked/user/imageDetail.spec.ts
+++ b/tests/playwright/mocked/user/imageDetail.spec.ts
@@ -70,6 +70,9 @@ const getBaseMocks = (username: string) => ({
   GetUserFavoriteChannels: () => ({
     data: { users: [{ username, FavoriteChannels: [] }] },
   }),
+  getUserFavoriteImage: () => ({
+    data: { users: [{ username, FavoriteImages: [] }] },
+  }),
   GetUserChannelCollectionsWithChannels: () => ({
     data: { users: [{ username, Collections: [] }] },
   }),
@@ -79,6 +82,21 @@ const getBaseMocks = (username: string) => ({
   GetImageDetails: () => ({ data: { images: [buildImage()] } }),
   GetImageAlbumUsage: () => ({
     data: { getImageAlbumUsage: buildImageAlbumUsage() },
+  }),
+  GetUserAlbums: () => ({ data: { albums: [] } }),
+  GetUserCollectionsImages: () => ({
+    data: {
+      users: [
+        {
+          username,
+          Collections: [],
+          FavoriteImages: [],
+        },
+      ],
+    },
+  }),
+  CheckImageInCollections: () => ({
+    data: { users: [{ username, Collections: [] }] },
   }),
 });
 
@@ -170,6 +188,7 @@ test.describe('User image detail', () => {
 
     const uploaderAlbum = buildAlbum({
       id: 'album-uploader',
+      imageOrder: ['image-2'],
       Images: [
         {
           id: 'image-2',
@@ -243,6 +262,130 @@ test.describe('User image detail', () => {
       await expect(page.getByText('Bob remixed this album')).toBeVisible();
       await expect(page.getByText('Other images in this album:')).toBeVisible();
       await expect(page.getByAltText('Another scenic photo')).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('saves another user image to the logged-in user album', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    let wasSaved = false;
+    const bobImage = buildImage({
+      Uploader: {
+        username: 'bob',
+        displayName: 'Bob',
+        profilePicURL: '',
+      },
+    });
+    const aliceAlbum = buildAlbum({
+      id: 'album-alice',
+      imageOrder: [],
+      Discussions: [
+        {
+          id: 'discussion-alice-album',
+          title: 'Alice inspiration board',
+          createdAt: '2024-01-04T00:00:00.000Z',
+          Author: { username: TEST_USER, displayName: 'Alice' },
+          DiscussionChannels: [
+            { id: 'channel-1', channelUniqueName: 'sims4_builds' },
+          ],
+        },
+      ],
+      ImagesAggregate: { count: 2 },
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      GetImageDetails: () => ({ data: { images: [bobImage] } }),
+      GetUserAlbums: () => ({
+        data: { albums: [aliceAlbum] },
+      }),
+      AddImageToAlbum: ({ body }) => {
+        expect(body.variables).toEqual({
+          albumId: 'album-alice',
+          imageId: IMAGE_ID,
+        });
+        wasSaved = true;
+        return { data: { addImageToAlbum: true } };
+      },
+      GetImageAlbumUsage: () => ({
+        data: {
+          getImageAlbumUsage: buildImageAlbumUsage(
+            wasSaved
+              ? {
+                  uploaderUsername: 'bob',
+                  uploaderOwnedAlbums: [],
+                  otherAlbums: [aliceAlbum],
+                }
+              : {
+                  uploaderUsername: 'bob',
+                  uploaderOwnedAlbums: [],
+                  otherAlbums: [],
+                }
+          ),
+        },
+      }),
+    });
+
+    try {
+      await page.goto('/u/bob/images/image-1');
+
+      await page.getByRole('button', { name: 'Save to album' }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Save image to album' })
+      ).toBeVisible();
+      await page.getByRole('button', { name: /Alice inspiration board/ }).click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'AddImageToAlbum'
+      );
+      await expect(page.getByText('Albums by other users')).toBeVisible();
+      await expect(page.getByText('Alice inspiration board')).toBeVisible();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('opens the existing image collection save modal', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const diagnostics = await installGraphqlMocks(page, getBaseMocks(TEST_USER));
+
+    try {
+      await page.goto(`/u/${TEST_USER}/images/${IMAGE_ID}`);
+
+      await page.getByRole('button', { name: 'Save to collection' }).click();
+      await expect(
+        page.getByRole('dialog', { name: 'Add to List' })
+      ).toBeVisible();
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'GetUserCollectionsImages'
+      );
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'CheckImageInCollections'
+      );
     } finally {
       await testInfo.attach('graphql-operations.json', {
         body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),


### PR DESCRIPTION
## Summary

- Add image-detail actions to save an existing image to one of the logged-in user's albums or image collections.
- Use the new backend album reuse mutation to link the same image node into an album, preserving original attribution.
- Disable albums that already contain the image and refetch album usage after a successful save.
- Reuse the existing `AddToListPopover` image collection flow for collection saves.
- Update `docs/FEATURE_ROADMAP.md` for the completed reuse slice and remaining album-editor picker work.

## Stack

- Stacked on frontend PR #289 / `codex/multi-album-image-usage-frontend`.
- Depends on backend PR #136 for `addImageToAlbum`.

## Verification

- `pnpm run tsc`
- `PLAYWRIGHT_FRONTEND_PORT=3107 PLAYWRIGHT_BACKEND_PORT=4107 pnpm exec playwright test tests/playwright/mocked/user/imageDetail.spec.ts`