### PR TITLE
fix: show external-link warning when baseUrl is unset

### DIFF
--- a/components/MarkdownPreview.spec.ts
+++ b/components/MarkdownPreview.spec.ts
@@ -15,6 +15,28 @@ vi.mock('nuxt/app', () => ({
   useRouter: () => createMockRouter(),
 }));
 
+// Force an empty baseUrl to reproduce the environment where VITE_BASE_URL is
+// unset (e.g. CI runs without repo secrets). This guards the external-link
+// warning against the `''.startsWith` bug where an empty baseUrl would
+// otherwise match every href and suppress the warning entirely.
+vi.mock('@/config', () => ({
+  config: {
+    baseUrl: '',
+    environment: 'test',
+    googleCloudStorageBucket: '',
+    googleMapsApiKey: '',
+    googleMapId: '',
+    graphqlUrl: '',
+    lightgalleryLicenseKey: '',
+    logoutUrl: '',
+    openCageApiKey: '',
+    openGraphApiKey: '',
+    serverName: '',
+    serverDisplayName: 'Untitled',
+    enableLanguagePicker: false,
+  },
+}));
+
 vi.mock('vue-easy-lightbox', () => ({
   default: defineComponent({
     name: 'VueEasyLightbox',

--- a/components/MarkdownPreview.vue
+++ b/components/MarkdownPreview.vue
@@ -175,10 +175,12 @@ const handleClick = (event: MouseEvent) => {
   // Handle link clicks
   const link = target.tagName === 'A' ? target : target.closest('a');
   if (link && link instanceof HTMLAnchorElement && link.href) {
-    // Only show warning for external links
+    // Only show warning for external links. Guard against an empty baseUrl:
+    // `''.startsWith` matches every href, which would suppress the warning for
+    // all links whenever VITE_BASE_URL is unset.
     const isExternalLink =
       !link.href.startsWith(window.location.origin) &&
-      !link.href.startsWith(config.baseUrl);
+      (!config.baseUrl || !link.href.startsWith(config.baseUrl));
 
     if (isExternalLink) {
       event.preventDefault();


### PR DESCRIPTION
## Problem

The external-link warning modal in `MarkdownPreview.vue` never opens whenever `VITE_BASE_URL` is unset. The check was:

```js
const isExternalLink =
  !link.href.startsWith(window.location.origin) &&
  !link.href.startsWith(config.baseUrl);
```

When `config.baseUrl` is an empty string, `link.href.startsWith('')` is `true` for **every** link, so `isExternalLink` is always `false` and no external link ever triggers the warning.

This affects any deployment where `VITE_BASE_URL` is not set, and it also makes `components/MarkdownPreview.spec.ts` fail in CI runs that don't receive the repo secrets — most visibly on **every open Dependabot PR**, since Dependabot-triggered workflows don't get regular Actions secrets. That's the shared `unit-tests` failure across PRs #310, #312, #313 (and contributes to #309/#311).

## Fix

- Guard the empty-`baseUrl` case so it no longer matches all links (a real correctness improvement — the warning now works even when `VITE_BASE_URL` is unset).
- Pin the spec's `config` mock to an empty `baseUrl` so this path is covered deterministically, independent of whether CI has the secret.

## Verification

- `vitest run components/MarkdownPreview.spec.ts` — 18 passed (previously 3 failed under empty baseUrl).
- `pnpm run tsc` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)