### PR TITLE
Add my-involvement filters to the admin open-issue list

### DIFF
--- a/components/admin/IssueFilterBar.spec.ts
+++ b/components/admin/IssueFilterBar.spec.ts
@@ -4,7 +4,7 @@ import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
 import SearchBar from '@/components/SearchBar.vue';
 import { issueSortValues } from '@/utils/issueSortOptions';
 
-const buildWrapper = () => {
+const buildWrapper = (props: Record<string, unknown> = {}) => {
   return mount(IssueFilterBar, {
     props: {
       searchInput: 'spam',
@@ -15,6 +15,7 @@ const buildWrapper = () => {
       showOnlyServerRuleViolations: true,
       selectedSort: issueSortValues.NEWEST,
       selectedSortLabel: 'Newest',
+      ...props,
     },
     global: {
       stubs: {
@@ -85,5 +86,47 @@ describe('IssueFilterBar', () => {
     await wrapper.findAll('.text-dropdown')[0].trigger('click');
 
     expect(wrapper.emitted('update:sort')).toEqual([[issueSortValues.OLDEST]]);
+  });
+
+  it('hides the involvement filters when not enabled', () => {
+    const wrapper = buildWrapper();
+
+    expect(
+      wrapper.find('[data-testid="issue-involvement-filters"]').exists()
+    ).toBe(false);
+  });
+
+  it('shows the involvement filters when enabled', () => {
+    const wrapper = buildWrapper({ showInvolvementFilters: true });
+
+    expect(
+      wrapper.find('[data-testid="issue-involvement-filters"]').exists()
+    ).toBe(true);
+  });
+
+  it('reflects the checked state of an involvement filter prop', () => {
+    const wrapper = buildWrapper({
+      showInvolvementFilters: true,
+      filterIReported: true,
+    });
+
+    expect(
+      (
+        wrapper.get('[data-testid="issue-filter-filterIReported"]')
+          .element as HTMLInputElement
+      ).checked
+    ).toBe(true);
+  });
+
+  it('emits an involvement filter update when a checkbox is toggled', async () => {
+    const wrapper = buildWrapper({ showInvolvementFilters: true });
+
+    await wrapper
+      .get('[data-testid="issue-filter-filterCreatedByMe"]')
+      .setValue(true);
+
+    expect(wrapper.emitted('update:involvementFilter')).toEqual([
+      [{ key: 'filterCreatedByMe', value: true }],
+    ]);
   });
 });

--- a/components/admin/IssueFilterBar.vue
+++ b/components/admin/IssueFilterBar.vue
@@ -7,6 +7,11 @@ import SearchableForumList from '@/components/channel/SearchableForumList.vue';
 import TextButtonDropdown from '@/components/TextButtonDropdown.vue';
 import { issueSortOptions, type IssueSortValue } from '@/utils/issueSortOptions';
 
+type InvolvementFilterKey =
+  | 'filterCreatedByMe'
+  | 'filterIAmOP'
+  | 'filterIReported';
+
 const props = defineProps<{
   searchInput: string;
   selectedChannels: string[];
@@ -16,6 +21,10 @@ const props = defineProps<{
   showOnlyServerRuleViolations: boolean;
   selectedSort: IssueSortValue;
   selectedSortLabel: string;
+  showInvolvementFilters?: boolean;
+  filterCreatedByMe?: boolean;
+  filterIAmOP?: boolean;
+  filterIReported?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -25,7 +34,30 @@ const emit = defineEmits<{
   'toggle-selected-channel': [channel: string];
   'update:showOnlyServerRuleViolations': [value: boolean];
   'update:sort': [value: string];
+  'update:involvementFilter': [
+    payload: { key: InvolvementFilterKey; value: boolean },
+  ];
 }>();
+
+const involvementFilters = computed<
+  { key: InvolvementFilterKey; label: string; checked: boolean }[]
+>(() => [
+  {
+    key: 'filterCreatedByMe',
+    label: 'Created by me',
+    checked: Boolean(props.filterCreatedByMe),
+  },
+  {
+    key: 'filterIAmOP',
+    label: 'About my content',
+    checked: Boolean(props.filterIAmOP),
+  },
+  {
+    key: 'filterIReported',
+    label: 'I reported',
+    checked: Boolean(props.filterIReported),
+  },
+]);
 
 const issueScopeOptions = [
   {
@@ -86,6 +118,31 @@ const issueScopeLabel = computed(() =>
             )
           "
         >
+      </label>
+    </div>
+    <div
+      v-if="showInvolvementFilters"
+      class="flex flex-wrap items-center gap-4"
+      data-testid="issue-involvement-filters"
+    >
+      <label
+        v-for="filter in involvementFilters"
+        :key="filter.key"
+        class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
+      >
+        <input
+          type="checkbox"
+          :checked="filter.checked"
+          :data-testid="`issue-filter-${filter.key}`"
+          class="rounded border-gray-300 text-orange-600 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-900"
+          @change="
+            emit('update:involvementFilter', {
+              key: filter.key,
+              value: ($event.target as HTMLInputElement).checked,
+            })
+          "
+        >
+        {{ filter.label }}
       </label>
     </div>
     <div class="flex flex-wrap items-center justify-end gap-2">

--- a/graphQLData/issue/queries.js
+++ b/graphQLData/issue/queries.js
@@ -405,6 +405,9 @@ export const GET_SITE_WIDE_ISSUE_LIST = gql`
     $endDate: String
     $showOnlyServerRuleViolations: Boolean
     $isOpen: Boolean!
+    $filterCreatedByMe: Boolean
+    $filterIAmOP: Boolean
+    $filterIReported: Boolean
     $options: IssueListOptions
   ) {
     getSiteWideIssueList(
@@ -414,6 +417,9 @@ export const GET_SITE_WIDE_ISSUE_LIST = gql`
       endDate: $endDate
       showOnlyServerRuleViolations: $showOnlyServerRuleViolations
       isOpen: $isOpen
+      filterCreatedByMe: $filterCreatedByMe
+      filterIAmOP: $filterIAmOP
+      filterIReported: $filterIReported
       options: $options
     ) {
       aggregateIssueCount

--- a/pages/admin/issues/index.spec.ts
+++ b/pages/admin/issues/index.spec.ts
@@ -17,10 +17,12 @@ const h = vi.hoisted(() => ({
   refetch: vi.fn(),
   setSelectedIssueSelection: vi.fn(),
   selectedIssueNumber: null as unknown as { value: number | null },
+  isAuthenticated: null as unknown as { value: boolean },
   updateFilters: vi.fn(),
 }));
 
 h.selectedIssueNumber = ref<number | null>(null);
+h.isAuthenticated = ref<boolean>(true);
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({
@@ -29,6 +31,10 @@ vi.mock('nuxt/app', () => ({
     query: h.query,
   }),
   useRouter: () => ({ push: h.routerPush, replace: h.routerReplace }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => h.isAuthenticated,
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
@@ -78,6 +84,10 @@ const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
             'showOnlyServerRuleViolations',
             'selectedSort',
             'selectedSortLabel',
+            'showInvolvementFilters',
+            'filterCreatedByMe',
+            'filterIAmOP',
+            'filterIReported',
           ],
           emits: [
             'update-search-input',
@@ -86,6 +96,7 @@ const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
             'update:endDate',
             'update:showOnlyServerRuleViolations',
             'update:sort',
+            'update:involvementFilter',
           ],
           template: '<div class="issue-filter-bar" />',
         },
@@ -109,7 +120,11 @@ beforeEach(() => {
   delete h.query.startDate;
   delete h.query.endDate;
   delete h.query.channels;
+  delete h.query.filterCreatedByMe;
+  delete h.query.filterIAmOP;
+  delete h.query.filterIReported;
   h.selectedIssueNumber.value = null;
+  h.isAuthenticated.value = true;
 });
 
 describe('admin server issues index page', () => {
@@ -250,6 +265,50 @@ describe('admin server issues index page', () => {
 
     expect(mockedUseQuery.mock.calls[0][1].value.options).toEqual({
       sort: issueSortValues.MOST_REPORTS,
+    });
+  });
+
+  it('shows the involvement filters in the bar when authenticated', async () => {
+    h.isAuthenticated.value = true;
+    const wrapper = await mountWith({ issues: [] });
+    expect(
+      wrapper.getComponent(IssueFilterBar).props('showInvolvementFilters')
+    ).toBe(true);
+  });
+
+  it('hides the involvement filters in the bar when unauthenticated', async () => {
+    h.isAuthenticated.value = false;
+    const wrapper = await mountWith({ issues: [] });
+    expect(
+      wrapper.getComponent(IssueFilterBar).props('showInvolvementFilters')
+    ).toBe(false);
+  });
+
+  it('passes an active involvement filter into the issues query variables', async () => {
+    h.query.filterIReported = 'true';
+    await mountWith({ issues: [] });
+    expect(mockedUseQuery.mock.calls[0][1].value.filterIReported).toBe(true);
+  });
+
+  it('forces involvement filters off in the query when unauthenticated', async () => {
+    h.isAuthenticated.value = false;
+    h.query.filterCreatedByMe = 'true';
+    await mountWith({ issues: [] });
+    expect(mockedUseQuery.mock.calls[0][1].value.filterCreatedByMe).toBe(false);
+  });
+
+  it('updates the route filters when an involvement filter is toggled', async () => {
+    const wrapper = await mountWith({ issues: [] });
+    await wrapper
+      .getComponent(IssueFilterBar)
+      .vm.$emit('update:involvementFilter', {
+        key: 'filterCreatedByMe',
+        value: true,
+      });
+    expect(h.updateFilters).toHaveBeenCalledWith({
+      router: { push: h.routerPush, replace: h.routerReplace },
+      route: { params: { forumId: '' }, path: '/admin/issues', query: h.query },
+      params: { filterCreatedByMe: true },
     });
   });
 });

--- a/pages/admin/issues/index.vue
+++ b/pages/admin/issues/index.vue
@@ -9,6 +9,7 @@ import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
 import { getChannelLabel } from '@/utils';
 import { updateFilters } from '@/utils/routerUtils';
 import { getServerIssueFilterValuesFromParams } from '@/utils/getServerIssueFilterValuesFromParams';
+import { useIsAuthenticated } from '@/composables/useAuthState';
 import { useUIStore } from '@/stores/uiStore';
 import { storeToRefs } from 'pinia';
 import { getIssueSortLabel } from '@/utils/issueSortOptions';
@@ -34,6 +35,10 @@ const searchInput = ref(initialFilterValues.searchInput);
 const startDate = ref(initialFilterValues.startDate);
 const endDate = ref(initialFilterValues.endDate);
 const selectedSort = ref(initialFilterValues.sort);
+const filterCreatedByMe = ref(initialFilterValues.filterCreatedByMe);
+const filterIAmOP = ref(initialFilterValues.filterIAmOP);
+const filterIReported = ref(initialFilterValues.filterIReported);
+const isAuthenticated = useIsAuthenticated();
 const channelLabel = computed(() => getChannelLabel(selectedChannels.value));
 const selectedSortLabel = computed(() => getIssueSortLabel(selectedSort.value));
 
@@ -44,6 +49,11 @@ const variables = computed(() => ({
   endDate: endDate.value || null,
   showOnlyServerRuleViolations: showOnlyServerRuleViolations.value,
   isOpen: true,
+  // Identity is resolved server-side, so these are only meaningful when the
+  // viewer is authenticated; keep them false otherwise to avoid emptying the list.
+  filterCreatedByMe: isAuthenticated.value && filterCreatedByMe.value,
+  filterIAmOP: isAuthenticated.value && filterIAmOP.value,
+  filterIReported: isAuthenticated.value && filterIReported.value,
   options: {
     sort: selectedSort.value,
   },
@@ -99,6 +109,17 @@ const updateSort = (value: string) => {
   });
 };
 
+const updateInvolvementFilter = (payload: {
+  key: 'filterCreatedByMe' | 'filterIAmOP' | 'filterIReported';
+  value: boolean;
+}) => {
+  updateFilters({
+    router,
+    route,
+    params: { [payload.key]: payload.value },
+  });
+};
+
 const toggleSelectedChannel = (channel: string) => {
   const nextChannels = [...selectedChannels.value];
   const selectedIndex = nextChannels.indexOf(channel);
@@ -137,6 +158,9 @@ watch(
       nextFilterValues.showOnlyServerRuleViolations;
     searchInput.value = nextFilterValues.searchInput;
     selectedSort.value = nextFilterValues.sort;
+    filterCreatedByMe.value = nextFilterValues.filterCreatedByMe;
+    filterIAmOP.value = nextFilterValues.filterIAmOP;
+    filterIReported.value = nextFilterValues.filterIReported;
 
     if (nextFilterValues.startDate !== startDate.value) {
       startDate.value = nextFilterValues.startDate;
@@ -178,6 +202,10 @@ watch([startDate, endDate], ([nextStartDate, nextEndDate]) => {
       :show-only-server-rule-violations="showOnlyServerRuleViolations"
       :selected-sort="selectedSort"
       :selected-sort-label="selectedSortLabel"
+      :show-involvement-filters="isAuthenticated"
+      :filter-created-by-me="filterCreatedByMe"
+      :filter-i-am-o-p="filterIAmOP"
+      :filter-i-reported="filterIReported"
       @update-search-input="updateSearchInput"
       @toggle-selected-channel="toggleSelectedChannel"
       @update:sort="updateSort"
@@ -186,6 +214,7 @@ watch([startDate, endDate], ([nextStartDate, nextEndDate]) => {
       @update:show-only-server-rule-violations="
         updateShowOnlyServerRuleViolations
       "
+      @update:involvement-filter="updateInvolvementFilter"
     />
     <ul
       class="divide-y border-t border-gray-200 dark:border-gray-800 dark:text-white"

--- a/utils/getServerIssueFilterValuesFromParams.spec.ts
+++ b/utils/getServerIssueFilterValuesFromParams.spec.ts
@@ -21,6 +21,9 @@ describe('getServerIssueFilterValuesFromParams', () => {
       startDate: '',
       endDate: '',
       showOnlyServerRuleViolations: true,
+      filterCreatedByMe: false,
+      filterIAmOP: false,
+      filterIReported: false,
       sort: issueSortValues.NEWEST,
     });
   });
@@ -89,6 +92,38 @@ describe('getServerIssueFilterValuesFromParams', () => {
         }),
       }).showOnlyServerRuleViolations
     ).toBe(true);
+  });
+
+  it('parses the involvement filters when set to "true"', () => {
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute({
+          filterCreatedByMe: 'true',
+          filterIAmOP: 'true',
+          filterIReported: 'true',
+        }),
+      })
+    ).toMatchObject({
+      filterCreatedByMe: true,
+      filterIAmOP: true,
+      filterIReported: true,
+    });
+  });
+
+  it('treats any non-"true" involvement filter value as false', () => {
+    expect(
+      getServerIssueFilterValuesFromParams({
+        route: createMockRoute({
+          filterCreatedByMe: 'false',
+          filterIAmOP: '1',
+          filterIReported: 'yes',
+        }),
+      })
+    ).toMatchObject({
+      filterCreatedByMe: false,
+      filterIAmOP: false,
+      filterIReported: false,
+    });
   });
 
   it('parses the sort value from query params', () => {

--- a/utils/getServerIssueFilterValuesFromParams.ts
+++ b/utils/getServerIssueFilterValuesFromParams.ts
@@ -19,6 +19,9 @@ export type ServerIssueFilterValues = {
   startDate: string;
   endDate: string;
   showOnlyServerRuleViolations: boolean;
+  filterCreatedByMe: boolean;
+  filterIAmOP: boolean;
+  filterIReported: boolean;
   sort: IssueSortValue;
 };
 
@@ -35,6 +38,9 @@ export const getServerIssueFilterValuesFromParams = (
     startDate: '',
     endDate: '',
     showOnlyServerRuleViolations: true,
+    filterCreatedByMe: false,
+    filterIAmOP: false,
+    filterIReported: false,
     sort: defaultIssueSort,
   };
 
@@ -70,6 +76,15 @@ export const getServerIssueFilterValuesFromParams = (
       case 'showOnlyServerRuleViolations':
         cleanedValues.showOnlyServerRuleViolations =
           getDefaultServerRuleViolationsFilter(val);
+        break;
+      case 'filterCreatedByMe':
+        cleanedValues.filterCreatedByMe = val === 'true';
+        break;
+      case 'filterIAmOP':
+        cleanedValues.filterIAmOP = val === 'true';
+        break;
+      case 'filterIReported':
+        cleanedValues.filterIReported = val === 'true';
         break;
       case 'sort':
         cleanedValues.sort = getIssueSortFromQuery(input.route.query);


### PR DESCRIPTION
## What

Adds three auth-gated checkboxes to the admin **open-issues** filter bar so moderators can narrow the list to issues they're personally involved in:

- **Created by me** — issues the viewer filed
- **About my content** — issues about content the viewer authored (they're the OP)
- **I reported** — issues with a report the viewer authored

Requires the backend query changes in **gennit-project/multiforum-backend#146** (adds `filterCreatedByMe` / `filterIAmOP` / `filterIReported` to `getSiteWideIssueList`).

## How

- New `Boolean` variables on `GET_SITE_WIDE_ISSUE_LIST`.
- Filters are stored as query params (`filterCreatedByMe`, `filterIAmOP`, `filterIReported`), parsed in `getServerIssueFilterValuesFromParams`, and synced through the existing `updateFilters` / route-watcher plumbing.
- Identity is resolved **server-side**, so the client only sends booleans. The page forces the flags off in the query variables when the viewer is unauthenticated, and the checkboxes are hidden (`showInvolvementFilters` gated on `useIsAuthenticated()`).

## Scope note

- These land on the **open** issues page (`pages/admin/issues/index.vue`), which is the active moderation queue and already uses `getSiteWideIssueList`.
- The **closed** issues page (`pages/admin/issues/closed.vue`) uses a different query (`GET_ISSUES` + `IssueWhere`) and has no filter bar today, so it's intentionally out of scope here. Bringing parity there would mean migrating it onto `getSiteWideIssueList` — happy to do that as a follow-up if wanted.

## Testing

- `pnpm run tsc` — 0 errors
- `pnpm exec eslint` on changed files — clean
- Unit tests (42 passing across the 4 affected specs): param parser, `IssueFilterBar` (show/hide, checked state, emit), and the index page (auth gating, query-variable passing, unauthenticated force-off, route update on toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)