### PR TITLE
Use computed favorite state in lists

### DIFF
--- a/components/channel/ChannelHeaderMobile.spec.ts
+++ b/components/channel/ChannelHeaderMobile.spec.ts
@@ -15,7 +15,11 @@ const mountHeader = (channel: Record<string, unknown>) =>
       stubs: {
         AvatarComponent: true,
         ClientOnly: { template: '<div><slot /></div>' },
-        AddToChannelFavorites: { template: '<div class="fav" />' },
+        AddToChannelFavorites: {
+          name: 'AddToChannelFavorites',
+          props: ['initialIsFavorited'],
+          template: '<div class="fav" />',
+        },
       },
     },
   });
@@ -34,6 +38,19 @@ describe('ChannelHeaderMobile', () => {
     mockIsAuthenticated.value = true;
     expect(
       mountHeader({ displayName: 'Cats', uniqueName: 'cats' }).find('.fav').exists()
+    ).toBe(true);
+  });
+
+  it('passes computed favorite state to the favorite button', () => {
+    mockIsAuthenticated.value = true;
+    const wrapper = mountHeader({
+      displayName: 'Cats',
+      uniqueName: 'cats',
+      isFavorited: true,
+    });
+
+    expect(
+      wrapper.getComponent({ name: 'AddToChannelFavorites' }).props('initialIsFavorited')
     ).toBe(true);
   });
 

--- a/components/channel/ChannelHeaderMobile.vue
+++ b/components/channel/ChannelHeaderMobile.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import AddToChannelFavorites from '@/components/favorites/AddToChannelFavorites.vue';
 import { useIsAuthenticated } from '@/composables/useAuthState';
 
 const isAuthenticatedVar = useIsAuthenticated();
 
