### PR TITLE
Give the closed admin issues page filter parity with the open page

### DIFF
--- a/components/admin/IssueFilterBar.spec.ts
+++ b/components/admin/IssueFilterBar.spec.ts
@@ -52,6 +52,22 @@ describe('IssueFilterBar', () => {
     expect(wrapper.emitted('update-search-input')).toEqual([['needle']]);
   });
 
+  it('defaults the search placeholder to "Search issues"', () => {
+    const wrapper = buildWrapper();
+
+    expect(wrapper.getComponent(SearchBar).props('searchPlaceholder')).toBe(
+      'Search issues'
+    );
+  });
+
+  it('uses a custom search placeholder when provided', () => {
+    const wrapper = buildWrapper({ searchPlaceholder: 'Search closed issues' });
+
+    expect(wrapper.getComponent(SearchBar).props('searchPlaceholder')).toBe(
+      'Search closed issues'
+    );
+  });
+
   it('emits date updates', async () => {
     const wrapper = buildWrapper();
 

--- a/components/admin/IssueFilterBar.vue
+++ b/components/admin/IssueFilterBar.vue
@@ -25,7 +25,16 @@ const props = defineProps<{
   filterCreatedByMe?: boolean;
   filterIAmOP?: boolean;
   filterIReported?: boolean;
+  searchPlaceholder?: string;
+  searchTestId?: string;
 }>();
+
+const searchPlaceholder = computed(
+  () => props.searchPlaceholder ?? 'Search issues'
+);
+const searchTestId = computed(
+  () => props.searchTestId ?? 'server-issue-search-input'
+);
 
 const emit = defineEmits<{
   'update-search-input': [value: string];
@@ -79,8 +88,8 @@ const issueScopeLabel = computed(() =>
   <div class="flex flex-col gap-3 px-4 pb-4">
     <SearchBar
       :initial-value="searchInput"
-      :search-placeholder="'Search issues'"
-      :test-id="'server-issue-search-input'"
+      :search-placeholder="searchPlaceholder"
+      :test-id="searchTestId"
       :debounce-ms="500"
       @update-search-input="emit('update-search-input', $event)"
     />

--- a/composables/useServerIssueList.ts
+++ b/composables/useServerIssueList.ts
@@ -1,0 +1,224 @@
+// composables/useServerIssueList.ts
+//
+// Shared state + query wiring for the server-wide (admin) issue lists. The open
+// and closed admin issue pages are identical except for the `isOpen` flag they
+// query on, so both consume this composable and render the same IssueFilterBar.
+import { computed, ref, watch } from 'vue';
+import type { Issue } from '@/__generated__/graphql';
+import { GET_SITE_WIDE_ISSUE_LIST } from '@/graphQLData/issue/queries';
+import { useQuery } from '@vue/apollo-composable';
+import { useRoute, useRouter } from 'nuxt/app';
+import { getChannelLabel } from '@/utils';
+import { updateFilters } from '@/utils/routerUtils';
+import { getServerIssueFilterValuesFromParams } from '@/utils/getServerIssueFilterValuesFromParams';
+import { useIsAuthenticated } from '@/composables/useAuthState';
+import { useUIStore } from '@/stores/uiStore';
+import { storeToRefs } from 'pinia';
+import { getIssueSortLabel } from '@/utils/issueSortOptions';
+
+export type SiteWideIssueListItem = Issue & {
+  channelUniqueName?: string | null;
+  channelIconURL?: string | null;
+  authorName?: string | null;
+  reportCount?: number | null;
+};
+
+export type InvolvementFilterKey =
+  | 'filterCreatedByMe'
+  | 'filterIAmOP'
+  | 'filterIReported';
+
+export function useServerIssueList({ isOpen }: { isOpen: boolean }) {
+  const route = useRoute();
+  const router = useRouter();
+  const uiStore = useUIStore();
+  const { selectedIssueNumber } = storeToRefs(uiStore);
+  const initialFilterValues = getServerIssueFilterValuesFromParams({ route });
+
+  const channelId = computed(() => {
+    if (typeof route.params.forumId !== 'string') {
+      return '';
+    }
+    return route.params.forumId;
+  });
+
+  const selectedChannels = ref(initialFilterValues.selectedChannels);
+  const showOnlyServerRuleViolations = ref(
+    initialFilterValues.showOnlyServerRuleViolations
+  );
+  const searchInput = ref(initialFilterValues.searchInput);
+  const startDate = ref(initialFilterValues.startDate);
+  const endDate = ref(initialFilterValues.endDate);
+  const selectedSort = ref(initialFilterValues.sort);
+  const filterCreatedByMe = ref(initialFilterValues.filterCreatedByMe);
+  const filterIAmOP = ref(initialFilterValues.filterIAmOP);
+  const filterIReported = ref(initialFilterValues.filterIReported);
+  const isAuthenticated = useIsAuthenticated();
+  const channelLabel = computed(() => getChannelLabel(selectedChannels.value));
+  const selectedSortLabel = computed(() => getIssueSortLabel(selectedSort.value));
+
+  const variables = computed(() => ({
+    searchInput: searchInput.value,
+    selectedChannels: selectedChannels.value,
+    startDate: startDate.value || null,
+    endDate: endDate.value || null,
+    showOnlyServerRuleViolations: showOnlyServerRuleViolations.value,
+    isOpen,
+    // Identity is resolved server-side, so these are only meaningful when the
+    // viewer is authenticated; keep them false otherwise to avoid emptying the list.
+    filterCreatedByMe: isAuthenticated.value && filterCreatedByMe.value,
+    filterIAmOP: isAuthenticated.value && filterIAmOP.value,
+    filterIReported: isAuthenticated.value && filterIReported.value,
+    options: {
+      sort: selectedSort.value,
+    },
+  }));
+
+  const {
+    result: getIssuesResult,
+    error: getIssuesError,
+    loading: getIssuesLoading,
+    refetch,
+  } = useQuery(GET_SITE_WIDE_ISSUE_LIST, variables, {
+    fetchPolicy: 'cache-first',
+  });
+
+  const issues = computed<SiteWideIssueListItem[]>(() => {
+    if (getIssuesLoading.value || getIssuesError.value) {
+      return [];
+    }
+    return getIssuesResult.value?.getSiteWideIssueList?.issues || [];
+  });
+
+  const updateShowOnlyServerRuleViolations = (value: boolean) => {
+    showOnlyServerRuleViolations.value = value;
+    updateFilters({
+      router,
+      route,
+      params: {
+        showOnlyServerRuleViolations: value,
+      },
+    });
+  };
+
+  const updateSearchInput = (value: string) => {
+    updateFilters({
+      router,
+      route,
+      params: { searchInput: value },
+    });
+  };
+
+  const updateSort = (value: string) => {
+    updateFilters({
+      router,
+      route,
+      params: { sort: value },
+    });
+  };
+
+  const updateInvolvementFilter = (payload: {
+    key: InvolvementFilterKey;
+    value: boolean;
+  }) => {
+    updateFilters({
+      router,
+      route,
+      params: { [payload.key]: payload.value },
+    });
+  };
+
+  const toggleSelectedChannel = (channel: string) => {
+    const nextChannels = [...selectedChannels.value];
+    const selectedIndex = nextChannels.indexOf(channel);
+
+    if (selectedIndex >= 0) {
+      nextChannels.splice(selectedIndex, 1);
+    } else {
+      nextChannels.push(channel);
+    }
+
+    updateFilters({
+      router,
+      route,
+      params: {
+        channels: nextChannels,
+      },
+    });
+  };
+
+  const handleSelectIssue = (payload: {
+    issueNumber: number;
+    title: string;
+    channelId: string;
+  }) => {
+    uiStore.setSelectedIssueSelection(payload);
+  };
+
+  // Sync local filter state from the URL and refetch on any query change.
+  watch(
+    () => route.query,
+    () => {
+      const nextFilterValues = getServerIssueFilterValuesFromParams({ route });
+
+      selectedChannels.value = nextFilterValues.selectedChannels;
+      showOnlyServerRuleViolations.value =
+        nextFilterValues.showOnlyServerRuleViolations;
+      searchInput.value = nextFilterValues.searchInput;
+      selectedSort.value = nextFilterValues.sort;
+      filterCreatedByMe.value = nextFilterValues.filterCreatedByMe;
+      filterIAmOP.value = nextFilterValues.filterIAmOP;
+      filterIReported.value = nextFilterValues.filterIReported;
+
+      if (nextFilterValues.startDate !== startDate.value) {
+        startDate.value = nextFilterValues.startDate;
+      }
+      if (nextFilterValues.endDate !== endDate.value) {
+        endDate.value = nextFilterValues.endDate;
+      }
+      refetch(variables.value);
+    }
+  );
+
+  watch([startDate, endDate], ([nextStartDate, nextEndDate]) => {
+    if (
+      route.query.startDate === nextStartDate &&
+      route.query.endDate === nextEndDate
+    ) {
+      return;
+    }
+
+    updateFilters({
+      router,
+      route,
+      params: {
+        startDate: nextStartDate,
+        endDate: nextEndDate,
+      },
+    });
+  });
+
+  return {
+    channelId,
+    selectedChannels,
+    showOnlyServerRuleViolations,
+    searchInput,
+    startDate,
+    endDate,
+    selectedSort,
+    filterCreatedByMe,
+    filterIAmOP,
+    filterIReported,
+    isAuthenticated,
+    channelLabel,
+    selectedSortLabel,
+    issues,
+    selectedIssueNumber,
+    updateShowOnlyServerRuleViolations,
+    updateSearchInput,
+    updateSort,
+    updateInvolvementFilter,
+    toggleSelectedChannel,
+    handleSelectIssue,
+  };
+}

--- a/pages/admin/issues/closed.spec.ts
+++ b/pages/admin/issues/closed.spec.ts
@@ -1,17 +1,57 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
-import { setActivePinia, createPinia } from 'pinia';
 import { useQuery } from '@vue/apollo-composable';
 import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
+import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
+
+const h = vi.hoisted(() => ({
+  query: {} as Record<string, string>,
+  routerPush: vi.fn(),
+  routerReplace: vi.fn(),
+  refetch: vi.fn(),
+  setSelectedIssueSelection: vi.fn(),
+  selectedIssueNumber: null as unknown as { value: number | null },
+  isAuthenticated: null as unknown as { value: boolean },
+  updateFilters: vi.fn(),
+}));
+
+h.selectedIssueNumber = ref<number | null>(null);
+h.isAuthenticated = ref<boolean>(true);
 
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({ params: { forumId: '' }, query: {} }),
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRoute: () => ({
+    params: { forumId: '' },
+    path: '/admin/issues/closed',
+    query: h.query,
+  }),
+  useRouter: () => ({ push: h.routerPush, replace: h.routerReplace }),
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
+}));
+
+vi.mock('@/utils/routerUtils', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  updateFilters: h.updateFilters,
+}));
+
+vi.mock('@/stores/uiStore', () => ({
+  useUIStore: () => ({
+    setSelectedIssueSelection: h.setSelectedIssueSelection,
+  }),
+}));
+
+vi.mock('pinia', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  storeToRefs: () => ({
+    selectedIssueNumber: h.selectedIssueNumber,
+  }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => h.isAuthenticated,
 }));
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
@@ -19,17 +59,81 @@ const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 const mountWith = async (opts: { loading?: boolean; issues?: unknown[] }) => {
   const { loading = false, issues = [] } = opts;
   mockedUseQuery.mockReturnValue({
-    result: ref({ issues }),
+    result: ref({ getSiteWideIssueList: { issues } }),
     error: ref(null),
     loading: ref(loading),
-    refetch: vi.fn(),
+    refetch: h.refetch,
   });
   const Page = (await import('./closed.vue')).default;
-  return shallowMount(Page);
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        IssueFilterBar: {
+          name: 'IssueFilterBar',
+          props: [
+            'searchInput',
+            'selectedChannels',
+            'channelLabel',
+            'startDate',
+            'endDate',
+            'showOnlyServerRuleViolations',
+            'selectedSort',
+            'selectedSortLabel',
+            'showInvolvementFilters',
+            'filterCreatedByMe',
+            'filterIAmOP',
+            'filterIReported',
+            'searchPlaceholder',
+            'searchTestId',
+          ],
+          emits: [
+            'update-search-input',
+            'toggle-selected-channel',
+            'update:startDate',
+            'update:endDate',
+            'update:showOnlyServerRuleViolations',
+            'update:sort',
+            'update:involvementFilter',
+          ],
+          template: '<div class="issue-filter-bar" />',
+        },
+        ModIssueListItem: {
+          name: 'ModIssueListItem',
+          props: ['issue'],
+          emits: ['select'],
+          template: '<li class="issue-item" />',
+        },
+      },
+    },
+  });
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.query = {};
+  h.selectedIssueNumber.value = null;
+  h.isAuthenticated.value = true;
+});
+
 describe('admin closed issues page', () => {
-  beforeEach(() => setActivePinia(createPinia()));
+  it('queries the site-wide issue list for closed issues', async () => {
+    await mountWith({ issues: [] });
+    expect(mockedUseQuery.mock.calls[0][1].value.isOpen).toBe(false);
+  });
+
+  it('passes the closed-issue search placeholder to the filter bar', async () => {
+    const wrapper = await mountWith({ issues: [] });
+    expect(
+      wrapper.getComponent(IssueFilterBar).props('searchPlaceholder')
+    ).toBe('Search closed issues');
+  });
+
+  it('passes the closed-issue search test id to the filter bar', async () => {
+    const wrapper = await mountWith({ issues: [] });
+    expect(wrapper.getComponent(IssueFilterBar).props('searchTestId')).toBe(
+      'closed-issue-search-input'
+    );
+  });
 
   it('renders an item per closed issue', async () => {
     const wrapper = await mountWith({ issues: [{ id: 'i1' }, { id: 'i2' }] });
@@ -39,5 +143,38 @@ describe('admin closed issues page', () => {
   it('renders no issues while the query is loading', async () => {
     const wrapper = await mountWith({ loading: true, issues: [{ id: 'i1' }] });
     expect(wrapper.findAllComponents(ModIssueListItem)).toHaveLength(0);
+  });
+
+  it('shows the involvement filters when authenticated', async () => {
+    h.isAuthenticated.value = true;
+    const wrapper = await mountWith({ issues: [] });
+    expect(
+      wrapper.getComponent(IssueFilterBar).props('showInvolvementFilters')
+    ).toBe(true);
+  });
+
+  it('passes an active involvement filter into the closed-issues query', async () => {
+    h.query.filterIReported = 'true';
+    await mountWith({ issues: [] });
+    expect(mockedUseQuery.mock.calls[0][1].value.filterIReported).toBe(true);
+  });
+
+  it('updates the route filters when an involvement filter is toggled', async () => {
+    const wrapper = await mountWith({ issues: [] });
+    await wrapper
+      .getComponent(IssueFilterBar)
+      .vm.$emit('update:involvementFilter', {
+        key: 'filterCreatedByMe',
+        value: true,
+      });
+    expect(h.updateFilters).toHaveBeenCalledWith({
+      router: { push: h.routerPush, replace: h.routerReplace },
+      route: {
+        params: { forumId: '' },
+        path: '/admin/issues/closed',
+        query: h.query,
+      },
+      params: { filterCreatedByMe: true },
+    });
   });
 });

--- a/pages/admin/issues/closed.vue
+++ b/pages/admin/issues/closed.vue
@@ -1,109 +1,60 @@
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue';
-import type { Issue } from '@/__generated__/graphql';
-import { GET_ISSUES } from '@/graphQLData/issue/queries';
-import { useQuery } from '@vue/apollo-composable';
-import { useRoute, useRouter } from 'nuxt/app';
 import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
-import SearchBar from '@/components/SearchBar.vue';
-import { updateFilters } from '@/utils/routerUtils';
-import { createCaseInsensitivePattern } from '@/utils/searchUtils';
-import { useUIStore } from '@/stores/uiStore';
-import { storeToRefs } from 'pinia';
-
-const route = useRoute();
-const router = useRouter();
-const uiStore = useUIStore();
-const { selectedIssueNumber } = storeToRefs(uiStore);
-
-const channelId = computed(() => {
-  if (typeof route.params.forumId !== 'string') {
-    return '';
-  }
-  return route.params.forumId;
-});
-
-const searchInput = ref(
-  typeof route.query.searchInput === 'string' ? route.query.searchInput : ''
-);
-
-const variables = computed(() => {
-  const searchPattern = createCaseInsensitivePattern(searchInput.value);
-  const searchFilter = searchPattern
-    ? {
-        OR: [
-          { title_MATCHES: searchPattern },
-          { body_MATCHES: searchPattern },
-        ],
-      }
-    : {};
-
-  return {
-    issueWhere: {
-      isOpen: false,
-      ...searchFilter,
-    },
-  };
-});
+import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
+import { useServerIssueList } from '@/composables/useServerIssueList';
 
 const {
-  result: getIssuesResult,
-  error: getIssuesError,
-  loading: getIssuesLoading,
-  refetch,
-} = useQuery(GET_ISSUES, variables, {
-  fetchPolicy: 'cache-first',
-});
-
-const issues = computed<Issue[]>(() => {
-  if (getIssuesLoading.value || getIssuesError.value) {
-    return [];
-  }
-  return getIssuesResult.value?.issues || [];
-});
-
-const updateSearchInput = (value: string) => {
-  updateFilters({
-    router,
-    route,
-    params: { searchInput: value },
-  });
-};
-
-const handleSelectIssue = (payload: {
-  issueNumber: number;
-  title: string;
-  channelId: string;
-}) => {
-  uiStore.setSelectedIssueSelection(payload);
-};
-
-// Watch for route change to update searchInput and refetch
-watch(
-  () => route.query,
-  () => {
-    if (route.query) {
-      searchInput.value =
-        typeof route.query.searchInput === 'string'
-          ? route.query.searchInput
-          : '';
-      refetch(variables.value);
-    }
-  }
-);
+  channelId,
+  selectedChannels,
+  showOnlyServerRuleViolations,
+  searchInput,
+  startDate,
+  endDate,
+  selectedSort,
+  filterCreatedByMe,
+  filterIAmOP,
+  filterIReported,
+  isAuthenticated,
+  channelLabel,
+  selectedSortLabel,
+  issues,
+  selectedIssueNumber,
+  updateShowOnlyServerRuleViolations,
+  updateSearchInput,
+  updateSort,
+  updateInvolvementFilter,
+  toggleSelectedChannel,
+  handleSelectIssue,
+} = useServerIssueList({ isOpen: false });
 </script>
 
 <template>
   <div>
-    <div class="flex flex-col gap-3 pb-4">
-      <SearchBar
-        :initial-value="searchInput"
-        :search-placeholder="'Search closed issues'"
-        :test-id="'closed-issue-search-input'"
-        :debounce-ms="500"
-        @update-search-input="updateSearchInput"
-      />
-    </div>
+    <IssueFilterBar
+      :search-input="searchInput"
+      :selected-channels="selectedChannels"
+      :channel-label="channelLabel"
+      :start-date="startDate"
+      :end-date="endDate"
+      :show-only-server-rule-violations="showOnlyServerRuleViolations"
+      :selected-sort="selectedSort"
+      :selected-sort-label="selectedSortLabel"
+      :show-involvement-filters="isAuthenticated"
+      :filter-created-by-me="filterCreatedByMe"
+      :filter-i-am-o-p="filterIAmOP"
+      :filter-i-reported="filterIReported"
+      :search-placeholder="'Search closed issues'"
+      :search-test-id="'closed-issue-search-input'"
+      @update-search-input="updateSearchInput"
+      @toggle-selected-channel="toggleSelectedChannel"
+      @update:sort="updateSort"
+      @update:start-date="startDate = $event"
+      @update:end-date="endDate = $event"
+      @update:show-only-server-rule-violations="
+        updateShowOnlyServerRuleViolations
+      "
+      @update:involvement-filter="updateInvolvementFilter"
+    />
     <ul
       class="divide-y border-t border-gray-200 dark:border-gray-800 dark:text-white"
       data-testid="issue-list"

--- a/pages/admin/issues/index.vue
+++ b/pages/admin/issues/index.vue
@@ -1,194 +1,31 @@
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue';
-import type { Issue } from '@/__generated__/graphql';
-import { GET_SITE_WIDE_ISSUE_LIST } from '@/graphQLData/issue/queries';
-import { useQuery } from '@vue/apollo-composable';
-import { useRoute, useRouter } from 'nuxt/app';
 import ModIssueListItem from '@/components/mod/ModIssueListItem.vue';
 import IssueFilterBar from '@/components/admin/IssueFilterBar.vue';
-import { getChannelLabel } from '@/utils';
-import { updateFilters } from '@/utils/routerUtils';
-import { getServerIssueFilterValuesFromParams } from '@/utils/getServerIssueFilterValuesFromParams';
-import { useIsAuthenticated } from '@/composables/useAuthState';
-import { useUIStore } from '@/stores/uiStore';
-import { storeToRefs } from 'pinia';
-import { getIssueSortLabel } from '@/utils/issueSortOptions';
-
-const route = useRoute();
-const router = useRouter();
-const uiStore = useUIStore();
-const { selectedIssueNumber } = storeToRefs(uiStore);
-const initialFilterValues = getServerIssueFilterValuesFromParams({ route });
-
-const channelId = computed(() => {
-  if (typeof route.params.forumId !== 'string') {
-    return '';
-  }
-  return route.params.forumId;
-});
-
-const selectedChannels = ref(initialFilterValues.selectedChannels);
-const showOnlyServerRuleViolations = ref(
-  initialFilterValues.showOnlyServerRuleViolations
-);
-const searchInput = ref(initialFilterValues.searchInput);
-const startDate = ref(initialFilterValues.startDate);
-const endDate = ref(initialFilterValues.endDate);
-const selectedSort = ref(initialFilterValues.sort);
-const filterCreatedByMe = ref(initialFilterValues.filterCreatedByMe);
-const filterIAmOP = ref(initialFilterValues.filterIAmOP);
-const filterIReported = ref(initialFilterValues.filterIReported);
-const isAuthenticated = useIsAuthenticated();
-const channelLabel = computed(() => getChannelLabel(selectedChannels.value));
-const selectedSortLabel = computed(() => getIssueSortLabel(selectedSort.value));
-
-const variables = computed(() => ({
-  searchInput: searchInput.value,
-  selectedChannels: selectedChannels.value,
-  startDate: startDate.value || null,
-  endDate: endDate.value || null,
-  showOnlyServerRuleViolations: showOnlyServerRuleViolations.value,
-  isOpen: true,
-  // Identity is resolved server-side, so these are only meaningful when the
-  // viewer is authenticated; keep them false otherwise to avoid emptying the list.
-  filterCreatedByMe: isAuthenticated.value && filterCreatedByMe.value,
-  filterIAmOP: isAuthenticated.value && filterIAmOP.value,
-  filterIReported: isAuthenticated.value && filterIReported.value,
-  options: {
-    sort: selectedSort.value,
-  },
-}));
+import { useServerIssueList } from '@/composables/useServerIssueList';
 
 const {
-  result: getIssuesResult,
-  error: getIssuesError,
-  loading: getIssuesLoading,
-  refetch,
-} = useQuery(GET_SITE_WIDE_ISSUE_LIST, variables, {
-  fetchPolicy: 'cache-first',
-});
-
-type SiteWideIssueListItem = Issue & {
-  channelUniqueName?: string | null;
-  channelIconURL?: string | null;
-  authorName?: string | null;
-  reportCount?: number | null;
-};
-
-const issues = computed<SiteWideIssueListItem[]>(() => {
-  if (getIssuesLoading.value || getIssuesError.value) {
-    return [];
-  }
-  return getIssuesResult.value?.getSiteWideIssueList?.issues || [];
-});
-
-const updateShowOnlyServerRuleViolations = (value: boolean) => {
-  showOnlyServerRuleViolations.value = value;
-  updateFilters({
-    router,
-    route,
-    params: {
-      showOnlyServerRuleViolations: value,
-    },
-  });
-};
-
-const updateSearchInput = (value: string) => {
-  updateFilters({
-    router,
-    route,
-    params: { searchInput: value },
-  });
-};
-
-const updateSort = (value: string) => {
-  updateFilters({
-    router,
-    route,
-    params: { sort: value },
-  });
-};
-
-const updateInvolvementFilter = (payload: {
-  key: 'filterCreatedByMe' | 'filterIAmOP' | 'filterIReported';
-  value: boolean;
-}) => {
-  updateFilters({
-    router,
-    route,
-    params: { [payload.key]: payload.value },
-  });
-};
-
-const toggleSelectedChannel = (channel: string) => {
-  const nextChannels = [...selectedChannels.value];
-  const selectedIndex = nextChannels.indexOf(channel);
-
-  if (selectedIndex >= 0) {
-    nextChannels.splice(selectedIndex, 1);
-  } else {
-    nextChannels.push(channel);
-  }
-
-  updateFilters({
-    router,
-    route,
-    params: {
-      channels: nextChannels,
-    },
-  });
-};
-
-const handleSelectIssue = (payload: {
-  issueNumber: number;
-  title: string;
-  channelId: string;
-}) => {
-  uiStore.setSelectedIssueSelection(payload);
-};
-
-// Watch for route change to update showOnlyServerRuleViolations and refetch
-watch(
-  () => route.query,
-  () => {
-    const nextFilterValues = getServerIssueFilterValuesFromParams({ route });
-
-    selectedChannels.value = nextFilterValues.selectedChannels;
-    showOnlyServerRuleViolations.value =
-      nextFilterValues.showOnlyServerRuleViolations;
-    searchInput.value = nextFilterValues.searchInput;
-    selectedSort.value = nextFilterValues.sort;
-    filterCreatedByMe.value = nextFilterValues.filterCreatedByMe;
-    filterIAmOP.value = nextFilterValues.filterIAmOP;
-    filterIReported.value = nextFilterValues.filterIReported;
-
-    if (nextFilterValues.startDate !== startDate.value) {
-      startDate.value = nextFilterValues.startDate;
-    }
-    if (nextFilterValues.endDate !== endDate.value) {
-      endDate.value = nextFilterValues.endDate;
-    }
-    refetch(variables.value);
-  }
-);
-
-watch([startDate, endDate], ([nextStartDate, nextEndDate]) => {
-  if (
-    route.query.startDate === nextStartDate &&
-    route.query.endDate === nextEndDate
-  ) {
-    return;
-  }
-
-  updateFilters({
-    router,
-    route,
-    params: {
-      startDate: nextStartDate,
-      endDate: nextEndDate,
-    },
-  });
-});
+  channelId,
+  selectedChannels,
+  showOnlyServerRuleViolations,
+  searchInput,
+  startDate,
+  endDate,
+  selectedSort,
+  filterCreatedByMe,
+  filterIAmOP,
+  filterIReported,
+  isAuthenticated,
+  channelLabel,
+  selectedSortLabel,
+  issues,
+  selectedIssueNumber,
+  updateShowOnlyServerRuleViolations,
+  updateSearchInput,
+  updateSort,
+  updateInvolvementFilter,
+  toggleSelectedChannel,
+  handleSelectIssue,
+} = useServerIssueList({ isOpen: true });
 </script>
 
 <template>


### PR DESCRIPTION
## What

The admin **closed** issues page (`/admin/issues/closed`) now has the same filtering as the open page — search, date range, sort, server-rule-violations, channels, and the three my-involvement filters (Created by me / About my content / I reported).

Follow-up to #305 (which added the involvement filters to the open page only).

## How

Per the request, the closed page now uses the **same query** as the open page, just passing `isOpen: false`:

- **`composables/useServerIssueList.ts`** (new) — extracts all the shared state, query variables, handlers, and route/query watchers from the open page. Parameterized only by `{ isOpen }`.
- **`pages/admin/issues/index.vue`** and **`closed.vue`** — now thin wrappers that call the composable (`isOpen: true` / `false`) and render `IssueFilterBar`. `closed.vue` drops its old `GET_ISSUES` + `IssueWhere` path.
- **`IssueFilterBar`** — gains optional `searchPlaceholder` / `searchTestId` props (defaults preserve the open page) so the closed page keeps its **"Search closed issues"** placeholder that existing Playwright specs assert on.

## Testing

- `pnpm run tsc` — 0 errors
- `pnpm exec eslint` on changed files — clean
- Unit tests: 61 passing across the affected specs (the untouched `index.spec.ts` still passes against the extracted composable; new closed-page tests cover `isOpen: false`, the closed placeholder/test-id, involvement wiring, and rendering).
- Playwright `moderationQueues.spec.ts` (incl. the closed-page placeholder assertion) — 3/3 passing.

## Note

The forum-scoped closed page (`pages/forums/[forumId]/issues/closed.vue`) still uses the old query — out of scope here; can follow up if you want parity there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)