### PR TITLE
refactor(comments): group forwarded context props behind a single v-bind

### DIFF
--- a/components/comments/Comment.vue
+++ b/components/comments/Comment.vue
@@ -477,6 +477,27 @@ const editorId = 'texteditor';
 
 const maxCommentDepth = MAX_COMMENT_DEPTH;
 
+// Context props forwarded unchanged to every nested reply. Grouped here so the
+// recursive <Comment> below binds them with a single v-bind instead of ~14
+// repeated lines. (Per-instance props — commentData, depth, parentCommentId,
+// the local editFormOpenAtCommentID — stay explicit on the tag.)
+const childPassThroughProps = computed(() => ({
+  createCommentError: props.createCommentError,
+  suspensionIssueNumber: props.suspensionIssueNumber,
+  suspensionChannelId: props.suspensionChannelId,
+  suspensionUntil: props.suspensionUntil,
+  suspensionIndefinitely: props.suspensionIndefinitely,
+  enableEmoji: props.enableEmoji,
+  locked: props.locked,
+  commentInProcess: props.commentInProcess,
+  replyFormOpenAtCommentID: props.replyFormOpenAtCommentID,
+  modProfileName: props.modProfileName,
+  originalPoster: props.originalPoster,
+  lengthOfCommentInProgress: props.lengthOfCommentInProgress,
+  answers: props.answers,
+  botUsernames: props.botUsernames,
+}));
+
 function createComment(parentCommentId: string) {
   emit('createComment', parentCommentId);
 }
@@ -867,23 +888,10 @@ const label = computed(() =>
                 v-if="childComment.id !== permalinkedCommentId"
                 :compact="true"
                 :comment-data="childComment"
-                :create-comment-error="props.createCommentError"
-                :suspension-issue-number="props.suspensionIssueNumber"
-                :suspension-channel-id="props.suspensionChannelId"
-                :suspension-until="props.suspensionUntil"
-                :suspension-indefinitely="props.suspensionIndefinitely"
                 :depth="props.depth + 1"
-                :enable-emoji="props.enableEmoji"
-                :locked="props.locked"
                 :parent-comment-id="props.commentData.id"
-                :comment-in-process="props.commentInProcess"
                 :edit-form-open-at-comment-i-d="editFormOpenAtCommentID"
-                :reply-form-open-at-comment-i-d="props.replyFormOpenAtCommentID"
-                :mod-profile-name="props.modProfileName"
-                :original-poster="props.originalPoster"
-                :length-of-comment-in-progress="props.lengthOfCommentInProgress"
-                :answers="props.answers"
-                :bot-usernames="props.botUsernames"
+                v-bind="childPassThroughProps"
                 @start-comment-save="emit('startCommentSave')"
                 @click-edit-comment="handleEdit"
                 @click-report="emit('clickReport', $event)"

--- a/components/comments/CommentSection.vue
+++ b/components/comments/CommentSection.vue
@@ -501,6 +501,28 @@ const replyHasBotMention = computed(() => {
     !props.allowBotMentions && hasBotMention(props.createFormValues?.text || '')
   );
 });
+
+// Context props that the top-level Comment forwards unchanged to every nested
+// reply. Grouped here so the <Comment> below binds them with a single v-bind
+// instead of ~14 repeated lines. Per-instance props (commentData, depth,
+// aggregateCommentCount, the edit-* / feedback / bot-suggestion props) stay
+// explicit on the tag.
+const commentPassThroughProps = computed(() => ({
+  createCommentError: createCommentError.value,
+  suspensionIssueNumber: suspensionIssueNumber.value ?? undefined,
+  suspensionChannelId: suspensionChannelId.value ?? '',
+  suspensionUntil: suspensionUntil.value ?? undefined,
+  suspensionIndefinitely: suspensionIndefinitely.value ?? false,
+  enableEmoji: props.enableEmoji,
+  locked: locked.value || props.archived,
+  commentInProcess: commentInProcess.value,
+  replyFormOpenAtCommentID: replyFormOpenAtCommentID.value,
+  modProfileName: modProfileNameVar.value,
+  originalPoster: props.originalPoster,
+  lengthOfCommentInProgress: lengthOfCommentInProgress.value,
+  answers: props.answers,
+  botUsernames: props.botUsernames,
+}));
 </script>
 
 <template>
