### PR TITLE
Secondary New Post button on the sitewide discussion list

### DIFF
--- a/components/discussion/list/DiscussionFilterBar.spec.ts
+++ b/components/discussion/list/DiscussionFilterBar.spec.ts
@@ -3,6 +3,8 @@ import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { createMockRoute, createMockRouter } from '@/tests/utils/mockRouter';
 
 import DiscussionFilterBar from '@/components/discussion/list/DiscussionFilterBar.vue';
+import PrimaryButton from '@/components/PrimaryButton.vue';
+import SecondaryButton from '@/components/SecondaryButton.vue';
 
 // Let the real useFilterBar run against a mocked route/router.
 const route = createMockRoute({ name: 'DiscussionList' });
@@ -18,6 +20,7 @@ const heavyStubs = {
   SortButtons: true,
   FilterChip: true,
   PrimaryButton: true,
+  SecondaryButton: true,
   ChannelIcon: true,
   TagIcon: true,
   FilterIcon: true,
@@ -67,5 +70,23 @@ describe('DiscussionFilterBar', () => {
     expect(aboutButton).toBeTruthy();
     await aboutButton!.trigger('click');
     expect(wrapper.emitted('openAbout')).toBeTruthy();
+  });
+
+  it('uses the primary New Post button on a forum-scoped list', () => {
+    const wrapper = mountBar({ isForumScoped: true });
+
+    expect(wrapper.findComponent(PrimaryButton).exists()).toBe(true);
+  });
+
+  it('uses the secondary New Post button on the sitewide list', () => {
+    const wrapper = mountBar({ isForumScoped: false });
+
+    expect(wrapper.findComponent(SecondaryButton).exists()).toBe(true);
+  });
+
+  it('does not use the primary New Post button on the sitewide list', () => {
+    const wrapper = mountBar({ isForumScoped: false });
+
+    expect(wrapper.findComponent(PrimaryButton).exists()).toBe(false);
   });
 });

--- a/components/discussion/list/DiscussionFilterBar.vue
+++ b/components/discussion/list/DiscussionFilterBar.vue
@@ -11,6 +11,7 @@ import { getDiscussionFilterValuesFromParams } from '@/utils/getDiscussionFilter
 import type { SearchDiscussionValues } from '@/types/Discussion';
 import FilterIcon from '@/components/icons/FilterIcon.vue';
 import PrimaryButton from '@/components/PrimaryButton.vue';
+import SecondaryButton from '@/components/SecondaryButton.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import SearchIcon from '@/components/icons/SearchIcon.vue';
 import { useUIStore } from '@/stores/uiStore';
@@ -23,7 +24,7 @@ import { updateFilters } from '@/utils/routerUtils';
 
 const emit = defineEmits(['openAbout']);
 
-defineProps({
+const props = defineProps({
   isForumScoped: {
     type: Boolean,
     default: false,
@@ -41,6 +42,12 @@ defineProps({
     default: 0,
   },
 });
+
+// The sitewide discussion list uses a lower-emphasis (secondary) New Post
+// button; forum-scoped lists keep the primary button.
+const newPostButton = computed(() =>
+  props.isForumScoped ? PrimaryButton : SecondaryButton
+);
 
 // Use shared filter bar composable
 const {
@@ -251,7 +258,8 @@ const isExpanded = computed(() => {
         <div v-if="!isDownloadPage">
           <RequireAuth :full-width="false">
             <template #has-auth>
-              <PrimaryButton
+              <component
+                :is="newPostButton"
                 :label="isDownloadPage ? 'New Upload' : 'New Post'"
                 @click="
                   $router.push(
@@ -265,7 +273,8 @@ const isExpanded = computed(() => {
               />
             </template>
             <template #does-not-have-auth>
-              <PrimaryButton
+              <component
+                :is="newPostButton"
                 :label="isDownloadPage ? 'New Upload' : 'New Post'"
               />
             </template>


### PR DESCRIPTION
## What

On the sitewide `/discussions` list, the **New Post** button is now a lower-emphasis **secondary** button instead of the primary (filled) button.

Forum-scoped discussion lists (`/forums/:forumId/discussions`) are unchanged — they keep the primary button.

## How

Both lists share [`DiscussionFilterBar.vue`](components/discussion/list/DiscussionFilterBar.vue), which already receives an `isForumScoped` prop (`false` on `/discussions`, `true` on forum lists). The New Post button now picks its component from that prop:

```ts
const newPostButton = computed(() =>
  props.isForumScoped ? PrimaryButton : SecondaryButton
);
```

and both the authed and unauthed `RequireAuth` slots render `<component :is="newPostButton" ... />`. The download page's "New Upload" button is untouched (it's in a separate `v-if="!isDownloadPage"` branch that this doesn't reach).

## Verification

- `pnpm run tsc` — passes
- `pnpm run test:unit` — passes; added 3 `DiscussionFilterBar.spec.ts` tests (primary on forum-scoped, secondary on sitewide, and no primary on sitewide)
- `eslint` — clean
- Verified in the running app: sitewide `/discussions` New Post renders as the secondary button (transparent bg, gray text); `/forums/cats/discussions` keeps the primary filled button (`rgb(22,27,34)` bg, white text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)