-defineProps({
+type ChannelWithFavoriteState = {
+  isFavorited?: boolean | null;
+  channelIconURL?: string | null;
+  displayName?: string | null;
+  uniqueName?: string | null;
+};
+
+const props = defineProps({
   channelId: {
     type: String,
     required: true,
@@ -15,6 +23,9 @@ defineProps({
   },
 });
 
+const initialIsFavorited = computed(
+  () => (props.channel as ChannelWithFavoriteState)?.isFavorited ?? undefined
+);
 </script>
 
 <template>
@@ -52,6 +63,7 @@ defineProps({
           :allow-add-to-list="true"
           :channel-unique-name="channelId"
           :channel-display-name="channel?.displayName || ''"
+          :initial-is-favorited="initialIsFavorited"
           size="medium"
         />
       </div>

--- a/components/channel/ChannelSidebar.spec.ts
+++ b/components/channel/ChannelSidebar.spec.ts
@@ -39,7 +39,11 @@ const mountSidebar = (props: Record<string, unknown> = {}) =>
         MarkdownPreview: { name: 'MarkdownPreview', props: ['text'], template: '<div class="md">{{ text }}</div>' },
         FontSizeControl: { name: 'FontSizeControl', template: '<div class="font-control" />' },
         BecomeAdminModal: { name: 'BecomeAdminModal', template: '<div />' },
-        AddToChannelFavorites: true,
+        AddToChannelFavorites: {
+          name: 'AddToChannelFavorites',
+          props: ['initialIsFavorited'],
+          template: '<div class="channel-favorite" />',
+        },
         ExpandableImage: true,
         AvatarComponent: true,
         NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
@@ -58,6 +62,16 @@ describe('ChannelSidebar content', () => {
     const wrapper = mountSidebar();
 
     expect(wrapper.text()).toContain('Cats Forum');
+  });
+
+  it('passes computed favorite state to the favorite button', () => {
+    const wrapper = mountSidebar({
+      channel: channel({ isFavorited: true }),
+    });
+
+    expect(
+      wrapper.getComponent({ name: 'AddToChannelFavorites' }).props('initialIsFavorited')
+    ).toBe(true);
   });
 
   it('renders the description', () => {

--- a/components/channel/ChannelSidebar.vue
+++ b/components/channel/ChannelSidebar.vue
@@ -24,6 +24,10 @@ type BotSummary = {
   } | null;
 };
 
+type ChannelWithFavoriteState = Channel & {
+  isFavorited?: boolean | null;
+};
+
 const props = defineProps({
   channel: {
     type: Object as PropType<Channel>,
@@ -49,6 +53,9 @@ const channelId = computed(() => {
 });
 
 const channelRules = computed(() => props.channel?.rules ?? '');
+const initialIsFavorited = computed(
+  () => (props.channel as ChannelWithFavoriteState)?.isFavorited ?? undefined
+);
 const pinnedWikiPages = computed(() => props.channel?.PinnedWikiPages ?? []);
 const botAccounts = computed(() => {
   const channel = props.channel as Channel & { Bots?: BotSummary[] };
@@ -141,6 +148,7 @@ const handleBecomeAdminSuccess = () => {
             :allow-add-to-list="true"
             :channel-unique-name="channelId"
             :channel-display-name="channel?.displayName || ''"
+            :initial-is-favorited="initialIsFavorited"
             size="medium"
           />
         </div>

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -192,16 +192,17 @@ Notes:
 - The admin Wiki Settings tab provides a searchable picker with explicit up/down ordering.
 - `/wiki/search` renders featured wiki pages above normal results and removes duplicates from the regular result list.
 
-### 14. Favorites API optimization `[partial]`
+### 14. Favorites API optimization `[complete]`
 
-- [ ] Update image and channel list queries to include computed favorite state where missing.
-- [ ] Pass `initialIsFavorited` from parent list components consistently.
-- [ ] Add an equivalent optimized path for comments instead of relying on a per-item lookup.
+- [x] Update image and channel list queries to include computed favorite state where missing. `[in backend/frontend PRs]`
+- [x] Pass `initialIsFavorited` from parent list components consistently. `[in frontend PR]`
+- [x] Add an equivalent optimized path for comments instead of relying on a per-item lookup.
 
 Notes:
 - Discussions are already optimized.
-- Image and channel favorite buttons now accept `initialIsFavorited`.
-- Comments still appear to use a separate lookup path.
+- Images and channels now expose computed favorite state for generated reads, and sorted channel results include authenticated favorite state.
+- Image grids and channel header/sidebar surfaces pass the computed state into favorite buttons so those buttons skip their fallback lookup.
+- Comment list/reply/event-comment payloads already include `isFavoritedByUser`, and `CommentButtons` passes it into `AddToCommentFavorites`; the per-item lookup remains only as a fallback for callers that do not provide state.
 
 ### 15. Auto-save for server settings and channel admin settings `[not started]`
 

--- a/graphQLData/channel/queries.js
+++ b/graphQLData/channel/queries.js
@@ -59,13 +59,14 @@ export const GET_WIKI_PAGE = gql`
 `;
 
 export const GET_CHANNEL = gql`
-  query getChannel($uniqueName: String!, $now: DateTime) {
+  query getChannel($uniqueName: String!, $now: DateTime, $loggedInUsername: String) {
     channels(where: { uniqueName: $uniqueName }) {
       uniqueName
       displayName
       description
       channelIconURL
       channelBannerURL
+      isFavorited(username: $loggedInUsername)
       rules
       locked
       lockedAt
@@ -337,6 +338,7 @@ export const GET_CHANNELS_DISCUSSIONS = gql`
     $limit: Int
     $tags: [String]
     $searchInput: String
+    $loggedInUsername: String
     $now: DateTime = "${now}"
   ) {
     getSortedChannels(
@@ -351,6 +353,7 @@ export const GET_CHANNELS_DISCUSSIONS = gql`
         displayName
         channelIconURL
         description
+        isFavorited(username: $loggedInUsername)
         Tags {
           text
         }

--- a/graphQLData/image/queries.js
+++ b/graphQLData/image/queries.js
@@ -181,6 +181,7 @@ export const GET_USER_ALBUMS = gql`
 export const GET_USER_IMAGES = gql`
   query GetUserImages(
     $username: String!
+    $loggedInUsername: String
     $offset: Int!
     $limit: Int!
     $where: ImageWhere
@@ -201,6 +202,7 @@ export const GET_USER_IMAGES = gql`
         hasSensitiveContent
         hasSpoiler
         createdAt
+        isFavorited(username: $loggedInUsername)
         Uploader {
           username
           displayName
@@ -246,6 +248,7 @@ export const GET_REUSABLE_ALBUM_IMAGES = gql`
         caption
         copyright
         createdAt
+        isFavorited(username: $username)
         Uploader {
           username
           displayName
@@ -267,6 +270,7 @@ export const GET_REUSABLE_ALBUM_IMAGES = gql`
           caption
           copyright
           createdAt
+          isFavorited(username: $username)
           Uploader {
             username
             displayName

--- a/pages/forums/[forumId].spec.ts
+++ b/pages/forums/[forumId].spec.ts
@@ -18,6 +18,10 @@ vi.mock('nuxt/app', () => ({
 
 vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
 
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('viewer'),
+}));
+
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
 const mountWith = async (channels: unknown[]) => {

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -31,9 +31,11 @@ import {
 } from '@/utils/localStorageUtils';
 import { getForumShellVisibility } from '@/utils/forumShellVisibility';
 import type { ForumItem } from '@/types/forum';
+import { useUsername } from '@/composables/useAuthState';
 
 const route = useRoute();
 const router = useRouter();
+const loggedInUsername = useUsername();
 const uiStore = useUIStore();
 const {
   selectedChannelDiscussionTitle,
@@ -105,6 +107,7 @@ const {
   GET_CHANNEL,
   () => ({
     uniqueName: channelId.value,
+    loggedInUsername: loggedInUsername.value || null,
     // Keep SSR/client Apollo variables identical during hydration.
     now: currentHour(),
   }),

--- a/pages/forums/index.spec.ts
+++ b/pages/forums/index.spec.ts
@@ -8,6 +8,9 @@ vi.mock('nuxt/app', () => ({
   useRoute: () => ({ query: {} }),
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
 }));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('viewer'),
+}));
 
 vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
 
@@ -64,5 +67,21 @@ describe('forums index page', () => {
       downloadCount: number;
     }>;
     expect(channels[0].downloadCount).toBe(2);
+  });
+
+  it('preserves channel favorite state from the list query', async () => {
+    const wrapper = await mountWith({
+      channels: [
+        {
+          uniqueName: 'cats',
+          isFavorited: true,
+          DiscussionChannelsAggregate: { count: 0 },
+        },
+      ],
+    });
+    const channels = wrapper.findComponent(ChannelList).props('channels') as Array<{
+      isFavorited: boolean;
+    }>;
+    expect(channels[0].isFavorited).toBe(true);
   });
 });

--- a/pages/forums/index.vue
+++ b/pages/forums/index.vue
@@ -22,9 +22,11 @@ import {
 } from '@/utils/forumListChannels';
 import type { LocationQueryValue } from 'vue-router';
 import type { Channel } from '@/__generated__/graphql';
+import { useUsername } from '@/composables/useAuthState';
 
 const route = useRoute();
 const router = useRouter();
+const loggedInUsername = useUsername();
 
 const selectedTags = ref<Array<string>>(
   route.query.tag && typeof route.query.tag === 'string'
@@ -93,6 +95,7 @@ const {
     offset: 0,
     tags: selectedTags,
     searchInput: searchInput,
+    loggedInUsername: loggedInUsername.value || null,
   },
   {
     fetchPolicy: 'cache-first',

--- a/pages/u/[username]/images/index.spec.ts
+++ b/pages/u/[username]/images/index.spec.ts
@@ -40,9 +40,17 @@ vi.mock('@/composables/useSelectedChannelsFromQuery', async () => {
 });
 
 vi.mock('@/graphQLData/image/queries', () => ({ GET_USER_IMAGES: 'q' }));
+vi.mock('@/composables/useAuthState', async () => {
+  const { ref } = await import('vue');
+  return { useUsername: () => ref('viewer') };
+});
 
 const stubs = {
-  ImageListItem: { name: 'ImageListItem', props: ['image', 'username'], template: '<div class="image-item" />' },
+  ImageListItem: {
+    name: 'ImageListItem',
+    props: ['image', 'username', 'initialIsFavorited'],
+    template: '<div class="image-item" />',
+  },
 };
 
 const mountImages = () => mountWithDefaults(ImagesPage, { global: { stubs } });
@@ -83,6 +91,14 @@ describe('User images page', () => {
     withImages([{ id: 'i1' }, { id: 'i2' }]);
     const wrapper = mountImages();
     expect(wrapper.findAllComponents({ name: 'ImageListItem' })).toHaveLength(2);
+  });
+
+  it('passes computed favorite state to image items', () => {
+    withImages([{ id: 'i1', isFavorited: true }]);
+    const wrapper = mountImages();
+    expect(
+      wrapper.getComponent({ name: 'ImageListItem' }).props('initialIsFavorited')
+    ).toBe(true);
   });
 
   it('shows the load-more button when more images remain', () => {

--- a/pages/u/[username]/images/index.vue
+++ b/pages/u/[username]/images/index.vue
@@ -6,9 +6,15 @@ import { GET_USER_IMAGES } from '@/graphQLData/image/queries';
 import type { Image } from '@/__generated__/graphql';
 import ImageListItem from '@/components/image/ImageListItem.vue';
 import { useSelectedChannelsFromQuery } from '@/composables/useSelectedChannelsFromQuery';
+import { useUsername } from '@/composables/useAuthState';
 
 const route = useRoute();
+const loggedInUsername = useUsername();
 const { selectedChannels, hasSelectedChannels } = useSelectedChannelsFromQuery();
+
+type ImageWithFavoriteState = Image & {
+  isFavorited?: boolean | null;
+};
 
 const username = computed(() => {
   return typeof route.params.username === 'string' ? route.params.username : '';
@@ -50,6 +56,7 @@ const {
   GET_USER_IMAGES,
   () => ({
     username: username.value,
+    loggedInUsername: loggedInUsername.value || null,
     offset: 0,
     limit: pageSize,
     where: imagesWhere.value,
@@ -67,7 +74,7 @@ const user = computed(() => {
   return null;
 });
 
-const images = computed((): Image[] => {
+const images = computed((): ImageWithFavoriteState[] => {
   if (!user.value?.Images) return [];
   return user.value.Images;
 });
@@ -101,6 +108,7 @@ const loadMoreImages = async () => {
     await fetchMore({
       variables: {
         username: username.value,
+        loggedInUsername: loggedInUsername.value || null,
         offset: newOffset,
         limit: pageSize,
         where: imagesWhere.value,
@@ -176,6 +184,7 @@ const loadMoreImages = async () => {
           :key="image.id"
           :image="image"
           :username="username"
+          :initial-is-favorited="image.isFavorited ?? undefined"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- request computed favorite state in image and channel queries
- pass initialIsFavorited into image grid items and channel header/sidebar favorites controls
- keep sorted channel favorite state through the forums list data merge
- update the roadmap to mark Favorites API optimization complete

## Depends on
- Backend: https://github.com/gennit-project/multiforum-backend/pull/143

## Tests
- corepack pnpm run tsc
- corepack pnpm exec vitest run --config vitest.config.ts pages/forums/index.spec.ts 'pages/u/[username]/images/index.spec.ts' components/channel/ChannelHeaderMobile.spec.ts components/channel/ChannelSidebar.spec.ts