### PR TITLE
test: cover DiscussionDetailContent (75% -> 86%)

### DIFF
--- a/components/discussion/detail/DiscussionDetailContent.spec.ts
+++ b/components/discussion/detail/DiscussionDetailContent.spec.ts
@@ -29,6 +29,14 @@ const DiscussionCommentsWrapperStub = {
   template: '<div class="comments-wrapper-stub" />',
 };
 
+// Spies exposed via the FeedbackModalManager stub's template ref, so the
+// parent's delegating handlers can be asserted.
+const feedbackManagerSpies = {
+  handleClickGiveFeedback: vi.fn(),
+  handleClickUndoFeedback: vi.fn(),
+  handleClickEditFeedback: vi.fn(),
+};
+
 const stubs = {
   DiscussionHeader: {
     name: 'DiscussionHeader',
@@ -74,11 +82,7 @@ const stubs = {
     name: 'FeedbackModalManager',
     emits: ['feedback-submitted'],
     template: '<div class="feedback-modal-manager-stub" />',
-    methods: {
-      handleClickGiveFeedback: vi.fn(),
-      handleClickUndoFeedback: vi.fn(),
-      handleClickEditFeedback: vi.fn(),
-    },
+    methods: feedbackManagerSpies,
   },
 };
 
@@ -128,6 +132,7 @@ const setup = (params: {
   hasCommentSection?: boolean;
   discussionChannelOverrides?: Record<string, unknown>;
   issueResult?: Record<string, unknown>;
+  commentIssueResult?: Record<string, unknown>;
 } = {}) => {
   const {
     discussions = [makeDiscussion()],
@@ -135,15 +140,24 @@ const setup = (params: {
     hasCommentSection = true,
     discussionChannelOverrides = {},
     issueResult = { issues: [] },
+    commentIssueResult = { discussionChannels: [] },
   } = params;
   const section = commentSection(comments);
   Object.assign(
     section.getCommentSection.DiscussionChannel,
     discussionChannelOverrides
   );
-  const discussionQuery = createQueryMock({ discussions });
+  // Fire the onResult callbacks the component registers so the
+  // lastValidDiscussion / lastValidCommentSection caching paths are exercised.
+  const discussionQuery = createQueryMock(
+    { discussions },
+    { onResult: (cb: (r: unknown) => void) => cb({ data: { discussions } }) }
+  );
+  const csData = hasCommentSection ? section : { getCommentSection: null };
   const commentSectionQuery = {
-    ...createQueryMock(hasCommentSection ? section : { getCommentSection: null }),
+    ...createQueryMock(csData, {
+      onResult: (cb: (r: unknown) => void) => cb({ data: csData }),
+    }),
     fetchMore: vi.fn(),
   } as ReturnType<typeof createQueryMock> & { fetchMore: ReturnType<typeof vi.fn> };
   const commentAggregateQuery = createQueryMock({
@@ -153,7 +167,7 @@ const setup = (params: {
     discussionChannels: [{ CommentsAggregate: { count: comments.length } }],
   });
   const issueQuery = createQueryMock(issueResult);
-  const commentIssueQuery = createQueryMock({ discussionChannels: [] });
+  const commentIssueQuery = createQueryMock(commentIssueResult);
   configureApolloMocks({
     useQuery,
     queries: {
@@ -311,5 +325,90 @@ describe('DiscussionDetailContent', () => {
       discussionRefetches: 2,
       channelRefetches: 1,
     });
+  });
+
+  describe('feedback delegation to the modal manager', () => {
+    it.each([
+      ['handle-click-give-feedback', 'handleClickGiveFeedback'],
+      ['handle-click-undo-feedback', 'handleClickUndoFeedback'],
+      ['handle-click-edit-feedback', 'handleClickEditFeedback'],
+    ] as const)('forwards %s to the feedback modal manager', async (event, method) => {
+      const { wrapper } = setup();
+      await wrapper
+        .findComponent({ name: 'DiscussionLayoutManager' })
+        .vm.$emit(event);
+
+      expect(feedbackManagerSpies[method]).toHaveBeenCalled();
+    });
+  });
+
+  it('enters album edit mode from the layout edit-album event', async () => {
+    const { wrapper } = setup();
+    await wrapper.findComponent({ name: 'DiscussionLayoutManager' }).vm.$emit('edit-album');
+
+    expect(wrapper.find('.album-edit-stub').exists()).toBe(true);
+  });
+
+  it('does not enter album edit mode from edit-album when uploads are disabled', async () => {
+    const { wrapper } = setup({
+      discussionChannelOverrides: { Channel: { imageUploadsEnabled: false } },
+    });
+    await wrapper.findComponent({ name: 'DiscussionLayoutManager' }).vm.$emit('edit-album');
+
+    expect(wrapper.find('.album-edit-stub').exists()).toBe(false);
+  });
+
+  it('merges the fetched page of comments in loadMore updateQuery', async () => {
+    const { wrapper, commentSectionQuery } = setup({
+      comments: [makeComment('a')],
+    });
+    await wrapper.findComponent(DiscussionCommentsWrapperStub).vm.$emit('load-more');
+
+    const { updateQuery } = commentSectionQuery.fetchMore.mock.calls[0]![0];
+    const merged = updateQuery(
+      { getCommentSection: { Comments: [makeComment('a')] } },
+      { fetchMoreResult: { getCommentSection: { Comments: [makeComment('b')] } } }
+    );
+
+    expect(merged.getCommentSection.Comments.map((c: Comment) => c.id)).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('returns the previous result when loadMore has no more comments', async () => {
+    const { wrapper, commentSectionQuery } = setup({ comments: [makeComment('a')] });
+    await wrapper.findComponent(DiscussionCommentsWrapperStub).vm.$emit('load-more');
+
+    const { updateQuery } = commentSectionQuery.fetchMore.mock.calls[0]![0];
+    const previous = { getCommentSection: { Comments: [makeComment('a')] } };
+
+    expect(updateQuery(previous, { fetchMoreResult: null })).toBe(previous);
+  });
+
+  it('falls back to a related issue linked from a comment', () => {
+    const { wrapper } = setup({
+      issueResult: { issues: [] },
+      commentIssueResult: {
+        discussionChannels: [
+          { Comments: [{ RelatedIssues: [{ issueNumber: 7 }] }] },
+        ],
+      },
+    });
+
+    expect(
+      wrapper.findComponent({ name: 'DiscussionHeader' }).props('relatedIssueLink')
+    ).toEqual({
+      name: 'forums-forumId-issues-issueNumber',
+      params: { forumId: 'cats', issueNumber: 7 },
+    });
+  });
+
+  it('passes a null related issue link when there is no issue', () => {
+    const { wrapper } = setup();
+
+    expect(
+      wrapper.findComponent({ name: 'DiscussionHeader' }).props('relatedIssueLink')
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Unit-test coverage for `DiscussionDetailContent`, the discussion detail-page orchestrator — the follow-up flagged in #320. Test-only (no production code changed). Branched off `main`, independent of #320.

## Coverage

`components/discussion/detail/DiscussionDetailContent.vue`: **75% → 86%** lines (+10 tests).

Newly covered:
- Feedback give/undo/edit delegation from the layout to the `FeedbackModalManager` template ref.
- Album-edit entry via the layout `edit-album` event, including the image-uploads-disabled guard.
- The `loadMore` `updateQuery` callback — merging the fetched page of comments and the no-more-results (`fetchMoreResult` null) branch.
- The related-issue link fallback resolved from a comment's `RelatedIssues`, plus the null-issue case.
- The discussion and comment-section `onResult` caching callbacks (`lastValidDiscussion` / `lastValidCommentSection`).

The remaining ~14% is auth/username/sort watchers, the `onMounted` auth-refetch branch, and reactive `useQuery` variable functions — all needing mock-infrastructure changes (mutable route, reactive auth state) for marginal line gains, so they're left out.

## Test plan

- [x] Spec passes with per-file coverage measured (20 tests)
- [x] `pnpm exec eslint` — 0 errors
- [ ] `pnpm run tsc` — clean for this file; the only errors are the pre-existing local `node_modules` drift in the untouched `Map.vue` (`@googlemaps/js-api-loader` 1.16.10 vs `^2.1.1` pinned; CI uses the pinned version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
