### PR TITLE
refactor(comments): extract Comment subscription + sticky mutations to composables

### DIFF
--- a/components/comments/Comment.vue
+++ b/components/comments/Comment.vue
@@ -2,12 +2,7 @@
 import { ref, computed } from 'vue';
 import { useRoute } from 'nuxt/app';
 import type { PropType } from 'vue';
-import type {
-  ApolloCache,
-  ApolloError,
-  NormalizedCacheObject,
-} from '@apollo/client/core';
-import { useMutation } from '@vue/apollo-composable';
+import type { ApolloError } from '@apollo/client/core';
 import type { Comment } from '@/__generated__/graphql';
 import type { CreateReplyInputData } from '@/types/Comment';
 import TextEditor from '../TextEditor.vue';
@@ -26,7 +21,8 @@ import ArchivedCommentText from './ArchivedCommentText.vue';
 import { useCommentPermissions } from '@/composables/useCommentPermissions';
 import { useBestAnswerMutations } from '@/composables/useBestAnswerMutations';
 import { useCommentPermalink } from '@/composables/useCommentPermalink';
-import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
+import { useCommentSubscription } from '@/composables/useCommentSubscription';
+import { useCommentStickyMutations } from '@/composables/useCommentStickyMutations';
 import { getCommentMenuItems } from '@/utils/headerPermissionUtils';
 import { getAuthorBadges } from '@/utils/roleBadges';
 import {
@@ -37,12 +33,6 @@ import {
 } from '@/utils/commentDisplay';
 import { useForumRoleMembership } from '@/composables/useForumRoleMembership';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
-import {
-  SUBSCRIBE_TO_COMMENT,
-  STICKY_COMMENT,
-  UNSUBSCRIBE_FROM_COMMENT,
-  UNSTICKY_COMMENT,
-} from '@/graphQLData/comment/mutations';
 
 const usernameVar = useUsername();
 
@@ -380,96 +370,17 @@ const commentMenuItems = computed(() => {
   });
 });
 
-const { mutate: subscribeToComment } = useMutation(SUBSCRIBE_TO_COMMENT, {
-  update: (cache, result) => {
-    if (result.data?.subscribeToComment) {
-      cache.modify({
-        id: cache.identify({
-          __typename: 'Comment',
-          id: props.commentData.id,
-        }),
-        fields: {
-          SubscribedToNotifications(_) {
-            return result.data.subscribeToComment.SubscribedToNotifications;
-          },
-        },
-      });
-    }
-  },
-});
+// Reply-notification subscription (subscribe/unsubscribe + one-click
+// unsubscribe) and sticky/unsticky mutations live in dedicated composables.
+const {
+  watchReplies: handleWatchReplies,
+  unwatchReplies: handleUnwatchReplies,
+} = useCommentSubscription(commentDataRef);
 
-const { mutate: unsubscribeFromComment } = useMutation(
-  UNSUBSCRIBE_FROM_COMMENT,
-  {
-    update: (cache, result) => {
-      if (result.data?.unsubscribeFromComment) {
-        cache.modify({
-          id: cache.identify({
-            __typename: 'Comment',
-            id: props.commentData.id,
-          }),
-          fields: {
-            SubscribedToNotifications(_) {
-              return result.data.unsubscribeFromComment.SubscribedToNotifications;
-            },
-          },
-        });
-      }
-    },
-  }
-);
-
-const updateStickyCache = (
-  cache: ApolloCache<NormalizedCacheObject>,
-  comment: StickyCommentFields | null | undefined
-) => {
-  if (!comment?.id) {
-    return;
-  }
-
-  cache.modify({
-    id: cache.identify({
-      __typename: 'Comment',
-      id: comment.id,
-    }),
-    fields: {
-      isSticky() {
-        return !!comment.isSticky;
-      },
-      stickyAt() {
-        return comment.stickyAt ?? null;
-      },
-      stickyByUsername() {
-        return comment.stickyByUsername ?? null;
-      },
-    },
-  });
-};
-
-const { mutate: stickyComment } = useMutation(STICKY_COMMENT, {
-  update: (cache, result) => {
-    updateStickyCache(cache, result.data?.stickyComment);
-  },
-});
-
-const { mutate: unstickyComment } = useMutation(UNSTICKY_COMMENT, {
-  update: (cache, result) => {
-    updateStickyCache(cache, result.data?.unstickyComment);
-  },
-});
-
-const isSubscribed = computed(() =>
-  isCommentSubscribedByUser(props.commentData, usernameVar.value)
-);
-
-useAutoUnsubscribe({
-  entityId: commentIdRef,
-  unsubscribeFn: async (id: string) => {
-    await unsubscribeFromComment({ commentId: id });
-  },
-  entityType: 'comment',
-  isSubscribed,
-});
+const {
+  stickyCurrentComment: handleStickyComment,
+  unstickyCurrentComment: handleUnstickyComment,
+} = useCommentStickyMutations(commentDataRef);
 
 const showReplies = ref(true);
 const highlight = ref(false);
