### PR TITLE
[codex] Fix download filter group editor gaps

### DIFF
--- a/components/filter/FilterGroupManager.spec.ts
+++ b/components/filter/FilterGroupManager.spec.ts
@@ -12,7 +12,14 @@ import FilterGroupManager from '@/components/filter/FilterGroupManager.vue';
 // re-emits the events the parent listens for.
 const FilterOptionManagerStub = {
   name: 'FilterOptionManager',
-  props: ['filterGroup', 'groupIndex', 'canMoveUp', 'canMoveDown', 'disabled', 'existingKeys'],
+  props: [
+    'filterGroup',
+    'groupIndex',
+    'canMoveUp',
+    'canMoveDown',
+    'disabled',
+    'existingKeys',
+  ],
   emits: ['updateGroup', 'removeGroup', 'moveGroup'],
   template: '<div class="fom-stub" />',
 };
@@ -27,7 +34,7 @@ const makeGroup = (overrides: Partial<FilterGroup> = {}): FilterGroup =>
     options: [],
     __typename: 'FilterGroup',
     ...overrides,
-  } as unknown as FilterGroup);
+  }) as unknown as FilterGroup;
 
 const mountManager = (filterGroups: FilterGroup[] = [], disabled = false) =>
   mountWithDefaults(FilterGroupManager, {
@@ -36,7 +43,10 @@ const mountManager = (filterGroups: FilterGroup[] = [], disabled = false) =>
   });
 
 const openNewGroupForm = async (wrapper: ReturnType<typeof mountManager>) => {
-  await wrapper.findAll('button').find((b) => b.text() === 'Add New Filter Group')!.trigger('click');
+  await wrapper
+    .findAll('button')
+    .find((b) => b.text() === 'Add New Filter Group')!
+    .trigger('click');
 };
 
 describe('FilterGroupManager', () => {
@@ -46,7 +56,10 @@ describe('FilterGroupManager', () => {
   });
 
   it('renders one option manager per existing group', () => {
-    const wrapper = mountManager([makeGroup(), makeGroup({ id: 'g2', key: 'color' })]);
+    const wrapper = mountManager([
+      makeGroup(),
+      makeGroup({ id: 'g2', key: 'color' }),
+    ]);
     expect(wrapper.findAllComponents(FilterOptionManagerStub)).toHaveLength(2);
   });
 
@@ -59,30 +72,45 @@ describe('FilterGroupManager', () => {
   it('disables the Add Group button until key and display name are valid', async () => {
     const wrapper = mountManager([]);
     await openNewGroupForm(wrapper);
-    const addBtn = wrapper.findAll('button').find((b) => b.text() === 'Add Group')!;
+    const addBtn = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Add Group')!;
     expect(addBtn.attributes('disabled')).toBeDefined();
   });
 
   it('rejects a key with invalid characters', async () => {
     const wrapper = mountManager([]);
     await openNewGroupForm(wrapper);
-    await wrapper.get('input[placeholder="e.g. lot_size"]').setValue('bad key!');
-    expect(wrapper.text()).toContain('Key can only contain letters, numbers, and underscores.');
+    await wrapper
+      .get('input[placeholder="e.g. lot_size"]')
+      .setValue('bad key!');
+    expect(wrapper.text()).toContain(
+      'Key can only contain letters, numbers, and underscores.'
+    );
   });
 
   it('flags a duplicate key', async () => {
     const wrapper = mountManager([makeGroup({ id: 'g1', key: 'color' })]);
     await openNewGroupForm(wrapper);
     await wrapper.get('input[placeholder="e.g. lot_size"]').setValue('color');
-    expect(wrapper.text()).toContain('This key is already used by another filter group.');
+    expect(wrapper.text()).toContain(
+      'This key is already used by another filter group.'
+    );
   });
 
   it('emits updateFilterGroups with the new group when added', async () => {
     const wrapper = mountManager([]);
     await openNewGroupForm(wrapper);
-    await wrapper.get('input[placeholder="e.g. lot_size"]').setValue('lot_size');
-    await wrapper.get('input[placeholder="e.g. Lot Size"]').setValue('Lot Size');
-    await wrapper.findAll('button').find((b) => b.text() === 'Add Group')!.trigger('click');
+    await wrapper
+      .get('input[placeholder="e.g. lot_size"]')
+      .setValue('lot_size');
+    await wrapper
+      .get('input[placeholder="e.g. Lot Size"]')
+      .setValue('Lot Size');
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Add Group')!
+      .trigger('click');
     expect(wrapper.emitted('updateFilterGroups')?.[0]?.[0]).toHaveLength(1);
   });
 
@@ -90,46 +118,86 @@ describe('FilterGroupManager', () => {
     const wrapper = mountManager([]);
     await openNewGroupForm(wrapper);
     await wrapper.get('select').setValue(FilterMode.Exclude);
-    await wrapper.get('input[placeholder="e.g. lot_size"]').setValue('blocked_packs');
-    await wrapper.get('input[placeholder="e.g. Lot Size"]').setValue('Blocked Packs');
-    await wrapper.findAll('button').find((b) => b.text() === 'Add Group')!.trigger('click');
-    const emitted = wrapper.emitted('updateFilterGroups')?.[0]?.[0] as FilterGroup[];
+    await wrapper
+      .get('input[placeholder="e.g. lot_size"]')
+      .setValue('blocked_packs');
+    await wrapper
+      .get('input[placeholder="e.g. Lot Size"]')
+      .setValue('Blocked Packs');
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Add Group')!
+      .trigger('click');
+    const emitted = wrapper.emitted(
+      'updateFilterGroups'
+    )?.[0]?.[0] as FilterGroup[];
     expect(emitted[0].mode).toBe(FilterMode.Exclude);
   });
 
   it('emits the filtered list when a group is removed', () => {
-    const wrapper = mountManager([makeGroup({ id: 'g1' }), makeGroup({ id: 'g2', key: 'color' })]);
-    wrapper.findAllComponents(FilterOptionManagerStub)[0].vm.$emit('removeGroup', 'g1');
-    const emitted = wrapper.emitted('updateFilterGroups')?.[0]?.[0] as FilterGroup[];
+    const wrapper = mountManager([
+      makeGroup({ id: 'g1' }),
+      makeGroup({ id: 'g2', key: 'color' }),
+    ]);
+    wrapper
+      .findAllComponents(FilterOptionManagerStub)[0]
+      .vm.$emit('removeGroup', 'g1');
+    const emitted = wrapper.emitted(
+      'updateFilterGroups'
+    )?.[0]?.[0] as FilterGroup[];
     expect(emitted.map((g) => g.id)).toEqual(['g2']);
   });
 
   it('applies an updated group field when a child requests it', () => {
     const wrapper = mountManager([makeGroup({ id: 'g1', displayName: 'Old' })]);
-    wrapper.findComponent(FilterOptionManagerStub).vm.$emit('updateGroup', 'g1', { displayName: 'New' });
-    const emitted = wrapper.emitted('updateFilterGroups')?.[0]?.[0] as FilterGroup[];
+    wrapper
+      .findComponent(FilterOptionManagerStub)
+      .vm.$emit('updateGroup', 'g1', { displayName: 'New' });
+    const emitted = wrapper.emitted(
+      'updateFilterGroups'
+    )?.[0]?.[0] as FilterGroup[];
     expect(emitted[0].displayName).toBe('New');
   });
 
   it('reorders groups when a child requests a move down', () => {
-    const wrapper = mountManager([makeGroup({ id: 'g1' }), makeGroup({ id: 'g2', key: 'color' })]);
-    wrapper.findAllComponents(FilterOptionManagerStub)[0].vm.$emit('moveGroup', 'g1', 'down');
-    const emitted = wrapper.emitted('updateFilterGroups')?.[0]?.[0] as FilterGroup[];
+    const wrapper = mountManager([
+      makeGroup({ id: 'g1' }),
+      makeGroup({ id: 'g2', key: 'color' }),
+    ]);
+    wrapper
+      .findAllComponents(FilterOptionManagerStub)[0]
+      .vm.$emit('moveGroup', 'g1', 'down');
+    const emitted = wrapper.emitted(
+      'updateFilterGroups'
+    )?.[0]?.[0] as FilterGroup[];
     expect(emitted.map((g) => g.id)).toEqual(['g2', 'g1']);
   });
 
   it('switches to the YAML editor and serializes the current groups', async () => {
     const wrapper = mountManager([makeGroup({ id: 'g1', key: 'lot_size' })]);
-    await wrapper.findAll('button').find((b) => b.text() === 'YAML Editor')!.trigger('click');
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'YAML Editor')!
+      .trigger('click');
     expect(wrapper.get('textarea').element.value).toContain('lot_size');
   });
 
   it('applies the full Sims 4 filter set from YAML', async () => {
     const wrapper = mountManager([]);
-    await wrapper.findAll('button').find((b) => b.text() === 'YAML Editor')!.trigger('click');
-    await wrapper.get('textarea').setValue(serializeFilterGroupsToYaml(sims4BuildsFilterGroups));
-    await wrapper.findAll('button').find((b) => b.text() === 'Apply Changes')!.trigger('click');
-    const emitted = wrapper.emitted('updateFilterGroups')?.[0]?.[0] as FilterGroup[];
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'YAML Editor')!
+      .trigger('click');
+    await wrapper
+      .get('textarea')
+      .setValue(serializeFilterGroupsToYaml(sims4BuildsFilterGroups));
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Apply Changes')!
+      .trigger('click');
+    const emitted = wrapper.emitted(
+      'updateFilterGroups'
+    )?.[0]?.[0] as FilterGroup[];
     expect(emitted.map((group) => [group.key, group.options.length])).toEqual([
       ['size', 10],
       ['price', 6],
@@ -141,11 +209,65 @@ describe('FilterGroupManager', () => {
     ]);
   });
 
+  it('preserves existing group and option ids when YAML keeps the same keys and values', async () => {
+    const wrapper = mountManager([
+      makeGroup({
+        id: 'group-1',
+        key: 'style',
+        displayName: 'Style',
+        options: [
+          {
+            id: 'option-1',
+            value: 'modern',
+            displayName: 'Modern',
+            order: 0,
+            __typename: 'FilterOption',
+          },
+        ],
+      }),
+    ]);
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'YAML Editor')!
+      .trigger('click');
+    await wrapper.get('textarea').setValue(`- key: style
+  displayName: Build Style
+  mode: INCLUDE
+  order: 0
+  options:
+    - value: modern
+      displayName: Contemporary
+      order: 0`);
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Apply Changes')!
+      .trigger('click');
+    const emitted = wrapper.emitted(
+      'updateFilterGroups'
+    )?.[0]?.[0] as FilterGroup[];
+    expect(emitted).toMatchObject([
+      {
+        id: 'group-1',
+        key: 'style',
+        displayName: 'Build Style',
+        options: [
+          { id: 'option-1', value: 'modern', displayName: 'Contemporary' },
+        ],
+      },
+    ]);
+  });
+
   it('shows a YAML error when applying invalid YAML', async () => {
     const wrapper = mountManager([]);
-    await wrapper.findAll('button').find((b) => b.text() === 'YAML Editor')!.trigger('click');
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'YAML Editor')!
+      .trigger('click');
     await wrapper.get('textarea').setValue('not: [valid yaml');
-    await wrapper.findAll('button').find((b) => b.text() === 'Apply Changes')!.trigger('click');
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Apply Changes')!
+      .trigger('click');
     expect(wrapper.text()).toContain('YAML Error:');
   });
 });

