### PR TITLE
Cut test fixture casts via DeepPartial factories

### DIFF
--- a/components/channel/DownloadSidebar.spec.ts
+++ b/components/channel/DownloadSidebar.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { defineComponent, nextTick, ref } from 'vue';
 import DownloadSidebar from '@/components/channel/DownloadSidebar.vue';
-import type { Discussion } from '@/__generated__/graphql';
+import { makeDiscussion } from '@/tests/utils/factories';
 
 const authState = ref(false);
 const trackDownloadMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
@@ -58,7 +58,7 @@ vi.mock('@/components/download/DownloadSuccessPopover.vue', () => ({
   }),
 }));
 
-const discussionWithFile = {
+const discussionWithFile = makeDiscussion({
   id: 'discussion-1',
   title: 'Test Download',
   Author: {
@@ -82,7 +82,7 @@ const discussionWithFile = {
       },
     },
   ],
-} as Partial<Discussion>;
+});
 
 describe('DownloadSidebar', () => {
   beforeEach(() => {
@@ -101,7 +101,7 @@ describe('DownloadSidebar', () => {
 
     const wrapper = mount(DownloadSidebar, {
       props: {
-        discussion: discussionWithFile as Discussion,
+        discussion: discussionWithFile,
         discussionId: 'discussion-1',
         channelUniqueName: 'test-forum',
       },
@@ -124,7 +124,7 @@ describe('DownloadSidebar', () => {
 
     const wrapper = mount(DownloadSidebar, {
       props: {
-        discussion: discussionWithFile as Discussion,
+        discussion: discussionWithFile,
         discussionId: 'discussion-1',
         channelUniqueName: 'test-forum',
       },
@@ -144,7 +144,7 @@ describe('DownloadSidebar', () => {
   it('shows total and unique download counts', () => {
     const wrapper = mount(DownloadSidebar, {
       props: {
-        discussion: discussionWithFile as Discussion,
+        discussion: discussionWithFile,
         discussionId: 'discussion-1',
         channelUniqueName: 'test-forum',
       },
@@ -162,7 +162,7 @@ describe('DownloadSidebar', () => {
         discussion: {
           ...discussionWithFile,
           DownloadableFiles: [],
-        } as Discussion,
+        },
         discussionId: 'discussion-1',
         channelUniqueName: 'test-forum',
       },

--- a/components/discussion/list/SitewideDiscussionListItem.spec.ts
+++ b/components/discussion/list/SitewideDiscussionListItem.spec.ts
@@ -4,7 +4,7 @@ import { asMock, createQueryMock } from '@/tests/utils/mockApollo';
 import { createMockRoute } from '@/tests/utils/mockRouter';
 import { createAuthStateMock } from '@/tests/utils/mockAuth';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
-import { makeDiscussion } from '@/tests/utils/factories';
+import { makeDiscussion, type DeepPartial } from '@/tests/utils/factories';
 import type {
   Discussion,
   DiscussionChannel,
@@ -36,12 +36,12 @@ const mountItem = (discussion: Discussion) => {
   });
 };
 
-const discussion = (overrides: Record<string, unknown> = {}): Discussion =>
+const discussion = (overrides: DeepPartial<Discussion> = {}): Discussion =>
   makeDiscussion({
     Author: { username: 'alice' },
     DiscussionChannels: [],
     ...overrides,
-  } as Partial<Discussion>);
+  });
 
 const channel = (
   uniqueName: string,

--- a/components/download/DownloadSuccessPopover.spec.ts
+++ b/components/download/DownloadSuccessPopover.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import DownloadSuccessPopover from '@/components/download/DownloadSuccessPopover.vue';
-import type { Discussion } from '@/__generated__/graphql';
+import { makeDiscussion } from '@/tests/utils/factories';
 
-const baseDiscussion = {
+const baseDiscussion = makeDiscussion({
   id: 'discussion-1',
   title: 'Useful Download',
   Author: {
@@ -21,7 +21,7 @@ const baseDiscussion = {
       supportPayPalMeUrl: '',
     },
   ],
-} as Partial<Discussion>;
+});
 
 const mountPopover = (discussion: unknown = baseDiscussion) =>
   mount(DownloadSuccessPopover, {
@@ -45,7 +45,7 @@ describe('DownloadSuccessPopover', () => {
   it('does not render the support section when no support links are configured', () => {
     const wrapper = mount(DownloadSuccessPopover, {
       props: {
-        discussion: baseDiscussion as Discussion,
+        discussion: baseDiscussion,
         visible: true,
       },
     });
@@ -56,17 +56,17 @@ describe('DownloadSuccessPopover', () => {
   it('renders custom attribution and configured support links', () => {
     const wrapper = mount(DownloadSuccessPopover, {
       props: {
-        discussion: {
+        discussion: makeDiscussion({
           ...baseDiscussion,
           DownloadableFiles: [
             {
-              ...baseDiscussion.DownloadableFiles[0],
+              ...baseDiscussion.DownloadableFiles?.[0],
               attributionOverride: 'Please credit Alice Studio.',
               supportPatreonUrl: 'https://patreon.com/alice',
               supportKoFiUrl: 'https://ko-fi.com/alice',
             },
           ],
-        } as Discussion,
+        }),
         visible: true,
       },
     });

--- a/composables/useIssueBodyEdit.spec.ts
+++ b/composables/useIssueBodyEdit.spec.ts
@@ -2,9 +2,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { nextTick, ref } from 'vue';
 import { useMutation } from '@vue/apollo-composable';
 import type { Issue } from '@/__generated__/graphql';
+import { makeIssue } from '@/tests/utils/factories';
 import { useIssueBodyEdit } from './useIssueBodyEdit';
-
-type ActiveIssueRef = Parameters<typeof useIssueBodyEdit>[0]['activeIssue'];
 
 vi.mock('@vue/apollo-composable', () => ({
   useMutation: vi.fn(),
@@ -28,7 +27,9 @@ describe('useIssueBodyEdit', () => {
 
   it('initializes edited body from the active issue', () => {
     const bodyEdit = useIssueBodyEdit({
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(
+        makeIssue({ id: 'issue-1', issueNumber: 1, body: 'Original' })
+      ),
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
@@ -41,7 +42,9 @@ describe('useIssueBodyEdit', () => {
 
   it('enters edit mode only for an unlocked issue author', () => {
     const bodyEdit = useIssueBodyEdit({
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(
+        makeIssue({ id: 'issue-1', issueNumber: 1, body: 'Original' })
+      ),
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
@@ -56,7 +59,9 @@ describe('useIssueBodyEdit', () => {
 
   it('does not enter edit mode when the issue is locked', () => {
     const bodyEdit = useIssueBodyEdit({
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(
+        makeIssue({ id: 'issue-1', issueNumber: 1, body: 'Original' })
+      ),
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(true),
@@ -70,9 +75,11 @@ describe('useIssueBodyEdit', () => {
   });
 
   it('tracks body changes reactively', async () => {
-    const activeIssue = ref<Issue | null>({ id: 'issue-1', issueNumber: 1, body: 'Original' } as Issue);
+    const activeIssue = ref<Issue | null>(
+      makeIssue({ id: 'issue-1', issueNumber: 1, body: 'Original' })
+    );
     const bodyEdit = useIssueBodyEdit({
-      activeIssue: activeIssue as ActiveIssueRef,
+      activeIssue,
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
@@ -80,7 +87,7 @@ describe('useIssueBodyEdit', () => {
       refetchIssue,
     });
 
-    activeIssue.value = { id: 'issue-1', issueNumber: 1, body: 'Updated' } as Issue;
+    activeIssue.value = makeIssue({ id: 'issue-1', issueNumber: 1, body: 'Updated' });
     await nextTick();
 
     expect(bodyEdit.editedIssueBody.value).toBe('Updated');
@@ -88,7 +95,9 @@ describe('useIssueBodyEdit', () => {
 
   it('saves changed issue body and exits edit mode', async () => {
     const bodyEdit = useIssueBodyEdit({
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(
+        makeIssue({ id: 'issue-1', issueNumber: 1, body: 'Original' })
+      ),
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
@@ -113,7 +122,9 @@ describe('useIssueBodyEdit', () => {
 
   it('does not enter edit mode when the moderator is suspended', () => {
     const bodyEdit = useIssueBodyEdit({
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(
+        makeIssue({ id: 'issue-1', issueNumber: 1, body: 'Original' })
+      ),
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
@@ -128,7 +139,9 @@ describe('useIssueBodyEdit', () => {
 
   it('does not save the issue body when the moderator is suspended', async () => {
     const bodyEdit = useIssueBodyEdit({
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(
+        makeIssue({ id: 'issue-1', issueNumber: 1, body: 'Original' })
+      ),
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),
@@ -144,7 +157,9 @@ describe('useIssueBodyEdit', () => {
 
   it('exits edit mode without saving when the body is unchanged', async () => {
     const bodyEdit = useIssueBodyEdit({
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1, body: 'Original' } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(
+        makeIssue({ id: 'issue-1', issueNumber: 1, body: 'Original' })
+      ),
       activeIssueId: ref('issue-1'),
       isIssueAuthor: ref(true),
       isLocked: ref(false),

--- a/composables/useIssueCloseReopen.spec.ts
+++ b/composables/useIssueCloseReopen.spec.ts
@@ -2,9 +2,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
 import { useMutation } from '@vue/apollo-composable';
 import type { Issue } from '@/__generated__/graphql';
+import { makeIssue } from '@/tests/utils/factories';
 import { useIssueCloseReopen } from './useIssueCloseReopen';
-
-type ActiveIssueRef = Parameters<typeof useIssueCloseReopen>[0]['activeIssue'];
 
 vi.mock('@vue/apollo-composable', () => ({
   useMutation: vi.fn(),
@@ -30,7 +29,7 @@ describe('useIssueCloseReopen', () => {
   it('returns close and reopen mutation handlers', () => {
     const issueActions = useIssueCloseReopen({
       activeIssueId: ref('issue-1'),
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1 } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(makeIssue({ id: 'issue-1', issueNumber: 1 })),
       channelId: ref('general'),
     });
 
@@ -47,10 +46,14 @@ describe('useIssueCloseReopen', () => {
   });
 
   it('close updater moves the issue from open to closed cache data', () => {
-    const activeIssue = { id: 'issue-1', issueNumber: 1, body: 'Issue body' };
+    const activeIssue = makeIssue({
+      id: 'issue-1',
+      issueNumber: 1,
+      body: 'Issue body',
+    });
     useIssueCloseReopen({
       activeIssueId: ref('issue-1'),
-      activeIssue: ref(activeIssue as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(activeIssue),
       channelId: ref('general'),
     });
     const closeOptionsFactory = (useMutation as unknown as ReturnType<typeof vi.fn>)
@@ -111,10 +114,14 @@ describe('useIssueCloseReopen', () => {
   });
 
   it('reopen updater moves the issue from closed to open cache data', () => {
-    const activeIssue = { id: 'issue-1', issueNumber: 1, body: 'Issue body' };
+    const activeIssue = makeIssue({
+      id: 'issue-1',
+      issueNumber: 1,
+      body: 'Issue body',
+    });
     useIssueCloseReopen({
       activeIssueId: ref('issue-1'),
-      activeIssue: ref(activeIssue as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(activeIssue),
       channelId: ref('general'),
     });
     const reopenOptionsFactory = (useMutation as unknown as ReturnType<typeof vi.fn>)

--- a/composables/useIssueLock.spec.ts
+++ b/composables/useIssueLock.spec.ts
@@ -2,9 +2,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
 import { useMutation } from '@vue/apollo-composable';
 import type { Issue } from '@/__generated__/graphql';
+import { makeIssue } from '@/tests/utils/factories';
 import { useIssueLock } from './useIssueLock';
-
-type ActiveIssueRef = Parameters<typeof useIssueLock>[0]['activeIssue'];
 
 vi.mock('@vue/apollo-composable', () => ({
   useMutation: vi.fn(),
@@ -37,7 +36,7 @@ describe('useIssueLock', () => {
   it('opens and closes the lock dialog while clearing the reason', () => {
     const issueLock = useIssueLock({
       activeIssueId: ref('issue-1'),
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1 } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(makeIssue({ id: 'issue-1', issueNumber: 1 })),
       isSuspendedMod: ref(false),
       refetchIssue,
     });
@@ -59,7 +58,7 @@ describe('useIssueLock', () => {
   it('locks an active issue and refetches it', async () => {
     const issueLock = useIssueLock({
       activeIssueId: ref('issue-1'),
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1 } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(makeIssue({ id: 'issue-1', issueNumber: 1 })),
       isSuspendedMod: ref(false),
       refetchIssue,
     });
@@ -84,7 +83,7 @@ describe('useIssueLock', () => {
   it('does not lock when the mod is suspended', async () => {
     const issueLock = useIssueLock({
       activeIssueId: ref('issue-1'),
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1 } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(makeIssue({ id: 'issue-1', issueNumber: 1 })),
       isSuspendedMod: ref(true),
       refetchIssue,
     });
@@ -98,7 +97,7 @@ describe('useIssueLock', () => {
   it('unlocks an active issue and refetches it', async () => {
     const issueLock = useIssueLock({
       activeIssueId: ref('issue-1'),
-      activeIssue: ref({ id: 'issue-1', issueNumber: 1 } as Issue) as ActiveIssueRef,
+      activeIssue: ref<Issue | null>(makeIssue({ id: 'issue-1', issueNumber: 1 })),
       isSuspendedMod: ref(false),
       refetchIssue,
     });

--- a/tests/unit/composables/useAlbumAutoSave.spec.ts
+++ b/tests/unit/composables/useAlbumAutoSave.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAlbumAutoSave } from '@/composables/useAlbumAutoSave';
-import type { Album } from '@/__generated__/graphql';
+import { makeAlbum } from '@/tests/utils/factories';
 
 const mockMutate = vi.fn();
 
@@ -94,13 +94,13 @@ describe('useAlbumAutoSave', () => {
     });
 
     it('builds connect array for new images added to existing album', async () => {
-      const existingAlbum = {
+      const existingAlbum = makeAlbum({
         id: 'album-1',
         Images: [
           { id: 'img-1', url: 'http://example.com/1.jpg', alt: 'existing', caption: '', copyright: '' },
         ],
         imageOrder: ['img-1'],
-      } as Partial<Album> as Album;
+      });
 
       const getAlbumData = () => ({
         images: [
@@ -138,14 +138,14 @@ describe('useAlbumAutoSave', () => {
     });
 
     it('builds disconnect array for removed images', async () => {
-      const existingAlbum = {
+      const existingAlbum = makeAlbum({
         id: 'album-1',
         Images: [
           { id: 'img-1', url: 'http://example.com/1.jpg', alt: 'first', caption: '', copyright: '' },
           { id: 'img-2', url: 'http://example.com/2.jpg', alt: 'second', caption: '', copyright: '' },
         ],
         imageOrder: ['img-1', 'img-2'],
-      } as Partial<Album> as Album;
+      });
 
       const getAlbumData = () => ({
         images: [
@@ -182,13 +182,13 @@ describe('useAlbumAutoSave', () => {
     });
 
     it('builds update array when image properties change', async () => {
-      const existingAlbum = {
+      const existingAlbum = makeAlbum({
         id: 'album-1',
         Images: [
           { id: 'img-1', url: 'http://example.com/1.jpg', alt: 'old alt', caption: 'old caption', copyright: '' },
         ],
         imageOrder: ['img-1'],
-      } as Partial<Album> as Album;
+      });
 
       const getAlbumData = () => ({
         images: [
@@ -233,13 +233,13 @@ describe('useAlbumAutoSave', () => {
     });
 
     it('does not include update operation when image properties unchanged', async () => {
-      const existingAlbum = {
+      const existingAlbum = makeAlbum({
         id: 'album-1',
         Images: [
           { id: 'img-1', url: 'http://example.com/1.jpg', alt: 'same', caption: '', copyright: '' },
         ],
         imageOrder: ['img-1'],
-      } as Partial<Album> as Album;
+      });
 
       const getAlbumData = () => ({
         images: [
@@ -284,11 +284,11 @@ describe('useAlbumAutoSave', () => {
 
       const { performAutoSave, isAutoSaving } = useAlbumAutoSave({
         discussionId: 'disc-1',
-        existingAlbum: {
+        existingAlbum: makeAlbum({
           id: 'album-1',
           Images: [],
           imageOrder: [],
-        } as Partial<Album> as Album,
+        }),
         getAlbumData: () => ({
           images: [{ id: 'img-1', url: 'test.jpg', alt: '', caption: '', copyright: '' }],
           imageOrder: ['img-1'],
@@ -309,11 +309,11 @@ describe('useAlbumAutoSave', () => {
 
       const { performAutoSave, autoSaveSuccess } = useAlbumAutoSave({
         discussionId: 'disc-1',
-        existingAlbum: {
+        existingAlbum: makeAlbum({
           id: 'album-1',
           Images: [],
           imageOrder: [],
-        } as Partial<Album> as Album,
+        }),
         getAlbumData: () => ({
           images: [{ id: 'img-1', url: 'test.jpg', alt: '', caption: '', copyright: '' }],
           imageOrder: ['img-1'],

--- a/tests/unit/utils/channelUtils.spec.ts
+++ b/tests/unit/utils/channelUtils.spec.ts
@@ -7,11 +7,8 @@ import {
   isDiscussionDetailPage,
   isDownloadDetailPage,
 } from '@/utils/channelUtils';
-import type {
-  Channel,
-  User,
-  ModerationProfile,
-} from '@/__generated__/graphql';
+import type { Channel } from '@/__generated__/graphql';
+import type { DeepPartial } from '@/tests/utils/factories';
 
 describe('channelUtils', () => {
   describe('getBotInvokeHandle', () => {
@@ -73,7 +70,7 @@ describe('channelUtils', () => {
   });
 
   describe('generateChannelTabs', () => {
-    function createMockChannel(overrides: Partial<Channel> = {}): Channel {
+    function createMockChannel(overrides: DeepPartial<Channel> = {}): Channel {
       return {
         uniqueName: 'test-channel',
         displayName: 'Test Channel',
@@ -168,7 +165,7 @@ describe('channelUtils', () => {
 
     it('includes settings tab for admin users', () => {
       const channel = createMockChannel({
-        Admins: [{ username: 'adminuser' }] as unknown as User[],
+        Admins: [{ username: 'adminuser' }],
       });
       const tabs = generateChannelTabs({
         channel,
@@ -183,7 +180,7 @@ describe('channelUtils', () => {
 
     it('excludes settings tab for non-admin users', () => {
       const channel = createMockChannel({
-        Admins: [{ username: 'adminuser' }] as unknown as User[],
+        Admins: [{ username: 'adminuser' }],
       });
       const tabs = generateChannelTabs({
         channel,
@@ -198,7 +195,7 @@ describe('channelUtils', () => {
 
     it('includes moderation tab for admin users', () => {
       const channel = createMockChannel({
-        Admins: [{ username: 'adminuser' }] as unknown as User[],
+        Admins: [{ username: 'adminuser' }],
       });
       const tabs = generateChannelTabs({
         channel,
@@ -216,7 +213,7 @@ describe('channelUtils', () => {
         Admins: [],
         Moderators: [
           { displayName: 'ModProfile1' },
-        ] as unknown as ModerationProfile[],
+        ],
       });
       const tabs = generateChannelTabs({
         channel,
@@ -231,8 +228,8 @@ describe('channelUtils', () => {
 
     it('excludes moderation tab for regular users', () => {
       const channel = createMockChannel({
-        Admins: [{ username: 'admin' }] as unknown as User[],
-        Moderators: [{ displayName: 'SomeMod' }] as unknown as ModerationProfile[],
+        Admins: [{ username: 'admin' }],
+        Moderators: [{ displayName: 'SomeMod' }],
       });
       const tabs = generateChannelTabs({
         channel,

--- a/tests/utils/factories.ts
+++ b/tests/utils/factories.ts
@@ -1,8 +1,13 @@
 import type {
+  Album,
   Channel,
   Comment,
   Discussion,
+  DiscussionChannel,
   Event,
+  EventChannel,
+  Issue,
+  ModerationProfile,
   User,
 } from '@/__generated__/graphql';
 
@@ -15,14 +20,32 @@ import type {
  * and cast to the full type — matching how specs already hand-roll fixtures,
  * but without the repetition.
  *
+ * Overrides are `DeepPartial`, so nested relations can be supplied partially
+ * (e.g. `Author: { username: 'alice' }`) without any per-call `as` cast — the
+ * single unavoidable cast onto the strict generated type lives here, once per
+ * factory, instead of being scattered across every spec.
+ *
  *   const channel = makeChannel({ uniqueName: 'cats' });
  *   const events = [makeEvent({ id: '1' }), makeEvent({ id: '2' })];
+ *   const issue = makeIssue({ issueNumber: 7, Channel: { uniqueName: 'cats' } });
  */
+
+/**
+ * Recursively-optional version of a type. Unlike the built-in `Partial<T>`
+ * (which only makes the top level optional while keeping each value's full
+ * required shape), this lets fixtures supply nested relation objects partially.
+ * Keys are still checked, so typos in override field names remain errors.
+ */
+export type DeepPartial<T> = T extends (infer U)[]
+  ? DeepPartial<U>[]
+  : T extends object
+    ? { [K in keyof T]?: DeepPartial<T[K]> }
+    : T;
 
 /** Stable timestamp so snapshots/assertions are deterministic. */
 export const MOCK_DATE = '2024-01-01T00:00:00.000Z';
 
-export function makeUser(overrides: Partial<User> = {}): User {
+export function makeUser(overrides: DeepPartial<User> = {}): User {
   return {
     __typename: 'User',
     username: 'testuser',
@@ -35,7 +58,7 @@ export function makeUser(overrides: Partial<User> = {}): User {
   } as User;
 }
 
-export function makeChannel(overrides: Partial<Channel> = {}): Channel {
+export function makeChannel(overrides: DeepPartial<Channel> = {}): Channel {
   return {
     __typename: 'Channel',
     uniqueName: 'test-forum',
@@ -54,7 +77,7 @@ export function makeChannel(overrides: Partial<Channel> = {}): Channel {
 }
 
 export function makeDiscussion(
-  overrides: Partial<Discussion> = {}
+  overrides: DeepPartial<Discussion> = {}
 ): Discussion {
   return {
     __typename: 'Discussion',
@@ -73,7 +96,7 @@ export function makeDiscussion(
   } as Discussion;
 }
 
-export function makeEvent(overrides: Partial<Event> = {}): Event {
+export function makeEvent(overrides: DeepPartial<Event> = {}): Event {
   return {
     __typename: 'Event',
     id: 'test-event-1',
@@ -94,7 +117,7 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
   } as Event;
 }
 
-export function makeComment(overrides: Partial<Comment> = {}): Comment {
+export function makeComment(overrides: DeepPartial<Comment> = {}): Comment {
   return {
     __typename: 'Comment',
     id: 'test-comment-1',
@@ -106,4 +129,67 @@ export function makeComment(overrides: Partial<Comment> = {}): Comment {
     deleted: false,
     ...overrides,
   } as Comment;
+}
+
+export function makeAlbum(overrides: DeepPartial<Album> = {}): Album {
+  return {
+    __typename: 'Album',
+    id: 'test-album-1',
+    imageOrder: [],
+    Images: [],
+    ...overrides,
+  } as Album;
+}
+
+export function makeIssue(overrides: DeepPartial<Issue> = {}): Issue {
+  return {
+    __typename: 'Issue',
+    id: 'test-issue-1',
+    issueNumber: 1,
+    title: 'Test Issue',
+    body: 'Issue body',
+    isOpen: true,
+    locked: false,
+    createdAt: MOCK_DATE,
+    ...overrides,
+  } as Issue;
+}
+
+export function makeModerationProfile(
+  overrides: DeepPartial<ModerationProfile> = {}
+): ModerationProfile {
+  return {
+    __typename: 'ModerationProfile',
+    displayName: 'TestMod',
+    createdAt: MOCK_DATE,
+    ...overrides,
+  } as ModerationProfile;
+}
+
+export function makeEventChannel(
+  overrides: DeepPartial<EventChannel> = {}
+): EventChannel {
+  return {
+    __typename: 'EventChannel',
+    id: 'test-event-channel-1',
+    eventId: 'test-event-1',
+    channelUniqueName: 'test-forum',
+    archived: false,
+    createdAt: MOCK_DATE,
+    ...overrides,
+  } as EventChannel;
+}
+
+export function makeDiscussionChannel(
+  overrides: DeepPartial<DiscussionChannel> = {}
+): DiscussionChannel {
+  return {
+    __typename: 'DiscussionChannel',
+    id: 'test-discussion-channel-1',
+    discussionId: 'test-discussion-1',
+    channelUniqueName: 'test-forum',
+    archived: false,
+    createdAt: MOCK_DATE,
+    ...overrides,
+  } as DiscussionChannel;
 }


### PR DESCRIPTION
## Summary

Follow-up to #291 (merged). That PR typed the test suite's GraphQL I/O with generated types; this one **concentrates the fixture casts** those changes left behind into the shared typed factories, so specs stop scattering `as` casts.

A cast can't be fully removed — a partial mock always needs one to become a strict generated type — but it should be **owned once in a factory**, not repeated at every call site.

## Changes (9 files)

- Added a `DeepPartial<T>` override type to `tests/utils/factories.ts` and widened every factory's override param to it. Fixtures can now supply nested relations partially (e.g. `Author: { username: 'alice' }`) with **no per-call cast**; the single `as T` lives inside the factory.
- New factories: `makeAlbum`, `makeIssue`, `makeModerationProfile`, `makeEventChannel`, `makeDiscussionChannel`.
- Routed the Issue composable specs, `useAlbumAutoSave`, `DownloadSidebar`, `DownloadSuccessPopover`, `channelUtils`, and `SitewideDiscussionListItem` through the factories.
- Removed the double-casts (`as Partial<X> as X`, `as unknown as User[]`), per-prop `as Discussion`/`as Issue`, and the `ActiveIssueRef` alias workaround. **Entity casts in these files: 45 → 7** — the remaining 7 are Vitest mock plumbing (`useMutation as unknown as ReturnType<typeof vi.fn>`) and one factory-internal `as unknown as Channel`.

Because the factories now type-check their overrides (vs. the old blind `as` assertions), this also validates previously-unchecked nested mock shapes. One `useIssueCloseReopen` cache test had been relying on object-reference identity between the composable input and the cache mock; it now uses a shared `makeIssue` fixture so the data flow is explicit.

## Verification

- `vue-tsc --noEmit` (full project): **0 errors**
- Unit tests: all touched specs + every other factory consumer passing
- ESLint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)