### PR TITLE
[codex] Add album existing image picker

### DIFF
--- a/components/discussion/detail/AlbumEditForm.vue
+++ b/components/discussion/detail/AlbumEditForm.vue
@@ -28,6 +28,10 @@ type AlbumFormImage = {
   hasSensitiveContent: boolean;
   hasSpoiler: boolean;
   copyright: string;
+  Uploader?: {
+    username?: string | null;
+    displayName?: string | null;
+  } | null;
 };
 
 // Define types for form data

--- a/components/discussion/form/AlbumEditor.spec.ts
+++ b/components/discussion/form/AlbumEditor.spec.ts
@@ -47,7 +47,7 @@ vi.mock('@/composables/useAlbumAutoSave', () => ({
 
 const AlbumImageItemStub = {
   name: 'AlbumImageItem',
-  props: ['image', 'index', 'isFirst', 'isLast'],
+  props: ['image', 'index', 'isFirst', 'isLast', 'canPermanentlyDelete'],
   emits: ['update-field', 'delete', 'move-up', 'move-down'],
   template: '<div class="image-item-stub" />',
 };
@@ -68,6 +68,13 @@ const AlbumUrlInputFormStub = {
   template: '<div class="url-input-stub" />',
 };
 
+const AlbumExistingImagePickerStub = {
+  name: 'AlbumExistingImagePicker',
+  props: ['selectedImageIds', 'isLimitReached'],
+  emits: ['add-image'],
+  template: '<div class="existing-image-picker-stub" />',
+};
+
 const WarningModalStub = {
   name: 'WarningModal',
   props: ['open', 'title', 'body', 'loading', 'error'],
@@ -79,6 +86,7 @@ const stubs = {
   AlbumImageItem: AlbumImageItemStub,
   AlbumDropZone: AlbumDropZoneStub,
   AlbumUrlInputForm: AlbumUrlInputFormStub,
+  AlbumExistingImagePicker: AlbumExistingImagePickerStub,
   WarningModal: WarningModalStub,
   ErrorBanner: { props: ['text'], template: '<div />' },
   LoadingSpinner: { template: '<div />' },
@@ -158,6 +166,26 @@ describe('AlbumEditor', () => {
     expect(wrapper.emitted('updateFormValues')).toBeUndefined();
   });
 
+  it('removes a reused image by another uploader without permanent deletion', async () => {
+    const wrapper = mountEditor([
+      {
+        ...makeImage('a'),
+        Uploader: { username: 'bob', displayName: 'Bob' },
+      },
+    ], ['a']);
+    wrapper.findComponent(AlbumImageItemStub).vm.$emit('delete');
+    await flushPromises();
+    expect({
+      imageIds: lastEmit(wrapper).images.map((i) => i.id),
+      permanentDeleteCalls: permanentlyDeleteImage.mock.calls.length,
+      modalOpen: warningModal(wrapper).props('open'),
+    }).toEqual({
+      imageIds: [],
+      permanentDeleteCalls: 0,
+      modalOpen: false,
+    });
+  });
+
   it('reorders imageOrder when an image moves up', () => {
     const wrapper = mountEditor();
     wrapper.findAllComponents(AlbumImageItemStub)[1].vm.$emit('move-up');
@@ -175,6 +203,20 @@ describe('AlbumEditor', () => {
     wrapper.findAllComponents(AlbumImageItemStub)[0].vm.$emit('update-field', 'alt', 'new alt');
     const updated = lastEmit(wrapper).images.find((i) => i.id === 'a') as { alt: string };
     expect(updated.alt).toBe('new alt');
+  });
+
+  it('adds an existing image from the picker', async () => {
+    const wrapper = mountEditor();
+    wrapper.findComponent(AlbumExistingImagePickerStub).vm.$emit('add-image', makeImage('d'));
+    await flushPromises();
+    expect(lastEmit(wrapper).imageOrder).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('does not add a duplicate existing image from the picker', async () => {
+    const wrapper = mountEditor();
+    wrapper.findComponent(AlbumExistingImagePickerStub).vm.$emit('add-image', makeImage('a'));
+    await flushPromises();
+    expect(wrapper.emitted('updateFormValues')).toBeUndefined();
   });
 
   describe('reorder guards', () => {

--- a/components/discussion/form/AlbumEditor.vue
+++ b/components/discussion/form/AlbumEditor.vue
@@ -6,6 +6,7 @@ import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import AlbumImageItem from './AlbumImageItem.vue';
 import AlbumDropZone from './AlbumDropZone.vue';
 import AlbumUrlInputForm from './AlbumUrlInputForm.vue';
+import AlbumExistingImagePicker from './AlbumExistingImagePicker.vue';
 import { useAlbumImageUpload } from '@/composables/useAlbumImageUpload';
 import { useAlbumAutoSave } from '@/composables/useAlbumAutoSave';
 import { useMutation } from '@vue/apollo-composable';
@@ -29,6 +30,17 @@ type ImageInput = {
   alt: string;
   copyright: string;
   caption: string;
+  Uploader?: {
+    username?: string | null;
+    displayName?: string | null;
+  } | null;
+};
+
+type ExistingImageInput = Omit<Partial<ImageInput>, 'alt' | 'caption' | 'copyright' | 'url'> & {
+  url?: string | null;
+  alt?: string | null;
+  caption?: string | null;
+  copyright?: string | null;
 };
 
 const props = defineProps<{
@@ -58,6 +70,12 @@ const orderedImages = computed(() =>
   })
 );
 
+const selectedImageIds = computed(() =>
+  props.formValues.album.images
+    .map((image) => image.id)
+    .filter((id): id is string => Boolean(id))
+);
+
 // Helper to update imageOrder after changes
 const updateImageOrderAfterChange = (images: ImageInput[]) =>
   getImageIdOrder(images);
@@ -69,7 +87,11 @@ const addNewImage = (input: Partial<ImageInput>) => {
     return;
   }
 
-  const { url, alt, caption, copyright, id } = input;
+  const { url, alt, caption, copyright, id, Uploader } = input;
+
+  if (id && selectedImageIds.value.includes(id)) {
+    return;
+  }
 
   const newImage: ImageInput = {
     id,
@@ -77,6 +99,7 @@ const addNewImage = (input: Partial<ImageInput>) => {
     alt: alt || '',
     caption: caption || '',
     copyright: copyright || '',
+    Uploader,
   };
 
   const updatedImages = [...props.formValues.album.images, newImage];
@@ -94,6 +117,17 @@ const addNewImage = (input: Partial<ImageInput>) => {
   });
 
   debouncedAutoSave();
+};
+
+const addExistingImage = (image: ExistingImageInput) => {
+  addNewImage({
+    id: image.id,
+    url: image.url || '',
+    alt: image.alt || '',
+    caption: image.caption || '',
+    copyright: image.copyright || '',
+    Uploader: image.Uploader,
+  });
 };
 
 // Initialize image upload composable
@@ -192,8 +226,19 @@ const removeImageFromAlbum = (index: number) => {
   debouncedAutoSave();
 };
 
+const canPermanentlyDeleteImage = (image: ImageInput | undefined) => {
+  const uploaderUsername = image?.Uploader?.username;
+  return !uploaderUsername || uploaderUsername === usernameVar.value;
+};
+
 // Delete image handler
 const requestDeleteImage = (index: number) => {
+  const orderedImage = orderedImages.value[index];
+  if (!canPermanentlyDeleteImage(orderedImage)) {
+    removeImageFromAlbum(index);
+    return;
+  }
+
   pendingDeleteImageIndex.value = index;
   permanentDeleteImageError.value = '';
 };
@@ -360,10 +405,17 @@ const handleUrlCancel = () => {
       :is-first="index === 0"
       :is-last="index === orderedImages.length - 1"
       :is-loading="loadingStates[index] ?? false"
+      :can-permanently-delete="canPermanentlyDeleteImage(image)"
       @update-field="(field, value) => updateImageField(index, field, value)"
       @delete="requestDeleteImage(index)"
       @move-up="moveImageUp(index)"
       @move-down="moveImageDown(index)"
+    />
+
+    <AlbumExistingImagePicker
+      :selected-image-ids="selectedImageIds"
+      :is-limit-reached="isImageLimitReached"
+      @add-image="addExistingImage"
     />
 
     <!-- Drop zone -->

--- a/components/discussion/form/AlbumExistingImagePicker.spec.ts
+++ b/components/discussion/form/AlbumExistingImagePicker.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import AlbumExistingImagePicker from '@/components/discussion/form/AlbumExistingImagePicker.vue';
+
+const { usernameRef, queryResult, queryLoading, queryError } = vi.hoisted(
+  () => ({
+    usernameRef: { value: 'alice' as string },
+    queryResult: {
+      value: {
+        users: [
+          {
+            Images: [
+              {
+                id: 'img-1',
+                url: 'https://img.test/one.jpg',
+                alt: 'One',
+                caption: 'First image',
+                copyright: '',
+                Uploader: { username: 'alice', displayName: 'Alice' },
+              },
+            ],
+            FavoriteImages: [
+              {
+                id: 'img-1',
+                url: 'https://img.test/one.jpg',
+                alt: 'One',
+                caption: 'First image',
+                copyright: '',
+                Uploader: { username: 'alice', displayName: 'Alice' },
+              },
+              {
+                id: 'img-2',
+                url: 'https://img.test/two.jpg',
+                alt: 'Two',
+                caption: 'Second image',
+                copyright: '',
+                Uploader: { username: 'bob', displayName: 'Bob' },
+              },
+            ],
+            Collections: [
+              {
+                id: 'collection-1',
+                name: 'Inspiration',
+                Images: [
+                  {
+                    id: 'img-3',
+                    url: 'https://img.test/three.jpg',
+                    alt: 'Three',
+                    caption: 'Third image',
+                    copyright: '',
+                    Uploader: { username: 'carol', displayName: 'Carol' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    queryLoading: { value: false },
+    queryError: { value: null as Error | null },
+  })
+);
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => usernameRef,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(() => ({
+    result: queryResult,
+    loading: queryLoading,
+    error: queryError,
+  })),
+}));
+
+const mountPicker = (selectedImageIds: string[] = []) =>
+  mountWithDefaults(AlbumExistingImagePicker, {
+    props: {
+      selectedImageIds,
+      isLimitReached: false,
+    },
+    global: {
+      stubs: {
+        LoadingSpinner: { template: '<div />' },
+        ErrorBanner: { props: ['text'], template: '<div class="error" />' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  usernameRef.value = 'alice';
+  queryLoading.value = false;
+  queryError.value = null;
+});
+
+describe('AlbumExistingImagePicker', () => {
+  it('dedupes images across uploads, favorites, and image collections', () => {
+    const wrapper = mountPicker();
+    expect({
+      cardCount: wrapper.findAll('article').length,
+      sourceCopy: wrapper.text(),
+    }).toMatchObject({
+      cardCount: 3,
+      sourceCopy: expect.stringContaining('Your uploads · Favorites'),
+    });
+  });
+
+  it('emits the selected image when adding it to the album', async () => {
+    const wrapper = mountPicker();
+    await wrapper.findAll('button')[2].trigger('click');
+    expect(wrapper.emitted('addImage')?.[0]?.[0]).toMatchObject({
+      id: 'img-3',
+      Uploader: { username: 'carol' },
+    });
+  });
+
+  it('disables images already selected in the album', () => {
+    const wrapper = mountPicker(['img-1']);
+    const firstButton = wrapper.find('button');
+    expect({
+      disabled: firstButton.attributes('disabled'),
+      text: firstButton.text(),
+    }).toEqual({
+      disabled: '',
+      text: 'Already in album',
+    });
+  });
+});

--- a/components/discussion/form/AlbumExistingImagePicker.vue
+++ b/components/discussion/form/AlbumExistingImagePicker.vue
@@ -1,0 +1,241 @@
+<script lang="ts" setup>
+import { computed, ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { useUsername } from '@/composables/useAuthState';
+import { GET_REUSABLE_ALBUM_IMAGES } from '@/graphQLData/image/queries';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import ErrorBanner from '@/components/ErrorBanner.vue';
+import type { ImageWhere } from '@/__generated__/graphql';
+
+type ReusableImage = {
+  id: string;
+  url: string;
+  alt?: string | null;
+  caption?: string | null;
+  copyright?: string | null;
+  createdAt?: string | null;
+  Uploader?: {
+    username?: string | null;
+    displayName?: string | null;
+  } | null;
+};
+
+type ReusableImageResult = {
+  users?: Array<{
+    Images?: ReusableImage[] | null;
+    FavoriteImages?: ReusableImage[] | null;
+    Collections?: Array<{
+      id: string;
+      name?: string | null;
+      Images?: ReusableImage[] | null;
+    }> | null;
+  }> | null;
+};
+
+type PickerImage = ReusableImage & {
+  sourceLabels: string[];
+};
+
+const props = defineProps<{
+  selectedImageIds: string[];
+  isLimitReached: boolean;
+}>();
+
+const emit = defineEmits<{
+  addImage: [image: ReusableImage];
+}>();
+
+const usernameVar = useUsername();
+const searchTerm = ref('');
+const limit = 30;
+
+const selectedImageIdsSet = computed(() => new Set(props.selectedImageIds));
+
+const imageWhere = computed<ImageWhere>(() => {
+  const base: ImageWhere = {
+    archived: false,
+    permanentlyRemoved: false,
+  };
+  const trimmedSearch = searchTerm.value.trim();
+
+  if (!trimmedSearch) {
+    return base;
+  }
+
+  return {
+    AND: [
+      base,
+      {
+        OR: [
+          { id_CONTAINS: trimmedSearch },
+          { url_CONTAINS: trimmedSearch },
+          { alt_CONTAINS: trimmedSearch },
+          { caption_CONTAINS: trimmedSearch },
+          { copyright_CONTAINS: trimmedSearch },
+        ],
+      },
+    ],
+  };
+});
+
+const { result, loading, error } = useQuery<ReusableImageResult>(
+  GET_REUSABLE_ALBUM_IMAGES,
+  () => ({
+    username: usernameVar.value,
+    where: imageWhere.value,
+    limit,
+  }),
+  () => ({
+    enabled: Boolean(usernameVar.value),
+    fetchPolicy: 'cache-and-network',
+  })
+);
+
+const pushImage = (
+  map: Map<string, PickerImage>,
+  image: ReusableImage,
+  sourceLabel: string
+) => {
+  if (!image.id) return;
+
+  const existing = map.get(image.id);
+  if (existing) {
+    if (!existing.sourceLabels.includes(sourceLabel)) {
+      existing.sourceLabels.push(sourceLabel);
+    }
+    return;
+  }
+
+  map.set(image.id, {
+    ...image,
+    sourceLabels: [sourceLabel],
+  });
+};
+
+const images = computed<PickerImage[]>(() => {
+  const user = result.value?.users?.[0];
+  const imageMap = new Map<string, PickerImage>();
+
+  for (const image of user?.Images || []) {
+    pushImage(imageMap, image, 'Your uploads');
+  }
+
+  for (const image of user?.FavoriteImages || []) {
+    pushImage(imageMap, image, 'Favorites');
+  }
+
+  for (const collection of user?.Collections || []) {
+    const collectionName = collection.name || 'Image collection';
+    for (const image of collection.Images || []) {
+      pushImage(imageMap, image, collectionName);
+    }
+  }
+
+  return [...imageMap.values()];
+});
+
+const getImageAlt = (image: ReusableImage) =>
+  image.alt || image.caption || 'Reusable album image';
+
+const getUploaderLabel = (image: ReusableImage) => {
+  const uploader = image.Uploader;
+  if (!uploader?.username) return 'Unknown uploader';
+  return uploader.displayName
+    ? `${uploader.displayName} (${uploader.username})`
+    : uploader.username;
+};
+</script>
+
+<template>
+  <section
+    class="mt-4 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-3 dark:border-gray-600 dark:bg-gray-900/40"
+    aria-labelledby="existing-image-picker-heading"
+  >
+    <div class="mb-3">
+      <h4
+        id="existing-image-picker-heading"
+        class="text-sm font-semibold text-gray-900 dark:text-white"
+      >
+        Add an existing image
+      </h4>
+      <p class="mt-1 text-xs text-gray-600 dark:text-gray-300">
+        Reuse images from your uploads, favorites, or image collections without
+        re-uploading. Original uploader attribution is preserved.
+      </p>
+    </div>
+
+    <label
+      class="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-200"
+      for="existing-image-search"
+    >
+      Search reusable images
+    </label>
+    <input
+      id="existing-image-search"
+      v-model="searchTerm"
+      type="search"
+      class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+      placeholder="Search by caption, alt text, URL, or image ID"
+    >
+
+    <ErrorBanner
+      v-if="error"
+      class="mt-3"
+      :text="error.message"
+    />
+
+    <div
+      v-if="loading && images.length === 0"
+      class="mt-3 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
+    >
+      <LoadingSpinner class="h-4 w-4" />
+      <span>Loading reusable images...</span>
+    </div>
+
+    <p
+      v-else-if="images.length === 0"
+      class="mt-3 text-sm text-gray-600 dark:text-gray-300"
+    >
+      No reusable images found.
+    </p>
+
+    <div
+      v-else
+      class="mt-3 grid max-h-96 grid-cols-1 gap-3 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3"
+    >
+      <article
+        v-for="image in images"
+        :key="image.id"
+        class="overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800"
+      >
+        <img
+          :src="image.url"
+          :alt="getImageAlt(image)"
+          class="h-32 w-full object-cover"
+          loading="lazy"
+        >
+        <div class="space-y-2 p-3">
+          <p class="line-clamp-2 text-sm font-medium text-gray-900 dark:text-white">
+            {{ image.caption || image.alt || image.id }}
+          </p>
+          <p class="text-xs text-gray-600 dark:text-gray-300">
+            Uploaded by {{ getUploaderLabel(image) }}
+          </p>
+          <p class="line-clamp-1 text-xs text-gray-500 dark:text-gray-400">
+            {{ image.sourceLabels.join(' · ') }}
+          </p>
+          <button
+            type="button"
+            class="w-full rounded-md bg-orange-600 px-3 py-2 text-sm font-medium text-white hover:bg-orange-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-600 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+            :disabled="selectedImageIdsSet.has(image.id) || isLimitReached"
+            @click="emit('addImage', image)"
+          >
+            <span v-if="selectedImageIdsSet.has(image.id)">Already in album</span>
+            <span v-else-if="isLimitReached">Album limit reached</span>
+            <span v-else>Add to album</span>
+          </button>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>

--- a/components/discussion/form/AlbumImageItem.vue
+++ b/components/discussion/form/AlbumImageItem.vue
@@ -15,6 +15,10 @@ type ImageData = {
   alt: string;
   caption: string;
   copyright: string;
+  Uploader?: {
+    username?: string | null;
+    displayName?: string | null;
+  } | null;
 };
 
 defineProps<{
@@ -23,6 +27,7 @@ defineProps<{
   isFirst: boolean;
   isLast: boolean;
   isLoading: boolean;
+  canPermanentlyDelete?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -31,6 +36,14 @@ const emit = defineEmits<{
 }>();
 
 const { mdAndDown } = useDisplay();
+
+const getUploaderLabel = (image: ImageData) => {
+  const uploader = image.Uploader;
+  if (!uploader?.username) return '';
+  return uploader.displayName
+    ? `${uploader.displayName} (${uploader.username})`
+    : uploader.username;
+};
 </script>
 
 <template>
@@ -38,6 +51,12 @@ const { mdAndDown } = useDisplay();
     <div class="mb-2 flex items-center justify-between">
       <div class="flex items-center">
         <span class="font-bold dark:text-white">Image {{ index + 1 }}</span>
+        <span
+          v-if="getUploaderLabel(image)"
+          class="ml-2 text-xs text-gray-500 dark:text-gray-400"
+        >
+          Uploaded by {{ getUploaderLabel(image) }}
+        </span>
       </div>
       <div class="flex items-center gap-2">
         <div class="ml-4 flex gap-1">
@@ -66,7 +85,7 @@ const { mdAndDown } = useDisplay();
           @click="emit('delete')"
         >
           <XmarkIcon class="h-4" />
-          Delete
+          {{ canPermanentlyDelete ? 'Delete' : 'Remove' }}
         </button>
       </div>
     </div>

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -117,7 +117,7 @@ Notes:
 - Discussion/channel owners cannot disable discussion submissions, so there is intentionally no `Does not allow discussions` flag or picker gating for discussion-sharing flows.
 - Unit coverage now includes event eligibility in normal search results, favorite forums, collection-based bulk selection, disabled-option rendering, blocked selection behavior, and locked forum mode.
 
-### 8. Images in multiple albums and fuller image-usage display `[partial]`
+### 8. Images in multiple albums and fuller image-usage display `[complete]`
 
 - [x] Change album-image modeling so one image can belong to multiple albums without re-uploading. `[in backend PR]`
 - [x] Preserve uploader/original attribution on the image node anywhere it is reused by linking the same image node instead of creating a copy. `[in backend/frontend PRs]`
@@ -127,11 +127,11 @@ Notes:
 - [x] Add tests for permission enforcement and existing-image add/remove flows. `[in this slice]`
 - [x] Add backend album add/remove flows that link existing images instead of requiring re-upload. `[in this slice]`
 - [x] Let users save permitted images from image detail to their own album or image collection. `[in this slice]`
-- [ ] Add existing-image picker/search to album editor flows.
+- [x] Add existing-image picker/search to album editor flows. `[in this slice]`
 - [x] On image detail pages, show grouped image usage by original poster vs others. `[in frontend PR]`
 
 Notes:
-- The remaining work in this section is a fuller album-editor reuse flow, such as browsing/searching existing images while editing an album.
+- Album editor flows now include a reusable-image picker for the user's uploads, favorites, and image collections.
 
 ### 9. Permanent media deletion and storage cleanup `[partial]`
 

--- a/graphQLData/image/queries.js
+++ b/graphQLData/image/queries.js
@@ -212,3 +212,67 @@ export const GET_USER_IMAGES = gql`
     }
   }
 `;
+
+export const GET_REUSABLE_ALBUM_IMAGES = gql`
+  query GetReusableAlbumImages(
+    $username: String!
+    $where: ImageWhere
+    $limit: Int!
+  ) {
+    users(where: { username: $username }) {
+      username
+      Images(
+        where: $where
+        options: { limit: $limit, sort: { createdAt: DESC } }
+      ) {
+        id
+        url
+        alt
+        caption
+        copyright
+        createdAt
+        Uploader {
+          username
+          displayName
+        }
+      }
+      FavoriteImages(
+        where: $where
+        options: { limit: $limit, sort: { createdAt: DESC } }
+      ) {
+        id
+        url
+        alt
+        caption
+        copyright
+        createdAt
+        Uploader {
+          username
+          displayName
+        }
+      }
+      Collections(
+        where: { collectionType: IMAGES }
+        options: { sort: [{ updatedAt: DESC }] }
+      ) {
+        id
+        name
+        Images(
+          where: $where
+          options: { limit: $limit, sort: { createdAt: DESC } }
+        ) {
+          id
+          url
+          alt
+          caption
+          copyright
+          createdAt
+          Uploader {
+            username
+            displayName
+          }
+        }
+      }
+    }
+  }
+`;

--- a/utils/albumImages.ts
+++ b/utils/albumImages.ts
@@ -9,6 +9,10 @@ export type AlbumImageSource = {
   alt?: string | null;
   caption?: string | null;
   copyright?: string | null;
+  Uploader?: {
+    username?: string | null;
+    displayName?: string | null;
+  } | null;
 };
 
 export type AlbumEditorImage = {
@@ -20,6 +24,10 @@ export type AlbumEditorImage = {
   hasSensitiveContent: boolean;
   hasSpoiler: boolean;
   copyright: string;
+  Uploader?: {
+    username?: string | null;
+    displayName?: string | null;
+  } | null;
 };
 
 export function mapAlbumImagesToForm(
@@ -35,6 +43,7 @@ export function mapAlbumImagesToForm(
     hasSensitiveContent: false,
     hasSpoiler: false,
     copyright: image.copyright || '',
+    Uploader: image.Uploader,
   }));
 }
 


### PR DESCRIPTION
## Summary

- Add an album-editor picker for reusing existing images from the logged-in user's uploads, favorite images, and image collections.
- Add a reusable image query that returns active images with original uploader attribution.
- Preserve attribution in the album form and show uploader copy on image rows.
- Treat reused images from another uploader as "remove from album" instead of permanent deletion.
- Mark the multi-album image roadmap section complete.

## Verification

- `npx pnpm@10.28.2 exec vitest run components/discussion/form/AlbumExistingImagePicker.spec.ts components/discussion/form/AlbumEditor.spec.ts`
- `npx pnpm@10.28.2 exec vitest run components/discussion/detail/AlbumEditForm.spec.ts tests/unit/utils/albumUtils.spec.ts tests/unit/utils/albumUpdateInput.spec.ts`
- `npx pnpm@10.28.2 run tsc`
- `npx pnpm@10.28.2 exec eslint components/discussion/form/AlbumExistingImagePicker.vue components/discussion/form/AlbumExistingImagePicker.spec.ts components/discussion/form/AlbumEditor.vue components/discussion/form/AlbumEditor.spec.ts components/discussion/form/AlbumImageItem.vue components/discussion/detail/AlbumEditForm.vue utils/albumImages.ts`
- `git diff --check`

Note: local verification ran on Node 22 and emitted the expected engine warning; CI runs Node 24.