@@ -751,27 +773,14 @@ const replyHasBotMention = computed(() => {
               :aggregate-comment-count="aggregateCommentCount"
               :compact="true"
               :comment-data="comment"
-              :create-comment-error="createCommentError"
-              :suspension-issue-number="suspensionIssueNumber ?? undefined"
-              :suspension-channel-id="suspensionChannelId ?? ''"
-              :suspension-until="suspensionUntil ?? undefined"
-              :suspension-indefinitely="suspensionIndefinitely ?? false"
               :enable-feedback="enableFeedback"
-              :enable-emoji="enableEmoji"
               :depth="1"
-              :locked="locked || archived"
-              :comment-in-process="commentInProcess"
-              :reply-form-open-at-comment-i-d="replyFormOpenAtCommentID"
               :edit-form-open-at-comment-i-d="editFormOpenAtCommentID"
               :edit-comment-error="editCommentError"
-              :mod-profile-name="modProfileNameVar"
-              :original-poster="originalPoster"
-              :length-of-comment-in-progress="lengthOfCommentInProgress"
               :reply-has-bot-mention="replyHasBotMention"
               :bot-suggestions="botSuggestions"
-              :bot-usernames="botUsernames"
               :mod-suggestions="modSuggestions"
-              :answers="answers"
+              v-bind="commentPassThroughProps"
               @start-comment-save="commentInProcess = true"
               @open-reply-editor="openReplyEditor"
               @hide-reply-editor="hideReplyEditor"

--- a/components/comments/PinnedAnswers.vue
+++ b/components/comments/PinnedAnswers.vue
@@ -102,6 +102,24 @@ const emit = defineEmits([
 const hasAnswers = computed(() => {
   return props.answers && props.answers.length > 0;
 });
+
+// Context props forwarded unchanged to each answer's <Comment>. Grouped here so
+// the tag binds them with a single v-bind instead of ~13 repeated lines.
+const answerPassThroughProps = computed(() => ({
+  enableFeedback: props.enableFeedback,
+  locked: props.locked || props.archived,
+  originalPoster: props.originalPoster,
+  answers: props.answers,
+  replyHasBotMention: props.replyHasBotMention,
+  createCommentError: props.createCommentError,
+  suspensionIssueNumber: props.suspensionIssueNumber,
+  suspensionChannelId: props.suspensionChannelId,
+  suspensionUntil: props.suspensionUntil,
+  suspensionIndefinitely: props.suspensionIndefinitely,
+  botSuggestions: props.botSuggestions,
+  botUsernames: props.botUsernames,
+  modSuggestions: props.modSuggestions,
+}));
 </script>
 
 <template>
@@ -127,21 +145,9 @@ const hasAnswers = computed(() => {
         <Comment
           :comment-data="answer"
           :depth="1"
-          :enable-feedback="enableFeedback"
-          :locked="locked || archived"
-          :original-poster="originalPoster"
-          :answers="answers"
-          :reply-has-bot-mention="replyHasBotMention"
-          :create-comment-error="createCommentError"
-          :suspension-issue-number="suspensionIssueNumber"
-          :suspension-channel-id="suspensionChannelId"
-          :suspension-until="suspensionUntil"
-          :suspension-indefinitely="suspensionIndefinitely"
-          :bot-suggestions="botSuggestions"
-          :bot-usernames="botUsernames"
-          :mod-suggestions="modSuggestions"
           :show-comment-buttons="true"
           :show-header="true"
+          v-bind="answerPassThroughProps"
           @create-comment="emit('createComment', $event)"
           @delete-comment="emit('delete-comment', $event)"
           @click-edit-comment="emit('click-edit-comment', $event)"


### PR DESCRIPTION
## Summary

Readability/maintainability refactor of the comment components. **Behavior-preserving** — no logic, props API, or emits changed. Branched off `main`.

## The problem

The same ~14 "context" props (suspension state, `locked`, `originalPoster`, `modProfileName`, `answers`, `botUsernames`, form state, …) were threaded **unchanged** from `CommentSection` → `Comment` → every nested reply, re-listed line-by-line at each render site. The recursive `<Comment>` was the worst — 19 prop bindings, most of them `:x="props.x"` pass-throughs — and `PinnedAnswers` is a second identical drill layer.

## The change

Group those forwarded props into a single named, documented computed per component and bind with one `v-bind`:

- `CommentSection` → `commentPassThroughProps`
- `Comment` (recursive child) → `childPassThroughProps`
- `PinnedAnswers` → `answerPassThroughProps`

Per-instance props (`commentData`, `depth`, `parentCommentId`, the local `editFormOpenAtCommentID`, and the feedback/bot-suggestion props that are *not* forwarded to children) stay explicit on the tag. The recursive `<Comment>` drops from **19 prop lines to 6**.

## Why it's safe

- Each object's keys are exactly the previously-bound props with **identical source expressions** (`suspensionIssueNumber.value ?? undefined`, `locked || archived`, etc.).
- **No overlap** between the `v-bind` object keys and the still-explicit bindings, so binding order doesn't matter.
- `Comment`'s **public prop API is unchanged**, so the standalone render sites (permalink pages, user/mod comment lists) are unaffected — this deliberately avoids `provide/inject`, which would have needed a fallback in those non-provider sites.

## Scope note

This is the "group props" step. The heavier options discussed — `provide/inject` context and replacing the ~20 re-emit event pass-throughs with injected actions — are **not** included here (they change wiring and touch the standalone sites), and can be follow-ups.

## Test plan

- [x] All 269 `components/comments` unit tests pass, including the `realmount` specs that mount the real recursive tree
- [x] `pnpm exec eslint` on the 3 files — 0 errors
- [ ] `pnpm run tsc` — clean for these files; only the pre-existing local `Map.vue` `node_modules` drift remains (CI unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
