### PR TITLE
Add featured wiki pages UI

### DIFF
--- a/components/admin/CreateEditServerFields.vue
+++ b/components/admin/CreateEditServerFields.vue
@@ -81,6 +81,12 @@ const tabs = [
     fontAwesome: null,
   },
   {
+    key: 'wiki',
+    label: 'Wiki Settings',
+    icon: BookIcon,
+    fontAwesome: null,
+  },
+  {
     key: 'roles',
     label: 'Roles',
     icon: IdentificationIcon,

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -182,10 +182,15 @@ Notes:
 - Discussion and event comment queries return sticky metadata and sort sticky comments above the selected normal sort order.
 - The frontend shows a `Stickied` badge and exposes sticky/unsticky actions from the comment menu for users with comment-hide permission.
 
-### 13. Wiki search: featured wiki pages from server settings `[not started]`
+### 13. Wiki search: featured wiki pages from server settings `[complete]`
 
-- [ ] Add server-admin configuration for featured wiki pages.
-- [ ] Surface featured pages in `/wiki/search`.
+- [x] Add server-admin configuration for featured wiki pages. `[in backend/frontend PRs]`
+- [x] Surface featured pages in `/wiki/search`. `[in backend/frontend PRs]`
+
+Notes:
+- Server settings now store an ordered list of featured wiki page IDs through a dedicated backend mutation.
+- The admin Wiki Settings tab provides a searchable picker with explicit up/down ordering.
+- `/wiki/search` renders featured wiki pages above normal results and removes duplicates from the regular result list.
 
 ### 14. Favorites API optimization `[partial]`
 

--- a/graphQLData/admin/mutations.js
+++ b/graphQLData/admin/mutations.js
@@ -19,6 +19,18 @@ export const UPDATE_SERVER_CONFIG = gql`
   }
 `;
 
+export const SET_FEATURED_WIKI_PAGES = gql`
+  mutation setFeaturedWikiPages($serverName: String!, $wikiPageIds: [ID!]!) {
+    setFeaturedWikiPages(
+      serverName: $serverName
+      wikiPageIds: $wikiPageIds
+    ) {
+      serverName
+      featuredWikiPageIds
+    }
+  }
+`;
+
 export const REFRESH_PLUGINS = gql`
   mutation RefreshPlugins {
     refreshPlugins {

--- a/graphQLData/admin/queries.js
+++ b/graphQLData/admin/queries.js
@@ -6,6 +6,7 @@ export const GET_SERVER_CONFIG = gql`
       serverName
       serverIconURL
       serverDescription
+      featuredWikiPageIds
       Admins {
         username
       }

--- a/graphQLData/wiki/queries.js
+++ b/graphQLData/wiki/queries.js
@@ -12,6 +12,20 @@ export const GET_SITE_WIDE_WIKI_LIST = gql`
       options: $options
     ) {
       aggregateWikiPageCount
+      featuredWikiPages {
+        id
+        title
+        body
+        slug
+        channelUniqueName
+        createdAt
+        updatedAt
+        VersionAuthor {
+          username
+          displayName
+          profilePicURL
+        }
+      }
       wikiPages {
         id
         title
@@ -25,6 +39,25 @@ export const GET_SITE_WIDE_WIKI_LIST = gql`
           displayName
           profilePicURL
         }
+      }
+    }
+  }
+`;
+
+export const GET_WIKI_PAGES_BY_IDS = gql`
+  query getWikiPagesByIds($ids: [ID!]!) {
+    wikiPages(where: { id_IN: $ids }) {
+      id
+      title
+      body
+      slug
+      channelUniqueName
+      createdAt
+      updatedAt
+      VersionAuthor {
+        username
+        displayName
+        profilePicURL
       }
     }
   }

