### PR TITLE
docs: refresh plugin docs after standalone-repo migration + download-trigger fix

### DIFF
--- a/docs/MODERATION_PLAN.md
+++ b/docs/MODERATION_PLAN.md
@@ -2509,24 +2509,17 @@ These steps verify the auto-moderation bot plugin that analyzes content for rule
 
 ### Automated Verification
 
-Run these from `/Users/catherineluse/gennit/gennit-nuxt/multiforum-plugins`:
+Each plugin now lives in its own repository (the old in-repo
+`multiforum-plugins/plugins/<id>/` layout was removed). Clone the plugin's repo
+and build it per its own README:
 
 ```bash
-cd plugins/auto-moderation-bot
-npm run build
+git clone https://github.com/gennit-project/multiforum-plugin-auto-moderation-bot
+cd multiforum-plugin-auto-moderation-bot
+npm install && npm run ci   # validates plugin.json, runs tests, builds, bundles
 ```
 
 Expected outcome:
 
 - TypeScript compilation succeeds with no errors
-- `dist/index.js` is generated
-
-Run the full build from the plugins root:
-
-```bash
-npm run build:plugin -- --plugin auto-moderation-bot
-```
-
-Expected outcome:
-
-- Plugin builds successfully via the root build script
+- `dist/index.js` is generated and a release bundle is produced under `out/`

--- a/docs/PLUGINS_BOT_BETABOT_PLAN.md
+++ b/docs/PLUGINS_BOT_BETABOT_PLAN.md
@@ -147,23 +147,22 @@ This document tracks the end-to-end work to add `/bot/<name>` mentions, forum-sc
 
 ## Phase 5.5 — Demo Plugins (Multiforum Plugins Repo)
 
-### Plugins repo (multiforum-plugins)
+### Standalone plugin repos
+
+Each plugin lives in its own GitHub repo (the `multiforum-plugins` repo is now
+just the registry-source index + generator).
 
 - [x] **Generic ChatGPT Bot Profiles**
   - `id: chatgpt-bot-profiles`
   - Configurable profile array + default profile
   - Uses `/bot/<name>` with profile selection
-  - Files:
-    - `multiforum-plugins/plugins/chatgpt-bot-profiles/plugin.json`
-    - `multiforum-plugins/plugins/chatgpt-bot-profiles/index.ts`
+  - Repo `github.com/gennit-project/multiforum-plugin-chatgpt-bot-profiles`: `plugin.json`, `index.ts`
 
 - [x] **Creative Writing Beta Reader**
   - `id: beta-reader-bot`
   - Ships with 4 default prompts
   - Same bot reply flow, tuned to writing feedback
-  - Files:
-    - `multiforum-plugins/plugins/beta-reader-bot/plugin.json`
-    - `multiforum-plugins/plugins/beta-reader-bot/index.ts`
+  - Repo `github.com/gennit-project/multiforum-plugin-beta-reader-bot`: `plugin.json`, `index.ts`
 
 ---
 

--- a/docs/PLUGINS_IMPLEMENTED.md
+++ b/docs/PLUGINS_IMPLEMENTED.md
@@ -28,6 +28,12 @@ Plugins execute in response to events at two scopes:
 **Channel-Scoped Events** (configured by channel admin):
 - `discussionChannel.created` - When a discussion with download is submitted to a channel
 
+> **Note:** the download-create flow did not actually fire the
+> `downloadableFile.created` trigger until the backend fix in
+> [multiforum-backend#152](https://github.com/gennit-project/multiforum-backend/pull/152)
+> (the event and pipeline config existed, but uploads never invoked download
+> plugins). `discussionChannel.created` was wired up already.
+
 Plugins run in configurable pipelines with ordering, conditions, and error handling.
 
 ---


### PR DESCRIPTION
## Summary

Updates plugin-related docs that were stale after (a) the monorepo→standalone-repo plugin migration and (b) the download-trigger fix.

- **`docs/MODERATION_PLAN.md`** — the "Automated Verification" steps told you to `cd /…/multiforum-plugins`, `cd plugins/auto-moderation-bot`, and run `npm run build:plugin -- --plugin …` (the removed monorepo workspace). Replaced with the standalone-repo flow (clone the plugin repo, `npm run ci`).
- **`docs/PLUGINS_BOT_BETABOT_PLAN.md`** — replaced `multiforum-plugins/plugins/<id>/plugin.json|index.ts` paths with the standalone repo model.
- **`docs/PLUGINS_IMPLEMENTED.md`** — added a note that `downloadableFile.created` did not actually fire on upload until backend fix multiforum-backend#152 (the event/pipeline existed, but uploads never invoked download plugins).

Backend plugin docs (`PLUGIN_REQUIREMENTS.md`, `README.md`, `docs/architecture.md`) were checked and are current — no changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
