### PR TITLE
[codex] Add wiki page lock UI

### DIFF
--- a/components/wiki/WikiPageLockButton.spec.ts
+++ b/components/wiki/WikiPageLockButton.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+
+import WikiPageLockButton from './WikiPageLockButton.vue';
+
+const h = vi.hoisted(() => ({
+  username: { value: 'alice' },
+  success: vi.fn(),
+  error: vi.fn(),
+  lockMutate: vi.fn(async () => ({ data: { lockWikiPage: { id: 'wiki-1' } } })),
+  unlockMutate: vi.fn(async () => ({ data: { unlockWikiPage: { id: 'wiki-1' } } })),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => h.username,
+}));
+
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({ success: h.success, error: h.error }),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: vi.fn(),
+}));
+
+const mockedUseMutation = useMutation as unknown as ReturnType<typeof vi.fn>;
+
+const channel = (overrides: Record<string, unknown> = {}) => ({
+  Admins: [{ username: 'alice' }],
+  ElevatedChannelRole: { canUpdateChannel: true },
+  ...overrides,
+});
+
+const mountButton = (overrides: Record<string, unknown> = {}) =>
+  mount(WikiPageLockButton, {
+    props: {
+      channel: channel(),
+      wikiPage: { id: 'wiki-1', locked: false },
+      ...overrides,
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.username.value = 'alice';
+  h.lockMutate.mockResolvedValue({ data: { lockWikiPage: { id: 'wiki-1' } } });
+  h.unlockMutate.mockResolvedValue({ data: { unlockWikiPage: { id: 'wiki-1' } } });
+  Object.defineProperty(window, 'prompt', {
+    value: vi.fn(() => 'Settled canon'),
+    configurable: true,
+  });
+  mockedUseMutation
+    .mockReturnValueOnce({ mutate: h.lockMutate, loading: ref(false) })
+    .mockReturnValueOnce({ mutate: h.unlockMutate, loading: ref(false) });
+});
+
+describe('WikiPageLockButton', () => {
+  it('locks an unlocked wiki page with the provided reason', async () => {
+    const wrapper = mountButton();
+
+    await wrapper.get('button').trigger('click');
+
+    expect(h.lockMutate).toHaveBeenCalledWith({
+      wikiPageId: 'wiki-1',
+      reason: 'Settled canon',
+    });
+  });
+
+  it('unlocks a locked wiki page', async () => {
+    const wrapper = mountButton({
+      wikiPage: { id: 'wiki-1', locked: true },
+    });
+
+    await wrapper.get('button').trigger('click');
+
+    expect(h.unlockMutate).toHaveBeenCalledWith({ wikiPageId: 'wiki-1' });
+  });
+
+  it('hides for non-owners', () => {
+    h.username.value = 'bob';
+    const wrapper = mountButton();
+
+    expect(wrapper.find('button').exists()).toBe(false);
+  });
+
+  it('does not lock when the reason prompt is empty', async () => {
+    vi.mocked(window.prompt).mockReturnValue('');
+    const wrapper = mountButton();
+
+    await wrapper.get('button').trigger('click');
+
+    expect(h.lockMutate).not.toHaveBeenCalled();
+  });
+
+  it('shows a toast when the mutation fails', async () => {
+    h.lockMutate.mockRejectedValue(new Error('denied'));
+    const wrapper = mountButton();
+
+    await wrapper.get('button').trigger('click');
+
+    expect(h.error).toHaveBeenCalledWith(
+      'Could not update wiki page lock: denied'
+    );
+  });
+});

--- a/components/wiki/WikiPageLockButton.vue
+++ b/components/wiki/WikiPageLockButton.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { computed, type PropType } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import type { Channel, WikiPage } from '@/__generated__/graphql';
+import {
+  LOCK_WIKI_PAGE,
+  UNLOCK_WIKI_PAGE,
+} from '@/graphQLData/channel/mutations';
+import { useToast } from '@/composables/useToast';
+import { useUsername } from '@/composables/useAuthState';
+import { canManageLockedWikiPage } from '@/utils/wikiPageLockPermissions';
+
+type LockableWikiPage = Pick<WikiPage, 'id'> & {
+  locked?: boolean | null;
+};
+
+const props = defineProps({
+  channel: {
+    type: Object as PropType<Channel>,
+    required: true,
+  },
+  wikiPage: {
+    type: Object as PropType<LockableWikiPage>,
+    required: true,
+  },
+});
+
+const emit = defineEmits<{
+  (event: 'lockChanged'): void;
+}>();
+
+const toast = useToast();
+const username = useUsername();
+
+const { mutate: lockWikiPage, loading: lockLoading } =
+  useMutation(LOCK_WIKI_PAGE);
+const { mutate: unlockWikiPage, loading: unlockLoading } =
+  useMutation(UNLOCK_WIKI_PAGE);
+
+const isLocked = computed(() => props.wikiPage.locked === true);
+const canManage = computed(() =>
+  canManageLockedWikiPage({
+    channel: props.channel,
+    username: username.value,
+  })
+);
+const isSaving = computed(() => lockLoading.value || unlockLoading.value);
+
+const toggleLock = async () => {
+  try {
+    if (isLocked.value) {
+      await unlockWikiPage({ wikiPageId: props.wikiPage.id });
+      toast.success('Wiki page unlocked.');
+    } else {
+      const reason = window.prompt('Reason for locking this wiki page?');
+
+      if (!reason?.trim()) {
+        return;
+      }
+
+      await lockWikiPage({
+        wikiPageId: props.wikiPage.id,
+        reason: reason.trim(),
+      });
+      toast.success('Wiki page locked.');
+    }
+
+    emit('lockChanged');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    toast.error(`Could not update wiki page lock: ${message}`);
+  }
+};
+</script>
+
+<template>
+  <button
+    v-if="canManage"
+    type="button"
+    class="inline-flex items-center gap-2 rounded-md border border-amber-300 px-3 py-1.5 text-sm font-medium text-amber-800 transition-colors hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-600 dark:text-amber-200 dark:hover:bg-amber-950"
+    :disabled="isSaving"
+    @click="toggleLock"
+  >
+    <i :class="['fa-solid', isLocked ? 'fa-lock-open' : 'fa-lock']" />
+    <span>{{ isLocked ? 'Unlock page' : 'Lock page' }}</span>
+  </button>
+</template>

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -161,10 +161,15 @@ Notes:
 - The backend exposes dedicated `pinWikiPageToChannel` and `unpinWikiPageFromChannel` mutations so pinning uses the same channel/default-role permission path as wiki editing instead of a frontend owner-status shortcut.
 - The frontend refetches channel data after pin changes and renders pinned wiki pages in the forum sidebar.
 
-### 11. Wiki: lock wiki pages to owners `[not started]`
+### 11. Wiki: lock wiki pages to owners `[complete]`
 
-- [ ] Add a lock state for wiki pages.
-- [ ] Restrict editing of locked wiki pages to channel owners per product rules.
+- [x] Add a lock state for wiki pages.
+- [x] Restrict editing of locked wiki pages to channel owners per product rules.
+
+Notes:
+- Locked wiki pages can be locked/unlocked by channel owners whose elevated channel role grants `canUpdateChannel`.
+- Default-role wiki editors are blocked from editing locked pages even when they can edit unlocked wiki pages.
+- The frontend shows locked-page notices, hides edit actions for unauthorized users, and blocks the edit form when a page is locked.
 
 ### 12. Moderation: sticky comment on discussion or event `[not started]`
 

--- a/graphQLData/channel/mutations.js
+++ b/graphQLData/channel/mutations.js
@@ -197,6 +197,30 @@ export const UNPIN_WIKI_PAGE_FROM_CHANNEL = gql`
   }
 `;
 
+export const LOCK_WIKI_PAGE = gql`
+  mutation lockWikiPage($wikiPageId: ID!, $reason: String!) {
+    lockWikiPage(wikiPageId: $wikiPageId, reason: $reason) {
+      id
+      locked
+      lockedAt
+      lockReason
+      lockedByUsername
+    }
+  }
+`;
+
+export const UNLOCK_WIKI_PAGE = gql`
+  mutation unlockWikiPage($wikiPageId: ID!) {
+    unlockWikiPage(wikiPageId: $wikiPageId) {
+      id
+      locked
+      lockedAt
+      lockReason
+      lockedByUsername
+    }
+  }
+`;
+
 export const BECOME_CHANNEL_ADMIN = gql`
   mutation becomeChannelAdmin($channelUniqueName: String!) {
     becomeForumAdmin(channelUniqueName: $channelUniqueName)

--- a/graphQLData/channel/queries.js
+++ b/graphQLData/channel/queries.js
@@ -15,12 +15,16 @@ export const GET_CHANNEL_NAMES = gql`
 
 export const GET_WIKI_PAGE = gql`
   query getWikiPage($channelUniqueName: String!, $slug: String!) {
-    wikiPages(where: { channelUniqueName: $channelUniqueName, slug: $slug }) {
+      wikiPages(where: { channelUniqueName: $channelUniqueName, slug: $slug }) {
       id
       title
       body
       editReason
       slug
+      locked
+      lockedAt
+      lockReason
+      lockedByUsername
       createdAt
       updatedAt
       VersionAuthor {
@@ -31,6 +35,10 @@ export const GET_WIKI_PAGE = gql`
         title
         editReason
         slug
+        locked
+        lockedAt
+        lockReason
+        lockedByUsername
         createdAt
         updatedAt
         VersionAuthor {
@@ -79,6 +87,10 @@ export const GET_CHANNEL = gql`
         body
         editReason
         slug
+        locked
+        lockedAt
+        lockReason
+        lockedByUsername
         createdAt
         updatedAt
         VersionAuthor {

--- a/pages/forums/[forumId]/wiki/[slug].spec.ts
+++ b/pages/forums/[forumId]/wiki/[slug].spec.ts
@@ -12,22 +12,39 @@ vi.mock('nuxt/app', () => ({
 }));
 
 vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('bob'),
+}));
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
-const mountWith = async (wikiPage: unknown) => {
+const mountWith = async (
+  wikiPage: unknown,
+  channelOverrides: Record<string, unknown> = {}
+) => {
   mockedUseQuery
     // wiki page data
     .mockReturnValueOnce({
       result: ref({ wikiPages: wikiPage ? [wikiPage] : [] }),
       loading: ref(false),
       error: ref(null),
+      refetch: vi.fn(),
     })
     // channel (wikiEnabled)
     .mockReturnValueOnce({
-      result: ref({ channels: [{ wikiEnabled: true }] }),
+      result: ref({
+        channels: [
+          {
+            wikiEnabled: true,
+            Admins: [{ username: 'alice' }],
+            ElevatedChannelRole: { canUpdateChannel: true },
+            ...channelOverrides,
+          },
+        ],
+      }),
       loading: ref(false),
       error: ref(null),
+      refetch: vi.fn(),
     })
     // SEO query (onResult callback)
     .mockReturnValueOnce({ onResult: vi.fn() });
@@ -43,5 +60,16 @@ describe('wiki page', () => {
     expect(wrapper.findComponent(MarkdownRenderer).props('text')).toBe(
       'Welcome to the wiki'
     );
+  });
+
+  it('shows a locked notice when the wiki page is locked', async () => {
+    const wrapper = await mountWith({
+      title: 'Intro',
+      body: 'Welcome',
+      locked: true,
+      lockReason: 'Canon settled',
+    });
+
+    expect(wrapper.text()).toContain('Canon settled');
   });
 });

--- a/pages/forums/[forumId]/wiki/[slug].vue
+++ b/pages/forums/[forumId]/wiki/[slug].vue
@@ -10,11 +10,20 @@ import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue';
 import OnThisPage from '@/components/wiki/OnThisPage.vue';
 import WikiPagePinButton from '@/components/wiki/WikiPagePinButton.vue';
+import WikiPageLockButton from '@/components/wiki/WikiPageLockButton.vue';
 import FontSizeControl from '@/components/channel/FontSizeControl.vue';
 import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
 import { timeAgo } from '@/utils';
 import { buildWikiPageHead } from '@/utils/wikiSeo';
+import { useUsername } from '@/composables/useAuthState';
+import { canEditWikiPage } from '@/utils/wikiPageLockPermissions';
+import type { WikiPage } from '@/__generated__/graphql';
+
+type LockableWikiPage = WikiPage & {
+  locked?: boolean | null;
+  lockReason?: string | null;
+};
 
 const route = useRoute();
 const router = useRouter();
@@ -22,12 +31,14 @@ const forumId = route.params.forumId as string;
 const slug = route.params.slug as string;
 const uiStore = useUIStore();
 const { fontSize } = storeToRefs(uiStore);
+const username = useUsername();
 
 // Query wiki page data for the specific slug
 const {
   result: wikiPageResult,
   loading,
   error,
+  refetch: refetchWikiPage,
 } = useQuery(
   GET_WIKI_PAGE,
   {
@@ -38,7 +49,11 @@ const {
 );
 
 // Computed property for the wiki page data
-const wikiPage = computed(() => wikiPageResult.value?.wikiPages?.[0]);
+const wikiPage = computed(
+  () => wikiPageResult.value?.wikiPages?.[0] as LockableWikiPage | undefined
+);
+const wikiPageBody = computed(() => wikiPage.value?.body || '');
+const wikiPageSlug = computed(() => wikiPage.value?.slug || slug);
 
 // Query channel to check if wiki is enabled
 const {
@@ -50,6 +65,17 @@ const {
 
 // Computed property for the channel data
 const channel = computed(() => channelResult.value?.channels?.[0]);
+const canEditCurrentWikiPage = computed(() =>
+  canEditWikiPage({
+    channel: channel.value,
+    wikiPage: wikiPage.value,
+    username: username.value,
+  })
+);
+const refetchWikiLockState = () => {
+  refetchChannel();
+  refetchWikiPage();
+};
 
 // Check if wiki is enabled
 const wikiEnabled = computed(() => channel.value?.wikiEnabled);
@@ -154,15 +180,34 @@ onGetWikiPageResult((result) => {
               :channel-unique-name="forumId"
               @pinned-changed="refetchChannel"
             />
+            <WikiPageLockButton
+              v-if="channel"
+              :channel="channel"
+              :wiki-page="wikiPage"
+              @lock-changed="refetchWikiLockState"
+            />
             <PrimaryButton
+              v-if="canEditCurrentWikiPage"
               :label="'Edit Page'"
               @click="
-                router.push(`/forums/${forumId}/wiki/edit/${wikiPage.slug}`)
+                router.push(`/forums/${forumId}/wiki/edit/${wikiPageSlug}`)
               "
             >
               <PencilIcon class="mr-2 h-5 w-5" />
             </PrimaryButton>
           </div>
+        </div>
+        <div
+          v-if="wikiPage.locked"
+          class="mt-4 rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+        >
+          <p class="font-semibold">This wiki page is locked.</p>
+          <p v-if="wikiPage.lockReason" class="mt-1">
+            {{ wikiPage.lockReason }}
+          </p>
+          <p v-if="!canEditCurrentWikiPage" class="mt-1">
+            Only forum owners with wiki update permission can edit it.
+          </p>
         </div>
         <div
           class="mt-1 flex items-center text-sm text-gray-500 dark:text-gray-400"
@@ -178,7 +223,7 @@ onGetWikiPageResult((result) => {
           >
             <span class="mx-2">·</span>
             <router-link
-              :to="`/forums/${forumId}/wiki/revisions/${wikiPage.slug}`"
+              :to="`/forums/${forumId}/wiki/revisions/${wikiPageSlug}`"
               class="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
             >
               See edits
@@ -189,7 +234,7 @@ onGetWikiPageResult((result) => {
 
       <!-- Mobile On This Page Dropdown -->
       <div class="mb-4 block xl:hidden">
-        <OnThisPage :markdown-content="wikiPage.body" :is-mobile="true" />
+        <OnThisPage :markdown-content="wikiPageBody" :is-mobile="true" />
       </div>
 
       <!-- Mobile font size control -->
@@ -202,16 +247,17 @@ onGetWikiPageResult((result) => {
         <div class="min-w-0 flex-1 xl:order-2">
           <div class="flex w-full justify-center">
             <div>
-              <MarkdownRenderer :text="wikiPage.body" :font-size="fontSize" />
+              <MarkdownRenderer :text="wikiPageBody" :font-size="fontSize" />
             </div>
           </div>
 
           <!-- Bottom edit button - Docusaurus style -->
           <div class="mt-8 border-t border-gray-200 pt-6 dark:border-gray-700">
             <button
+              v-if="canEditCurrentWikiPage"
               class="flex items-center text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
               @click="
-                router.push(`/forums/${forumId}/wiki/edit/${wikiPage.slug}`)
+                router.push(`/forums/${forumId}/wiki/edit/${wikiPageSlug}`)
               "
             >
               <PencilIcon class="mr-2 h-4 w-4" />
@@ -225,7 +271,7 @@ onGetWikiPageResult((result) => {
           class="sticky top-0 hidden max-h-screen w-64 flex-shrink-0 overflow-y-auto xl:order-1 xl:flex"
         >
           <!-- On This Page Navigation -->
-          <OnThisPage :markdown-content="wikiPage.body" :is-mobile="false" />
+          <OnThisPage :markdown-content="wikiPageBody" :is-mobile="false" />
         </div>
 
         <!-- Right sidebar - controls (desktop only) -->

--- a/pages/forums/[forumId]/wiki/edit/[slug].vue
+++ b/pages/forums/[forumId]/wiki/edit/[slug].vue
@@ -16,6 +16,13 @@ import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
 import { useUsername } from '@/composables/useAuthState';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import { canEditWikiPage } from '@/utils/wikiPageLockPermissions';
+import type { WikiPage } from '@/__generated__/graphql';
+
+type LockableWikiPage = WikiPage & {
+  locked?: boolean | null;
+  lockReason?: string | null;
+};
 
 const usernameVar = useUsername();
 
@@ -51,18 +58,27 @@ const {
   { uniqueName: forumId },
   {
     errorPolicy: 'all',
-    enabled: isHomePage.value, // Only run this query for home page
   }
 );
 
 // Computed property for the wiki page data
 const wikiPage = computed(() => {
   if (isHomePage.value) {
-    return channelResult.value?.channels?.[0]?.WikiHomePage;
+    return channelResult.value?.channels?.[0]?.WikiHomePage as
+      | LockableWikiPage
+      | undefined;
   } else {
-    return wikiPageResult.value?.wikiPages?.[0];
+    return wikiPageResult.value?.wikiPages?.[0] as LockableWikiPage | undefined;
   }
 });
+const channel = computed(() => channelResult.value?.channels?.[0]);
+const canEditCurrentWikiPage = computed(() =>
+  canEditWikiPage({
+    channel: channel.value,
+    wikiPage: wikiPage.value,
+    username: usernameVar.value,
+  })
+);
 
 // Computed loading and error states
 const loading = computed(() => {
@@ -148,6 +164,7 @@ const updateError = computed(() => {
 // Handle form submission
 function handleSubmit() {
   if (wikiEditBlockedBySuspension.value) return;
+  if (!canEditCurrentWikiPage.value) return;
   if (!formValues.value.title || !formValues.value.body) return;
 
   if (isHomePage.value) {
@@ -281,9 +298,21 @@ onChannelDone(handleDone);
         :suspended-until="suspendedUntil ?? undefined"
         :suspended-indefinitely="suspendedIndefinitely"
       />
+      <div
+        v-else-if="!canEditCurrentWikiPage"
+        class="mb-4 rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+      >
+        <p class="font-semibold">This wiki page is locked.</p>
+        <p v-if="wikiPage.lockReason" class="mt-1">
+          {{ wikiPage.lockReason }}
+        </p>
+        <p class="mt-1">
+          Only forum owners with wiki update permission can edit it.
+        </p>
+      </div>
 
       <form
-        v-if="!wikiEditBlockedBySuspension"
+        v-if="!wikiEditBlockedBySuspension && canEditCurrentWikiPage"
         class="space-y-6"
         @submit.prevent="handleSubmit"
       >

--- a/tests/unit/utils/wikiPageLockPermissions.spec.ts
+++ b/tests/unit/utils/wikiPageLockPermissions.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  canEditWikiPage,
+  canManageLockedWikiPage,
+} from '@/utils/wikiPageLockPermissions';
+
+describe('wikiPageLockPermissions', () => {
+  it('allows a channel owner when no elevated role is configured', () => {
+    expect(
+      canManageLockedWikiPage({
+        channel: { Admins: [{ username: 'alice' }], ElevatedChannelRole: null },
+        username: 'alice',
+      })
+    ).toBe(true);
+  });
+
+  it('requires elevated canUpdateChannel when the elevated role is configured', () => {
+    expect(
+      canManageLockedWikiPage({
+        channel: {
+          Admins: [{ username: 'alice' }],
+          ElevatedChannelRole: { canUpdateChannel: false },
+        },
+        username: 'alice',
+      })
+    ).toBe(false);
+  });
+
+  it('blocks non-owners from managing locked wiki pages', () => {
+    expect(
+      canManageLockedWikiPage({
+        channel: {
+          Admins: [{ username: 'alice' }],
+          ElevatedChannelRole: { canUpdateChannel: true },
+        },
+        username: 'bob',
+      })
+    ).toBe(false);
+  });
+
+  it('allows unlocked wiki pages to be edited', () => {
+    expect(canEditWikiPage({ wikiPage: { locked: false } })).toBe(true);
+  });
+
+  it('blocks locked wiki page edits without owner permission', () => {
+    expect(
+      canEditWikiPage({
+        wikiPage: { locked: true },
+        channel: { Admins: [{ username: 'alice' }] },
+        username: 'bob',
+      })
+    ).toBe(false);
+  });
+});

--- a/utils/wikiPageLockPermissions.ts
+++ b/utils/wikiPageLockPermissions.ts
@@ -1,0 +1,54 @@
+type UserSummary = {
+  username?: string | null;
+};
+
+type ChannelRoleSummary = {
+  canUpdateChannel?: boolean | null;
+};
+
+type ChannelLockPermissionInput = {
+  Admins?: UserSummary[] | null;
+  ElevatedChannelRole?: ChannelRoleSummary | null;
+};
+
+type LockedWikiPageInput = {
+  locked?: boolean | null;
+};
+
+export function canManageLockedWikiPage(params: {
+  channel?: ChannelLockPermissionInput | null;
+  username?: string | null;
+}) {
+  const { channel, username } = params;
+
+  if (!channel || !username) {
+    return false;
+  }
+
+  const isChannelOwner = (channel.Admins || []).some(
+    (admin) => admin.username === username
+  );
+
+  if (!isChannelOwner) {
+    return false;
+  }
+
+  return channel.ElevatedChannelRole
+    ? channel.ElevatedChannelRole.canUpdateChannel === true
+    : true;
+}
+
+export function canEditWikiPage(params: {
+  channel?: ChannelLockPermissionInput | null;
+  wikiPage?: LockedWikiPageInput | null;
+  username?: string | null;
+}) {
+  if (params.wikiPage?.locked !== true) {
+    return true;
+  }
+
+  return canManageLockedWikiPage({
+    channel: params.channel,
+    username: params.username,
+  });
+}


### PR DESCRIPTION
## Summary

Adds the frontend wiki-page lock UI and client-side edit guards. Channel owners with elevated `canUpdateChannel` permission can lock/unlock pages with a reason, locked pages show a notice, and edit actions/forms are hidden or blocked for users who cannot manage locked pages.

Updates `docs/FEATURE_ROADMAP.md` to mark the wiki lock section complete.

This is stacked on frontend #295 (`codex/wiki-pinned-sidebar-pages`) and depends on backend #138 for the new lock/unlock mutations.

## Validation

- `./node_modules/.bin/vitest run --config vitest.config.ts components/wiki/WikiPageLockButton.spec.ts components/wiki/WikiPagePinButton.spec.ts 'pages/forums/[forumId]/wiki/[slug].spec.ts' 'pages/forums/[forumId]/wiki/edit/[slug].spec.ts' tests/unit/utils/wikiPageLockPermissions.spec.ts`
- `./node_modules/.bin/vue-tsc --noEmit`