### PR TITLE
perf: trim JS on the discussions critical path (highlight.js, three.js, maps, prefetch)

### DIFF
--- a/components/discussion/form/AlbumImageItem.vue
+++ b/components/discussion/form/AlbumImageItem.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { defineAsyncComponent } from 'vue';
 import { useDisplay } from 'vuetify';
 import XmarkIcon from '@/components/icons/XmarkIcon.vue';
 import TextInput from '@/components/TextInput.vue';
@@ -6,8 +7,13 @@ import FormRow from '@/components/FormRow.vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import ExpandableImage from '@/components/ExpandableImage.vue';
 import ModelViewer from '@/components/ModelViewer.vue';
-import StlViewer from '@/components/download/StlViewer.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
+
+// StlViewer statically imports three.js (~2MB decoded). Load it lazily so that
+// weight is only fetched when an STL image actually renders.
+const StlViewer = defineAsyncComponent(
+  () => import('@/components/download/StlViewer.vue')
+);
 
 type ImageData = {
   id?: string;

--- a/components/event/map/MapView.vue
+++ b/components/event/map/MapView.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, defineAsyncComponent } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { useRouter, useRoute } from 'nuxt/app';
 import { useDisplay } from 'vuetify';
 import EventPreview from '../list/EventPreview.vue';
 import EventList from '../list/EventList.vue';
-import EventMap, { type MarkerMap } from './Map.vue';
+import type { MarkerMap } from './Map.vue';
 import PreviewContainer from '../list/PreviewContainer.vue';
 import CloseButton from '../../CloseButton.vue';
 import ErrorBanner from '../../ErrorBanner.vue';
@@ -29,6 +29,11 @@ import type { Event as EventData } from '@/__generated__/graphql';
 import type { SearchEventValues } from '@/types/Event';
 import type { Ref, PropType } from 'vue';
 import { isEventSearchRoute } from '@/utils/isEventSearchRoute';
+
+// Map.vue statically imports the Google Maps JS API loader + marker clusterer
+// (~840KB decoded). Load it lazily so that weight is only fetched when the map
+// view actually renders, not prefetched with the event routes.
+const EventMap = defineAsyncComponent(() => import('./Map.vue'));
 
 const props = defineProps({
   selectedTags: {

--- a/components/image/ImageListItem.vue
+++ b/components/image/ImageListItem.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
+import { defineAsyncComponent } from 'vue';
 import type { PropType } from 'vue';
 import type { Image } from '@/__generated__/graphql';
 import ModelViewer from '@/components/ModelViewer.vue';
-import StlViewer from '@/components/download/StlViewer.vue';
 import AddToImageFavorites from '@/components/favorites/AddToImageFavorites.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
+
+// StlViewer statically imports three.js (~2MB decoded). Load it lazily so that
+// weight is only fetched when an STL image actually renders, not on every page
+// that shows an image list.
+const StlViewer = defineAsyncComponent(
+  () => import('@/components/download/StlViewer.vue')
+);
 
 const props = defineProps({
   allowAddToList: {

--- a/composables/useMarkdownRenderer.ts
+++ b/composables/useMarkdownRenderer.ts
@@ -1,7 +1,12 @@
 import MarkdownIt from 'markdown-it';
 import type Token from 'markdown-it/lib/token.mjs';
 import type Renderer from 'markdown-it/lib/renderer.mjs';
-import hljs from 'highlight.js';
+// Import the "common" bundle (~37 popular languages) instead of the full
+// highlight.js build (~190 languages). The full build adds ~1.5MB (decoded) of
+// language grammars we never render; `common` covers JS/TS, Python, bash, SQL,
+// JSON, GraphQL, etc. Unknown languages fall back to escaped plain text below,
+// which was already the behavior for any language hljs didn't recognize.
+import hljs from 'highlight.js/lib/common';
 import sanitizeHtml from 'sanitize-html';
 import { generateHeadingId } from '@/utils/markdown';
 import { config } from '@/config';

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -69,6 +69,16 @@ export default defineNuxtConfig({
   },
   experimental: {
     payloadExtraction: false,
+    defaults: {
+      // Default NuxtLink prefetch triggers on viewport visibility, so list
+      // pages (discussions, events, images) speculatively download the route
+      // chunks of every link on screen. Prefetch on hover/focus instead: links
+      // the user actually aims at still load instantly, but we stop pulling
+      // megabytes of route chunks for links that are merely visible.
+      nuxtLink: {
+        prefetchOn: { visibility: false, interaction: true },
+      },
+    },
   },
   compatibilityDate: '2024-04-03',
   components: true,


### PR DESCRIPTION
## Core Web Vitals: trim the JavaScript that loads on the discussions page

Analysis of deployed `topical.space` found the discussions page pulls **~8.4 MB decoded / 2.0 MB brotli of JS across 158 chunks**, with a **2,155 ms longest main-thread task**. The biggest offenders were heavy libraries statically bundled into common/eager paths. These four low-risk changes move them off the critical path. Each was verified with lint, the relevant unit specs, and a full production build.

### Changes

1. **`highlight.js` → `common` bundle** — the markdown renderer imported the full build (~190 language grammars). Switch to `highlight.js/lib/common` (~37 popular languages incl. JS/TS, Python, bash, SQL, JSON, GraphQL). Unknown languages still fall back to escaped plain text (unchanged behavior).
   - Markdown/highlight chunk: **2,098 → 940 KB decoded** (552 → **176 KB brotli**, −68% on the wire).

2. **Lazy-load `StlViewer`** — it statically imports three.js + STLLoader + OrbitControls (~2 MB) and was pulled into every image/album page. Now a `defineAsyncComponent`, so **three.js loads only when an STL image renders**. Verified: the chunk has no static importers, referenced only via dynamic `import()`.

3. **Lazy-load the event `Map`** — Google Maps API + marker clusterer (~840 KB) was `modulepreload` (eager) on the **discussions page** (co-bundled with Apollo/Sentry). Now dynamic — that 840 KB eager chunk decomposed to a **14 KB dynamic-only** chunk.

4. **NuxtLink prefetch on interaction, not visibility** — list pages were speculatively downloading the route chunks of every link on screen. Now prefetch fires on hover/focus (`experimental.defaults.nuxtLink.prefetchOn`).

### Not included
- **Fonts:** I looked at dropping the `Roboto` webfont but it's Vuetify's default theme font (24 Vuetify components render), so removing it changes typography — not a free win. Left as-is.

### Follow-ups (separate PRs)
- Removing Vuetify (biggest remaining CSS + hydration win) — scoped separately.
- Lazy-hydrating list items (targets the 2,155 ms long task).
- Luxon → lighter date lib; SSR route/data caching.

### Reviewer notes
- **highlight.js:** code posted in languages outside the common ~37 (Dockerfile, PowerShell, nginx) now renders unhighlighted — easy to re-add specific languages via `hljs.registerLanguage`.
- **Prefetch:** worth a feel-check that link clicks still feel instant (prefetch now triggers on hover rather than on-visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