@@ -506,30 +417,6 @@ function updateNewComment(input: CreateReplyInputData) {
 
 function handleReport() {
   emit('clickReport', props.commentData);
-}
-
-function handleWatchReplies() {
-  subscribeToComment({
-    commentId: props.commentData.id,
-  });
-}
-
-function handleUnwatchReplies() {
-  unsubscribeFromComment({
-    commentId: props.commentData.id,
-  });
-}
-
-function handleStickyComment() {
-  stickyComment({
-    commentId: props.commentData.id,
-  });
-}
-
-function handleUnstickyComment() {
-  unstickyComment({
-    commentId: props.commentData.id,
-  });
 }
 
 function handleFeedback(input: HandleFeedbackInput) {

--- a/composables/useCommentStickyMutations.spec.ts
+++ b/composables/useCommentStickyMutations.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import { asMock, createMutationRouter } from '@/tests/utils/mockApollo';
+import { useCommentStickyMutations } from './useCommentStickyMutations';
+import type { Comment } from '@/__generated__/graphql';
+
+vi.mock('@vue/apollo-composable', () => ({ useMutation: vi.fn() }));
+
+const router = createMutationRouter(['stickyComment', 'unstickyComment']);
+
+const comment = (): Comment =>
+  ({ id: 'c1', __typename: 'Comment' }) as unknown as Comment;
+
+beforeEach(() => {
+  router.reset();
+  asMock(useMutation).mockImplementation(router.useMutation);
+});
+
+// A cache whose modify() runs the field policies so their bodies are covered.
+const fakeCache = () => {
+  const fields: Record<string, () => unknown> = {};
+  return {
+    identify: vi.fn(() => 'Comment:c1'),
+    modify: vi.fn((opts: any) => {
+      Object.assign(fields, opts.fields);
+      Object.values(opts.fields).forEach((fn: any) => fn());
+    }),
+    fields,
+  };
+};
+
+describe('useCommentStickyMutations', () => {
+  it('stickies the current comment', () => {
+    const { stickyCurrentComment } = useCommentStickyMutations(ref(comment()));
+    stickyCurrentComment();
+    expect(router.get('stickyComment').mutate).toHaveBeenCalledWith({
+      commentId: 'c1',
+    });
+  });
+
+  it('unstickies the current comment', () => {
+    const { unstickyCurrentComment } = useCommentStickyMutations(ref(comment()));
+    unstickyCurrentComment();
+    expect(router.get('unstickyComment').mutate).toHaveBeenCalledWith({
+      commentId: 'c1',
+    });
+  });
+
+  it('writes the sticky fields into the cache on a successful sticky', () => {
+    useCommentStickyMutations(ref(comment()));
+    const cache = fakeCache();
+    router.get('stickyComment').update!(cache, {
+      data: {
+        stickyComment: {
+          id: 'c1',
+          isSticky: true,
+          stickyAt: '2026-01-01',
+          stickyByUsername: 'mod',
+        },
+      },
+    });
+    expect(cache.fields.isSticky()).toBe(true);
+  });
+
+  it('writes the sticky fields into the cache on a successful unsticky', () => {
+    useCommentStickyMutations(ref(comment()));
+    const cache = fakeCache();
+    router.get('unstickyComment').update!(cache, {
+      data: { unstickyComment: { id: 'c1', isSticky: false } },
+    });
+    expect(cache.fields.isSticky()).toBe(false);
+  });
+
+  it('defaults stickyAt and stickyByUsername to null when absent', () => {
+    useCommentStickyMutations(ref(comment()));
+    const cache = fakeCache();
+    router.get('stickyComment').update!(cache, {
+      data: { stickyComment: { id: 'c1', isSticky: true } },
+    });
+    expect([cache.fields.stickyAt(), cache.fields.stickyByUsername()]).toEqual([
+      null,
+      null,
+    ]);
+  });
+
+  it('skips the cache write when the mutation returned no comment id', () => {
+    useCommentStickyMutations(ref(comment()));
+    const cache = fakeCache();
+    router.get('stickyComment').update!(cache, { data: { stickyComment: null } });
+    expect(cache.modify).not.toHaveBeenCalled();
+  });
+});

--- a/composables/useCommentStickyMutations.spec.ts
+++ b/composables/useCommentStickyMutations.spec.ts
@@ -17,16 +17,17 @@ beforeEach(() => {
   asMock(useMutation).mockImplementation(router.useMutation);
 });
 
-// A cache whose modify() runs the field policies so their bodies are covered.
+// A cache whose modify() runs the field policies so their bodies are covered,
+// and exposes each captured field policy by name for assertions.
 const fakeCache = () => {
-  const fields: Record<string, () => unknown> = {};
+  const captured: Record<string, () => unknown> = {};
   return {
     identify: vi.fn(() => 'Comment:c1'),
-    modify: vi.fn((opts: any) => {
-      Object.assign(fields, opts.fields);
-      Object.values(opts.fields).forEach((fn: any) => fn());
+    modify: vi.fn((opts: { fields: Record<string, () => unknown> }) => {
+      Object.assign(captured, opts.fields);
+      Object.values(opts.fields).forEach((fn) => fn());
     }),
-    fields,
+    field: (name: string): (() => unknown) => captured[name] ?? (() => undefined),
   };
 };
 
@@ -60,7 +61,7 @@ describe('useCommentStickyMutations', () => {
         },
       },
     });
-    expect(cache.fields.isSticky()).toBe(true);
+    expect(cache.field('isSticky')()).toBe(true);
   });
 
   it('writes the sticky fields into the cache on a successful unsticky', () => {
@@ -69,7 +70,7 @@ describe('useCommentStickyMutations', () => {
     router.get('unstickyComment').update!(cache, {
       data: { unstickyComment: { id: 'c1', isSticky: false } },
     });
-    expect(cache.fields.isSticky()).toBe(false);
+    expect(cache.field('isSticky')()).toBe(false);
   });
 
   it('defaults stickyAt and stickyByUsername to null when absent', () => {
@@ -78,10 +79,10 @@ describe('useCommentStickyMutations', () => {
     router.get('stickyComment').update!(cache, {
       data: { stickyComment: { id: 'c1', isSticky: true } },
     });
-    expect([cache.fields.stickyAt(), cache.fields.stickyByUsername()]).toEqual([
-      null,
-      null,
-    ]);
+    expect([
+      cache.field('stickyAt')(),
+      cache.field('stickyByUsername')(),
+    ]).toEqual([null, null]);
   });
 
   it('skips the cache write when the mutation returned no comment id', () => {

--- a/composables/useCommentStickyMutations.ts
+++ b/composables/useCommentStickyMutations.ts
@@ -1,0 +1,69 @@
+import type { ComputedRef, Ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import type { ApolloCache, NormalizedCacheObject } from '@apollo/client/core';
+import type { Comment } from '@/__generated__/graphql';
+import {
+  STICKY_COMMENT,
+  UNSTICKY_COMMENT,
+} from '@/graphQLData/comment/mutations';
+
+type StickyCommentFields = Comment & {
+  isSticky?: boolean | null;
+  stickyAt?: string | null;
+  stickyByUsername?: string | null;
+};
+
+/**
+ * Sticky / unsticky mutations for a single comment. Each writes the sticky
+ * fields into the cache so the pin state updates without a refetch. Extracted
+ * from Comment.vue so this logic can be read and unit-tested on its own.
+ */
+export function useCommentStickyMutations(
+  commentData: Ref<Comment> | ComputedRef<Comment>
+) {
+  const updateStickyCache = (
+    cache: ApolloCache<NormalizedCacheObject>,
+    comment: StickyCommentFields | null | undefined
+  ) => {
+    if (!comment?.id) {
+      return;
+    }
+
+    cache.modify({
+      id: cache.identify({
+        __typename: 'Comment',
+        id: comment.id,
+      }),
+      fields: {
+        isSticky() {
+          return !!comment.isSticky;
+        },
+        stickyAt() {
+          return comment.stickyAt ?? null;
+        },
+        stickyByUsername() {
+          return comment.stickyByUsername ?? null;
+        },
+      },
+    });
+  };
+
+  const { mutate: stickyComment } = useMutation(STICKY_COMMENT, {
+    update: (cache, result) => {
+      updateStickyCache(cache, result.data?.stickyComment);
+    },
+  });
+
+  const { mutate: unstickyComment } = useMutation(UNSTICKY_COMMENT, {
+    update: (cache, result) => {
+      updateStickyCache(cache, result.data?.unstickyComment);
+    },
+  });
+
+  const stickyCurrentComment = () =>
+    stickyComment({ commentId: commentData.value.id });
+  const unstickyCurrentComment = () =>
+    unstickyComment({ commentId: commentData.value.id });
+
+  return { stickyCurrentComment, unstickyCurrentComment };
+}

--- a/composables/useCommentSubscription.spec.ts
+++ b/composables/useCommentSubscription.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
+import { asMock, createMutationRouter } from '@/tests/utils/mockApollo';
+import { useCommentSubscription } from './useCommentSubscription';
+import type { Comment } from '@/__generated__/graphql';
+
+vi.mock('@vue/apollo-composable', () => ({ useMutation: vi.fn() }));
+vi.mock('@/composables/useAutoUnsubscribe', () => ({
+  useAutoUnsubscribe: vi.fn(),
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ({ value: 'alice' }),
+}));
+
+const router = createMutationRouter([
+  'subscribeToComment',
+  'unsubscribeFromComment',
+]);
+
+const comment = (overrides: Record<string, unknown> = {}): Comment =>
+  ({
+    id: 'c1',
+    __typename: 'Comment',
+    SubscribedToNotifications: [],
+    ...overrides,
+  }) as unknown as Comment;
+
+const fakeCache = () => ({
+  identify: vi.fn(() => 'Comment:c1'),
+  modify: vi.fn(),
+});
+
+beforeEach(() => {
+  router.reset();
+  asMock(useMutation).mockImplementation(router.useMutation);
+  asMock(useAutoUnsubscribe).mockReset();
+});
+
+describe('useCommentSubscription', () => {
+  it('subscribes to the comment when watchReplies is called', () => {
+    const { watchReplies } = useCommentSubscription(ref(comment()));
+    watchReplies();
+    expect(router.get('subscribeToComment').mutate).toHaveBeenCalledWith({
+      commentId: 'c1',
+    });
+  });
+
+  it('unsubscribes from the comment when unwatchReplies is called', () => {
+    const { unwatchReplies } = useCommentSubscription(ref(comment()));
+    unwatchReplies();
+    expect(router.get('unsubscribeFromComment').mutate).toHaveBeenCalledWith({
+      commentId: 'c1',
+    });
+  });
+
+  it('writes the new subscriber list on a successful subscribe', () => {
+    useCommentSubscription(ref(comment()));
+    let fieldFn: (existing?: unknown) => unknown = () => undefined;
+    const cache = {
+      identify: vi.fn(() => 'Comment:c1'),
+      modify: vi.fn((opts: any) => {
+        fieldFn = opts.fields.SubscribedToNotifications;
+      }),
+    };
+    router.get('subscribeToComment').update!(cache, {
+      data: { subscribeToComment: { SubscribedToNotifications: [{ username: 'alice' }] } },
+    });
+    expect(fieldFn()).toEqual([{ username: 'alice' }]);
+  });
+
+  it('writes the new subscriber list on a successful unsubscribe', () => {
+    useCommentSubscription(ref(comment()));
+    const cache = fakeCache();
+    router.get('unsubscribeFromComment').update!(cache, {
+      data: { unsubscribeFromComment: { SubscribedToNotifications: [] } },
+    });
+    expect(cache.modify).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing on subscribe when the mutation returned no data', () => {
+    useCommentSubscription(ref(comment()));
+    const cache = fakeCache();
+    router.get('subscribeToComment').update!(cache, { data: {} });
+    expect(cache.modify).not.toHaveBeenCalled();
+  });
+
+  it('reports isSubscribed true when the current user is in the list', () => {
+    const { isSubscribed } = useCommentSubscription(
+      ref(comment({ SubscribedToNotifications: [{ username: 'alice' }] }))
+    );
+    expect(isSubscribed.value).toBe(true);
+  });
+
+  it('reports isSubscribed false when the current user is not in the list', () => {
+    const { isSubscribed } = useCommentSubscription(
+      ref(comment({ SubscribedToNotifications: [{ username: 'bob' }] }))
+    );
+    expect(isSubscribed.value).toBe(false);
+  });
+
+  it('wires an auto-unsubscribe handler that calls the unsubscribe mutation', async () => {
+    useCommentSubscription(ref(comment()));
+    const params = asMock(useAutoUnsubscribe).mock.calls[0]![0] as {
+      unsubscribeFn: (id: string) => Promise<void>;
+    };
+    await params.unsubscribeFn('c9');
+    expect(router.get('unsubscribeFromComment').mutate).toHaveBeenCalledWith({
+      commentId: 'c9',
+    });
+  });
+});

--- a/composables/useCommentSubscription.ts
+++ b/composables/useCommentSubscription.ts
@@ -1,0 +1,84 @@
+import { computed, type ComputedRef, type Ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import type { Comment } from '@/__generated__/graphql';
+import { useUsername } from '@/composables/useAuthState';
+import { useAutoUnsubscribe } from '@/composables/useAutoUnsubscribe';
+import { isCommentSubscribedByUser } from '@/utils/commentDisplay';
+import {
+  SUBSCRIBE_TO_COMMENT,
+  UNSUBSCRIBE_FROM_COMMENT,
+} from '@/graphQLData/comment/mutations';
+
+/**
+ * Reply-notification subscription for a single comment: the subscribe /
+ * unsubscribe mutations (each writing the fresh SubscribedToNotifications list
+ * back into the cache), the derived `isSubscribed` flag, and the one-click
+ * `?action=unsubscribe` handler. Extracted from Comment.vue so this logic can be
+ * read and unit-tested on its own.
+ */
+export function useCommentSubscription(
+  commentData: Ref<Comment> | ComputedRef<Comment>
+) {
+  const usernameVar = useUsername();
+  const commentId = computed(() => commentData.value.id);
+
+  const { mutate: subscribeToComment } = useMutation(SUBSCRIBE_TO_COMMENT, {
+    update: (cache, result) => {
+      if (result.data?.subscribeToComment) {
+        cache.modify({
+          id: cache.identify({
+            __typename: 'Comment',
+            id: commentData.value.id,
+          }),
+          fields: {
+            SubscribedToNotifications(_) {
+              return result.data.subscribeToComment.SubscribedToNotifications;
+            },
+          },
+        });
+      }
+    },
+  });
+
+  const { mutate: unsubscribeFromComment } = useMutation(
+    UNSUBSCRIBE_FROM_COMMENT,
+    {
+      update: (cache, result) => {
+        if (result.data?.unsubscribeFromComment) {
+          cache.modify({
+            id: cache.identify({
+              __typename: 'Comment',
+              id: commentData.value.id,
+            }),
+            fields: {
+              SubscribedToNotifications(_) {
+                return result.data.unsubscribeFromComment
+                  .SubscribedToNotifications;
+              },
+            },
+          });
+        }
+      },
+    }
+  );
+
+  const isSubscribed = computed(() =>
+    isCommentSubscribedByUser(commentData.value, usernameVar.value)
+  );
+
+  useAutoUnsubscribe({
+    entityId: commentId,
+    unsubscribeFn: async (id: string) => {
+      await unsubscribeFromComment({ commentId: id });
+    },
+    entityType: 'comment',
+    isSubscribed,
+  });
+
+  const watchReplies = () =>
+    subscribeToComment({ commentId: commentData.value.id });
+  const unwatchReplies = () =>
+    unsubscribeFromComment({ commentId: commentData.value.id });
+
+  return { isSubscribed, watchReplies, unwatchReplies };
+}


### PR DESCRIPTION
## Summary

Maintainability refactor: extract `Comment.vue`'s inlined mutation logic into two focused composables, matching the existing `useCommentX` pattern. **Behavior-preserving** — `Comment`'s public props/emits are unchanged. Branched off `main` (independent of #325).

## The change

`Comment.vue` (**933 → 820 lines**) had four mutations with their cache-update callbacks inlined in setup: subscribe/unsubscribe (writing `SubscribedToNotifications`) and sticky/unsticky (`updateStickyCache`). Moved them into:

- **`useCommentSubscription(commentData)`** — `watchReplies` / `unwatchReplies`, the derived `isSubscribed` flag, and the one-click `?action=unsubscribe` wiring.
- **`useCommentStickyMutations(commentData)`** — `stickyCurrentComment` / `unstickyCurrentComment` with the sticky-field cache writes.

In `Comment.vue`, the composable returns are aliased back to the existing handler names (`handleWatchReplies`, `handleStickyComment`, …), so the **template and every render site are untouched**. Removed the now-unused imports (`useMutation`, `useAutoUnsubscribe`, the four mutation docs, the Apollo cache types).

## Why it's a win

- The 933-line component shrinks and the mutation logic is now readable in isolation, next to the other comment composables.
- Those cache-update callbacks were previously uncovered inside `Comment.vue`; they're now **unit-tested directly** in the composable specs (14 tests, ~97%).

## Test plan

- [x] All 289 `components/comments` + composable tests pass (incl. the `realmount` specs that mount the real recursive tree)
- [x] Two new composable specs — 14 tests, ~97% coverage
- [x] `pnpm exec eslint` on changed files — 0 errors
- [ ] `pnpm run tsc` — clean for these files (only the pre-existing local `Map.vue` `node_modules` drift remains; CI unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
