### PR TITLE
Autosave channel toggle tabs — closes roadmap #15

### DIFF
--- a/components/channel/form/CreateEditChannelFields.spec.ts
+++ b/components/channel/form/CreateEditChannelFields.spec.ts
@@ -125,8 +125,15 @@ const fieldStubs = {
   },
   SuspensionNotice: { template: '<div data-testid="suspension-notice" />' },
   TailwindForm: {
-    template: '<form :data-needs-changes="String(needsChanges)"><slot /></form>',
-    props: ['formTitle', 'loading', 'needsChanges', 'showButtonsInHeader'],
+    template:
+      '<form :data-needs-changes="String(needsChanges)" :data-show-save="String(showSaveButton)"><slot /></form>',
+    props: [
+      'formTitle',
+      'loading',
+      'needsChanges',
+      'showButtonsInHeader',
+      'showSaveButton',
+    ],
   },
   FormRow: { template: '<div><slot name="content" /></div>', props: ['sectionTitle', 'required'] },
   TextInput: { template: '<input />', methods: { focus() {} } },
@@ -256,5 +263,49 @@ describe('CreateEditChannelFields — edit mode', () => {
     });
 
     expect(wrapper.find('form').attributes('data-needs-changes')).toBe('false');
+  });
+});
+
+describe('CreateEditChannelFields — autosave tabs', () => {
+  beforeEach(() => {
+    routeParams = { forumId: 'cats' };
+    routerPush.mockReset();
+  });
+
+  const mountEditTab = (name: string, props: Record<string, unknown> = {}) => {
+    routeName = name;
+    return mountFields({
+      editMode: true,
+      hasPermission: true,
+      dataLoaded: true,
+      formValues: { ...baseFormValues(), uniqueName: 'cats' },
+      ...props,
+    });
+  };
+
+  it('hides the shared Save button on the events (autosave) tab', () => {
+    const wrapper = mountEditTab('forums-forumId-edit-events');
+
+    expect(wrapper.find('form').attributes('data-show-save')).toBe('false');
+  });
+
+  it('shows the save status indicator on an autosave tab', () => {
+    const wrapper = mountEditTab('forums-forumId-edit-feedback', {
+      saveStatus: 'saving',
+    });
+
+    expect(wrapper.find('[data-testid="save-status"]').exists()).toBe(true);
+  });
+
+  it('keeps the shared Save button on a non-autosave tab', () => {
+    const wrapper = mountEditTab('forums-forumId-edit-rules');
+
+    expect(wrapper.find('form').attributes('data-show-save')).toBe('true');
+  });
+
+  it('hides the save status indicator on a non-autosave tab', () => {
+    const wrapper = mountEditTab('forums-forumId-edit-rules');
+
+    expect(wrapper.find('[data-testid="save-status"]').exists()).toBe(false);
   });
 });

--- a/components/channel/form/CreateEditChannelFields.vue
+++ b/components/channel/form/CreateEditChannelFields.vue
@@ -6,6 +6,8 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import type { CreateEditChannelFormValues } from '@/types/Channel';
 import TailwindForm from '@/components/FormComponent.vue';
+import SaveStatus from '@/components/settings/SaveStatus.vue';
+import type { AutosaveStatus } from '@/composables/useSettingAutosave';
 import { useRoute, useRouter } from 'nuxt/app';
 import { MAX_CHARS_IN_CHANNEL_NAME } from '@/utils/constants';
 import { isLoadingAuthVar } from '@/cache';
@@ -100,11 +102,30 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  // Autosave status for the tabs whose fields persist on change.
+  saveStatus: {
+    type: String as PropType<AutosaveStatus>,
+    default: 'idle',
+  },
+  saveErrorMessage: {
+    type: String,
+    default: '',
+  },
 });
 
 const emit = defineEmits(['submit', 'updateFormValues']);
 
 const CHANNEL_ALREADY_EXISTS_ERROR = 'Constraint validation failed';
