### PR TITLE
test: cover comment/feedback wrappers + add mutation-router test util

### DIFF
--- a/components/discussion/detail/DiscussionCommentsWrapper.spec.ts
+++ b/components/discussion/detail/DiscussionCommentsWrapper.spec.ts
@@ -9,6 +9,7 @@ import {
 import type { Comment, DiscussionChannel } from '@/__generated__/graphql';
 
 import { useQuery, useMutation } from '@vue/apollo-composable';
+import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
 
 import DiscussionCommentsWrapper from '@/components/discussion/detail/DiscussionCommentsWrapper.vue';
 
@@ -36,12 +37,33 @@ const SubscribeButtonStub = {
   template: '<button class="subscribe-stub" @click="$emit(\'toggle\')" />',
 };
 
+const NotificationStub = {
+  name: 'Notification',
+  props: ['show', 'title'],
+  emits: ['close-notification'],
+  template:
+    '<div class="notification-stub" :data-show="String(show)" :data-title="title" />',
+};
+
 const stubs = {
   CommentSection: CommentSectionStub,
   SubscribeButton: SubscribeButtonStub,
   InlineCommentForm: { template: '<div />' },
   DiscussionRootCommentFormWrapper: { template: '<div />' },
-  Notification: { template: '<div />' },
+  Notification: NotificationStub,
+};
+
+// Pull the options object (with the `update` cache callback) the component passed
+// to useMutation for a given operation, matched on its gql source body.
+const mutationOptions = (op: string) => {
+  const call = asMock(useMutation).mock.calls.find((c) =>
+    String(
+      (c[0] as { loc?: { source?: { body?: string } } })?.loc?.source?.body ?? ''
+    ).includes(op)
+  );
+  return call?.[1] as
+    | { update?: (cache: unknown, result: unknown) => void }
+    | undefined;
 };
 
 const makeComment = (id: string): Comment =>
@@ -244,5 +266,139 @@ describe('DiscussionCommentsWrapper — comment-section cache handlers', () => {
     });
 
     expect(commentSection(wrapper).exists()).toBe(true);
+  });
+
+  it('does not decrement when there is no discussion channel id', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = mountWrapper({ discussionChannel: makeChannel({ id: '' }) });
+    const cache = fakeCache();
+    await commentSection(wrapper).vm.$emit('decrement-comment-count', cache);
+    errorSpy.mockRestore();
+
+    expect(cache.modify).not.toHaveBeenCalled();
+  });
+
+  it('logs an error when the increment cache update throws', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = mountWrapper();
+    const throwingCache = {
+      identify: vi.fn(() => 'DiscussionChannel:dc1'),
+      modify: vi.fn(() => {
+        throw new Error('boom');
+      }),
+      evict: vi.fn(),
+    };
+    await commentSection(wrapper).vm.$emit('increment-comment-count', throwingCache);
+    const logged = errorSpy.mock.calls.some((c) =>
+      String(c[0]).includes('Error incrementing comment count')
+    );
+    errorSpy.mockRestore();
+
+    expect(logged).toBe(true);
+  });
+});
+
+describe('DiscussionCommentsWrapper — subscription effects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    asMock(useMutation).mockReset();
+    asMock(useQuery).mockReset();
+  });
+
+  const fakeCache = () => ({
+    identify: vi.fn(() => 'DiscussionChannel:dc1'),
+    modify: vi.fn(),
+  });
+
+  it('writes the subscriber list to the cache on a successful subscribe', async () => {
+    const wrapper = mountWrapper();
+    const cache = fakeCache();
+    mutationOptions('subscribeToDiscussionChannel')!.update!(cache, {
+      data: {
+        subscribeToDiscussionChannel: {
+          SubscribedToNotifications: [{ username: 'alice' }],
+        },
+      },
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(cache.modify).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes the subscriber list to the cache on a successful unsubscribe', async () => {
+    const wrapper = mountWrapper({
+      discussionChannel: makeChannel({
+        SubscribedToNotifications: [{ username: 'alice' }],
+      }),
+    });
+    const cache = fakeCache();
+    mutationOptions('unsubscribeFromDiscussionChannel')!.update!(cache, {
+      data: {
+        unsubscribeFromDiscussionChannel: { SubscribedToNotifications: [] },
+      },
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(cache.modify).toHaveBeenCalledTimes(1);
+  });
+
+  const toast = (wrapper: ReturnType<typeof mountWrapper>, needle: string) =>
+    wrapper
+      .findAllComponents(NotificationStub)
+      .find((n) => String(n.props('title')).includes(needle))!;
+
+  it('shows then dismisses the subscribed notification', async () => {
+    const wrapper = mountWrapper();
+    // Fire the onDone callback the component registered on the subscribe mutation.
+    subscribeMock.onDone.mock.calls[0]![0]();
+    await wrapper.vm.$nextTick();
+    const shownAfterDone = toast(wrapper, 'subscribed to').props('show');
+
+    await toast(wrapper, 'subscribed to').vm.$emit('close-notification');
+    expect([shownAfterDone, toast(wrapper, 'subscribed to').props('show')]).toEqual(
+      [true, false]
+    );
+  });
+
+  it('shows then dismisses the unsubscribed notification', async () => {
+    const wrapper = mountWrapper();
+    unsubscribeMock.onDone.mock.calls[0]![0]();
+    await wrapper.vm.$nextTick();
+    const shownAfterDone = toast(wrapper, 'unsubscribed from').props('show');
+
+    await toast(wrapper, 'unsubscribed from').vm.$emit('close-notification');
+    expect([
+      shownAfterDone,
+      toast(wrapper, 'unsubscribed from').props('show'),
+    ]).toEqual([true, false]);
+  });
+
+  it('re-emits loadMore from the comment section', async () => {
+    const wrapper = mountWrapper();
+    await wrapper.findComponent(CommentSectionStub).vm.$emit('load-more');
+
+    expect(wrapper.emitted('loadMore')).toBeTruthy();
+  });
+
+  it('wires an auto-unsubscribe handler that calls the unsubscribe mutation', async () => {
+    mountWrapper();
+    const params = asMock(useAutoUnsubscribe).mock.calls[0]![0] as {
+      unsubscribeFn: (id: string) => Promise<void>;
+    };
+    await params.unsubscribeFn('dc1');
+
+    expect(unsubscribeMock.mutate).toHaveBeenCalledWith({
+      discussionChannelId: 'dc1',
+    });
+  });
+
+  it('treats a channel with no subscriber list as not subscribed', async () => {
+    const wrapper = mountWrapper({
+      discussionChannel: makeChannel({ SubscribedToNotifications: null }),
+    });
+
+    expect(
+      wrapper.findComponent(SubscribeButtonStub).props('isSubscribed')
+    ).toBe(false);
   });
 });

--- a/components/discussion/detail/FeedbackModalManager.spec.ts
+++ b/components/discussion/detail/FeedbackModalManager.spec.ts
@@ -1,95 +1,247 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import { asMock, createMutationRouter } from '@/tests/utils/mockApollo';
 import FeedbackModalManager from './FeedbackModalManager.vue';
 
-vi.mock('@vue/apollo-composable', () => ({
-  useMutation: () => ({
-    mutate: vi.fn(),
-    error: ref(null),
-    loading: ref(false),
-    onDone: vi.fn(),
-  }),
-}));
+vi.mock('@vue/apollo-composable', () => ({ useMutation: vi.fn() }));
 
-vi.mock('@/components/NotificationComponent.vue', () => ({
-  default: {
-    template: '<div />',
+const router = createMutationRouter(['addFeedbackCommentToDiscussion']);
+const feedbackMutation = () => router.get('addFeedbackCommentToDiscussion');
+
+const FormModalStub = {
+  name: 'GenericFeedbackFormModal',
+  template: '<div data-testid="feedback-modal" />',
+  props: ['open', 'error', 'loading', 'primaryButtonDisabled'],
+  emits: ['close', 'primary-button-click', 'update-feedback'],
+};
+
+const stubs = {
+  GenericFeedbackFormModal: FormModalStub,
+  ConfirmUndoDiscussionFeedbackModal: {
+    name: 'ConfirmUndoDiscussionFeedbackModal',
+    template: '<div data-testid="undo-modal" />',
+    props: ['open', 'discussionId', 'modName'],
+    emits: ['close'],
+  },
+  EditFeedbackModal: {
+    name: 'EditFeedbackModal',
+    template: '<div data-testid="edit-modal" />',
+    props: ['open', 'discussionId', 'modName'],
+    emits: ['close'],
+  },
+  Notification: {
+    name: 'Notification',
+    template: '<div data-testid="notification" :data-show="String(show)" />',
     props: ['show', 'title'],
+    emits: ['close-notification'],
   },
-}));
+};
 
-vi.mock('@/components/GenericFeedbackFormModal.vue', () => ({
-  default: {
-    template: '<div data-testid="feedback-modal" />',
-    props: ['open', 'error', 'loading', 'primaryButtonDisabled'],
-  },
-}));
-
-vi.mock('@/components/discussion/detail/ConfirmUndoDiscussionFeedbackModal.vue', () => ({
-  default: {
-    template: '<div />',
-    props: ['discussionId', 'modName', 'open'],
-  },
-}));
-
-vi.mock('@/components/discussion/detail/EditFeedbackModal.vue', () => ({
-  default: {
-    template: '<div />',
-    props: ['discussionId', 'modName', 'open'],
-  },
-}));
-
-describe('FeedbackModalManager', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+const mountManager = (overrides: Record<string, unknown> = {}) =>
+  mount(FeedbackModalManager, {
+    props: {
+      discussionId: 'discussion-1',
+      loggedInUserModName: 'mod-alice',
+      activeDiscussionChannel: {
+        id: 'dc-1',
+        channelUniqueName: 'cats',
+        Channel: { feedbackEnabled: true },
+      },
+      ...overrides,
+    },
+    global: { stubs },
   });
 
-  const buildWrapper = (feedbackEnabled: boolean) =>
-    mount(FeedbackModalManager, {
-      props: {
-        discussionId: 'discussion-1',
-        loggedInUserModName: 'mod-alice',
-        activeDiscussionChannel: {
-          id: 'discussion-channel-1',
-          channelUniqueName: 'cats',
-          Channel: {
-            feedbackEnabled,
-          },
-        },
-      },
-      global: {
-        stubs: {
-          GenericFeedbackFormModal: {
-            template: '<div data-testid="feedback-modal" />',
-          },
-          ConfirmUndoDiscussionFeedbackModal: {
-            template: '<div />',
-          },
-          EditFeedbackModal: {
-            template: '<div />',
-          },
-          Notification: {
-            template: '<div />',
-          },
-        },
+type Vm = {
+  handleClickGiveFeedback: () => void;
+  handleClickUndoFeedback: () => void;
+  handleClickEditFeedback: () => void;
+  $nextTick: () => Promise<void>;
+};
+
+// Opens the feedback form, sets its text, and submits — the standard path to
+// handleSubmitFeedback (which is wired to the modal, not exposed directly).
+const submitFeedback = async (
+  wrapper: ReturnType<typeof mountManager>,
+  text: string | null
+) => {
+  (wrapper.vm as unknown as Vm).handleClickGiveFeedback();
+  await (wrapper.vm as unknown as Vm).$nextTick();
+  const modal = wrapper.findComponent(FormModalStub);
+  if (text !== null) await modal.vm.$emit('update-feedback', text);
+  await modal.vm.$emit('primary-button-click');
+};
+
+beforeEach(() => {
+  router.reset();
+  asMock(useMutation).mockImplementation(router.useMutation);
+});
+
+describe('FeedbackModalManager', () => {
+  it('opens the feedback form when feedback is enabled', async () => {
+    const wrapper = mountManager();
+    (wrapper.vm as unknown as Vm).handleClickGiveFeedback();
+    await (wrapper.vm as unknown as Vm).$nextTick();
+    expect(wrapper.find('[data-testid="feedback-modal"]').exists()).toBe(true);
+  });
+
+  it('does not open the feedback form when feedback is disabled', async () => {
+    const wrapper = mountManager({
+      activeDiscussionChannel: {
+        id: 'dc-1',
+        channelUniqueName: 'cats',
+        Channel: { feedbackEnabled: false },
       },
     });
+    (wrapper.vm as unknown as Vm).handleClickGiveFeedback();
+    await (wrapper.vm as unknown as Vm).$nextTick();
+    expect(wrapper.find('[data-testid="feedback-modal"]').exists()).toBe(false);
+  });
 
-  it.each([
-    { feedbackEnabled: true, expectedModalCount: 1 },
-    { feedbackEnabled: false, expectedModalCount: 0 },
-  ])(
-    'renders $expectedModalCount feedback modal when feedbackEnabled is $feedbackEnabled',
-    async ({ feedbackEnabled, expectedModalCount }) => {
-      const wrapper = buildWrapper(feedbackEnabled);
+  describe('submitting feedback', () => {
+    it('calls the mutation with the discussion, text, mod and channel', async () => {
+      const wrapper = mountManager();
+      await submitFeedback(wrapper, 'This breaks the rules');
+      expect(feedbackMutation().mutate).toHaveBeenCalledWith({
+        discussionId: 'discussion-1',
+        text: 'This breaks the rules',
+        modProfileName: 'mod-alice',
+        channelId: 'cats',
+        discussionChannelId: 'dc-1',
+      });
+    });
 
-      wrapper.vm.handleClickGiveFeedback();
-      await wrapper.vm.$nextTick();
+    it('does not submit when no feedback text was entered', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const wrapper = mountManager();
+      await submitFeedback(wrapper, null);
+      errorSpy.mockRestore();
+      expect(feedbackMutation().mutate).not.toHaveBeenCalled();
+    });
 
-      expect(wrapper.findAll('[data-testid="feedback-modal"]')).toHaveLength(
-        expectedModalCount
-      );
-    }
-  );
+    it('does not submit when the moderator name is missing', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const wrapper = mountManager({ loggedInUserModName: '' });
+      await submitFeedback(wrapper, 'text');
+      errorSpy.mockRestore();
+      expect(feedbackMutation().mutate).not.toHaveBeenCalled();
+    });
+
+    it('does not submit when the active channel has no unique name', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const wrapper = mountManager({
+        activeDiscussionChannel: {
+          id: 'dc-1',
+          channelUniqueName: '',
+          Channel: { feedbackEnabled: true },
+        },
+      });
+      await submitFeedback(wrapper, 'text');
+      errorSpy.mockRestore();
+      expect(feedbackMutation().mutate).not.toHaveBeenCalled();
+    });
+
+    it('does not submit when feedback was disabled after the form opened', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const wrapper = mountManager();
+      (wrapper.vm as unknown as Vm).handleClickGiveFeedback();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      await wrapper.setProps({
+        activeDiscussionChannel: {
+          id: 'dc-1',
+          channelUniqueName: 'cats',
+          Channel: { feedbackEnabled: false },
+        },
+      });
+      const modal = wrapper.findComponent(FormModalStub);
+      await modal.vm.$emit('update-feedback', 'text');
+      await modal.vm.$emit('primary-button-click');
+      errorSpy.mockRestore();
+      expect(feedbackMutation().mutate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on successful submission', () => {
+    it('emits feedbackSubmitted and shows the success notification', async () => {
+      const wrapper = mountManager();
+      (wrapper.vm as unknown as Vm).handleClickGiveFeedback();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      feedbackMutation().fireDone();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      expect([
+        !!wrapper.emitted('feedbackSubmitted'),
+        wrapper.get('[data-testid="notification"]').attributes('data-show'),
+      ]).toEqual([true, 'true']);
+    });
+
+    it('closes the feedback form after submission', async () => {
+      const wrapper = mountManager();
+      (wrapper.vm as unknown as Vm).handleClickGiveFeedback();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      feedbackMutation().fireDone();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      expect(wrapper.find('[data-testid="feedback-modal"]').exists()).toBe(false);
+    });
+  });
+
+  describe('undo and edit modals', () => {
+    it('opens the undo-feedback modal', async () => {
+      const wrapper = mountManager();
+      (wrapper.vm as unknown as Vm).handleClickUndoFeedback();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      expect(wrapper.find('[data-testid="undo-modal"]').exists()).toBe(true);
+    });
+
+    it('opens the edit-feedback modal', async () => {
+      const wrapper = mountManager();
+      (wrapper.vm as unknown as Vm).handleClickEditFeedback();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      expect(wrapper.find('[data-testid="edit-modal"]').exists()).toBe(true);
+    });
+  });
+
+  describe('dismissing modals', () => {
+    it('closes the feedback form on its close event', async () => {
+      const wrapper = mountManager();
+      (wrapper.vm as unknown as Vm).handleClickGiveFeedback();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      await wrapper.findComponent(FormModalStub).vm.$emit('close');
+      expect(wrapper.find('[data-testid="feedback-modal"]').exists()).toBe(false);
+    });
+
+    it('closes the undo modal on its close event', async () => {
+      const wrapper = mountManager();
+      (wrapper.vm as unknown as Vm).handleClickUndoFeedback();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      await wrapper
+        .findComponent({ name: 'ConfirmUndoDiscussionFeedbackModal' })
+        .vm.$emit('close');
+      expect(wrapper.find('[data-testid="undo-modal"]').exists()).toBe(false);
+    });
+
+    it('closes the edit modal on its close event', async () => {
+      const wrapper = mountManager();
+      (wrapper.vm as unknown as Vm).handleClickEditFeedback();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      await wrapper
+        .findComponent({ name: 'EditFeedbackModal' })
+        .vm.$emit('close');
+      expect(wrapper.find('[data-testid="edit-modal"]').exists()).toBe(false);
+    });
+
+    it('dismisses the success notification on its close event', async () => {
+      const wrapper = mountManager();
+      (wrapper.vm as unknown as Vm).handleClickGiveFeedback();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      feedbackMutation().fireDone();
+      await (wrapper.vm as unknown as Vm).$nextTick();
+      await wrapper
+        .findComponent({ name: 'Notification' })
+        .vm.$emit('close-notification');
+      expect(
+        wrapper.get('[data-testid="notification"]').attributes('data-show')
+      ).toBe('false');
+    });
+  });
 });

--- a/components/event/detail/EventCommentsWrapper.spec.ts
+++ b/components/event/detail/EventCommentsWrapper.spec.ts
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils';
 import { defineComponent, h, ref } from 'vue';
 import EventCommentsWrapper from './EventCommentsWrapper.vue';
 import { useMutation, useQuery } from '@vue/apollo-composable';
+import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
 
 const mutateSpies = [vi.fn(), vi.fn(), vi.fn(), vi.fn()];
 const onDoneCallbacks: Array<(() => void) | undefined> = [];
@@ -309,5 +310,104 @@ describe('EventCommentsWrapper', () => {
     });
 
     expect(commentSection(wrapper).exists()).toBe(true);
+  });
+
+  // Run an update callback through a cache whose modify() executes the field
+  // policies, so the SubscribedToNotifications field bodies are covered too.
+  const runUpdate = (callIndex: number, resultData: unknown) => {
+    const cache = fakeCache();
+    (useMutation as unknown as ReturnType<typeof vi.fn>).mock.calls[callIndex]![1]!.update(
+      cache,
+      { data: resultData }
+    );
+    return cache;
+  };
+
+  it('writes the subscriber list on comment unsubscribe', () => {
+    buildWrapper([], { SubscribedToNotifications: [{ username: 'alice' }] });
+    const cache = runUpdate(1, {
+      unsubscribeFromEvent: { SubscribedToNotifications: [] },
+    });
+    expect(cache.modify).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes the update-subscriber list on event-updates subscribe', () => {
+    buildWrapper();
+    const cache = runUpdate(2, {
+      subscribeToEventUpdates: { SubscribedToEventUpdates: [{ username: 'alice' }] },
+    });
+    expect(cache.modify).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes the update-subscriber list on event-updates unsubscribe', () => {
+    buildWrapper([{ username: 'alice' }]);
+    const cache = runUpdate(3, {
+      unsubscribeFromEventUpdates: { SubscribedToEventUpdates: [] },
+    });
+    expect(cache.modify).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the comment-notifications-off notice after unsubscribing completes', async () => {
+    const wrapper = buildWrapper([], {
+      SubscribedToNotifications: [{ username: 'alice' }],
+    });
+    onDoneCallbacks[1]?.();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get('[data-testid="notification"]').attributes('data-show')).toBe(
+      'true'
+    );
+  });
+
+  it('shows a notice after unsubscribing from event updates completes', async () => {
+    const wrapper = buildWrapper([{ username: 'alice' }]);
+    onDoneCallbacks[3]?.();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get('[data-testid="notification"]').attributes('data-show')).toBe(
+      'true'
+    );
+  });
+
+  it('does not decrement when the event has no id', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = buildWrapper([], { id: undefined });
+    const cache = fakeCache();
+    await commentSection(wrapper).vm.$emit('decrement-comment-count', cache);
+    errorSpy.mockRestore();
+    expect(cache.modify).not.toHaveBeenCalled();
+  });
+
+  it('does not toggle comment subscription without an event id', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = buildWrapper([], { id: undefined });
+    await wrapper.get('[data-testid="toggle-comments"]').trigger('click');
+    errorSpy.mockRestore();
+    expect(mutateSpies[0]).not.toHaveBeenCalled();
+  });
+
+  it('does not toggle update subscription without an event id', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = buildWrapper([], { id: undefined });
+    await wrapper.get('[data-testid="toggle-updates"]').trigger('click');
+    errorSpy.mockRestore();
+    expect(mutateSpies[2]).not.toHaveBeenCalled();
+  });
+
+  it('re-emits loadMore from the comment section', async () => {
+    const wrapper = buildWrapper();
+    await commentSection(wrapper).vm.$emit('load-more');
+    expect(wrapper.emitted('loadMore')).toBeTruthy();
+  });
+
+  it('wires an auto-unsubscribe handler that calls the unsubscribe mutation', async () => {
+    buildWrapper();
+    const params = (useAutoUnsubscribe as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { unsubscribeFn: (id: string) => Promise<void> };
+    await params.unsubscribeFn('event-1');
+    expect(mutateSpies[1]).toHaveBeenCalledWith({ eventId: 'event-1' });
+  });
+
+  it('treats an event with no subscriber list as not subscribed', () => {
+    const wrapper = buildWrapper([], { SubscribedToNotifications: null });
+    expect(wrapper.get('[data-testid="watch-comments"]').text()).toBe('false');
   });
 });

