### PR TITLE
Add event title/description edit history UI

### DIFF
--- a/__generated__/graphql.ts
+++ b/__generated__/graphql.ts
@@ -28283,6 +28283,7 @@ export type Event = {
   Comments: Array<Comment>;
   CommentsAggregate?: Maybe<EventCommentCommentsAggregationSelection>;
   CommentsConnection: EventCommentsConnection;
+  DescriptionLastEditedBy?: Maybe<User>;
   EventChannels: Array<EventChannel>;
   EventChannelsAggregate?: Maybe<EventEventChannelEventChannelsAggregationSelection>;
   EventChannelsConnection: EventEventChannelsConnection;
@@ -28292,6 +28293,8 @@ export type Event = {
   FeedbackComments: Array<Comment>;
   FeedbackCommentsAggregate?: Maybe<EventCommentFeedbackCommentsAggregationSelection>;
   FeedbackCommentsConnection: EventFeedbackCommentsConnection;
+  PastDescriptionVersions: Array<TextVersion>;
+  PastTitleVersions: Array<TextVersion>;
   Poster?: Maybe<User>;
   PosterAggregate?: Maybe<EventUserPosterAggregationSelection>;
   PosterConnection: EventPosterConnection;
@@ -48605,6 +48608,7 @@ export type Mutation = {
   deleteDayData: DeleteInfo;
   deleteDeleteEventInSeriesResults: DeleteInfo;
   deleteDiscussionBodyRevision?: Maybe<TextVersion>;
+  deleteEventDescriptionRevision?: Maybe<TextVersion>;
   deleteDiscussionChannelInfos: DeleteInfo;
   deleteDiscussionChannelListFormats: DeleteInfo;
   deleteDiscussionChannelListItems: DeleteInfo;
@@ -49468,6 +49472,10 @@ export type MutationDeleteDeleteEventInSeriesResultsArgs = {
 
 
 export type MutationDeleteDiscussionBodyRevisionArgs = {
+  textVersionId: Scalars['ID']['input'];
+};
+
+export type MutationDeleteEventDescriptionRevisionArgs = {
   textVersionId: Scalars['ID']['input'];
 };
 

--- a/components/discussion/detail/activityFeed/RevisionDiffModal.vue
+++ b/components/discussion/detail/activityFeed/RevisionDiffModal.vue
@@ -5,6 +5,7 @@ import type { TextVersion } from '@/__generated__/graphql';
 import GenericModal from '@/components/GenericModal.vue';
 import RevisionDiffContent from '@/components/revision/RevisionDiffContent.vue';
 import { useMutation } from '@vue/apollo-composable';
+import type { DocumentNode } from 'graphql';
 import { DELETE_DISCUSSION_BODY_REVISION } from '@/graphQLData/discussion/mutations';
 
 interface VersionData {
@@ -35,6 +36,13 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  // The redaction mutation to run. Defaults to the discussion body revision
+  // mutation so existing callers are unchanged; event surfaces pass the event
+  // description revision mutation.
+  deleteMutation: {
+    type: Object as PropType<DocumentNode>,
+    default: () => DELETE_DISCUSSION_BODY_REVISION,
+  },
 });
 
 const emit = defineEmits<{
@@ -49,7 +57,7 @@ const {
   loading,
   error,
   onDone,
-} = useMutation(DELETE_DISCUSSION_BODY_REVISION);
+} = useMutation(props.deleteMutation);
 
 const handleDelete = async () => {
   if (

--- a/components/event/detail/EventDetail.vue
+++ b/components/event/detail/EventDetail.vue
@@ -28,6 +28,8 @@ import 'md-editor-v3/lib/style.css';
 import EventFooter from '@/components/event/detail/EventFooter.vue';
 import EventHeader from '@/components/event/detail/EventHeader.vue';
 import EventBody from '@/components/event/detail/EventBody.vue';
+import EventTitleVersions from '@/components/event/detail/activityFeed/EventTitleVersions.vue';
+import EventDescriptionEditsDropdown from '@/components/event/detail/activityFeed/EventDescriptionEditsDropdown.vue';
 import ExpandableImage from '@/components/ExpandableImage.vue';
 import EventCommentsWrapper from '@/components/event/detail/EventCommentsWrapper.vue';
 import EventRootCommentFormWrapper from '@/components/event/detail/EventRootCommentFormWrapper.vue';
@@ -496,6 +498,8 @@ watchEffect(() => {
               </div>
             </div>
 
+            <EventTitleVersions v-if="showTitle && event" :event="event" />
+
             <ExpandableImage
               v-if="event.coverImageURL"
               :src="event.coverImageURL"
@@ -520,6 +524,12 @@ watchEffect(() => {
                 "
                 @close-edit-event-description="eventDescriptionEditMode = false"
               />
+              <div
+                v-if="event.PastDescriptionVersions?.length"
+                class="px-1 pt-1"
+              >
+                <EventDescriptionEditsDropdown :event="event" />
+              </div>
             </div>
 
             <div v-if="event.Tags?.length > 0" class="my-2 px-0 sm:px-4">

--- a/components/event/detail/activityFeed/EventDescriptionEditsDropdown.spec.ts
+++ b/components/event/detail/activityFeed/EventDescriptionEditsDropdown.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import EventDescriptionEditsDropdown from '@/components/event/detail/activityFeed/EventDescriptionEditsDropdown.vue';
+import type { Event } from '@/__generated__/graphql';
+
+// Build an event whose description has been edited `authors.length` times.
+// authors[0] is the most recent editor (DescriptionLastEditedBy); each past
+// version is authored by the next name in the list.
+const makeEvent = (
+  authors: (string | null)[],
+  overrides: Record<string, unknown> = {}
+) =>
+  ({
+    description: 'current description',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-10T00:00:00Z',
+    DescriptionLastEditedBy: authors[0] ? { username: authors[0] } : null,
+    PastDescriptionVersions: authors.map((_, i) => ({
+      id: `v${i}`,
+      body: `old description ${i}`,
+      createdAt: `2024-01-0${authors.length - i}T00:00:00Z`,
+      Author: authors[i + 1] ? { username: authors[i + 1] } : null,
+    })),
+    ...overrides,
+  }) as unknown as Event;
+
+const mountDropdown = (event: Event) =>
+  mount(EventDescriptionEditsDropdown, {
+    props: { event },
+    global: {
+      stubs: {
+        Teleport: { template: '<div><slot /></div>' },
+        RevisionDiffModal: {
+          name: 'RevisionDiffModal',
+          props: ['open', 'oldVersion', 'newVersion', 'isMostRecent', 'deleteMutation'],
+          emits: ['close', 'deleted'],
+          template: '<div class="diff-modal" />',
+        },
+      },
+    },
+  });
+
+const openDropdown = async (wrapper: ReturnType<typeof mount>) => {
+  await wrapper.get('button').trigger('click');
+};
+
+describe('EventDescriptionEditsDropdown visibility', () => {
+  it('renders nothing when the event has no past description versions', () => {
+    const wrapper = mountDropdown(makeEvent([]));
+
+    expect(wrapper.find('button').exists()).toBe(false);
+  });
+
+  it('renders the Edits trigger when there is at least one edit', () => {
+    const wrapper = mountDropdown(makeEvent(['alice']));
+
+    expect(wrapper.get('button').text()).toBe('Edits');
+  });
+});
+
+describe('EventDescriptionEditsDropdown contents', () => {
+  it('summarizes the number of edits', async () => {
+    const wrapper = mountDropdown(makeEvent(['alice', 'bob']));
+
+    await openDropdown(wrapper);
+
+    expect(wrapper.text()).toContain('Edited 2 times');
+  });
+
+  it('attributes the most recent edit to DescriptionLastEditedBy', async () => {
+    const wrapper = mountDropdown(makeEvent(['alice', 'bob']));
+
+    await openDropdown(wrapper);
+
+    expect(wrapper.findAll('li')[0].text()).toContain('alice');
+  });
+
+  it('attributes an older edit to the next version author', async () => {
+    const wrapper = mountDropdown(makeEvent(['alice', 'bob']));
+
+    await openDropdown(wrapper);
+
+    expect(wrapper.findAll('li')[1].text()).toContain('bob');
+  });
+
+  it('falls back to [Deleted] when the editor is unknown', async () => {
+    const wrapper = mountDropdown(makeEvent([null]));
+
+    await openDropdown(wrapper);
+
+    expect(wrapper.get('li').text()).toContain('[Deleted]');
+  });
+});
+
+describe('EventDescriptionEditsDropdown revision modal', () => {
+  it('opens the diff modal when an edit is clicked', async () => {
+    const wrapper = mountDropdown(makeEvent(['alice']));
+    await openDropdown(wrapper);
+
+    await wrapper.get('li').trigger('click');
+
+    expect(wrapper.findComponent({ name: 'RevisionDiffModal' }).exists()).toBe(
+      true
+    );
+  });
+
+  it('passes the event description delete mutation to the diff modal', async () => {
+    const wrapper = mountDropdown(makeEvent(['alice']));
+    await openDropdown(wrapper);
+    await wrapper.get('li').trigger('click');
+
+    expect(
+      wrapper.findComponent({ name: 'RevisionDiffModal' }).props('deleteMutation')
+    ).toBeTruthy();
+  });
+
+  it('closes the diff modal when a revision is deleted', async () => {
+    const wrapper = mountDropdown(makeEvent(['alice']));
+    await openDropdown(wrapper);
+    await wrapper.get('li').trigger('click');
+
+    await wrapper
+      .findComponent({ name: 'RevisionDiffModal' })
+      .vm.$emit('deleted', 'v0');
+
+    expect(wrapper.findComponent({ name: 'RevisionDiffModal' }).exists()).toBe(
+      false
+    );
+  });
+});
+
+describe('EventDescriptionEditsDropdown toggle', () => {
+  it('closes when a click lands outside the dropdown', async () => {
+    const wrapper = mountDropdown(makeEvent(['alice']));
+    await openDropdown(wrapper);
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await nextTick();
+
+    expect(wrapper.find('li').exists()).toBe(false);
+  });
+});

--- a/components/event/detail/activityFeed/EventDescriptionEditsDropdown.vue
+++ b/components/event/detail/activityFeed/EventDescriptionEditsDropdown.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import type { PropType } from 'vue';
+import type { Event, TextVersion, User } from '@/__generated__/graphql';
+import {
+  usePopoverPositioning,
+  type PopoverPosition,
+} from '@/composables/usePopoverPositioning';
+import { timeAgo } from '@/utils';
+import { DELETE_EVENT_DESCRIPTION_REVISION } from '@/graphQLData/event/mutations';
+import RevisionDiffModal from '@/components/discussion/detail/activityFeed/RevisionDiffModal.vue';
+
+const props = defineProps({
+  event: {
+    type: Object as PropType<Event>,
+    required: true,
+  },
+});
+
+const isOpen = ref(false);
+const triggerRef = ref<HTMLElement | null>(null);
+const popoverRef = ref<HTMLElement | null>(null);
+const popoverPosition = ref<PopoverPosition>({
+  top: 0,
+  left: 0,
+  placement: 'below',
+});
+
+interface RevisionData {
+  id: string;
+  type: 'description';
+  author: string;
+  createdAt: string;
+  isCurrent: boolean;
+  oldVersion:
+    | TextVersion
+    | {
+        id: string;
+        body?: string;
+        createdAt: string;
+        Author?: User | null;
+      };
+  newVersion:
+    | TextVersion
+    | {
+        id: string;
+        body?: string;
+        createdAt: string;
+        Author?: User | null;
+      };
+}
+
+const activeRevision = ref<RevisionData | null>(null);
+
+const totalEdits = computed(() => {
+  return props.event?.PastDescriptionVersions?.length || 0;
+});
+
+const hasEdits = computed(() => {
+  return totalEdits.value >= 1;
+});
+
+// Build the description edit transitions. Mirrors the discussion body model:
+// - TextVersion.Author = author of the OLD content stored in that version
+// - DescriptionLastEditedBy = author of the current description (most recent edit)
+const allEdits = computed(() => {
+  const edits: RevisionData[] = [];
+
+  if (props.event?.PastDescriptionVersions?.length) {
+    const currentVersionBody = {
+      id: 'current',
+      body: props.event.description ?? undefined,
+      createdAt: String(props.event.updatedAt || props.event.createdAt),
+    };
+
+    props.event.PastDescriptionVersions.forEach((version, index) => {
+      const authorOfNewContent =
+        index === 0
+          ? props.event.DescriptionLastEditedBy
+          : props.event.PastDescriptionVersions[index - 1]?.Author;
+
+      const nextVersionBody =
+        index === 0
+          ? currentVersionBody
+          : props.event.PastDescriptionVersions[index - 1];
+
+      if (!nextVersionBody) {
+        return;
+      }
+
+      edits.push({
+        id: version.id,
+        type: 'description' as const,
+        author: authorOfNewContent?.username || '[Deleted]',
+        createdAt: version.createdAt,
+        isCurrent: false,
+        oldVersion: version,
+        newVersion: {
+          id: nextVersionBody.id,
+          body: nextVersionBody.body ?? undefined,
+          Author: authorOfNewContent,
+          createdAt: version.createdAt,
+        },
+      });
+    });
+  }
+
+  return edits.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+});
+
+const isVisibleRef = computed(() => isOpen.value);
+const { adjustedPosition, updateAdjustedPosition } = usePopoverPositioning({
+  popoverRef,
+  position: popoverPosition,
+  isVisible: isVisibleRef,
+  contentDependencies: [allEdits],
+});
+
+const toggleDropdown = () => {
+  if (isOpen.value) {
+    isOpen.value = false;
+    return;
+  }
+
+  if (triggerRef.value) {
+    const rect = triggerRef.value.getBoundingClientRect();
+    popoverPosition.value = {
+      top: rect.bottom + 8,
+      left: rect.left,
+      placement: 'below',
+      triggerRect: {
+        top: rect.top,
+        bottom: rect.bottom,
+        height: rect.height,
+        width: rect.width,
+      },
+    };
+  }
+
+  isOpen.value = true;
+  updateAdjustedPosition();
+};
+
+const closeDropdown = () => {
+  isOpen.value = false;
+};
+
+const openRevisionDiff = (revision: RevisionData) => {
+  activeRevision.value = revision;
+  closeDropdown();
+};
+
+const closeRevisionDiff = () => {
+  activeRevision.value = null;
+};
+
+const handleRevisionDeleted = () => {
+  closeRevisionDiff();
+  isOpen.value = false;
+};
+
+const handleDocumentClick = (event: MouseEvent) => {
+  const target = event.target as Node;
+  if (triggerRef.value?.contains(target) || popoverRef.value?.contains(target)) {
+    return;
+  }
+  closeDropdown();
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleDocumentClick);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleDocumentClick);
+});
+</script>
+
+<template>
+  <div v-if="hasEdits" class="relative">
+    <button
+      ref="triggerRef"
+      class="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+      @click="toggleDropdown"
+    >
+      Edits
+    </button>
+
+    <Teleport to="body">
+      <div
+        v-if="isOpen"
+        ref="popoverRef"
+        class="fixed z-[100] w-64 max-w-[calc(100vw-1rem)] rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
+        :style="{
+          top: `${adjustedPosition.top}px`,
+          left: `${adjustedPosition.left}px`,
+        }"
+      >
+        <div
+          class="border-b border-gray-200 p-2 text-xs font-medium text-gray-700 dark:border-gray-700 dark:text-gray-300"
+        >
+          Edited {{ totalEdits }} time{{ totalEdits > 1 ? 's' : '' }}
+        </div>
+
+        <ul class="max-h-80 overflow-y-auto py-1">
+          <li
+            v-for="edit in allEdits"
+            :key="edit.id"
+            class="cursor-pointer px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            @click="openRevisionDiff(edit)"
+          >
+            <div class="flex flex-col">
+              <div class="flex items-center text-sm">
+                <span class="font-medium text-gray-900 dark:text-gray-200">{{
+                  edit.author
+                }}</span>
+                <span class="ml-1 text-xs text-gray-500 dark:text-gray-400"
+                  >(description)</span
+                >
+              </div>
+              <div class="text-xs text-gray-500 dark:text-gray-400">
+                {{ timeAgo(new Date(edit.createdAt)) }}
+                <span
+                  v-if="edit === allEdits[0]"
+                  class="ml-1 text-orange-600 dark:text-orange-400"
+                >
+                  Most recent
+                </span>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </Teleport>
+
+    <RevisionDiffModal
+      v-if="activeRevision"
+      :open="!!activeRevision"
+      :old-version="activeRevision.oldVersion"
+      :new-version="activeRevision.newVersion"
+      :is-most-recent="activeRevision === allEdits[0]"
+      :delete-mutation="DELETE_EVENT_DESCRIPTION_REVISION"
+      @close="closeRevisionDiff"
+      @deleted="handleRevisionDeleted"
+    />
+  </div>
+</template>

--- a/components/event/detail/activityFeed/EventTitleVersions.spec.ts
+++ b/components/event/detail/activityFeed/EventTitleVersions.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EventTitleVersions from './EventTitleVersions.vue';
+
+vi.mock('@/utils', () => ({ timeAgo: () => 'just now' }));
+
+// PastTitleVersions are returned newest-first by the query.
+const buildEvent = (overrides: Record<string, unknown> = {}) => ({
+  title: 'Current Title',
+  PastTitleVersions: [
+    {
+      id: 'v2',
+      body: 'Second Title',
+      createdAt: '2024-02-01T00:00:00Z',
+      Author: { username: 'bob' },
+    },
+    {
+      id: 'v1',
+      body: 'First Title',
+      createdAt: '2024-01-01T00:00:00Z',
+      Author: { username: 'alice' },
+    },
+  ],
+  ...overrides,
+});
+
+const mountVersions = (event: Record<string, unknown>) =>
+  mount(EventTitleVersions, { props: { event: event as never } });
+
+describe('EventTitleVersions', () => {
+  it('renders nothing when there are no past title versions', () => {
+    const wrapper = mountVersions(buildEvent({ PastTitleVersions: [] }));
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('shows the most recent title change with old (strikethrough) → new and author', () => {
+    const wrapper = mountVersions(buildEvent());
+
+    expect(wrapper.text()).toContain('Title Edit History');
+    expect(wrapper.text()).toContain('bob');
+    expect(wrapper.text()).toContain('Current Title');
+
+    const struck = wrapper.findAll('.line-through').map((s) => s.text());
+    expect(struck).toContain('Second Title');
+
+    expect(wrapper.text()).not.toContain('First Title');
+  });
+
+  it('expands older edits on demand', async () => {
+    const wrapper = mountVersions(buildEvent());
+
+    const showButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Show 1 older edit'));
+    expect(showButton).toBeTruthy();
+
+    await showButton!.trigger('click');
+
+    expect(wrapper.text()).toContain('First Title');
+  });
+
+  it('attributes the older edit to its author when expanded', async () => {
+    const wrapper = mountVersions(buildEvent());
+    const showButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Show 1 older edit'));
+    await showButton!.trigger('click');
+
+    expect(wrapper.text()).toContain('alice');
+  });
+
+  it('falls back to [Deleted] when a past version has no author', () => {
+    const wrapper = mountVersions(
+      buildEvent({
+        PastTitleVersions: [
+          {
+            id: 'v1',
+            body: 'First Title',
+            createdAt: '2024-01-01T00:00:00Z',
+            Author: null,
+          },
+        ],
+      })
+    );
+
+    expect(wrapper.text()).toContain('[Deleted]');
+  });
+});

--- a/components/event/detail/activityFeed/EventTitleVersions.vue
+++ b/components/event/detail/activityFeed/EventTitleVersions.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { PropType } from 'vue';
+import type { Event } from '@/__generated__/graphql';
+import { timeAgo } from '@/utils';
+
+interface TitleTransition {
+  id: string;
+  author: string;
+  oldTitle: string;
+  newTitle: string;
+  timestamp: Date;
+  isLatest: boolean;
+}
+
+const props = defineProps({
+  event: {
+    type: Object as PropType<Event>,
+    required: true,
+  },
+});
+
+const showOlderEdits = ref(false);
+
+// Process the past title versions into old -> new transitions, oldest first.
+const titleVersionsWithCurrent = computed((): TitleTransition[] => {
+  if (
+    !props.event?.PastTitleVersions ||
+    props.event.PastTitleVersions.length === 0
+  ) {
+    return [];
+  }
+
+  // PastTitleVersions come back newest-first; reverse for chronological order.
+  const pastVersions = props.event.PastTitleVersions.slice().reverse();
+
+  const transitions: TitleTransition[] = [];
+
+  for (let i = 0; i < pastVersions.length; i++) {
+    const oldVersion = pastVersions[i];
+    const newerVersion =
+      i === pastVersions.length - 1
+        ? { body: props.event.title }
+        : pastVersions[i + 1];
+
+    transitions.push({
+      id: oldVersion?.id || '',
+      author: oldVersion?.Author?.username || '[Deleted]',
+      oldTitle: oldVersion?.body || '',
+      newTitle: newerVersion?.body || '',
+      timestamp: new Date(oldVersion?.createdAt || Date.now()),
+      isLatest: i === pastVersions.length - 1,
+    });
+  }
+
+  return transitions;
+});
+
+const showActivityFeed = computed(() => {
+  return titleVersionsWithCurrent.value.length > 0;
+});
+
+const visibleItems = computed((): TitleTransition[] => {
+  if (showOlderEdits.value || titleVersionsWithCurrent.value.length <= 1) {
+    return titleVersionsWithCurrent.value;
+  }
+  const lastItem =
+    titleVersionsWithCurrent.value[titleVersionsWithCurrent.value.length - 1];
+  return lastItem ? [lastItem] : [];
+});
+
+const hiddenCount = computed(() => {
+  return titleVersionsWithCurrent.value.length - 1;
+});
+
+const toggleOlderEdits = () => {
+  showOlderEdits.value = !showOlderEdits.value;
+};
+</script>
+
+<template>
+  <div v-if="showActivityFeed" class="mb-6 mt-4">
+    <p class="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
+      Title Edit History
+    </p>
+    <ul role="list" class="flow-root">
+      <li v-if="hiddenCount > 0 && !showOlderEdits" class="relative pb-4">
+        <div class="relative flex items-center space-x-3">
+          <div class="relative flex h-6 w-6 items-center justify-center">
+            <span
+              class="absolute top-3 h-full w-0.5 bg-gray-200 dark:bg-gray-600"
+              aria-hidden="true"
+            />
+          </div>
+          <button
+            class="text-xs text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+            @click="toggleOlderEdits"
+          >
+            Show {{ hiddenCount }} older edit{{ hiddenCount > 1 ? 's' : '' }}
+          </button>
+        </div>
+      </li>
+
+      <li
+        v-for="(item, index) in visibleItems"
+        :key="item.id"
+        class="relative pb-4"
+      >
+        <div class="relative flex items-center space-x-3">
+          <div class="relative flex h-6 w-6 items-center justify-center">
+            <span
+              v-if="index > 0 || (showOlderEdits && hiddenCount > 0)"
+              class="absolute bottom-3 h-full w-0.5 bg-gray-200 dark:bg-gray-600"
+              aria-hidden="true"
+            />
+            <span
+              v-if="index < visibleItems.length - 1"
+              class="absolute top-3 h-full w-0.5 bg-gray-200 dark:bg-gray-600"
+              aria-hidden="true"
+            />
+            <div
+              class="relative z-10 flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 ring-4 ring-white dark:bg-gray-700 dark:ring-gray-800"
+            >
+              <i
+                class="fa-solid fa-pencil text-xs text-gray-500 dark:text-gray-300"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+
+          <div class="min-w-0 flex-1">
+            <div class="text-xs leading-6">
+              <span class="font-medium text-gray-900 dark:text-gray-200">{{
+                item.author
+              }}</span>
+              <span class="text-gray-500 dark:text-gray-400">
+                changed the title
+              </span>
+              <span class="text-gray-500 line-through dark:text-gray-400">{{
+                item.oldTitle
+              }}</span>
+              <span class="text-gray-500 dark:text-gray-400"> → </span>
+              <span class="text-gray-900 dark:text-gray-200">{{
+                item.newTitle
+              }}</span>
+              <span
+                class="whitespace-nowrap text-xs text-gray-500 dark:text-gray-400"
+              >
+                {{ timeAgo(item.timestamp) }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </li>
+
+      <li v-if="hiddenCount > 0 && showOlderEdits" class="relative">
+        <div class="relative flex items-center space-x-3">
+          <div class="flex h-6 w-6 items-center justify-center" />
+          <button
+            class="text-xs text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+            @click="toggleOlderEdits"
+          >
+            Hide older edits
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -30,7 +30,7 @@ Notes:
 - The add-to-list creation flow now defaults to `PRIVATE` and includes an explicit public visibility override.
 - The backend collection-create sanitizer also defaults missing visibility to `PRIVATE` while preserving explicit overrides.
 
-### 3. Downloadable file permanent delete permission flow `[partial]`
+### 3. Downloadable file permanent delete permission flow `[complete]`
 
 - [x] Define the exact moderator permission using the existing moderation permission model.
 - [x] Decide whether OP/uploader self-delete is allowed and under what product rules.
@@ -50,6 +50,7 @@ Notes:
 - The current draft slice adds an owner-scoped backend query and `/library/uploads` management page for uploaded downloadable files.
 - This slice adds scalar permanent-removal audit fields and focused authorization/storage-failure tests for downloadable-file deletion.
 - Backend draft PR gennit-project/multiforum-backend#116 and frontend draft PR gennit-project/multiforum-nuxt#266 add verified upload storage metadata for new downloadable files, including `storageObjectName` and `storageUrl`.
+- Status reconciled to `[complete]`: the referenced draft PRs have merged. Backend `main` exposes `permanentlyDeleteDownloadableFile` (and the storage-deletion hardening from multiforum-backend#121); no related PRs remain open.
 
 ### 4. Download filters: review and finish include/exclude semantics `[complete]`
 
@@ -133,7 +134,7 @@ Notes:
 Notes:
 - Album editor flows now include a reusable-image picker for the user's uploads, favorites, and image collections.
 
-### 9. Permanent media deletion and storage cleanup `[partial]`
+### 9. Permanent media deletion and storage cleanup `[complete]`
 
 - [x] Let authorized users delete album images permanently and remove the backing object from GCP/storage. `[in this PR]`
 - [x] Store backend-verified storage metadata for new image and downloadable-file uploads, including the actual storage URL/object name returned by signed upload creation. `[in draft PR]`
@@ -150,6 +151,7 @@ Notes:
 Notes:
 - Album edit deletion now confirms and calls the backend permanent-delete mutation before removing the image from the album UI.
 - This slice adds storage-backed permanent delete for URL-backed profile images and forum banners by resolving active URLs through upload audit metadata before clearing the owning profile/forum field.
+- Status reconciled to `[complete]`: the referenced draft PRs have merged. Backend `main` exposes `permanentlyDeleteImage`, `permanentlyDeleteProfileImage`, and `permanentlyDeleteChannelBanner` (plus the profile/banner storage-cleanup work from multiforum-backend#124); no related PRs remain open.
 
 ### 10. Wiki: pinned sidebar pages `[complete]`
 
@@ -209,17 +211,30 @@ Notes:
 - [ ] Replace explicit save-button flows where appropriate with autosave behavior.
 - [ ] Start with plugins/settings areas called out in the original note.
 
-### 16. Event edit history: title and description revisions `[partial]`
+### 16. Event edit history: title and description revisions `[complete]`
 
-- [ ] Add event version-history schema fields for title and description revisions plus `DescriptionLastEditedBy`.
-- [ ] Add backend middleware/hook logic to snapshot prior values on update.
-- [ ] Add query support for event revision history.
-- [ ] Add frontend activity-feed components similar to discussion edit history.
-- [ ] Add moderator redaction/delete support for event description revisions if required.
+- [x] Add event version-history schema fields for title and description revisions plus `DescriptionLastEditedBy`.
+- [x] Add backend middleware/hook logic to snapshot prior values on update.
+- [x] Add query support for event revision history.
+- [x] Add frontend activity-feed components similar to discussion edit history.
+- [x] Add moderator redaction/delete support for event description revisions if required.
 
 Notes:
-- Discussions already have full version history.
-- The roadmap notes indicate events still do not.
+- Mirrors the discussion version-history pattern. The `Event` type now exposes
+  `PastTitleVersions`, `PastDescriptionVersions`, and `DescriptionLastEditedBy`
+  (reusing `TextVersion`); an `eventVersionHistoryHook` snapshots the prior
+  title/description on update, wired via `eventVersionHistoryMiddleware`
+  (generated `updateEvents`) and the custom `updateEventWithChannelConnections`
+  resolver.
+- Description revisions are redactable via `deleteEventDescriptionRevision`
+  (the shared `redactTextVersionRevision`, `canEditEvents` permission). Titles
+  are non-redactable, consistent with discussions.
+- The frontend `GET_EVENT` query fetches the revision fields; `EventTitleVersions`
+  renders the title feed and `EventDescriptionEditsDropdown` renders description
+  edits, both reusing the shared `RevisionDiffModal`/`RevisionDiffContent`.
+- Series edits (`updateEventInSeries`) are intentionally out of scope; single-event
+  edits are covered. Extending history to series edits is a possible follow-up.
+- Backend PR gennit-project/multiforum-backend#145; frontend PR stacked on top.
 
 ## Removed From This Roadmap As Completed
 

--- a/graphQLData/event/mutations.js
+++ b/graphQLData/event/mutations.js
@@ -275,3 +275,18 @@ export const UNSUBSCRIBE_FROM_EVENT_UPDATES = gql`
     }
   }
 `;
+
+export const DELETE_EVENT_DESCRIPTION_REVISION = gql`
+  mutation deleteEventDescriptionRevision($textVersionId: ID!) {
+    deleteEventDescriptionRevision(textVersionId: $textVersionId) {
+      id
+      body
+      editReason
+      createdAt
+      updatedAt
+      Author {
+        username
+      }
+    }
+  }
+`;

--- a/graphQLData/event/queries.js
+++ b/graphQLData/event/queries.js
@@ -111,6 +111,27 @@ export const GET_EVENT = gql`
         discussionKarma
         commentKarma
       }
+      PastTitleVersions(options: { sort: [{ createdAt: DESC }] }) {
+        id
+        Author {
+          username
+        }
+        body
+        editReason
+        createdAt
+      }
+      PastDescriptionVersions(options: { sort: [{ createdAt: DESC }] }) {
+        id
+        Author {
+          username
+        }
+        body
+        editReason
+        createdAt
+      }
+      DescriptionLastEditedBy {
+        username
+      }
     }
   }
   ${EVENT_FIELDS}


### PR DESCRIPTION
## Summary

Adds the frontend for **event title/description edit history** (roadmap item #16), mirroring how discussions display revision history. **Stacked on [multiforum-backend#145](https://github.com/gennit-project/multiforum-backend/pull/145)** — the backend adds the `Event` revision fields, snapshot hook, and `deleteEventDescriptionRevision` mutation.

## Changes

- **Query/mutation**: `GET_EVENT` now fetches `PastTitleVersions`, `PastDescriptionVersions`, and `DescriptionLastEditedBy`; added `DELETE_EVENT_DESCRIPTION_REVISION`.
- **Components**: `EventTitleVersions.vue` (title edit feed) and `EventDescriptionEditsDropdown.vue` (description edits + redaction), both reusing the shared `RevisionDiffModal` / `RevisionDiffContent`. Rendered in `EventDetail.vue` near the title and description.
- **`RevisionDiffModal` made content-neutral**: a backward-compatible `deleteMutation` prop (defaults to the discussion mutation), so events pass `DELETE_EVENT_DESCRIPTION_REVISION`. Existing discussion behavior and specs are unchanged.
- **Roadmap**: #16 → `[complete]`; also reconciled #3 and #9 → `[complete]` (their permanent-delete draft PRs merged on backend `main`; no related PRs remain open).

## Generated types

The committed `__generated__/graphql.ts` is minimally augmented with the three new `Event` members and the new mutation, since frontend codegen runs against the deployed schema (which won't have these until the backend lands). A full recompile after the backend deploys will produce the same shape. CI runs `pnpm run tsc` against the committed file (no codegen step), so this is stable.

## Tests

- `EventTitleVersions.spec.ts` and `EventDescriptionEditsDropdown.spec.ts` (15 tests): visibility, edit summaries, author attribution, `[Deleted]` fallback, modal open/close, redaction mutation wiring, outside-click close.
- `pnpm run tsc` clean; existing discussion revision specs still pass.

## Scope

Series-edit history (`updateEventInSeries`) is intentionally out of scope for this slice; single-event edits are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)