### PR TITLE
refactor(comments): extract CommentSection editor state to useCommentFormState

### DIFF
--- a/components/comments/CommentSection.vue
+++ b/components/comments/CommentSection.vue
@@ -43,6 +43,7 @@ import { useCommentSectionNotifications } from '@/composables/useCommentSectionN
 import { useCommentSectionModals } from '@/composables/useCommentSectionModals';
 import { useCommentFeedbackMutation } from '@/composables/useCommentFeedbackMutation';
 import { useCommentCrudMutations } from '@/composables/useCommentCrudMutations';
+import { useCommentFormState } from '@/composables/useCommentFormState';
 
 const modProfileNameVar = useModProfileName();
 
@@ -216,12 +217,26 @@ const {
   feedbackEnabled: computed(() => props.enableFeedback),
 });
 
-// Comment form state
-const commentToEdit = ref<CommentType | null>(null);
-const commentInProcess = ref(false);
-const submitAttempted = ref(false);
-const replyFormOpenAtCommentID = ref('');
-const editFormOpenAtCommentID = ref('');
+// Comment reply/edit editor state: which comment is being edited/replied to,
+// the in-progress edit form values, and the pure open/close transitions. The
+// submit handlers below drive it via the exposed refs + reset helpers.
+const {
+  commentToEdit,
+  commentInProcess,
+  submitAttempted,
+  replyFormOpenAtCommentID,
+  editFormOpenAtCommentID,
+  editFormValues,
+  openReplyEditor,
+  hideReplyEditor,
+  openEditCommentEditor,
+  hideEditCommentEditor,
+  startEditing: handleClickEdit,
+  updateEditInputValues,
+  updateFeedbackText: updateFeedback,
+  resetAfterCreate,
+  resetAfterUpdate,
+} = useCommentFormState();
 
 // Comment search state
 const searchText = ref('');