--- a/tests/utils/mockApollo.ts
+++ b/tests/utils/mockApollo.ts
@@ -143,3 +143,92 @@ export function configureApolloMocks(params: {
     );
   }
 }
+
+/**
+ * A per-operation mutation mock that also captures the two callbacks a component
+ * registers with `useMutation` — the `update` cache function passed in the
+ * options, and the `onDone` handlers — so a spec can invoke that logic directly
+ * (drive `submit()`, fire the mutation's `onDone`, run its cache updater against
+ * a fake cache) instead of standing up a real Apollo client.
+ */
+export type MutationTracker = {
+  mutate: Mock<(...args: unknown[]) => unknown>;
+  loading: Ref<boolean>;
+  error: Ref<Error | null>;
+  onDone: Mock;
+  onError: Mock;
+  /** The `update` fn the component passed as `options.update` (null if none). */
+  update: ((cache: unknown, result?: unknown) => void) | null;
+  /** Invoke every `onDone` callback the component registered. */
+  fireDone: () => void;
+};
+
+export type MutationRouter = {
+  /** Drop-in `useMutation` implementation (routes by gql operation name). */
+  useMutation: (doc: unknown, options?: unknown) => MutationTracker;
+  /** Get (creating if needed) the tracker for an operation name. */
+  get: (name: string) => MutationTracker;
+  /** Forget all trackers — call in `beforeEach`. */
+  reset: () => void;
+};
+
+/**
+ * Route each `useMutation(<gql>, <options>)` call to a per-operation
+ * {@link MutationTracker}, matched on the operation name appearing in the gql
+ * source body. Longer names are matched first, so `undoSuperUpvote` wins over a
+ * bare `upvote` substring.
+ *
+ *   vi.mock('@vue/apollo-composable', () => ({ useMutation: vi.fn(), useQuery: vi.fn() }));
+ *   import { useMutation } from '@vue/apollo-composable';
+ *   const router = createMutationRouter(['subscribeToEvent', 'unsubscribeFromEvent']);
+ *   beforeEach(() => { router.reset(); asMock(useMutation).mockImplementation(router.useMutation); });
+ *   // ...mount, then:
+ *   router.get('subscribeToEvent').fireDone();
+ *   router.get('subscribeToEvent').update!(fakeCache, { data });
+ */
+export function createMutationRouter(names: string[]): MutationRouter {
+  const byLongestName = [...names].sort((a, b) => b.length - a.length);
+  const trackers = new Map<string, MutationTracker>();
+
+  const detect = (src: string) =>
+    byLongestName.find((n) => src.includes(n)) ?? 'unknown';
+
+  const get = (name: string): MutationTracker => {
+    if (!trackers.has(name)) {
+      const doneCbs: Array<() => void> = [];
+      trackers.set(name, {
+        mutate: vi.fn<(...args: unknown[]) => unknown>(),
+        loading: ref(false),
+        error: ref<Error | null>(null),
+        onDone: vi.fn((cb: () => void) => {
+          doneCbs.push(cb);
+        }),
+        onError: vi.fn(),
+        update: null,
+        fireDone: () => doneCbs.forEach((cb) => cb()),
+      });
+    }
+    return trackers.get(name)!;
+  };
+
+  const useMutation = (doc: unknown, options?: unknown): MutationTracker => {
+    const src =
+      (doc as { loc?: { source?: { body?: string } } })?.loc?.source?.body ??
+      String(doc);
+    const tracker = get(detect(src));
+    // Options may be a plain object or a function returning reactive options.
+    let resolved: unknown = options;
+    if (typeof options === 'function') {
+      try {
+        resolved = (options as () => unknown)();
+      } catch {
+        resolved = undefined;
+      }
+    }
+    const update = (resolved as { update?: MutationTracker['update'] })?.update;
+    if (update) tracker.update = update;
+    return tracker;
+  };
+
+  return { useMutation, get, reset: () => trackers.clear() };
+}