+
+// Tabs whose fields are simple toggles that autosave on change; these hide the
+// shared Save button and show a status indicator instead.
+const AUTOSAVE_TAB_KEYS = ['events', 'images', 'emoji', 'feedback'];
+const isAutosaveTab = computed(() =>
+  AUTOSAVE_TAB_KEYS.some(
+    (key) =>
+      typeof route.name === 'string' && route.name.includes(`edit-${key}`)
+  )
+);
 
 const tabs = computed(() => {
   const baseTabs: TabItem[] = [
@@ -356,6 +377,7 @@ const showCreateChannelError = computed(() => {
           :loading="editChannelLoading"
           :needs-changes="titleIsInvalid"
           :show-cancel-button="false"
+          :show-save-button="!isAutosaveTab"
           @input="touched = true"
           @submit="emit('submit')"
         >
@@ -573,6 +595,12 @@ const showCreateChannelError = computed(() => {
                   :owner-list="ownerList"
                   @submit="$emit('submit', $event)"
                   @update-form-values="emit('updateFormValues', $event)"
+                />
+                <SaveStatus
+                  v-if="hasPermission && isAutosaveTab"
+                  class="mt-4"
+                  :status="saveStatus"
+                  :error-message="saveErrorMessage"
                 />
               </div>
             </div>

--- a/docs/feature-roadmap.md
+++ b/docs/feature-roadmap.md
@@ -206,10 +206,35 @@ Notes:
 - Image grids and channel header/sidebar surfaces pass the computed state into favorite buttons so those buttons skip their fallback lookup.
 - Comment list/reply/event-comment payloads already include `isFavoritedByUser`, and `CommentButtons` passes it into `AddToCommentFavorites`; the per-item lookup remains only as a fallback for callers that do not provide state.
 
-### 15. Auto-save for server settings and channel admin settings `[not started]`
+### 15. Auto-save for server settings and channel admin settings `[complete]`
 
-- [ ] Replace explicit save-button flows where appropriate with autosave behavior.
-- [ ] Start with plugins/settings areas called out in the original note.
+- [x] Replace explicit save-button flows where appropriate with autosave behavior.
+- [x] Start with plugins/settings areas called out in the original note.
+
+Notes:
+- Added a shared `useSettingAutosave` composable (per-field debounced save with
+  visible Saving/Saved/error state, no-op skipping, coalescing, and no
+  overlapping saves) plus a `SaveStatus` indicator (`aria-live` / `role=alert`).
+  `FormComponent` gained an opt-in `showSaveButton` prop.
+- Converted the settings tabs whose fields are simple, non-destructive scalars —
+  each sends a SCOPED partial update, and the shared Save button is replaced by
+  the status indicator on those tabs:
+  - Server: Basic (`serverDescription`), Calendar (`enableEvents`).
+  - Channel: Events (`eventsEnabled`), Images (`imageUploadsEnabled`,
+    `markdownImagesEnabled`), Emoji (`emojiEnabled`), Feedback (`feedbackEnabled`).
+- **Intentionally kept on explicit Save** (autosave is not appropriate — the
+  "where appropriate" boundary): roles & permissions, plugins & secrets, rules
+  editors, server/channel download **filter groups** and allowed file types,
+  mods/owners management, suspensions, banner/icon upload & delete, and any
+  drag-to-reorder flow (batched). These involve destructive, secret, permission,
+  or complex nested-CRUD changes that should be deliberate.
+- Mixed tabs (e.g. channel Basic: name/description alongside tags/banner) remain
+  on explicit Save to avoid a half-autosaving form; converting just their scalar
+  text fields is a possible future refinement, not required for this item.
+- Backend needed no changes: `updateServerConfigs`/`updateChannels` already apply
+  the update input as a partial update, so scoped single-field saves are safe.
+- Frontend PRs gennit-project/multiforum-nuxt#323 (pattern + server tabs) and the
+  channel-rollout PR stacked on it.
 
 ### 16. Event edit history: title and description revisions `[complete]`
 

--- a/pages/forums/[forumId]/edit.vue
+++ b/pages/forums/[forumId]/edit.vue
@@ -15,11 +15,60 @@ import type {
 } from '@/__generated__/graphql';
 import { useRoute } from 'nuxt/app';
 import { useQuery, useMutation } from '@vue/apollo-composable';
+import {
+  useSettingAutosave,
+  type AutosaveStatus,
+} from '@/composables/useSettingAutosave';
 
 const usernameVar = useUsername();
 
 const route = useRoute();
 const channelId = route.params.forumId as string;
+
+// Autosave for the simple toggle tabs (Events, Images, Emoji, Feedback). Uses a
+// separate UPDATE_CHANNEL instance so a toggle save doesn't trigger the
+// form-wide "changes saved" toast/refetch — the SaveStatus indicator covers it.
+// Each toggle sends a SCOPED partial update (only its own field). Declared
+// before the channel query's immediate watch so the watch can prime baselines.
+const { mutate: updateChannelField } = useMutation(UPDATE_CHANNEL);
+const saveChannelField = (update: ChannelUpdateInput) =>
+  updateChannelField({ where: { uniqueName: channelId }, update });
+
+const eventsAutosave = useSettingAutosave<boolean>({
+  save: (eventsEnabled) => saveChannelField({ eventsEnabled }),
+});
+const imageUploadsAutosave = useSettingAutosave<boolean>({
+  save: (imageUploadsEnabled) => saveChannelField({ imageUploadsEnabled }),
+});
+const markdownImagesAutosave = useSettingAutosave<boolean>({
+  save: (markdownImagesEnabled) => saveChannelField({ markdownImagesEnabled }),
+});
+const feedbackAutosave = useSettingAutosave<boolean>({
+  save: (feedbackEnabled) => saveChannelField({ feedbackEnabled }),
+});
+const emojiAutosave = useSettingAutosave<boolean>({
+  save: (emojiEnabled) => saveChannelField({ emojiEnabled }),
+});
+
+const channelAutosaves = [
+  eventsAutosave,
+  imageUploadsAutosave,
+  markdownImagesAutosave,
+  feedbackAutosave,
+  emojiAutosave,
+];
+
+const autosaveStatus = computed<AutosaveStatus>(() => {
+  const statuses = channelAutosaves.map((a) => a.status.value);
+  if (statuses.includes('saving')) return 'saving';
+  if (statuses.includes('error')) return 'error';
+  if (statuses.includes('saved')) return 'saved';
+  return 'idle';
+});
+const autosaveErrorMessage = computed(
+  () =>
+    channelAutosaves.find((a) => a.error.value)?.error.value?.message || ''
+);
 
 const {
   result: getChannelResult,
@@ -85,6 +134,16 @@ watch(
         downloadFilterGroups: channelData.FilterGroups || [],
         rules,
       };
+
+      // Prime autosave baselines so the first edit matching the loaded value
+      // does not fire a redundant save.
+      eventsAutosave.setInitial(Boolean(channelData.eventsEnabled));
+      imageUploadsAutosave.setInitial(channelData.imageUploadsEnabled !== false);
+      markdownImagesAutosave.setInitial(
+        channelData.markdownImagesEnabled !== false
+      );
+      feedbackAutosave.setInitial(Boolean(channelData.feedbackEnabled));
+      emojiAutosave.setInitial(channelData.emojiEnabled !== false);
 
       dataLoaded.value = true;
     }
@@ -301,6 +360,24 @@ function submit() {
 
 function updateFormValues(data: CreateEditChannelFormValues) {
   formValues.value = { ...formValues.value, ...data };
+
+  // The Events, Images, Emoji, and Feedback tabs autosave their toggles on
+  // change. Other tabs continue to batch through submit().
+  if ('eventsEnabled' in data) {
+    eventsAutosave.trigger(Boolean(data.eventsEnabled));
+  }
+  if ('imageUploadsEnabled' in data) {
+    imageUploadsAutosave.trigger(Boolean(data.imageUploadsEnabled));
+  }
+  if ('markdownImagesEnabled' in data) {
+    markdownImagesAutosave.trigger(Boolean(data.markdownImagesEnabled));
+  }
+  if ('feedbackEnabled' in data) {
+    feedbackAutosave.trigger(Boolean(data.feedbackEnabled));
+  }
+  if ('emojiEnabled' in data) {
+    emojiAutosave.trigger(Boolean(data.emojiEnabled));
+  }
 }
 
 const hasError = computed(() => {
@@ -336,6 +413,8 @@ const hasError = computed(() => {
         :owner-list="ownerList"
         :has-permission="isOwner"
         :data-loaded="dataLoaded"
+        :save-status="autosaveStatus"
+        :save-error-message="autosaveErrorMessage"
         @submit="submit"
         @update-form-values="updateFormValues"
       />


### PR DESCRIPTION
## Summary

Second and final slice of roadmap item **#15 — autosave for admin settings**. Builds on the merged pattern from #323 (`useSettingAutosave` + `SaveStatus`) and rolls it out to the channel side, then **marks #15 complete — closing the feature roadmap** (all 17 items done).

## What's here

- **Converted channel tabs** (all simple, non-destructive toggles) to autosave, replacing their Save button with the status indicator:
  - **Events** (`eventsEnabled`), **Images** (`imageUploadsEnabled`, `markdownImagesEnabled`), **Emoji** (`emojiEnabled`), **Feedback** (`feedbackEnabled`).
- Each toggle sends a **scoped** `UPDATE_CHANNEL` partial update via a **dedicated mutation instance**, so a toggle save doesn't trigger the form-wide "changes saved" toast/refetch — the `SaveStatus` indicator covers it.
- `CreateEditChannelFields` hides the shared Save button and shows the status indicator only on the autosave tabs (route-based); all other tabs are unchanged.
- **Roadmap #15 → complete**, with an explicit list of settings that **intentionally keep explicit Save** (the "where appropriate" boundary): roles/permissions, plugins/secrets, rules editors, download filter groups & allowed file types, mods/owners, suspensions, banner/icon upload+delete, and drag-reorder flows.

## Notes / correctness

- Autosave instances are declared **before** the channel query's `{ immediate: true }` watch so baselines prime on load without a temporal-dead-zone error (caught by the existing edit-page spec).
- **Backend: no changes** — `updateChannels` applies the update input as a partial update, so single-field scoped saves are safe (same basis as the server side in #323).
- ⚠️ **Worth verifying against a live/preview backend before merge:** that a scoped single-field `UPDATE_CHANNEL` passes the `updateChannelInputIsValid` + owner-permission checks (mocked Playwright can't exercise real backend validation). The pattern matches the server-side conversion already merged in #323.

## Tests

- `CreateEditChannelFields.spec.ts` (+4): Save button hidden + status shown on autosave tabs; both preserved on non-autosave tabs.
- All existing specs for the touched files pass (channel fields, edit page, and the events/images/feedback/emoji tabs); `pnpm run tsc` clean.

## Stacking

Independent of #323 (already merged to main). Merges standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)