@@ -261,12 +276,6 @@ watch(
 const shouldShowLoadingSpinner = computed(
   () => props.loading && !hasLoadedComments.value
 );
-
-const editFormValues = ref<CreateEditCommentFormValues>({
-  text: commentToEdit.value?.text || '',
-  isRootComment: true,
-  depth: 1,
-});
 
 // Use feedback mutation composable
 const {
@@ -319,9 +328,7 @@ const {
 });
 
 onDoneCreatingComment(() => {
-  commentInProcess.value = false;
-  submitAttempted.value = false;
-  replyFormOpenAtCommentID.value = '';
+  resetAfterCreate();
   emit('updateCreateFormValues', {
     text: '',
     isRootComment: true,
@@ -335,14 +342,7 @@ onErrorCreatingComment(() => {
 });
 
 onDoneUpdatingComment(() => {
-  commentInProcess.value = false;
-  editFormOpenAtCommentID.value = '';
-  commentToEdit.value = null;
-  editFormValues.value = {
-    text: '',
-    isRootComment: true,
-    depth: 1,
-  };
+  resetAfterUpdate();
 });
 
 const effectiveChannelUniqueName = computed(() =>
@@ -381,24 +381,6 @@ function updateCreateInputValuesForReply(input: CreateReplyInputData) {
   emit('updateCreateReplyCommentInput', buildReplyCommentInput(input));
 }
 
-function handleClickEdit(commentData: CommentType) {
-  commentToEdit.value = commentData;
-  editFormOpenAtCommentID.value = commentData.id;
-  editFormValues.value = {
-    text: commentData.text || '',
-    isRootComment: !commentData.ParentComment,
-    depth: 1,
-  };
-}
-
-function updateEditInputValues(text: string, isRootComment: boolean) {
-  editFormValues.value = {
-    ...editFormValues.value,
-    text,
-    isRootComment,
-  };
-}
-
 function handleSaveEdit() {
   if (!commentToEdit.value?.id) {
     console.error('No comment to edit');
@@ -431,25 +413,6 @@ function scrollToTop() {
   window.scrollTo(0, 0);
 }
 
-function openReplyEditor(commentId: string) {
-  replyFormOpenAtCommentID.value = commentId;
-  editFormOpenAtCommentID.value = ''; // Close edit form if open
-}
-
-function hideReplyEditor() {
-  replyFormOpenAtCommentID.value = '';
-}
-
-function openEditCommentEditor(commentId: string) {
-  editFormOpenAtCommentID.value = commentId;
-  replyFormOpenAtCommentID.value = ''; // Close reply form if open
-}
-
-function hideEditCommentEditor() {
-  editFormOpenAtCommentID.value = '';
-  commentToEdit.value = null; // Clear edited comment data
-}
-
 function handleSubmitFeedback() {
   if (!props.enableFeedback) {
     console.error('Feedback is disabled for this forum.');
@@ -470,10 +433,6 @@ function handleSubmitFeedback() {
     channelId: channelId.value,
   };
   addFeedbackCommentToComment(feedbackInput);
-}
-
-function updateFeedback(text: string) {
-  editFormValues.value.text = text;
 }
 
 function handleViewFeedback(commentId: string) {

--- a/composables/useCommentFormState.spec.ts
+++ b/composables/useCommentFormState.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { useCommentFormState } from './useCommentFormState';
+import type { Comment } from '@/__generated__/graphql';
+
+const comment = (overrides: Record<string, unknown> = {}): Comment =>
+  ({ id: 'c1', text: 'hello', __typename: 'Comment', ...overrides }) as unknown as Comment;
+
+describe('useCommentFormState', () => {
+  it('opens the reply editor and closes any open edit editor', () => {
+    const s = useCommentFormState();
+    s.editFormOpenAtCommentID.value = 'c9';
+    s.openReplyEditor('c1');
+    expect([s.replyFormOpenAtCommentID.value, s.editFormOpenAtCommentID.value]).toEqual(
+      ['c1', '']
+    );
+  });
+
+  it('hides the reply editor', () => {
+    const s = useCommentFormState();
+    s.replyFormOpenAtCommentID.value = 'c1';
+    s.hideReplyEditor();
+    expect(s.replyFormOpenAtCommentID.value).toBe('');
+  });
+
+  it('opens the edit editor and closes any open reply editor', () => {
+    const s = useCommentFormState();
+    s.replyFormOpenAtCommentID.value = 'c9';
+    s.openEditCommentEditor('c1');
+    expect([s.editFormOpenAtCommentID.value, s.replyFormOpenAtCommentID.value]).toEqual(
+      ['c1', '']
+    );
+  });
+
+  it('hides the edit editor and clears the edited comment', () => {
+    const s = useCommentFormState();
+    s.startEditing(comment());
+    s.hideEditCommentEditor();
+    expect([s.editFormOpenAtCommentID.value, s.commentToEdit.value]).toEqual(['', null]);
+  });
+
+  it('starts editing a root comment', () => {
+    const s = useCommentFormState();
+    s.startEditing(comment({ id: 'c1', text: 'root text', ParentComment: null }));
+    expect({
+      editing: s.commentToEdit.value?.id,
+      open: s.editFormOpenAtCommentID.value,
+      form: s.editFormValues.value,
+    }).toEqual({
+      editing: 'c1',
+      open: 'c1',
+      form: { text: 'root text', isRootComment: true, depth: 1 },
+    });
+  });
+
+  it('marks a reply (has ParentComment) as a non-root comment when editing', () => {
+    const s = useCommentFormState();
+    s.startEditing(comment({ ParentComment: { id: 'p1' } }));
+    expect(s.editFormValues.value.isRootComment).toBe(false);
+  });
+
+  it('defaults the edit text to empty when the comment has none', () => {
+    const s = useCommentFormState();
+    s.startEditing(comment({ text: null }));
+    expect(s.editFormValues.value.text).toBe('');
+  });
+
+  it('merges text and isRootComment into the edit form values', () => {
+    const s = useCommentFormState();
+    s.updateEditInputValues('edited', false);
+    expect(s.editFormValues.value).toMatchObject({ text: 'edited', isRootComment: false });
+  });
+
+  it('updates just the feedback text', () => {
+    const s = useCommentFormState();
+    s.updateFeedbackText('feedback');
+    expect(s.editFormValues.value.text).toBe('feedback');
+  });
+
+  it('resets create-related state after a successful create', () => {
+    const s = useCommentFormState();
+    s.commentInProcess.value = true;
+    s.submitAttempted.value = true;
+    s.replyFormOpenAtCommentID.value = 'c1';
+    s.resetAfterCreate();
+    expect([
+      s.commentInProcess.value,
+      s.submitAttempted.value,
+      s.replyFormOpenAtCommentID.value,
+    ]).toEqual([false, false, '']);
+  });
+
+  it('resets edit-related state after a successful update', () => {
+    const s = useCommentFormState();
+    s.startEditing(comment());
+    s.commentInProcess.value = true;
+    s.resetAfterUpdate();
+    expect({
+      inProcess: s.commentInProcess.value,
+      open: s.editFormOpenAtCommentID.value,
+      editing: s.commentToEdit.value,
+      form: s.editFormValues.value,
+    }).toEqual({
+      inProcess: false,
+      open: '',
+      editing: null,
+      form: { text: '', isRootComment: true, depth: 1 },
+    });
+  });
+});

--- a/composables/useCommentFormState.ts
+++ b/composables/useCommentFormState.ts
@@ -1,0 +1,103 @@
+import { ref } from 'vue';
+import type { Comment as CommentType } from '@/__generated__/graphql';
+import type { CreateEditCommentFormValues } from '@/types/Comment';
+
+const emptyFormValues = (): CreateEditCommentFormValues => ({
+  text: '',
+  isRootComment: true,
+  depth: 1,
+});
+
+/**
+ * Local reply/edit editor state for the comment section: which comment (if any)
+ * is being edited, the in-progress edit form values, which comment has its reply
+ * or edit editor open, and the pure open/close transitions. Extracted from
+ * CommentSection.vue so this UI state is readable and unit-testable on its own.
+ *
+ * The submit handlers that actually call mutations (create/edit/delete) stay in
+ * CommentSection and drive this state through the exposed refs and the
+ * `resetAfterCreate` / `resetAfterUpdate` helpers (called from the mutations'
+ * onDone hooks).
+ */
+export function useCommentFormState() {
+  const commentToEdit = ref<CommentType | null>(null);
+  const commentInProcess = ref(false);
+  const submitAttempted = ref(false);
+  const replyFormOpenAtCommentID = ref('');
+  const editFormOpenAtCommentID = ref('');
+  const editFormValues = ref<CreateEditCommentFormValues>(emptyFormValues());
+
+  const openReplyEditor = (commentId: string) => {
+    replyFormOpenAtCommentID.value = commentId;
+    editFormOpenAtCommentID.value = ''; // Close edit form if open
+  };
+
+  const hideReplyEditor = () => {
+    replyFormOpenAtCommentID.value = '';
+  };
+
+  const openEditCommentEditor = (commentId: string) => {
+    editFormOpenAtCommentID.value = commentId;
+    replyFormOpenAtCommentID.value = ''; // Close reply form if open
+  };
+
+  const hideEditCommentEditor = () => {
+    editFormOpenAtCommentID.value = '';
+    commentToEdit.value = null; // Clear edited comment data
+  };
+
+  const startEditing = (commentData: CommentType) => {
+    commentToEdit.value = commentData;
+    editFormOpenAtCommentID.value = commentData.id;
+    editFormValues.value = {
+      text: commentData.text || '',
+      isRootComment: !commentData.ParentComment,
+      depth: 1,
+    };
+  };
+
+  const updateEditInputValues = (text: string, isRootComment: boolean) => {
+    editFormValues.value = {
+      ...editFormValues.value,
+      text,
+      isRootComment,
+    };
+  };
+
+  const updateFeedbackText = (text: string) => {
+    editFormValues.value.text = text;
+  };
+
+  // Called from the create mutation's onDone.
+  const resetAfterCreate = () => {
+    commentInProcess.value = false;
+    submitAttempted.value = false;
+    replyFormOpenAtCommentID.value = '';
+  };
+
+  // Called from the update mutation's onDone.
+  const resetAfterUpdate = () => {
+    commentInProcess.value = false;
+    editFormOpenAtCommentID.value = '';
+    commentToEdit.value = null;
+    editFormValues.value = emptyFormValues();
+  };
+
+  return {
+    commentToEdit,
+    commentInProcess,
+    submitAttempted,
+    replyFormOpenAtCommentID,
+    editFormOpenAtCommentID,
+    editFormValues,
+    openReplyEditor,
+    hideReplyEditor,
+    openEditCommentEditor,
+    hideEditCommentEditor,
+    startEditing,
+    updateEditInputValues,
+    updateFeedbackText,
+    resetAfterCreate,
+    resetAfterUpdate,
+  };
+}


### PR DESCRIPTION
## Summary

Maintainability refactor continuing the comment-component cleanup: extract `CommentSection.vue`'s inline editor/form state into a `useCommentFormState()` composable, matching the existing `useCommentX` pattern. **Behavior-preserving** — public props/emits and the template are unchanged. Branched off `main`.

## The change

`CommentSection.vue` (**940 → 899 lines**) held the reply/edit editor state inline: six refs (`commentToEdit`, `commentInProcess`, `submitAttempted`, the reply/edit open-ids, `editFormValues`), the pure open/close transitions (`openReplyEditor`, `handleClickEdit`, …), and the `onDone` reset logic. All of it moves into **`useCommentFormState()`**.

The submit handlers that actually call mutations (`handleClickCreate`, `handleSaveEdit`, `handleDeleteComment`, `handleSubmitFeedback`) **stay in `CommentSection`** and drive the state through the exposed refs; the create/update `onDone` hooks now call `resetAfterCreate()` / `resetAfterUpdate()`.

Handlers keep their template-facing names via destructure aliases (`startEditing` → `handleClickEdit`, `updateFeedbackText` → `updateFeedback`), so **the template is untouched**.

## Why it's a win

- The 940-line component shrinks and the editor state is now readable/testable in isolation.
- Clear seam between *UI state* (composable) and *mutation submission* (component).
- New composable spec: **11 tests, ~100%** — the reset lifecycle and open/close transitions are now unit-tested directly.

## Test plan

- [x] All 33 `CommentSection` unit tests pass (incl. the `realmount` spec)
- [x] New `useCommentFormState` spec — 11 tests, ~100%
- [x] `pnpm run tsc` — clean (only the pre-existing local `Map.vue` `node_modules` drift; CI unaffected)
- [x] `pnpm exec eslint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
