### PR TITLE
Settings autosave: pattern + first two server tabs (#15)

### DIFF
--- a/components/FormComponent.vue
+++ b/components/FormComponent.vue
@@ -29,6 +29,12 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  // Allows a form to hide the Save button entirely, e.g. when its fields
+  // autosave on change and persistence is shown via a status indicator instead.
+  showSaveButton: {
+    type: Boolean,
+    default: true,
+  },
   handleCancelInParent: {
     type: Boolean,
     default: false,
@@ -69,6 +75,7 @@ function handleCancel() {
             @click.prevent="handleCancel"
           />
           <SaveButton
+            v-if="props.showSaveButton"
             :disabled="props.needsChanges"
             :loading="props.loading"
             @click.prevent="emit('submit')"
@@ -91,6 +98,7 @@ function handleCancel() {
                 @click.prevent="handleCancel"
               />
               <SaveButton
+                v-if="props.showSaveButton"
                 :disabled="props.needsChanges"
                 :loading="props.loading"
                 @click.prevent="emit('submit')"

--- a/components/admin/CreateEditServerFields.spec.ts
+++ b/components/admin/CreateEditServerFields.spec.ts
@@ -17,7 +17,12 @@ const mountFields = (props: Record<string, unknown> = {}) =>
     props: { editMode: true, formValues: {}, ...props },
     global: {
       stubs: {
-        TailwindForm: { name: 'TailwindForm', emits: ['submit'], template: '<form><slot /></form>' },
+        TailwindForm: {
+          name: 'TailwindForm',
+          props: ['showSaveButton'],
+          emits: ['submit'],
+          template: '<form><slot /></form>',
+        },
         NuxtPage: { name: 'NuxtPage', emits: ['submit', 'update-form-values'], template: '<div />' },
         ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
         RouterLink: routerLinkStub,
@@ -105,6 +110,40 @@ describe('CreateEditServerFields current tab label', () => {
     const wrapper = mountFields();
 
     expect(dropdownToggle(wrapper)!.text()).toContain('Settings');
+  });
+});
+
+describe('CreateEditServerFields autosave tabs', () => {
+  it('hides the shared Save button on the basic (autosave) tab', () => {
+    h.route = { name: 'admin-settings-basic' };
+    const wrapper = mountFields();
+
+    expect(
+      wrapper.getComponent({ name: 'TailwindForm' }).props('showSaveButton')
+    ).toBe(false);
+  });
+
+  it('shows the save status indicator on an autosave tab', () => {
+    h.route = { name: 'admin-settings-calendar' };
+    const wrapper = mountFields({ saveStatus: 'saving' });
+
+    expect(wrapper.find('[data-testid="save-status"]').exists()).toBe(true);
+  });
+
+  it('keeps the shared Save button on a non-autosave tab', () => {
+    h.route = { name: 'admin-settings-rules' };
+    const wrapper = mountFields();
+
+    expect(
+      wrapper.getComponent({ name: 'TailwindForm' }).props('showSaveButton')
+    ).toBe(true);
+  });
+
+  it('hides the save status indicator on a non-autosave tab', () => {
+    h.route = { name: 'admin-settings-rules' };
+    const wrapper = mountFields();
+
+    expect(wrapper.find('[data-testid="save-status"]').exists()).toBe(false);
   });
 });
 

--- a/components/admin/CreateEditServerFields.vue
+++ b/components/admin/CreateEditServerFields.vue
@@ -5,6 +5,8 @@ import type { ApolloError } from '@apollo/client/errors';
 import type { ServerConfigUpdateInput } from '@/__generated__/graphql';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import TailwindForm from '@/components/FormComponent.vue';
+import SaveStatus from '@/components/settings/SaveStatus.vue';
+import type { AutosaveStatus } from '@/composables/useSettingAutosave';
 import { useRoute, useRouter } from 'nuxt/app';
 
 // Import icons
@@ -48,12 +50,32 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  // Autosave status for the tabs that persist on change (Basic, Calendar).
+  saveStatus: {
+    type: String as PropType<AutosaveStatus>,
+    default: 'idle',
+  },
+  saveErrorMessage: {
+    type: String,
+    default: '',
+  },
 });
 
 const emit = defineEmits(['submit', 'updateFormValues']);
 
 const route = useRoute();
 const router = useRouter();
+
+// Tabs whose fields autosave on change; these hide the shared Save button and
+// show a status indicator instead.
+const AUTOSAVE_TAB_KEYS = ['basic', 'calendar'];
+const isAutosaveTab = computed(() =>
+  AUTOSAVE_TAB_KEYS.some(
+    (key) =>
+      typeof route.name === 'string' &&
+      route.name.includes(`settings-${key}`)
+  )
+);
 
 const tabs = [
   {
@@ -150,6 +172,7 @@ const getCurrentTabLabel = computed(() => {
         :needs-changes="false"
         :show-cancel-button="false"
         :show-buttons-in-header="false"
+        :show-save-button="!isAutosaveTab"
         @submit="emit('submit')"
       >
         <div class="mt-5 w-full">
@@ -328,6 +351,12 @@ const getCurrentTabLabel = computed(() => {
                 :form-values="formValues"
                 @submit="$emit('submit', $event)"
                 @update-form-values="emit('updateFormValues', $event)"
+              />
+              <SaveStatus
+                v-if="isAutosaveTab"
+                class="mt-4"
+                :status="saveStatus"
+                :error-message="saveErrorMessage"
               />
             </div>
           </div>

--- a/components/settings/SaveStatus.spec.ts
+++ b/components/settings/SaveStatus.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import SaveStatus from './SaveStatus.vue';
+
+const mountStatus = (props: Record<string, unknown>) =>
+  mount(SaveStatus, { props });
+
+describe('SaveStatus', () => {
+  it('renders nothing visible in the idle state', () => {
+    expect(mountStatus({ status: 'idle' }).text()).toBe('');
+  });
+
+  it('announces saving via a polite live region', () => {
+    const wrapper = mountStatus({ status: 'saving' });
+    expect(wrapper.get('[aria-live="polite"]').text()).toContain('Saving');
+  });
+
+  it('shows the saved confirmation', () => {
+    expect(mountStatus({ status: 'saved' }).text()).toContain('Saved');
+  });
+
+  it('surfaces a save error with an alert role', () => {
+    const wrapper = mountStatus({
+      status: 'error',
+      errorMessage: 'Server said no',
+    });
+    expect(wrapper.get('[role="alert"]').text()).toContain('Server said no');
+  });
+
+  it('falls back to default error copy when no message is provided', () => {
+    const wrapper = mountStatus({ status: 'error' });
+    expect(wrapper.get('[role="alert"]').text()).toContain('Could not save');
+  });
+});

--- a/components/settings/SaveStatus.vue
+++ b/components/settings/SaveStatus.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { PropType } from 'vue';
+import type { AutosaveStatus } from '@/composables/useSettingAutosave';
+
+defineProps({
+  status: {
+    type: String as PropType<AutosaveStatus>,
+    default: 'idle',
+  },
+  errorMessage: {
+    type: String,
+    default: '',
+  },
+});
+</script>
+
+<template>
+  <!--
+    Autosave status for settings that persist on change instead of via a Save
+    button. The live region announces "Saving…"/"Saved" to assistive tech;
+    errors are shown with role="alert".
+  -->
+  <div
+    class="flex min-h-[1.25rem] items-center text-xs"
+    data-testid="save-status"
+  >
+    <span
+      v-if="status === 'saving'"
+      class="flex items-center text-gray-500 dark:text-gray-400"
+      role="status"
+      aria-live="polite"
+    >
+      <i class="fa-solid fa-spinner mr-1.5 animate-spin" aria-hidden="true" />
+      Saving…
+    </span>
+    <span
+      v-else-if="status === 'saved'"
+      class="flex items-center text-green-600 dark:text-green-400"
+      role="status"
+      aria-live="polite"
+    >
+      <i class="fa-solid fa-check mr-1.5" aria-hidden="true" />
+      Saved
+    </span>
+    <span
+      v-else-if="status === 'error'"
+      class="flex items-center text-red-600 dark:text-red-400"
+      role="alert"
+    >
+      <i
+        class="fa-solid fa-triangle-exclamation mr-1.5"
+        aria-hidden="true"
+      />
+      {{ errorMessage || 'Could not save. Retrying on your next change.' }}
+    </span>
+  </div>
+</template>

--- a/composables/useSettingAutosave.spec.ts
+++ b/composables/useSettingAutosave.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useSettingAutosave } from './useSettingAutosave';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useSettingAutosave debounce', () => {
+  it('does not save before the debounce window elapses', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { trigger } = useSettingAutosave({ save, debounceMs: 500 });
+
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('coalesces rapid changes into a single save with the latest value', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { trigger } = useSettingAutosave({ save, debounceMs: 500 });
+
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(200);
+    trigger('b');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(save.mock.calls).toEqual([['b']]);
+  });
+});
+
+describe('useSettingAutosave status', () => {
+  it('reports the saving state while the save is in flight', async () => {
+    let resolveSave: () => void = () => {};
+    const save = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+    const { trigger, isSaving } = useSettingAutosave({ save, debounceMs: 500 });
+
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(isSaving.value).toBe(true);
+    resolveSave();
+  });
+
+  it('reports the saved state after a successful save', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { trigger, status } = useSettingAutosave({ save, debounceMs: 500 });
+
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(status.value).toBe('saved');
+  });
+
+  it('returns to idle after the saved window elapses', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { trigger, status } = useSettingAutosave({
+      save,
+      debounceMs: 500,
+      savedResetMs: 2000,
+    });
+
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(status.value).toBe('idle');
+  });
+
+  it('captures the error and reports the error state when the save fails', async () => {
+    const save = vi.fn().mockRejectedValue(new Error('boom'));
+    const { trigger, status } = useSettingAutosave({
+      save,
+      debounceMs: 500,
+    });
+
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(status.value).toBe('error');
+  });
+
+  it('exposes the thrown error message', async () => {
+    const save = vi.fn().mockRejectedValue(new Error('boom'));
+    const { trigger, error } = useSettingAutosave({ save, debounceMs: 500 });
+
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(error.value?.message).toBe('boom');
+  });
+});
+
+describe('useSettingAutosave no-op skipping', () => {
+  it('does not save a value that matches the primed initial value', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { trigger, setInitial } = useSettingAutosave({
+      save,
+      debounceMs: 500,
+    });
+
+    setInitial('a');
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('does not re-save an unchanged value after a successful save', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { trigger } = useSettingAutosave({ save, debounceMs: 500 });
+
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(500);
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useSettingAutosave cancel', () => {
+  it('cancels a pending save so it never runs', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const { trigger, cancel } = useSettingAutosave({ save, debounceMs: 500 });
+
+    trigger('a');
+    await vi.advanceTimersByTimeAsync(200);
+    cancel();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/composables/useSettingAutosave.ts
+++ b/composables/useSettingAutosave.ts
@@ -1,0 +1,131 @@
+import { ref, computed } from 'vue';
+
+export type AutosaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+type UseSettingAutosaveParams<T> = {
+  /**
+   * Persist the given payload. Typically wraps a GraphQL mutation and sends a
+   * SCOPED update input (only the changed field), so it is safe to call
+   * independently of any surrounding form-wide save.
+   */
+  save: (payload: T) => Promise<unknown>;
+  /** Debounce window in ms. Rapid changes within this window collapse into one save. */
+  debounceMs?: number;
+  /** How long the "saved" state stays visible before returning to idle. */
+  savedResetMs?: number;
+};
+
+/**
+ * Debounced autosave for a single settings value, with visible save state.
+ *
+ * - Coalesces rapid changes: only the latest payload within the debounce
+ *   window is saved.
+ * - Skips no-op saves: if the payload matches what was last saved, nothing is
+ *   sent.
+ * - Avoids overlapping saves: a change made while a save is in flight is
+ *   applied after it settles (only if still different).
+ *
+ * The `save` callback is injected so this composable stays independent of
+ * Apollo and is unit-testable without mounting a component.
+ */
+export function useSettingAutosave<T>(params: UseSettingAutosaveParams<T>) {
+  const { save, debounceMs = 500, savedResetMs = 2000 } = params;
+
+  const status = ref<AutosaveStatus>('idle');
+  const error = ref<Error | null>(null);
+
+  const isSaving = computed(() => status.value === 'saving');
+  const saved = computed(() => status.value === 'saved');
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let savedResetTimer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight = false;
+  let pendingPayload: { value: T } | null = null;
+  // Serialized snapshot of the last successfully saved payload, used to skip
+  // redundant saves. `undefined` means "nothing saved yet".
+  let lastSavedSerialized: string | undefined;
+
+  const serialize = (payload: T) => JSON.stringify(payload);
+
+  const runSave = async (payload: T) => {
+    const serialized = serialize(payload);
+    if (serialized === lastSavedSerialized) {
+      // No-op: value is already persisted.
+      return;
+    }
+
+    if (inFlight) {
+      // A save is already running; remember the latest and let it flush after.
+      pendingPayload = { value: payload };
+      return;
+    }
+
+    inFlight = true;
+    status.value = 'saving';
+    error.value = null;
+
+    if (savedResetTimer) {
+      clearTimeout(savedResetTimer);
+      savedResetTimer = null;
+    }
+
+    try {
+      await save(payload);
+      lastSavedSerialized = serialized;
+      status.value = 'saved';
+      savedResetTimer = setTimeout(() => {
+        if (status.value === 'saved') {
+          status.value = 'idle';
+        }
+      }, savedResetMs);
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err));
+      status.value = 'error';
+    } finally {
+      inFlight = false;
+      // Flush any change that arrived while we were saving.
+      if (pendingPayload) {
+        const next = pendingPayload.value;
+        pendingPayload = null;
+        await runSave(next);
+      }
+    }
+  };
+
+  /** Schedule a debounced save of `payload`. Safe to call on every keystroke/toggle. */
+  const trigger = (payload: T) => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      void runSave(payload);
+    }, debounceMs);
+  };
+
+  /** Cancel any pending debounced save without persisting it. */
+  const cancel = () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+  };
+
+  /**
+   * Prime the last-saved snapshot from server data so the first user edit that
+   * matches the current value does not trigger a redundant save.
+   */
+  const setInitial = (payload: T) => {
+    lastSavedSerialized = serialize(payload);
+  };
+
+  return {
+    status,
+    error,
+    isSaving,
+    saved,
+    trigger,
+    cancel,
+    setInitial,
+  };
+}

--- a/pages/admin/settings.vue
+++ b/pages/admin/settings.vue
@@ -11,6 +11,10 @@ import type { ServerConfigUpdateInput } from '@/__generated__/graphql';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 import { config } from '@/config';
 import CreateEditServerFields from '@/components/admin/CreateEditServerFields.vue';
+import {
+  useSettingAutosave,
+  type AutosaveStatus,
+} from '@/composables/useSettingAutosave';
 
 type ServerSettingsFormValues = ServerConfigUpdateInput & {
   featuredWikiPageIds?: string[];
@@ -69,6 +73,11 @@ onGetServerResult((result) => {
     pluginRegistries: serverConfig.pluginRegistries || [],
     featuredWikiPageIds: serverConfig.featuredWikiPageIds || [],
   };
+
+  // Prime the autosave baselines so the first edit that happens to match the
+  // loaded value does not fire a redundant save.
+  descriptionAutosave.setInitial(serverConfig.serverDescription || '');
+  enableEventsAutosave.setInitial(Boolean(serverConfig.enableEvents));
 });
 
 const serverUpdateInput = computed(() => {
@@ -149,6 +158,37 @@ const {
   error: setFeaturedWikiPagesError,
 } = useMutation(SET_FEATURED_WIKI_PAGES);
 
+// Autosave for the scalar fields on the Basic and Calendar tabs. Each field
+// gets its own debounced instance so an in-flight edit to one can't coalesce
+// with — and drop — a change to the other. Each saves a SCOPED update input,
+// which UPDATE_SERVER_CONFIG applies as a partial update.
+const saveServerField = (input: ServerConfigUpdateInput) =>
+  updateServer({ input, serverName: config.serverName });
+
+const descriptionAutosave = useSettingAutosave<string>({
+  save: (serverDescription) => saveServerField({ serverDescription }),
+});
+const enableEventsAutosave = useSettingAutosave<boolean>({
+  save: (enableEvents) => saveServerField({ enableEvents }),
+});
+
+const autosaveStatus = computed<AutosaveStatus>(() => {
+  const statuses = [
+    descriptionAutosave.status.value,
+    enableEventsAutosave.status.value,
+  ];
+  if (statuses.includes('saving')) return 'saving';
+  if (statuses.includes('error')) return 'error';
+  if (statuses.includes('saved')) return 'saved';
+  return 'idle';
+});
+const autosaveErrorMessage = computed(
+  () =>
+    descriptionAutosave.error.value?.message ||
+    enableEventsAutosave.error.value?.message ||
+    ''
+);
+
 const isSaving = computed(
   () => editServerLoading.value || setFeaturedWikiPagesLoading.value
 );
@@ -170,6 +210,15 @@ async function submit() {
 
 function updateFormValues(data: ServerSettingsFormValues) {
   formValues.value = { ...formValues.value, ...data };
+
+  // The Basic and Calendar tabs autosave their scalar fields on change instead
+  // of waiting for a form-wide Save. Other tabs continue to batch via submit().
+  if ('serverDescription' in data) {
+    descriptionAutosave.trigger(data.serverDescription ?? '');
+  }
+  if ('enableEvents' in data) {
+    enableEventsAutosave.trigger(Boolean(data.enableEvents));
+  }
 }
 </script>
 
@@ -186,6 +235,8 @@ function updateFormValues(data: ServerSettingsFormValues) {
             :update-server-error="combinedUpdateError"
             :edit-server-loading="isSaving"
             :form-values="formValues"
+            :save-status="autosaveStatus"
+            :save-error-message="autosaveErrorMessage"
             @submit="submit"
             @update-form-values="updateFormValues"
           />


### PR DESCRIPTION
## Summary

First slice of roadmap item **#15 — autosave for server/channel admin settings** (the last open roadmap item). This PR establishes the reusable autosave pattern and proves it on two server-settings tabs; a follow-up PR rolls it out to the remaining safe settings and closes the item.

Per the agreed scope: convert **safe scalar/toggle** settings only, and **replace** the Save button with a status indicator on converted tabs.

## What's here

- **`composables/useSettingAutosave.ts`** — per-field debounced autosave with visible `Saving…/Saved/error` state. Skips no-op saves, coalesces rapid changes into one, and never overlaps saves (a change made mid-save flushes after). The `save` callback is injected, so it's Apollo-independent and unit-testable.
- **`components/settings/SaveStatus.vue`** — small accessible indicator (`aria-live="polite"` for saving/saved, `role="alert"` for errors).
- **`FormComponent.vue`** — new backward-compatible `showSaveButton` prop (defaults `true`).
- **Converted tabs:** server **Basic** (description) and **Calendar** (`enableEvents`). Each field has its own autosave instance sending a **scoped** `UPDATE_SERVER_CONFIG` partial update (verified: the generated `updateServerConfigs(update:)` only touches provided fields). `CreateEditServerFields` hides the shared Save button and shows the status indicator on these tabs; other tabs keep the Save button unchanged.

## Design notes

- **One instance per field** (not one shared instance) so a description edit and an events toggle can't coalesce and drop one another.
- **No leaf-component changes** — the tab components already emit `updateFormValues`; the page decides what autosaves.
- Baselines are primed from server data on load, so the first no-op edit doesn't fire a save.

## Tests

- `useSettingAutosave.spec.ts` (10): debounce, coalescing, saving/saved/idle transitions, error capture, no-op skipping, cancel.
- `SaveStatus.spec.ts` (5): idle/saving/saved/error rendering + a11y roles.
- `CreateEditServerFields.spec.ts` (+4): Save-button hidden and status shown on autosave tabs; both preserved on non-autosave tabs.
- All existing specs for the touched files pass (FormComponent, CreateEditServerFields, admin settings, basic/calendar tabs); `pnpm run tsc` clean.

## Follow-up (PR 2)

Roll out to the rest of the safe set (server calendar already done; channel events/images/feedback toggles, safe scalars), document the intentional explicit-save exclusions (roles/secrets/rules/mods/owners/filter-groups/destructive actions), and mark roadmap #15 complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)