--- a/components/filter/FilterGroupManager.vue
+++ b/components/filter/FilterGroupManager.vue
@@ -63,6 +63,58 @@ const createLocalId = (kind: 'group' | 'option', index: number) =>
 const convertFilterGroupsToYaml = (filterGroups: FilterGroup[]): string =>
   serializeFilterGroupsToYaml(filterGroups);
 
+const normalizeKey = (value: string) => value.trim().toLowerCase();
+
+const preserveExistingIds = (
+  parsedGroups: ReturnType<typeof parseFilterGroupsYaml>['groups']
+): FilterGroup[] => {
+  const existingGroupsByKey = new Map(
+    props.filterGroups.map((group) => [normalizeKey(group.key), group])
+  );
+
+  return (parsedGroups || []).map((group, index) => {
+    const existingGroup = existingGroupsByKey.get(normalizeKey(group.key));
+    const existingOptionsByValue = new Map(
+      (existingGroup?.options || []).map((option) => [
+        normalizeKey(option.value),
+        option,
+      ])
+    );
+
+    return {
+      id: existingGroup?.id || createLocalId('group', index),
+      key: group.key,
+      displayName: group.displayName,
+      mode: group.mode as FilterMode,
+      order: group.order ?? index,
+      options: (group.options || []).map((option, optionIndex) => {
+        const existingOption = existingOptionsByValue.get(
+          normalizeKey(option.value)
+        );
+
+        return {
+          id: existingOption?.id || createLocalId('option', optionIndex),
+          value: option.value,
+          displayName: option.displayName,
+          order: option.order ?? optionIndex,
+          // Required GraphQL fields
+          __typename: 'FilterOption' as const,
+          group: emptyFilterGroup, // Will be populated by parent
+          groupAggregate: null,
+          groupConnection: emptyGroupConnection,
+        };
+      }),
+      // Required GraphQL fields
+      __typename: 'FilterGroup' as const,
+      channel: emptyChannel,
+      channelAggregate: null,
+      channelConnection: emptyChannelConnection,
+      optionsAggregate: null,
+      optionsConnection: emptyOptionsConnection,
+    };
+  });
+};
+
 const convertYamlToFilterGroups = (
   yamlString: string
 ): { success: boolean; filterGroups?: FilterGroup[]; error?: string } => {
@@ -71,32 +123,9 @@ const convertYamlToFilterGroups = (
     return { success: false, error: result.error };
   }
 
-  // Map the validated plain groups onto full GraphQL FilterGroup objects.
-  const filterGroups: FilterGroup[] = result.groups.map((group, index) => ({
-    id: createLocalId('group', index),
-    key: group.key,
-    displayName: group.displayName,
-    mode: group.mode as FilterMode,
-    order: group.order ?? index,
-    options: (group.options || []).map((option, optionIndex) => ({
-      id: createLocalId('option', optionIndex),
-      value: option.value,
-      displayName: option.displayName,
-      order: option.order ?? optionIndex,
-      // Required GraphQL fields
-      __typename: 'FilterOption' as const,
-      group: emptyFilterGroup, // Will be populated by parent
-      groupAggregate: null,
-      groupConnection: emptyGroupConnection,
-    })),
-    // Required GraphQL fields
-    __typename: 'FilterGroup' as const,
-    channel: emptyChannel,
-    channelAggregate: null,
-    channelConnection: emptyChannelConnection,
-    optionsAggregate: null,
-    optionsConnection: emptyOptionsConnection,
-  }));
+  // Preserve persisted IDs when keys/values still match so bulk YAML edits do
+  // not orphan downloads that reference filter-option IDs.
+  const filterGroups = preserveExistingIds(result.groups);
 
   return { success: true, filterGroups };
 };
