### PR TITLE
[codex] Add sticky comment UI

### DIFF
--- a/components/comments/Comment.spec.ts
+++ b/components/comments/Comment.spec.ts
@@ -18,6 +18,8 @@ const h = vi.hoisted(() => ({
   }),
   subscribeToComment: vi.fn(),
   unsubscribeFromComment: vi.fn(),
+  stickyComment: vi.fn(),
+  unstickyComment: vi.fn(),
   handleMarkAsBestAnswer: vi.fn(),
   handleUnmarkAsBestAnswer: vi.fn(),
 }));
@@ -31,13 +33,19 @@ vi.mock('@vue/apollo-composable', () => ({
     mutate:
       mutation === 'SUBSCRIBE_TO_COMMENT'
         ? h.subscribeToComment
-        : h.unsubscribeFromComment,
+        : mutation === 'UNSUBSCRIBE_FROM_COMMENT'
+          ? h.unsubscribeFromComment
+          : mutation === 'STICKY_COMMENT'
+            ? h.stickyComment
+            : h.unstickyComment,
   }),
 }));
 
 vi.mock('@/graphQLData/comment/mutations', () => ({
   SUBSCRIBE_TO_COMMENT: 'SUBSCRIBE_TO_COMMENT',
   UNSUBSCRIBE_FROM_COMMENT: 'UNSUBSCRIBE_FROM_COMMENT',
+  STICKY_COMMENT: 'STICKY_COMMENT',
+  UNSTICKY_COMMENT: 'UNSTICKY_COMMENT',
 }));
 
 vi.mock('@/composables/useAuthState', () => ({

--- a/components/comments/Comment.vue
+++ b/components/comments/Comment.vue
@@ -2,7 +2,11 @@
 import { ref, computed } from 'vue';
 import { useRoute } from 'nuxt/app';
 import type { PropType } from 'vue';
-import type { ApolloError } from '@apollo/client/core';
+import type {
+  ApolloCache,
+  ApolloError,
+  NormalizedCacheObject,
+} from '@apollo/client/core';
 import { useMutation } from '@vue/apollo-composable';
 import type { Comment } from '@/__generated__/graphql';
 import type { CreateReplyInputData } from '@/types/Comment';
@@ -35,7 +39,9 @@ import { useForumRoleMembership } from '@/composables/useForumRoleMembership';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import {
   SUBSCRIBE_TO_COMMENT,
+  STICKY_COMMENT,
   UNSUBSCRIBE_FROM_COMMENT,
+  UNSTICKY_COMMENT,
 } from '@/graphQLData/comment/mutations';
 
 const usernameVar = useUsername();
@@ -47,6 +53,12 @@ type DeleteCommentInputData = {
   commentId: string;
   parentCommentId: string;
   replyCount: number;
+};
+
+type StickyCommentFields = Comment & {
+  isSticky?: boolean | null;
+  stickyAt?: string | null;
+  stickyByUsername?: string | null;
 };
 
 export type HandleFeedbackInput = {
@@ -340,6 +352,7 @@ const authorBadges = computed(() => {
 
 // Compute menu items using the utility function
 const commentMenuItems = computed(() => {
+  const commentData = props.commentData as StickyCommentFields;
   const isOwnComment = isCommentOwnedByUser(
     props.commentData,
     usernameVar.value
@@ -353,6 +366,7 @@ const commentMenuItems = computed(() => {
     isOwnComment,
     isWatchingReplies,
     isArchived: !!props.commentData.archived,
+    isSticky: !!commentData.isSticky,
     isDiscussionAuthor: isDiscussionAuthor.value,
     isMarkedAsAnswer: isMarkedAsAnswer.value,
     depth: props.depth,
@@ -404,6 +418,45 @@ const { mutate: unsubscribeFromComment } = useMutation(
     },
   }
 );
+
+const updateStickyCache = (
+  cache: ApolloCache<NormalizedCacheObject>,
+  comment: StickyCommentFields | null | undefined
+) => {
+  if (!comment?.id) {
+    return;
+  }
+
+  cache.modify({
+    id: cache.identify({
+      __typename: 'Comment',
+      id: comment.id,
+    }),
+    fields: {
+      isSticky() {
+        return !!comment.isSticky;
+      },
+      stickyAt() {
+        return comment.stickyAt ?? null;
+      },
+      stickyByUsername() {
+        return comment.stickyByUsername ?? null;
+      },
+    },
+  });
+};
+
+const { mutate: stickyComment } = useMutation(STICKY_COMMENT, {
+  update: (cache, result) => {
+    updateStickyCache(cache, result.data?.stickyComment);
+  },
+});
+
+const { mutate: unstickyComment } = useMutation(UNSTICKY_COMMENT, {
+  update: (cache, result) => {
+    updateStickyCache(cache, result.data?.unstickyComment);
+  },
+});
 
 const isSubscribed = computed(() =>
   isCommentSubscribedByUser(props.commentData, usernameVar.value)
@@ -463,6 +516,18 @@ function handleWatchReplies() {
 
 function handleUnwatchReplies() {
   unsubscribeFromComment({
+    commentId: props.commentData.id,
+  });
+}
+
+function handleStickyComment() {
+  stickyComment({
+    commentId: props.commentData.id,
+  });
+}
+
+function handleUnstickyComment() {
+  unstickyComment({
     commentId: props.commentData.id,
   });
 }
@@ -756,6 +821,8 @@ const label = computed(() =>
                       "
                       @handle-mark-as-best-answer="handleMarkAsBestAnswer"
                       @handle-unmark-as-best-answer="handleUnmarkAsBestAnswer"
+                      @handle-sticky-comment="handleStickyComment"
+                      @handle-unsticky-comment="handleUnstickyComment"
                     >
                       <EllipsisHorizontal
                         class="h-5 w-5 cursor-pointer hover:text-black dark:text-gray-300 dark:hover:text-white"

--- a/components/comments/CommentHeader.spec.ts
+++ b/components/comments/CommentHeader.spec.ts
@@ -168,6 +168,14 @@ describe('CommentHeader badges', () => {
 
     expect(wrapper.text()).toContain('Best Answer');
   });
+
+  it('shows a Stickied badge', () => {
+    const wrapper = mountHeader({
+      commentData: makeComment({ isSticky: true }),
+    });
+
+    expect(wrapper.text()).toContain('Stickied');
+  });
 });
 
 describe('CommentHeader context link', () => {

--- a/components/comments/CommentHeader.vue
+++ b/components/comments/CommentHeader.vue
@@ -11,6 +11,10 @@ import {
 } from '@/utils/routerUtils';
 import CommentEditsDropdown from './CommentEditsDropdown.vue';
 
+type StickyCommentFields = Comment & {
+  isSticky?: boolean | null;
+};
+
 // Props definition using defineProps
 const props = defineProps({
   commentData: {
@@ -202,6 +206,10 @@ const contextLinkObject = computed(() => {
     commentId: props.commentData.id,
   });
 });
+
+const isSticky = computed(
+  () => !!(props.commentData as StickyCommentFields).isSticky
+);
 </script>
 
 <template>
@@ -348,6 +356,12 @@ const contextLinkObject = computed(() => {
               class="ml-2"
               :comment="commentData"
             />
+          </span>
+          <span
+            v-if="isSticky"
+            class="rounded-lg border border-amber-500 bg-amber-100 px-2 py-1 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+          >
+            Stickied
           </span>
           <span
             v-if="isHighlighted"

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -166,10 +166,15 @@ Notes:
 - [ ] Add a lock state for wiki pages.
 - [ ] Restrict editing of locked wiki pages to channel owners per product rules.
 
-### 12. Moderation: sticky comment on discussion or event `[not started]`
+### 12. Moderation: sticky comment on discussion or event `[complete]`
 
-- [ ] Let moderators sticky a comment so it appears at the top of a discussion or event comment list.
-- [ ] Define ordering, permissions, and unsticky behavior.
+- [x] Let moderators sticky a comment so it appears at the top of a discussion or event comment list.
+- [x] Define ordering, permissions, and unsticky behavior.
+
+Notes:
+- Sticky comments use the existing `canHideComment` moderation permission and are limited to root, active, non-feedback comments.
+- Discussion and event comment queries return sticky metadata and sort sticky comments above the selected normal sort order.
+- The frontend shows a `Stickied` badge and exposes sticky/unsticky actions from the comment menu for users with comment-hide permission.
 
 ### 13. Wiki search: featured wiki pages from server settings `[not started]`
 

--- a/graphQLData/comment/mutations.js
+++ b/graphQLData/comment/mutations.js
@@ -217,6 +217,28 @@ export const UNSUBSCRIBE_FROM_COMMENT = gql`
   }
 `;
 
+export const STICKY_COMMENT = gql`
+  mutation stickyComment($commentId: ID!) {
+    stickyComment(commentId: $commentId) {
+      id
+      isSticky
+      stickyAt
+      stickyByUsername
+    }
+  }
+`;
+
+export const UNSTICKY_COMMENT = gql`
+  mutation unstickyComment($commentId: ID!) {
+    unstickyComment(commentId: $commentId) {
+      id
+      isSticky
+      stickyAt
+      stickyByUsername
+    }
+  }
+`;
+
 export const ADD_FEEDBACK_COMMENT_TO_COMMENT = gql`
   mutation addFeedbackCommentToComment(
     $modProfileName: String!

--- a/graphQLData/comment/queries.js
+++ b/graphQLData/comment/queries.js
@@ -84,6 +84,9 @@ export const COMMENT_FIELDS = gql`
     updatedAt
     textLastEdited
     archived
+    isSticky
+    stickyAt
+    stickyByUsername
     isFavoritedByUser
     CommentAuthor {
       ... on ModerationProfile {
@@ -225,6 +228,9 @@ export const GET_DISCUSSION_COMMENTS = gql`
         updatedAt
         textLastEdited
         archived
+        isSticky
+        stickyAt
+        stickyByUsername
         isFavoritedByUser
         CommentAuthor {
           ...AuthorFields

--- a/tests/playwright/helpers/graphqlFixtures.ts
+++ b/tests/playwright/helpers/graphqlFixtures.ts
@@ -15,6 +15,9 @@ export type MockCommentState = {
   text: string;
   parentCommentId: string | null;
   archived?: boolean;
+  isSticky?: boolean;
+  stickyAt?: string | null;
+  stickyByUsername?: string | null;
 };
 
 type CountAggregate = { count: number };
@@ -202,6 +205,9 @@ export type CommentFixture = Pick<
   | 'PastVersions'
   | 'Event'
 > & {
+  isSticky: boolean;
+  stickyAt: string | null;
+  stickyByUsername: string | null;
   CommentAuthor: UserFixture;
   ChildCommentsAggregate: CountAggregate;
   ParentComment: Pick<Comment, 'id'> | null;
@@ -580,6 +586,9 @@ export const buildComment = ({
   createdAt: MOCK_DATE,
   updatedAt: MOCK_DATE,
   archived: comment.archived ?? false,
+  isSticky: comment.isSticky ?? false,
+  stickyAt: comment.stickyAt ?? null,
+  stickyByUsername: comment.stickyByUsername ?? null,
   isFavoritedByUser: false,
   CommentAuthor: buildUser(),
   ChildCommentsAggregate: {

--- a/tests/playwright/mocked/superUpvote/giveCommentSuperUpvote.spec.ts
+++ b/tests/playwright/mocked/superUpvote/giveCommentSuperUpvote.spec.ts
@@ -39,11 +39,14 @@ test('user can give and undo a super upvote on another user\'s comment', async (
   await expect(superUpvoteButton).toHaveCount(0);
 
   // Upvote alice's comment.
-  await upvoteButton.click();
-  await page.waitForResponse(
+  const upvoteResponse = page.waitForResponse(
     (response) =>
-      response.url().includes('/graphql') && response.request().method() === 'POST'
+      response.url().includes('/graphql') &&
+      response.request().method() === 'POST' &&
+      !!response.request().postData()?.includes('upvoteComment')
   );
+  await upvoteButton.click();
+  await upvoteResponse;
 
   // The super upvote button appears, inactive.
   await expect(superUpvoteButton).toBeVisible();

--- a/utils/headerPermissionUtils.spec.ts
+++ b/utils/headerPermissionUtils.spec.ts
@@ -1034,6 +1034,38 @@ describe('headerPermissionUtils', () => {
 
         expect(menuItems.find((item) => item.event === 'handleClickArchive')).toBeDefined();
       });
+
+      it('should include sticky option for root comments', () => {
+        const menuItems = getCommentMenuItems({
+          ...defaultParams,
+          userPermissions: elevatedModPermissions,
+          isLoggedIn: true,
+        });
+
+        expect(menuItems.find((item) => item.event === 'handleStickyComment')).toBeDefined();
+      });
+
+      it('should include unsticky option for stickied comments', () => {
+        const menuItems = getCommentMenuItems({
+          ...defaultParams,
+          isSticky: true,
+          userPermissions: elevatedModPermissions,
+          isLoggedIn: true,
+        });
+
+        expect(menuItems.find((item) => item.event === 'handleUnstickyComment')).toBeDefined();
+      });
+
+      it('should not include sticky option for nested comments', () => {
+        const menuItems = getCommentMenuItems({
+          ...defaultParams,
+          depth: 2,
+          userPermissions: elevatedModPermissions,
+          isLoggedIn: true,
+        });
+
+        expect(menuItems.find((item) => item.event === 'handleStickyComment')).toBeUndefined();
+      });
     });
 
     describe('for suspended moderators', () => {

--- a/utils/headerPermissionUtils.ts
+++ b/utils/headerPermissionUtils.ts
@@ -529,6 +529,7 @@ export const getCommentMenuItems = (params: {
   isOwnComment: boolean;
   isWatchingReplies: boolean;
   isArchived: boolean;
+  isSticky?: boolean;
   isDiscussionAuthor: boolean;
   isMarkedAsAnswer: boolean;
   depth: number;
@@ -544,6 +545,7 @@ export const getCommentMenuItems = (params: {
     isOwnComment,
     isWatchingReplies,
     isArchived,
+    isSticky = false,
     isDiscussionAuthor,
     isMarkedAsAnswer,
     depth,
@@ -671,6 +673,15 @@ export const getCommentMenuItems = (params: {
         value: '',
         event: 'clickEditFeedback',
         icon: ALLOWED_ICONS.EDIT,
+      });
+    }
+
+    if (depth === 1 && userPermissions.canHideComment && !isArchived) {
+      modActions.push({
+        label: isSticky ? 'Unsticky Comment' : 'Sticky Comment',
+        value: '',
+        event: isSticky ? 'handleUnstickyComment' : 'handleStickyComment',
+        icon: isSticky ? ALLOWED_ICONS.UNDO : ALLOWED_ICONS.MARK_BEST_ANSWER,
       });
     }
 


### PR DESCRIPTION
## Summary

Adds frontend support for sticky comments on discussion and event comment lists.

- Selects sticky metadata in comment GraphQL queries and adds sticky/unsticky mutations.
- Shows a `Stickied` badge in comment headers.
- Adds `Sticky Comment` / `Unsticky Comment` menu actions for root comments when the viewer has comment-hide moderation permission.
- Updates Apollo's cached sticky fields after mutation.
- Marks the roadmap sticky-comment section complete.

Depends on backend #139 for the schema fields and mutations.

## Validation

- `./node_modules/.bin/vitest run --config vitest.config.ts components/comments/CommentHeader.spec.ts utils/headerPermissionUtils.spec.ts`
- `./node_modules/.bin/vue-tsc --noEmit`