### PR DESCRIPTION
## Summary

Unit-test coverage for the discussion/event **detail-page comment & feedback** subsystem, plus a reusable Apollo test helper. Test-only (no production code changed). Continues the coverage drive toward 90% combined.

## Reusable test helper

Adds `createMutationRouter()` to `tests/utils/mockApollo.ts` — routes each `useMutation` to a per-operation tracker (matched on the gql operation name) and **captures the `update` cache callback and `onDone` handlers** the component registers, so specs can drive `submit()`, fire a mutation's `onDone`, and run its cache updater against a fake cache without a real Apollo client. This is the reusable form of the inline pattern used in the vote/report specs; those can be migrated onto it in a follow-up.

## Coverage raised

| file | before → after |
|---|---|
| `FeedbackModalManager` | 48 → ~100% |
| `DiscussionCommentsWrapper` | 79 → 93% |
| `EventCommentsWrapper` | 73 → 91% |

Covered: submit guards + the feedback mutation, subscribe/unsubscribe cache-update callbacks and their `onDone` toasts (show + dismiss), increment/decrement guards and catch paths, the subscription-toggle no-id guards, `loadMore` re-emit, the auto-unsubscribe handlers, and the not-subscribed computed cases.

## Not included (planned follow-up)

`DiscussionDetailContent` (the detail-page orchestrator, 75%) was the fourth file in the plan. It's the highest-setup one (many child refs, 3 queries), so it's deferred to a focused follow-up to keep this PR reviewable.

## Test plan

- [x] Each new/changed spec passes with coverage measured per-file
- [x] `pnpm exec eslint` on changed specs — 0 errors
- [ ] `pnpm run tsc` — clean **for these files**; the only errors are pre-existing in the untouched `components/event/map/Map.vue` (local `node_modules` drift: `@googlemaps/js-api-loader` 1.16.10 installed vs `^2.1.1` pinned — CI installs the pinned version with `--frozen-lockfile`, so CI tsc is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