@@ -238,8 +267,8 @@ watch(
           </h3>
           <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
             Configure filter groups that will appear in the downloads sidebar.
-            Include groups require selected labels; exclude groups hide downloads
-            with selected labels.
+            Include groups require selected labels; exclude groups hide
+            downloads with selected labels.
           </p>
         </div>
 
@@ -517,6 +546,11 @@ watch(
               <code>order</code>
             </li>
           </ul>
+          <p class="mt-3">
+            Existing group and option IDs are preserved when the YAML keeps the
+            same group keys and option values. Renaming a key or option value is
+            treated as delete plus create.
+          </p>
         </div>
 
         <!-- Action Buttons -->

--- a/components/filter/FilterOptionManager.spec.ts
+++ b/components/filter/FilterOptionManager.spec.ts
@@ -13,7 +13,7 @@ const makeOption = (overrides: Partial<FilterOption> = {}): FilterOption =>
     order: 0,
     __typename: 'FilterOption',
     ...overrides,
-  } as unknown as FilterOption);
+  }) as unknown as FilterOption;
 
 const makeGroup = (overrides: Partial<FilterGroup> = {}): FilterGroup =>
   ({
@@ -25,7 +25,7 @@ const makeGroup = (overrides: Partial<FilterGroup> = {}): FilterGroup =>
     options: [],
     __typename: 'FilterGroup',
     ...overrides,
-  } as unknown as FilterGroup);
+  }) as unknown as FilterGroup;
 
 const mountOM = (props: Record<string, unknown> = {}) =>
   mountWithDefaults(FilterOptionManager, {
@@ -50,7 +50,9 @@ describe('FilterOptionManager', () => {
   });
 
   it('shows the mode label in read mode', () => {
-    const wrapper = mountOM({ filterGroup: makeGroup({ mode: FilterMode.Exclude }) });
+    const wrapper = mountOM({
+      filterGroup: makeGroup({ mode: FilterMode.Exclude }),
+    });
     expect(wrapper.text()).toContain('Must exclude selected labels');
   });
 
@@ -62,7 +64,9 @@ describe('FilterOptionManager', () => {
 
   it('hides the Move Up button when canMoveUp is false', () => {
     const wrapper = mountOM({ canMoveUp: false });
-    expect(wrapper.findAll('button').some((b) => b.text() === '↑ Move Up')).toBe(false);
+    expect(
+      wrapper.findAll('button').some((b) => b.text() === '↑ Move Up')
+    ).toBe(false);
   });
 
   it('emits removeGroup when Remove Group is clicked', async () => {
@@ -89,14 +93,18 @@ describe('FilterOptionManager', () => {
     await byText(wrapper, 'Edit Group Settings').trigger('click');
     await wrapper.get('input[type="text"]').setValue('new_key');
     await byText(wrapper, 'Save Changes').trigger('click');
-    expect(wrapper.emitted('updateGroup')?.[0]?.[1]).toMatchObject({ key: 'new_key' });
+    expect(wrapper.emitted('updateGroup')?.[0]?.[1]).toMatchObject({
+      key: 'new_key',
+    });
   });
 
   it('disables Save Changes for an invalid key', async () => {
     const wrapper = mountOM();
     await byText(wrapper, 'Edit Group Settings').trigger('click');
     await wrapper.get('input[type="text"]').setValue('bad key!');
-    expect(byText(wrapper, 'Save Changes').attributes('disabled')).toBeDefined();
+    expect(
+      byText(wrapper, 'Save Changes').attributes('disabled')
+    ).toBeDefined();
   });
 
   it('leaves edit mode when cancelled', async () => {
@@ -108,7 +116,9 @@ describe('FilterOptionManager', () => {
 
   it('shows the empty-options state when there are no options', () => {
     const wrapper = mountOM();
-    expect(wrapper.text()).toContain('No options configured. Add at least one option before saving this group.');
+    expect(wrapper.text()).toContain(
+      'No options configured. Add at least one option before saving this group.'
+    );
   });
 
   it('emits updateGroup with the new option when added', async () => {
@@ -117,31 +127,102 @@ describe('FilterOptionManager', () => {
     await wrapper.get('input[placeholder="e.g. 10x20"]').setValue('5x5');
     await wrapper.get('input[placeholder="e.g. 10 × 20"]').setValue('5 by 5');
     await byText(wrapper, 'Add Option').trigger('click');
-    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as { options: FilterOption[] };
+    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as {
+      options: FilterOption[];
+    };
     expect(payload.options).toHaveLength(1);
   });
 
+  it('reveals inline fields when editing an existing option', async () => {
+    const wrapper = mountOM({
+      filterGroup: makeGroup({ options: [makeOption({ id: 'o1' })] }),
+    });
+    await byText(wrapper, 'Edit').trigger('click');
+    expect(
+      wrapper
+        .findAll('input')
+        .filter((input) => !input.attributes('placeholder'))
+    ).toHaveLength(2);
+  });
+
+  it('emits updateGroup with edited option fields when saved', async () => {
+    const wrapper = mountOM({
+      filterGroup: makeGroup({ options: [makeOption({ id: 'o1' })] }),
+    });
+    await byText(wrapper, 'Edit').trigger('click');
+    const editInputs = wrapper
+      .findAll('input')
+      .filter((input) => !input.attributes('placeholder'));
+    await editInputs[0]!.setValue('20x20');
+    await editInputs[1]!.setValue('20 x 20');
+    await byText(wrapper, 'Save').trigger('click');
+    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as {
+      options: FilterOption[];
+    };
+    expect(payload.options[0]).toMatchObject({
+      id: 'o1',
+      value: '20x20',
+      displayName: '20 x 20',
+    });
+  });
+
+  it('blocks saving an edited option when its value duplicates another option', async () => {
+    const wrapper = mountOM({
+      filterGroup: makeGroup({
+        options: [
+          makeOption({ id: 'o1', value: '10x20' }),
+          makeOption({ id: 'o2', value: '5x5' }),
+        ],
+      }),
+    });
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Edit')!
+      .trigger('click');
+    const editInputs = wrapper
+      .findAll('input')
+      .filter((input) => !input.attributes('placeholder'));
+    await editInputs[0]!.setValue('5x5');
+    expect(wrapper.text()).toContain(
+      'This value already exists in this group.'
+    );
+    expect(byText(wrapper, 'Save').attributes('disabled')).toBeDefined();
+  });
+
   it('flags a duplicate option value', async () => {
-    const wrapper = mountOM({ filterGroup: makeGroup({ options: [makeOption({ value: '5x5' })] }) });
+    const wrapper = mountOM({
+      filterGroup: makeGroup({ options: [makeOption({ value: '5x5' })] }),
+    });
     await byText(wrapper, '+ Add New Option').trigger('click');
     await wrapper.get('input[placeholder="e.g. 10x20"]').setValue('5x5');
-    expect(wrapper.text()).toContain('This value already exists in this group.');
+    expect(wrapper.text()).toContain(
+      'This value already exists in this group.'
+    );
   });
 
   it('flags an option value with invalid characters', async () => {
     const wrapper = mountOM();
     await byText(wrapper, '+ Add New Option').trigger('click');
     await wrapper.get('input[placeholder="e.g. 10x20"]').setValue('bad value');
-    expect(wrapper.text()).toContain('Value can only contain letters, numbers, underscores, and hyphens.');
+    expect(wrapper.text()).toContain(
+      'Value can only contain letters, numbers, underscores, and hyphens.'
+    );
     expect(byText(wrapper, 'Add Option').attributes('disabled')).toBeDefined();
   });
 
   it('emits updateGroup with the option removed', async () => {
     const wrapper = mountOM({
-      filterGroup: makeGroup({ options: [makeOption({ id: 'o1' }), makeOption({ id: 'o2', value: 'x' })] }),
+      filterGroup: makeGroup({
+        options: [
+          makeOption({ id: 'o1' }),
+          makeOption({ id: 'o2', value: 'x' }),
+        ],
+      }),
     });
     await byText(wrapper, 'Remove').trigger('click');
-    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as { options: FilterOption[] };
+    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as {
+      options: FilterOption[];
+    };
     expect(payload.options.map((o) => o.id)).toEqual(['o2']);
   });
 
@@ -156,10 +237,17 @@ describe('FilterOptionManager', () => {
 
   it('reorders options when moved down', async () => {
     const wrapper = mountOM({
-      filterGroup: makeGroup({ options: [makeOption({ id: 'o1' }), makeOption({ id: 'o2', value: 'x' })] }),
+      filterGroup: makeGroup({
+        options: [
+          makeOption({ id: 'o1' }),
+          makeOption({ id: 'o2', value: 'x' }),
+        ],
+      }),
     });
     await wrapper.get('button[title="Move down"]').trigger('click');
-    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as { options: FilterOption[] };
+    const payload = wrapper.emitted('updateGroup')?.[0]?.[1] as {
+      options: FilterOption[];
+    };
     expect(payload.options.map((o) => o.id)).toEqual(['o2', 'o1']);
   });
 });

--- a/components/filter/FilterOptionManager.vue
+++ b/components/filter/FilterOptionManager.vue
@@ -34,6 +34,7 @@ const emit = defineEmits(['updateGroup', 'removeGroup', 'moveGroup']);
 
 const isEditing = ref(false);
 const showNewOptionForm = ref(false);
+const editingOptionId = ref<string | null>(null);
 
 const editForm = ref({
   key: props.filterGroup.key,
@@ -46,6 +47,11 @@ const newOptionForm = ref({
   displayName: '',
 });
 
+const optionEditForm = ref({
+  value: '',
+  displayName: '',
+});
+
 const createLocalOptionId = () =>
   `local-filter-option-${Date.now()}-${props.filterGroup.options?.length || 0}`;
 
@@ -53,7 +59,8 @@ const filterModeOptions = [
   {
     value: FilterMode.Include,
     label: 'Must include selected labels',
-    description: 'Downloads must have at least one selected option from this group.',
+    description:
+      'Downloads must have at least one selected option from this group.',
   },
   {
     value: FilterMode.Exclude,
@@ -67,6 +74,12 @@ const isValidOptionValue = (value: string) => /^[a-zA-Z0-9_-]+$/.test(value);
 
 const isKeyUnique = (key: string) => {
   return !props.existingKeys.includes(key);
+};
+
+const isOptionValueUnique = (value: string, excludeId?: string) => {
+  return !props.filterGroup.options?.some(
+    (option) => option.value === value && option.id !== excludeId
+  );
 };
 
 const canSaveGroup = computed(() => {
@@ -84,9 +97,20 @@ const canAddOption = computed(() => {
     newOptionForm.value.value &&
     newOptionForm.value.displayName &&
     isValidOptionValue(newOptionForm.value.value) &&
-    !props.filterGroup.options?.some(
-      (option) => option.value === newOptionForm.value.value
-    )
+    isOptionValueUnique(newOptionForm.value.value)
+  );
+});
+
+const canSaveOption = computed(() => {
+  if (!editingOptionId.value) {
+    return false;
+  }
+
+  return (
+    optionEditForm.value.value &&
+    optionEditForm.value.displayName &&
+    isValidOptionValue(optionEditForm.value.value) &&
+    isOptionValueUnique(optionEditForm.value.value, editingOptionId.value)
   );
 });
 
@@ -148,6 +172,40 @@ const addOption = () => {
     displayName: '',
   };
   showNewOptionForm.value = false;
+};
+
+const startEditingOption = (option: FilterOption) => {
+  optionEditForm.value = {
+    value: option.value,
+    displayName: option.displayName,
+  };
+  editingOptionId.value = option.id;
+};
+
+const cancelEditingOption = () => {
+  optionEditForm.value = {
+    value: '',
+    displayName: '',
+  };
+  editingOptionId.value = null;
+};
+
+const saveOption = (optionId: string) => {
+  if (!canSaveOption.value) return;
+
+  const updatedOptions =
+    props.filterGroup.options?.map((option) =>
+      option.id === optionId
+        ? {
+            ...option,
+            value: optionEditForm.value.value,
+            displayName: optionEditForm.value.displayName,
+          }
+        : option
+    ) || [];
+
+  emit('updateGroup', props.filterGroup.id, { options: updatedOptions });
+  cancelEditingOption();
 };
 
 const removeOption = (optionId: string) => {
@@ -428,7 +486,9 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
               }"
             >
             <p
-              v-if="newOptionForm.value && !isValidOptionValue(newOptionForm.value)"
+              v-if="
+                newOptionForm.value && !isValidOptionValue(newOptionForm.value)
+              "
               class="mt-1 text-xs text-red-500"
             >
               Value can only contain letters, numbers, underscores, and hyphens.
@@ -489,7 +549,10 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
           :key="option.id"
           class="flex items-center justify-between rounded border border-gray-200 bg-white p-2 dark:border-gray-600 dark:bg-gray-800"
         >
-          <div class="grid flex-1 grid-cols-1 gap-2 md:grid-cols-2">
+          <div
+            v-if="editingOptionId !== option.id"
+            class="grid flex-1 grid-cols-1 gap-2 md:grid-cols-2"
+          >
             <div>
               <span class="text-xs text-gray-500 dark:text-gray-400"
                 >Option Value:</span
@@ -508,9 +571,89 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
               }}</span>
             </div>
           </div>
+          <div v-else class="flex-1 space-y-3">
+            <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div>
+                <label
+                  class="block text-xs font-medium text-gray-700 dark:text-gray-300"
+                >
+                  Option Value
+                </label>
+                <input
+                  v-model="optionEditForm.value"
+                  type="text"
+                  class="mt-1 block w-full rounded border border-gray-300 px-2 py-1 font-mono text-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-600 dark:text-white"
+                  :class="{
+                    'border-red-500':
+                      optionEditForm.value &&
+                      (!isValidOptionValue(optionEditForm.value) ||
+                        !isOptionValueUnique(optionEditForm.value, option.id)),
+                  }"
+                >
+                <p
+                  v-if="
+                    optionEditForm.value &&
+                    !isValidOptionValue(optionEditForm.value)
+                  "
+                  class="mt-1 text-xs text-red-500"
+                >
+                  Value can only contain letters, numbers, underscores, and
+                  hyphens.
+                </p>
+                <p
+                  v-else-if="
+                    optionEditForm.value &&
+                    !isOptionValueUnique(optionEditForm.value, option.id)
+                  "
+                  class="mt-1 text-xs text-red-500"
+                >
+                  This value already exists in this group.
+                </p>
+              </div>
+              <div>
+                <label
+                  class="block text-xs font-medium text-gray-700 dark:text-gray-300"
+                >
+                  Display Name
+                </label>
+                <input
+                  v-model="optionEditForm.displayName"
+                  type="text"
+                  class="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-600 dark:text-white"
+                >
+              </div>
+            </div>
+          </div>
           <div class="ml-4 flex space-x-1">
+            <template v-if="editingOptionId === option.id">
+              <button
+                type="button"
+                class="rounded border border-green-300 bg-green-100 px-2 py-1 text-xs font-medium text-green-700 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:border-green-700 dark:bg-green-900 dark:text-green-300 dark:hover:bg-green-800"
+                :disabled="disabled || !canSaveOption"
+                @click="saveOption(option.id)"
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                class="hover:bg-gray-50 rounded border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:hover:bg-gray-700"
+                :disabled="disabled"
+                @click="cancelEditingOption"
+              >
+                Cancel
+              </button>
+            </template>
             <button
-              v-if="optionIndex > 0"
+              v-else
+              type="button"
+              class="rounded border border-blue-300 bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-blue-700 dark:bg-blue-900 dark:text-blue-300 dark:hover:bg-blue-800"
+              :disabled="disabled"
+              @click="startEditingOption(option)"
+            >
+              Edit
+            </button>
+            <button
+              v-if="editingOptionId !== option.id && optionIndex > 0"
               type="button"
               class="px-1 py-1 text-xs text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
               :disabled="disabled"
@@ -520,7 +663,10 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
               ↑
             </button>
             <button
-              v-if="optionIndex < (filterGroup.options?.length || 0) - 1"
+              v-if="
+                editingOptionId !== option.id &&
+                optionIndex < (filterGroup.options?.length || 0) - 1
+              "
               type="button"
               class="px-1 py-1 text-xs text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
               :disabled="disabled"


### PR DESCRIPTION
## What changed
- preserve existing filter-group and filter-option IDs when admins bulk-edit download filters through the YAML editor, as long as the group keys and option values stay the same
- add inline editing for existing filter options in the form editor, including the same uniqueness and character validation used for new options
- document the remaining YAML rename behavior so key/value renames are understood as delete-and-recreate operations
- add focused unit coverage for YAML ID preservation and inline option editing

## Why
The current YAML path rebuilt every filter group and option with fresh local IDs. Downloads store label associations by filter-option ID, so a bulk YAML edit could orphan existing download labels even when the admin only meant to rename display text or reorder items. The form editor also lacked any way to edit an existing option without dropping to YAML.

## Impact
Forum admins can safely make ordinary YAML edits without breaking existing download labels, and they can now edit existing option values and display names directly in the channel settings UI.

## Validation
- `npx vitest run components/filter/FilterGroupManager.spec.ts components/filter/FilterOptionManager.spec.ts 'pages/forums/[forumId]/edit.spec.ts'`
- `npm run tsc`
- pre-commit hook (`vue-tsc --noEmit` and `eslint`) during commit