### PR TITLE
Remove author role badges from download list items

### DIFF
--- a/components/discussion/list/ChannelDownloadListItem.spec.ts
+++ b/components/discussion/list/ChannelDownloadListItem.spec.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 
@@ -7,29 +6,9 @@ import ChannelDownloadListItem from '@/components/discussion/list/ChannelDownloa
 
 const h = vi.hoisted(() => ({
   route: null as unknown,
-  adminUsernames: null as unknown,
-  serverModUsernames: null as unknown,
-  serverModProfileNames: null as unknown,
-  forumAdminUsernames: null as unknown,
-  forumModUsernames: null as unknown,
-  forumModProfileNames: null as unknown,
 }));
 
 vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
-vi.mock('@/composables/useServerRoleMembership', () => ({
-  useServerRoleMembership: () => ({
-    serverAdminUsernames: h.adminUsernames,
-    serverModUsernames: h.serverModUsernames,
-    serverModProfileNames: h.serverModProfileNames,
-  }),
-}));
-vi.mock('@/composables/useForumRoleMembership', () => ({
-  useForumRoleMembership: () => ({
-    forumAdminUsernames: h.forumAdminUsernames,
-    forumModUsernames: h.forumModUsernames,
-    forumModProfileNames: h.forumModProfileNames,
-  }),
-}));
 
 const makeChannel = (overrides: Record<string, unknown> = {}) =>
   ({
@@ -94,12 +73,6 @@ const author = (wrapper: ReturnType<typeof mount>) =>
 
 beforeEach(() => {
   h.route = { params: { forumId: 'cats' }, query: {} };
-  h.adminUsernames = ref<string[]>([]);
-  h.serverModUsernames = ref<string[]>([]);
-  h.serverModProfileNames = ref<string[]>([]);
-  h.forumAdminUsernames = ref<string[]>([]);
-  h.forumModUsernames = ref<string[]>([]);
-  h.forumModProfileNames = ref<string[]>([]);
 });
 
 describe('ChannelDownloadListItem title', () => {
@@ -175,42 +148,15 @@ describe('ChannelDownloadListItem metadata', () => {
 });
 
 describe('ChannelDownloadListItem author badges', () => {
-  it('marks the author as a server admin when listed', () => {
-    h.adminUsernames = ref(['alice']);
+  it.each([
+    'isServerAdmin',
+    'isServerMod',
+    'isForumAdmin',
+    'isForumMod',
+  ])('does not pass the %s role badge to the author', (badgeProp) => {
     const wrapper = mountItem(makeDiscussion());
 
-    expect(author(wrapper).props('isServerAdmin')).toBe(true);
-  });
-
-  it('marks the author as a server mod when listed (and not a server admin)', () => {
-    h.serverModUsernames = ref(['alice']);
-    const wrapper = mountItem(makeDiscussion());
-
-    expect(author(wrapper).props('isServerMod')).toBe(true);
-  });
-
-  it('marks the author as a Forum Admin when they own the channel', () => {
-    h.forumAdminUsernames = ref(['alice']);
-    const wrapper = mountItem(makeDiscussion());
-
-    expect(author(wrapper).props('isForumAdmin')).toBe(true);
-    expect(author(wrapper).props('isForumMod')).toBe(false);
-  });
-
-  it('marks the author as a Forum Mod when they moderate the channel', () => {
-    h.forumModUsernames = ref(['alice']);
-    const wrapper = mountItem(makeDiscussion());
-
-    expect(author(wrapper).props('isForumMod')).toBe(true);
-  });
-
-  it('suppresses the Forum Mod badge for a channel owner who also moderates', () => {
-    h.forumAdminUsernames = ref(['alice']);
-    h.forumModUsernames = ref(['alice']);
-    const wrapper = mountItem(makeDiscussion());
-
-    expect(author(wrapper).props('isForumAdmin')).toBe(true);
-    expect(author(wrapper).props('isForumMod')).toBe(false);
+    expect(author(wrapper).props(badgeProp)).toBeUndefined();
   });
 });
 

--- a/components/discussion/list/ChannelDownloadListItem.vue
+++ b/components/discussion/list/ChannelDownloadListItem.vue
@@ -17,9 +17,6 @@ import type { DiscussionChannelWithFavorited } from '@/types/Discussion';
 import CheckCircleIcon from '@/components/icons/CheckCircleIcon.vue';
 import ImageIcon from '@/components/icons/ImageIcon.vue';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
-import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
-import { useForumRoleMembership } from '@/composables/useForumRoleMembership';
-import { getAuthorBadges } from '@/utils/roleBadges';
 
 // Define props
 const props = defineProps({
@@ -59,24 +56,8 @@ const channelIdInParams = computed(() =>
 const defaultUniqueName = computed(
   () => channelIdInParams.value || props.discussionChannel.channelUniqueName
 );
-const { serverAdminUsernames, serverModUsernames, serverModProfileNames } =
-  useServerRoleMembership();
-const { forumAdminUsernames, forumModUsernames, forumModProfileNames } =
-  useForumRoleMembership();
 const commentCount = computed(
   () => props.discussionChannel?.CommentsAggregate?.count || 0
-);
-
-const authorBadges = computed(() =>
-  getAuthorBadges({
-    username: props.discussion?.Author?.username,
-    serverAdminUsernames: serverAdminUsernames.value,
-    serverModUsernames: serverModUsernames.value,
-    serverModProfileNames: serverModProfileNames.value,
-    forumAdminUsernames: forumAdminUsernames.value,
-    forumModUsernames: forumModUsernames.value,
-    forumModProfileNames: forumModProfileNames.value,
-  })
 );
 
 const errorMessage = ref('');
@@ -209,10 +190,6 @@ const filteredQuery = computed(() => {
                 :comment-karma="authorCommentKarma"
                 :discussion-karma="authorDiscussionKarma"
                 :display-name="authorDisplayName ?? ''"
-                :is-server-admin="authorBadges.isServerAdmin"
-                :is-server-mod="authorBadges.isServerMod"
-                :is-forum-admin="authorBadges.isForumAdmin"
-                :is-forum-mod="authorBadges.isForumMod"
                 :src="authorProfilePicURL ?? ''"
                 :username="authorUsername"
                 light-text

--- a/components/discussion/list/SitewideDownloadListItem.vue
+++ b/components/discussion/list/SitewideDownloadListItem.vue
@@ -10,8 +10,6 @@ import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue';
 import { relativeTime } from '@/utils';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 import type { DiscussionWithFavorited } from '@/types/Discussion';
-import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
-import { getServerRoleBadge } from '@/utils/serverRoleBadges';
 
 type AlbumPayload = {
   discussion: Discussion;
@@ -43,7 +41,6 @@ const emit = defineEmits<{
 }>();
 
 const route = useRoute();
-const { serverAdminUsernames } = useServerRoleMembership();
 
 const filteredQuery = computed(() => {
   const query = { ...route.query };
@@ -122,15 +119,6 @@ const authorDiscussionKarma = computed(
 const authorAccountCreated = computed(
   () => props.discussion?.Author?.createdAt || ''
 );
-
-const authorIsAdmin = computed(() => {
-  return (
-    getServerRoleBadge({
-      username: props.discussion?.Author?.username,
-      adminUsernames: serverAdminUsernames.value,
-    }) === 'serverAdmin'
-  );
-});
 
 const firstAlbumImage = computed(() => {
   const album = props.discussion?.Album;
@@ -216,7 +204,6 @@ const handleOpenAlbum = () => {
             :comment-karma="authorCommentKarma"
             :discussion-karma="authorDiscussionKarma"
             :account-created="authorAccountCreated"
-            :is-server-admin="authorIsAdmin"
             light-text
           /><template v-if="primaryChannel">
             in


### PR DESCRIPTION
## What

Removes the author **role badges** (Server Admin / Server Mod / Forum Admin / Forum Mod) from download list rows, so the author line is more compact.

Applies to both download list-item components:
- [`ChannelDownloadListItem.vue`](components/discussion/list/ChannelDownloadListItem.vue) — the forum-scoped list at `/forums/:forumId/downloads` (e.g. the linked `sims4_builds/downloads`)
- [`SitewideDownloadListItem.vue`](components/discussion/list/SitewideDownloadListItem.vue) — the global downloads feed

## Scope / what's untouched

The badges are **kept everywhere else** — discussion list items, comment headers, event headers/footers, mod activity feed, and library cards. Those render their own `UsernameWithTooltip` and are unaffected because the download list items are separate components.

The author name, karma, avatar, and tooltip all still render — only the role badges are gone.

## Cleanup

With the badge props removed, the role-membership plumbing that fed them became dead code and was removed too:
- `ChannelDownloadListItem`: `useServerRoleMembership`, `useForumRoleMembership`, `getAuthorBadges`, and the `authorBadges` computed
- `SitewideDownloadListItem`: `useServerRoleMembership`, `getServerRoleBadge`, and the `authorIsAdmin` computed

## Verification

- `pnpm run tsc` — passes
- `pnpm run test:unit` — passes; `ChannelDownloadListItem.spec.ts` updated: the old "author badges" tests (which asserted the badge props were set) are replaced with a parametrized test asserting no role-badge prop is passed to the author. `SitewideDownloadListItem.spec.ts` unaffected.
- `eslint` — clean

Note: I couldn't render the live download list locally (the dev server needs the GraphQL backend on `localhost:4000`, which isn't running here), so verification is via the unit tests that assert the badges are no longer passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)