--- a/pages/admin/settings.spec.ts
+++ b/pages/admin/settings.spec.ts
@@ -8,9 +8,9 @@ const h = vi.hoisted(() => ({
   result: null as unknown as { value: unknown },
   error: null as unknown as { value: unknown },
   loading: null as unknown as { value: boolean },
-  mutate: null as unknown as ReturnType<typeof vi.fn>,
+  updateMutate: null as unknown as ReturnType<typeof vi.fn>,
+  setFeaturedMutate: null as unknown as ReturnType<typeof vi.fn>,
   onResultCb: null as unknown as (r: unknown) => void,
-  onDoneCb: null as unknown as () => void,
 }));
 
 vi.mock('@vue/apollo-composable', async () => {
@@ -18,7 +18,8 @@ vi.mock('@vue/apollo-composable', async () => {
   h.result = ref(null);
   h.error = ref(null);
   h.loading = ref(false);
-  h.mutate = vi.fn();
+  h.updateMutate = vi.fn(async () => ({}));
+  h.setFeaturedMutate = vi.fn(async () => ({}));
   return {
     useQuery: () => ({
       result: h.result,
@@ -28,20 +29,20 @@ vi.mock('@vue/apollo-composable', async () => {
         h.onResultCb = cb;
       },
     }),
-    useMutation: () => ({
-      mutate: h.mutate,
+    useMutation: (document: string) => ({
+      mutate: document === 'setFeatured' ? h.setFeaturedMutate : h.updateMutate,
       loading: ref(false),
       error: ref(null),
-      onDone: (cb: () => void) => {
-        h.onDoneCb = cb;
-      },
     }),
   };
 });
 
 vi.mock('@/config', () => ({ config: { serverName: 'test-server' } }));
 vi.mock('@/graphQLData/admin/queries', () => ({ GET_SERVER_CONFIG: 'q' }));
-vi.mock('@/graphQLData/admin/mutations', () => ({ UPDATE_SERVER_CONFIG: 'm' }));
+vi.mock('@/graphQLData/admin/mutations', () => ({
+  UPDATE_SERVER_CONFIG: 'm',
+  SET_FEATURED_WIKI_PAGES: 'setFeatured',
+}));
 
 const FieldsStub = {
   name: 'CreateEditServerFields',
@@ -93,6 +94,7 @@ describe('Admin server settings page', () => {
             enableDownloads: true,
             enableEvents: false,
             pluginRegistries: ['https://r'],
+            featuredWikiPageIds: ['w1'],
           },
         ],
       },
@@ -102,6 +104,7 @@ describe('Admin server settings page', () => {
       serverDescription: string;
       enableDownloads: boolean;
       rules: unknown[];
+      featuredWikiPageIds: string[];
     };
     expect(fv.serverDescription).toBe('My server');
     expect(fv.enableDownloads).toBe(true);
@@ -123,7 +126,7 @@ describe('Admin server settings page', () => {
       rules: [{ summary: 'Rule' }],
     });
     await fields(wrapper).vm.$emit('submit');
-    expect(h.mutate).toHaveBeenCalledWith(
+    expect(h.updateMutate).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           serverDescription: 'Updated',
@@ -133,11 +136,16 @@ describe('Admin server settings page', () => {
     );
   });
 
-  it('shows a saved-changes notification when the update completes', async () => {
+  it('submits featured wiki page IDs through the custom mutation', async () => {
     const wrapper = mountPage();
-    h.onDoneCb();
-    await wrapper.vm.$nextTick();
-    expect(wrapper.findComponent({ name: 'Notification' }).exists()).toBe(true);
+    await fields(wrapper).vm.$emit('update-form-values', {
+      featuredWikiPageIds: ['w2', 'w1'],
+    });
+    await fields(wrapper).vm.$emit('submit');
+    expect(h.setFeaturedMutate).toHaveBeenCalledWith({
+      serverName: 'test-server',
+      wikiPageIds: ['w2', 'w1'],
+    });
   });
 
   it('shows the permission denied message when auth is missing', async () => {

--- a/pages/admin/settings.vue
+++ b/pages/admin/settings.vue
@@ -1,13 +1,20 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
-import { UPDATE_SERVER_CONFIG } from '@/graphQLData/admin/mutations';
+import {
+  SET_FEATURED_WIKI_PAGES,
+  UPDATE_SERVER_CONFIG,
+} from '@/graphQLData/admin/mutations';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import Notification from '@/components/NotificationComponent.vue';
 import type { ServerConfigUpdateInput } from '@/__generated__/graphql';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 import { config } from '@/config';
 import CreateEditServerFields from '@/components/admin/CreateEditServerFields.vue';
+
+type ServerSettingsFormValues = ServerConfigUpdateInput & {
+  featuredWikiPageIds?: string[];
+};
 
 const dataLoaded = ref(false);
 const {
@@ -31,13 +38,14 @@ const serverConfig = computed(() => {
   }
   return getServerResult.value.serverConfigs?.[0] || null;
 });
-const formValues = ref<ServerConfigUpdateInput>({
+const formValues = ref<ServerSettingsFormValues>({
   serverDescription: '',
   rules: [],
   allowedFileTypes: [],
   enableDownloads: false,
   enableEvents: false,
   pluginRegistries: [],
+  featuredWikiPageIds: [],
 });
 
 onGetServerResult((result) => {
@@ -59,6 +67,7 @@ onGetServerResult((result) => {
     enableDownloads: Boolean(serverConfig.enableDownloads),
     enableEvents: Boolean(serverConfig.enableEvents),
     pluginRegistries: serverConfig.pluginRegistries || [],
+    featuredWikiPageIds: serverConfig.featuredWikiPageIds || [],
   };
 });
 
@@ -82,7 +91,6 @@ const {
   mutate: updateServer,
   loading: editServerLoading,
   error: updateServerError,
-  onDone,
 } = useMutation(UPDATE_SERVER_CONFIG, {
   update: (cache, { data }) => {
     const newServerConfig = data?.updateServerConfigs.serverConfigs[0];
@@ -135,18 +143,32 @@ const {
   },
 });
 
-onDone(() => {
-  showSavedChangesNotification.value = true;
-});
+const {
+  mutate: setFeaturedWikiPages,
+  loading: setFeaturedWikiPagesLoading,
+  error: setFeaturedWikiPagesError,
+} = useMutation(SET_FEATURED_WIKI_PAGES);
 
-function submit() {
-  updateServer({
+const isSaving = computed(
+  () => editServerLoading.value || setFeaturedWikiPagesLoading.value
+);
+const combinedUpdateError = computed(
+  () => updateServerError.value || setFeaturedWikiPagesError.value
+);
+
+async function submit() {
+  await updateServer({
     input: serverUpdateInput.value,
     serverName: config.serverName,
   });
+  await setFeaturedWikiPages({
+    serverName: config.serverName,
+    wikiPageIds: formValues.value.featuredWikiPageIds || [],
+  });
+  showSavedChangesNotification.value = true;
 }
 
-function updateFormValues(data: ServerConfigUpdateInput) {
+function updateFormValues(data: ServerSettingsFormValues) {
   formValues.value = { ...formValues.value, ...data };
 }
 </script>
@@ -161,8 +183,8 @@ function updateFormValues(data: ServerConfigUpdateInput) {
             :edit-mode="true"
             :server-loading="getServerLoading"
             :get-server-error="getServerError"
-            :update-server-error="updateServerError"
-            :edit-server-loading="editServerLoading"
+            :update-server-error="combinedUpdateError"
+            :edit-server-loading="isSaving"
             :form-values="formValues"
             @submit="submit"
             @update-form-values="updateFormValues"

--- a/pages/admin/settings/wiki.spec.ts
+++ b/pages/admin/settings/wiki.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import WikiSettingsPage from './wiki.vue';
+
+const h = vi.hoisted(() => ({
+  searchResult: { value: {} },
+  selectedResult: { value: {} },
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn((document: string) => ({
+    result: document === 'selectedQuery' ? h.selectedResult : h.searchResult,
+    loading: { value: false },
+  })),
+}));
+
+vi.mock('@/graphQLData/wiki/queries', () => ({
+  GET_SITE_WIDE_WIKI_LIST: 'searchQuery',
+  GET_WIKI_PAGES_BY_IDS: 'selectedQuery',
+}));
+
+const mountPage = (featuredWikiPageIds: string[] = []) =>
+  shallowMount(WikiSettingsPage, {
+    props: {
+      editMode: true,
+      formValues: { featuredWikiPageIds },
+    },
+    global: {
+      stubs: {
+        FormRow: { template: '<div><slot name="content" /></div>' },
+        LoadingSpinner: { template: '<div />' },
+      },
+    },
+  });
+
+beforeEach(() => {
+  h.searchResult.value = {
+    getSiteWideWikiList: {
+      wikiPages: [
+        { id: 'w1', title: 'Alpha', slug: 'alpha', channelUniqueName: 'cats' },
+        { id: 'w2', title: 'Beta', slug: 'beta', channelUniqueName: 'dogs' },
+      ],
+    },
+  };
+  h.selectedResult.value = {
+    wikiPages: [
+      { id: 'w1', title: 'Alpha', slug: 'alpha', channelUniqueName: 'cats' },
+      { id: 'w2', title: 'Beta', slug: 'beta', channelUniqueName: 'dogs' },
+    ],
+  };
+});
+
+describe('admin wiki settings page', () => {
+  it('emits selected IDs when adding a featured page', async () => {
+    const wrapper = mountPage();
+    await wrapper.find('[data-testid="featured-wiki-search-results"] button').trigger('click');
+    expect(wrapper.emitted('updateFormValues')?.[0]).toEqual([
+      { featuredWikiPageIds: ['w1'] },
+    ]);
+  });
+
+  it('emits selected IDs when removing a featured page', async () => {
+    const wrapper = mountPage(['w1']);
+    await wrapper.find('[data-testid="featured-wiki-selected-list"] button:last-child').trigger('click');
+    expect(wrapper.emitted('updateFormValues')?.[0]).toEqual([
+      { featuredWikiPageIds: [] },
+    ]);
+  });
+
+  it('emits reordered IDs when moving a featured page', async () => {
+    const wrapper = mountPage(['w1', 'w2']);
+    const downButton = wrapper.findAll('[data-testid="featured-wiki-selected-list"] button')[1];
+    await downButton.trigger('click');
+    expect(wrapper.emitted('updateFormValues')?.[0]).toEqual([
+      { featuredWikiPageIds: ['w2', 'w1'] },
+    ]);
+  });
+});

--- a/pages/admin/settings/wiki.vue
+++ b/pages/admin/settings/wiki.vue
@@ -1,0 +1,235 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { PropType } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import type { ServerConfigUpdateInput } from '@/__generated__/graphql';
+import FormRow from '@/components/FormRow.vue';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import {
+  GET_SITE_WIDE_WIKI_LIST,
+  GET_WIKI_PAGES_BY_IDS,
+} from '@/graphQLData/wiki/queries';
+
+type WikiPageOption = {
+  id: string;
+  title?: string | null;
+  slug?: string | null;
+  channelUniqueName?: string | null;
+};
+
+type ServerSettingsFormValues = ServerConfigUpdateInput & {
+  featuredWikiPageIds?: string[];
+};
+
+const props = defineProps({
+  editMode: {
+    type: Boolean,
+    required: true,
+  },
+  formValues: {
+    type: Object as PropType<ServerSettingsFormValues | null>,
+    required: false,
+    default: null,
+  },
+});
+
+const emit = defineEmits(['updateFormValues']);
+
+const searchInput = ref('');
+const selectedIds = computed(() => props.formValues?.featuredWikiPageIds || []);
+
+const { result: searchResult, loading: searchLoading } = useQuery(
+  GET_SITE_WIDE_WIKI_LIST,
+  () => ({
+    searchInput: searchInput.value,
+    selectedChannels: [],
+    options: { limit: 12, offset: 0 },
+  }),
+  { fetchPolicy: 'cache-first' }
+);
+
+const { result: selectedPagesResult } = useQuery(
+  GET_WIKI_PAGES_BY_IDS,
+  () => ({ ids: selectedIds.value }),
+  {
+    enabled: computed(() => selectedIds.value.length > 0),
+    fetchPolicy: 'cache-first',
+  }
+);
+
+const selectedPagesById = computed(() => {
+  const pages = (selectedPagesResult.value?.wikiPages || []) as WikiPageOption[];
+  return new Map(pages.map((page) => [page.id, page]));
+});
+
+const selectedPages = computed(() =>
+  selectedIds.value.map(
+    (id) =>
+      selectedPagesById.value.get(id) || {
+        id,
+        title: id,
+        slug: '',
+        channelUniqueName: '',
+      }
+  )
+);
+
+const searchResults = computed(() => {
+  const pages = (searchResult.value?.getSiteWideWikiList?.wikiPages ||
+    []) as WikiPageOption[];
+  const selected = new Set(selectedIds.value);
+  return pages.filter((page) => !selected.has(page.id));
+});
+
+const updateIds = (ids: string[]) => {
+  emit('updateFormValues', { featuredWikiPageIds: ids });
+};
+
+const addPage = (page: WikiPageOption) => {
+  if (selectedIds.value.includes(page.id)) return;
+  updateIds([...selectedIds.value, page.id]);
+};
+
+const removePage = (pageId: string) => {
+  updateIds(selectedIds.value.filter((id) => id !== pageId));
+};
+
+const movePage = (pageId: string, direction: -1 | 1) => {
+  const ids = [...selectedIds.value];
+  const index = ids.indexOf(pageId);
+  const nextIndex = index + direction;
+
+  if (index === -1 || nextIndex < 0 || nextIndex >= ids.length) {
+    return;
+  }
+
+  const id = ids[index];
+  if (!id) {
+    return;
+  }
+
+  ids.splice(index, 1);
+  ids.splice(nextIndex, 0, id);
+  updateIds(ids);
+};
+</script>
+
+<template>
+  <div class="space-y-4 sm:space-y-5">
+    <FormRow section-title="Featured Wiki Pages">
+      <template #content>
+        <div class="space-y-5">
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            Choose wiki pages to feature above the normal results on the
+            server-wide wiki search page.
+          </p>
+
+          <div>
+            <label
+              for="featured-wiki-search"
+              class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              Search wiki pages
+            </label>
+            <input
+              id="featured-wiki-search"
+              v-model="searchInput"
+              type="search"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
+              placeholder="Search by title or body"
+            />
+          </div>
+
+          <div v-if="selectedPages.length" class="space-y-2">
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              Featured order
+            </h3>
+            <ol class="space-y-2" data-testid="featured-wiki-selected-list">
+              <li
+                v-for="(page, index) in selectedPages"
+                :key="page.id"
+                class="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-orange-200 bg-orange-50 px-3 py-2 dark:border-orange-800 dark:bg-orange-950/30"
+              >
+                <div>
+                  <div class="font-medium text-gray-900 dark:text-gray-100">
+                    {{ index + 1 }}. {{ page.title || page.id }}
+                  </div>
+                  <div class="text-xs text-gray-500 dark:text-gray-400">
+                    {{ page.channelUniqueName }}/{{ page.slug }}
+                  </div>
+                </div>
+                <div class="flex items-center gap-2">
+                  <button
+                    type="button"
+                    class="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:hover:bg-gray-900"
+                    :disabled="index === 0"
+                    @click="movePage(page.id, -1)"
+                  >
+                    Up
+                  </button>
+                  <button
+                    type="button"
+                    class="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:hover:bg-gray-900"
+                    :disabled="index === selectedPages.length - 1"
+                    @click="movePage(page.id, 1)"
+                  >
+                    Down
+                  </button>
+                  <button
+                    type="button"
+                    class="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950/40"
+                    @click="removePage(page.id)"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </li>
+            </ol>
+          </div>
+          <p v-else class="text-sm text-gray-500 dark:text-gray-400">
+            No featured wiki pages selected.
+          </p>
+
+          <div class="space-y-2">
+            <div class="flex items-center justify-between">
+              <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                Search results
+              </h3>
+              <LoadingSpinner v-if="searchLoading" size="sm" />
+            </div>
+            <ul
+              v-if="searchResults.length"
+              class="space-y-2"
+              data-testid="featured-wiki-search-results"
+            >
+              <li
+                v-for="page in searchResults"
+                :key="page.id"
+                class="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-900"
+              >
+                <div>
+                  <div class="font-medium text-gray-900 dark:text-gray-100">
+                    {{ page.title || page.id }}
+                  </div>
+                  <div class="text-xs text-gray-500 dark:text-gray-400">
+                    {{ page.channelUniqueName }}/{{ page.slug }}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  class="rounded-md bg-orange-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-orange-700"
+                  @click="addPage(page)"
+                >
+                  Add
+                </button>
+              </li>
+            </ul>
+            <p v-else class="text-sm text-gray-500 dark:text-gray-400">
+              No wiki pages match your search.
+            </p>
+          </div>
+        </div>
+      </template>
+    </FormRow>
+  </div>
+</template>

--- a/pages/wiki/search.spec.ts
+++ b/pages/wiki/search.spec.ts
@@ -19,11 +19,12 @@ vi.mock('@/utils/getDiscussionFilterValuesFromParams', () => ({
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
-const mountWith = async (wikiPages: unknown[]) => {
+const mountWith = async (wikiPages: unknown[], featuredWikiPages: unknown[] = []) => {
   mockedUseQuery.mockReturnValue({
     result: ref({
       getSiteWideWikiList: {
         wikiPages,
+        featuredWikiPages,
         aggregateWikiPageCount: wikiPages.length,
       },
     }),
@@ -50,5 +51,19 @@ describe('wiki search page', () => {
     expect(wrapper.findAll('[data-testid="wiki-search-results"] > li')).toHaveLength(
       2
     );
+  });
+
+  it('renders featured wiki pages above normal results', async () => {
+    const wrapper = await mountWith(
+      [{ id: 'w1', title: 'Cats', slug: 'cats', channelUniqueName: 'cats', body: 'hi' }],
+      [{ id: 'featured', title: 'Start here', slug: 'start', channelUniqueName: 'help', body: 'hello' }]
+    );
+    expect(wrapper.find('[data-testid="featured-wiki-pages"]').exists()).toBe(true);
+  });
+
+  it('does not duplicate featured wiki pages in normal results', async () => {
+    const page = { id: 'w1', title: 'Cats', slug: 'cats', channelUniqueName: 'cats', body: 'hi' };
+    const wrapper = await mountWith([page], [page]);
+    expect(wrapper.findAll('[data-testid="wiki-search-results"] > li')).toHaveLength(0);
   });
 });

--- a/pages/wiki/search.vue
+++ b/pages/wiki/search.vue
@@ -17,6 +17,21 @@ import { formatWordCount } from '@/utils/wikiSearchDisplay';
 
 const WIKI_PAGE_LIMIT = 25;
 
+type WikiSearchPage = {
+  id: string;
+  title?: string | null;
+  body?: string | null;
+  slug?: string | null;
+  channelUniqueName?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  VersionAuthor?: {
+    username?: string | null;
+    displayName?: string | null;
+    profilePicURL?: string | null;
+  } | null;
+};
+
 const route = useRoute();
 const router = useRouter();
 
@@ -89,11 +104,27 @@ const {
   },
 });
 
-const wikiPages = computed(() => {
+const wikiPages = computed<WikiSearchPage[]>(() => {
   if (!wikiResult.value?.getSiteWideWikiList) {
     return [];
   }
-  return wikiResult.value.getSiteWideWikiList.wikiPages || [];
+  return (
+    wikiResult.value.getSiteWideWikiList.wikiPages || []
+  ) as WikiSearchPage[];
+});
+
+const featuredWikiPages = computed<WikiSearchPage[]>(() => {
+  if (!wikiResult.value?.getSiteWideWikiList) {
+    return [];
+  }
+  return (
+    wikiResult.value.getSiteWideWikiList.featuredWikiPages || []
+  ) as WikiSearchPage[];
+});
+
+const regularWikiPages = computed<WikiSearchPage[]>(() => {
+  const featuredIds = new Set(featuredWikiPages.value.map((page) => page.id));
+  return wikiPages.value.filter((page) => !featuredIds.has(page.id));
 });
 
 const aggregateWikiPageCount = computed(() => {
@@ -161,46 +192,90 @@ watch(
         {{ wikiError.message }}
       </div>
       <div
-        v-else-if="wikiPages.length === 0"
+        v-else-if="wikiPages.length === 0 && featuredWikiPages.length === 0"
         class="mt-6 text-sm text-gray-500"
       >
         No wiki pages match your search.
       </div>
-      <ul
-        v-else
-        class="mt-6 flex flex-col gap-4"
-        data-testid="wiki-search-results"
-      >
-        <li
-          v-for="wikiPage in wikiPages"
-          :key="wikiPage.id"
-          class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+      <div v-else class="mt-6 space-y-8">
+        <section
+          v-if="featuredWikiPages.length > 0"
+          data-testid="featured-wiki-pages"
         >
-          <div class="flex flex-wrap items-center justify-between gap-2">
-            <nuxt-link
-              class="font-semibold text-base text-gray-900 hover:text-orange-600 dark:text-gray-100"
-              :to="`/forums/${wikiPage.channelUniqueName}/wiki/${wikiPage.slug}`"
+          <div class="mb-3">
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">
+              Featured wiki pages
+            </h2>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Curated starting points from the server admins.
+            </p>
+          </div>
+          <ul class="grid gap-4 sm:grid-cols-2">
+            <li
+              v-for="wikiPage in featuredWikiPages"
+              :key="wikiPage.id"
+              class="rounded-xl border border-orange-200 bg-orange-50 p-4 shadow-sm dark:border-orange-800 dark:bg-orange-950/30"
             >
-              <HighlightedSearchTerms
-                :text="wikiPage.title"
-                :search-input="searchInputComputed"
-              />
-            </nuxt-link>
-            <span class="text-xs text-gray-500 dark:text-gray-300">
-              {{ wikiPage.channelUniqueName }}
-            </span>
-          </div>
-          <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
-            <span>{{ formatWordCount(wikiPage.body) }}</span>
-            <span v-if="wikiPage.updatedAt">
-              Updated {{ relativeTime(wikiPage.updatedAt) }}
-            </span>
-            <span v-if="wikiPage.VersionAuthor">
-              by {{ wikiPage.VersionAuthor.displayName || wikiPage.VersionAuthor.username }}
-            </span>
-          </div>
-        </li>
-      </ul>
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <nuxt-link
+                  class="font-semibold text-base text-gray-900 hover:text-orange-700 dark:text-gray-100 dark:hover:text-orange-300"
+                  :to="`/forums/${wikiPage.channelUniqueName}/wiki/${wikiPage.slug}`"
+                >
+                  <HighlightedSearchTerms
+                    :text="wikiPage.title || undefined"
+                    :search-input="searchInputComputed"
+                  />
+                </nuxt-link>
+                <span class="text-xs text-gray-600 dark:text-gray-300">
+                  {{ wikiPage.channelUniqueName }}
+                </span>
+              </div>
+              <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-600 dark:text-gray-300">
+                <span>{{ formatWordCount(wikiPage.body) }}</span>
+                <span v-if="wikiPage.updatedAt">
+                  Updated {{ relativeTime(wikiPage.updatedAt) }}
+                </span>
+              </div>
+            </li>
+          </ul>
+        </section>
+
+        <ul
+          v-if="regularWikiPages.length > 0"
+          class="flex flex-col gap-4"
+          data-testid="wiki-search-results"
+        >
+          <li
+            v-for="wikiPage in regularWikiPages"
+            :key="wikiPage.id"
+            class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+          >
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <nuxt-link
+                class="font-semibold text-base text-gray-900 hover:text-orange-600 dark:text-gray-100"
+                :to="`/forums/${wikiPage.channelUniqueName}/wiki/${wikiPage.slug}`"
+              >
+                <HighlightedSearchTerms
+                  :text="wikiPage.title || undefined"
+                  :search-input="searchInputComputed"
+                />
+              </nuxt-link>
+              <span class="text-xs text-gray-500 dark:text-gray-300">
+                {{ wikiPage.channelUniqueName }}
+              </span>
+            </div>
+            <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
+              <span>{{ formatWordCount(wikiPage.body) }}</span>
+              <span v-if="wikiPage.updatedAt">
+                Updated {{ relativeTime(wikiPage.updatedAt) }}
+              </span>
+              <span v-if="wikiPage.VersionAuthor">
+                by {{ wikiPage.VersionAuthor.displayName || wikiPage.VersionAuthor.username }}
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>
     </div>
   </NuxtLayout>
 </template>


### PR DESCRIPTION
## Summary
- add a Wiki Settings tab for selecting ordered featured wiki pages
- render featured wiki pages above regular server-wide wiki search results without duplication
- update the feature roadmap to mark this slice complete

## Depends on
- Backend: https://github.com/gennit-project/multiforum-backend/pull/141

## Tests
- corepack pnpm run tsc
- corepack pnpm exec vitest run --config vitest.config.ts pages/admin/settings.spec.ts pages/admin/settings/wiki.spec.ts pages/wiki/search.spec.ts