### PR TITLE
refactor(event): extract EventHeader cancel/delete flow to useEventCancelDelete

### DIFF
--- a/components/event/detail/EventHeader.vue
+++ b/components/event/detail/EventHeader.vue
@@ -3,15 +3,9 @@ import { computed, ref } from 'vue';
 import type { PropType } from 'vue';
 import { useMutation, useQuery } from '@vue/apollo-composable';
 import type { Event } from '@/__generated__/graphql';
-import {
-  CANCEL_EVENT,
-  DELETE_EVENT,
-  DELETE_EVENT_IN_SERIES,
-  ADD_FEEDBACK_COMMENT_TO_EVENT,
-  UPDATE_EVENT_IN_SERIES,
-} from '@/graphQLData/event/mutations';
+import { ADD_FEEDBACK_COMMENT_TO_EVENT } from '@/graphQLData/event/mutations';
 import EditScopeModal from '@/components/event/form/EditScopeModal.vue';
-import type { EventEditScope } from '@/components/event/form/EditScopeModal.vue';
+import { useEventCancelDelete } from '@/composables/useEventCancelDelete';
 import CalendarIcon from '@/components/icons/CalendarIcon.vue';
 import LinkIcon from '@/components/icons/LinkIcon.vue';
 import LocationIcon from '@/components/icons/LocationIcon.vue';
@@ -76,15 +70,11 @@ const { forumAdminUsernames, forumModUsernames, forumModProfileNames } =
 const showCopiedLinkNotification = ref(false);
 const showFeedbackFormModal = ref(false);
 const showFeedbackSubmittedSuccessfully = ref(false);
-const confirmDeleteIsOpen = ref(false);
-const confirmCancelIsOpen = ref(false);
 
 // Series-related state
 // Note: EventSeries is a new field that may not be in generated types yet
 const eventDataWithSeries = computed(() => props.eventData as Event & { EventSeries?: { id?: string } });
 const isPartOfSeries = computed(() => Boolean(eventDataWithSeries.value?.EventSeries?.id));
-const showCancelScopeModal = ref(false);
-const showDeleteScopeModal = ref(false);
 const {
   showReportModal: showReportEventModal,
   showArchiveModal,
@@ -229,139 +219,27 @@ const permalinkObject = computed(() => {
   };
 });
 
+// Cancel/delete lifecycle (standalone event vs event-series scoping) lives in a
+// composable that owns the confirm/scope modal state, the four mutations, and
+// their post-action navigation/close side effects.
 const {
-  mutate: deleteEvent,
-  error: deleteEventError,
-  loading: deleteEventLoading,
-  onDone: onDoneDeleting,
-} = useMutation(DELETE_EVENT, {
-  variables: { id: eventId.value },
-  update: (cache) => {
-    cache.modify({
-      fields: {
-        events(existingEventRefs = [], { readField }) {
-          return existingEventRefs.filter(
-            (ref: { __ref?: string }) => readField('id', ref) !== eventId.value
-          );
-        },
-      },
-    });
-  },
-});
-
-onDoneDeleting(() => {
-  if (channelId.value) {
-    router.push({
-      name: 'forums-forumId-events',
-      params: { forumId: channelId.value },
-    });
-  }
-});
-
-const {
-  mutate: cancelEvent,
-  error: cancelEventError,
-  loading: cancelEventLoading,
-  onDone: onDoneCanceling,
-} = useMutation(CANCEL_EVENT, {
-  variables: {
-    updateEventInput: { canceled: true },
-    eventWhere: { id: eventId.value },
-    channelConnections: [],
-    channelDisconnections: [],
-  },
-});
-
-onDoneCanceling(() => {
-  confirmCancelIsOpen.value = false;
-});
-
-// Mutation for canceling events in a series
-const {
-  mutate: cancelEventInSeries,
-  error: cancelEventInSeriesError,
-  loading: cancelEventInSeriesLoading,
-  onDone: onDoneCancelingInSeries,
-} = useMutation(UPDATE_EVENT_IN_SERIES);
-
-onDoneCancelingInSeries(() => {
-  showCancelScopeModal.value = false;
-});
-
-// Combined cancel error
-const combinedCancelError = computed(() => {
-  return cancelEventError.value || cancelEventInSeriesError.value;
-});
-
-// Combined cancel loading
-const combinedCancelLoading = computed(() => {
-  return cancelEventLoading.value || cancelEventInSeriesLoading.value;
-});
-
-// Handle cancel button click - show scope modal if part of series
-function handleCancelClick() {
-  if (isPartOfSeries.value) {
-    showCancelScopeModal.value = true;
-  } else {
-    confirmCancelIsOpen.value = true;
-  }
-}
-
-// Handle cancel scope selection
-function handleCancelScopeConfirm(scope: EventEditScope) {
-  cancelEventInSeries({
-    eventId: eventId.value,
-    scope,
-    eventUpdateInput: { canceled: true },
-    channelConnections: [],
-    channelDisconnections: [],
-  });
-}
-
-// Mutation for deleting events in a series
-const {
-  mutate: deleteEventInSeriesMutation,
-  error: deleteEventInSeriesError,
-  loading: deleteEventInSeriesLoading,
-  onDone: onDoneDeletingInSeries,
-} = useMutation(DELETE_EVENT_IN_SERIES);
-
-onDoneDeletingInSeries(() => {
-  showDeleteScopeModal.value = false;
-  if (channelId.value) {
-    router.push({
-      name: 'forums-forumId-events',
-      params: { forumId: channelId.value },
-    });
-  }
-});
-
-// Combined delete error
-const combinedDeleteError = computed(() => {
-  return deleteEventError.value || deleteEventInSeriesError.value;
-});
-
-// Combined delete loading
-const combinedDeleteLoading = computed(() => {
-  return deleteEventLoading.value || deleteEventInSeriesLoading.value;
-});
-
-// Handle delete button click - show scope modal if part of series
-function handleDeleteClick() {
-  if (isPartOfSeries.value) {
-    showDeleteScopeModal.value = true;
-  } else {
-    confirmDeleteIsOpen.value = true;
-  }
-}
-
-// Handle delete scope selection
-function handleDeleteScopeConfirm(scope: EventEditScope) {
-  deleteEventInSeriesMutation({
-    eventId: eventId.value,
-    scope,
-  });
-}
+  confirmDeleteIsOpen,
+  confirmCancelIsOpen,
+  showCancelScopeModal,
+  showDeleteScopeModal,
+  deleteEvent,
+  cancelEvent,
+  deleteEventError,
+  cancelEventError,
+  combinedCancelError,
+  combinedCancelLoading,
+  combinedDeleteError,
+  combinedDeleteLoading,
+  handleCancelClick,
+  handleCancelScopeConfirm,
+  handleDeleteClick,
+  handleDeleteScopeConfirm,
+} = useEventCancelDelete({ eventId, channelId, isPartOfSeries });
 
 const {
   mutate: addFeedbackCommentToEvent,

--- a/composables/useEventCancelDelete.spec.ts
+++ b/composables/useEventCancelDelete.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import { asMock, createMutationRouter } from '@/tests/utils/mockApollo';
+import { useEventCancelDelete } from './useEventCancelDelete';
+
+const pushSpy = vi.fn();
+vi.mock('@vue/apollo-composable', () => ({ useMutation: vi.fn() }));
+vi.mock('nuxt/app', () => ({ useRouter: () => ({ push: pushSpy }) }));
+
+const router = createMutationRouter([
+  'updateEventInSeries',
+  'cancelEvent',
+  'deleteEvent',
+  'deleteEventInSeries',
+]);
+
+const setup = (opts: {
+  eventId?: string;
+  channelId?: string;
+  isPartOfSeries?: boolean;
+} = {}) => {
+  const { eventId = 'e1', channelId = 'cats', isPartOfSeries = false } = opts;
+  return useEventCancelDelete({
+    eventId: ref(eventId),
+    channelId: ref(channelId),
+    isPartOfSeries: ref(isPartOfSeries),
+  });
+};
+
+beforeEach(() => {
+  router.reset();
+  pushSpy.mockReset();
+  asMock(useMutation).mockImplementation(router.useMutation);
+});
+
+describe('useEventCancelDelete — scope routing', () => {
+  it('opens the plain delete confirm for a standalone event', () => {
+    const s = setup({ isPartOfSeries: false });
+    s.handleDeleteClick();
+    expect([s.confirmDeleteIsOpen.value, s.showDeleteScopeModal.value]).toEqual([
+      true,
+      false,
+    ]);
+  });
+
+  it('opens the delete scope modal for a series event', () => {
+    const s = setup({ isPartOfSeries: true });
+    s.handleDeleteClick();
+    expect([s.showDeleteScopeModal.value, s.confirmDeleteIsOpen.value]).toEqual([
+      true,
+      false,
+    ]);
+  });
+
+  it('opens the plain cancel confirm for a standalone event', () => {
+    const s = setup({ isPartOfSeries: false });
+    s.handleCancelClick();
+    expect(s.confirmCancelIsOpen.value).toBe(true);
+  });
+
+  it('opens the cancel scope modal for a series event', () => {
+    const s = setup({ isPartOfSeries: true });
+    s.handleCancelClick();
+    expect(s.showCancelScopeModal.value).toBe(true);
+  });
+});
+
+describe('useEventCancelDelete — series confirm handlers', () => {
+  it('deletes the chosen scope of the series', () => {
+    const s = setup();
+    s.handleDeleteScopeConfirm('thisEvent' as never);
+    expect(router.get('deleteEventInSeries').mutate).toHaveBeenCalledWith({
+      eventId: 'e1',
+      scope: 'thisEvent',
+    });
+  });
+
+  it('cancels the chosen scope of the series', () => {
+    const s = setup();
+    s.handleCancelScopeConfirm('allEvents' as never);
+    expect(router.get('updateEventInSeries').mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: 'e1', scope: 'allEvents' })
+    );
+  });
+});
+
+describe('useEventCancelDelete — post-action side effects', () => {
+  it('navigates to the forum event list after a delete completes', () => {
+    setup({ channelId: 'cats' });
+    router.get('deleteEvent').fireDone();
+    expect(pushSpy).toHaveBeenCalledWith({
+      name: 'forums-forumId-events',
+      params: { forumId: 'cats' },
+    });
+  });
+
+  it('does not navigate after delete when there is no channel', () => {
+    setup({ channelId: '' });
+    router.get('deleteEvent').fireDone();
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('closes the cancel confirm after a cancel completes', () => {
+    const s = setup();
+    s.confirmCancelIsOpen.value = true;
+    router.get('cancelEvent').fireDone();
+    expect(s.confirmCancelIsOpen.value).toBe(false);
+  });
+
+  it('closes the cancel scope modal after an in-series cancel completes', () => {
+    const s = setup({ isPartOfSeries: true });
+    s.showCancelScopeModal.value = true;
+    router.get('updateEventInSeries').fireDone();
+    expect(s.showCancelScopeModal.value).toBe(false);
+  });
+
+  it('closes the delete scope modal and navigates after an in-series delete', () => {
+    const s = setup({ isPartOfSeries: true, channelId: 'cats' });
+    s.showDeleteScopeModal.value = true;
+    router.get('deleteEventInSeries').fireDone();
+    expect([s.showDeleteScopeModal.value, pushSpy.mock.calls.length]).toEqual([
+      false,
+      1,
+    ]);
+  });
+});
+
+describe('useEventCancelDelete — cache + combined state', () => {
+  it('removes the deleted event from the cached events list', () => {
+    setup({ eventId: 'e1' });
+    let eventsFn: (refs: unknown[], h: unknown) => unknown[] = () => [];
+    const cache = {
+      modify: vi.fn((opts: any) => {
+        eventsFn = opts.fields.events;
+      }),
+    };
+    router.get('deleteEvent').update!(cache, {});
+    const remaining = eventsFn([{ __ref: 'e1' }, { __ref: 'e2' }], {
+      readField: (_f: string, r: { __ref: string }) => r.__ref,
+    });
+    expect(remaining).toEqual([{ __ref: 'e2' }]);
+  });
+
+  it('surfaces either delete error via combinedDeleteError', () => {
+    const s = setup();
+    router.get('deleteEventInSeries').error.value = new Error('series boom');
+    expect(s.combinedDeleteError.value?.message).toBe('series boom');
+  });
+
+  it('reports combinedCancelLoading when either cancel mutation is loading', () => {
+    const s = setup();
+    router.get('updateEventInSeries').loading.value = true;
+    expect(s.combinedCancelLoading.value).toBe(true);
+  });
+});

--- a/composables/useEventCancelDelete.ts
+++ b/composables/useEventCancelDelete.ts
@@ -1,0 +1,176 @@
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
+import { useMutation } from '@vue/apollo-composable';
+import { useRouter } from 'nuxt/app';
+import {
+  DELETE_EVENT,
+  CANCEL_EVENT,
+  UPDATE_EVENT_IN_SERIES,
+  DELETE_EVENT_IN_SERIES,
+} from '@/graphQLData/event/mutations';
+import type { EventEditScope } from '@/components/event/form/EditScopeModal.vue';
+
+type MaybeRef<T> = Ref<T> | ComputedRef<T>;
+
+/**
+ * Cancel/delete lifecycle for an event, including the standalone-event vs
+ * event-series scoping. Owns the confirm/scope modal state, the four mutations
+ * (delete, cancel, and their in-series variants) with their post-action
+ * navigation/close side effects, and the combined error/loading for the modals.
+ * Extracted from EventHeader.vue so this destructive-action flow is readable and
+ * unit-testable on its own.
+ */
+export function useEventCancelDelete(params: {
+  eventId: MaybeRef<string>;
+  channelId: MaybeRef<string>;
+  isPartOfSeries: MaybeRef<boolean>;
+}) {
+  const { eventId, channelId, isPartOfSeries } = params;
+  const router = useRouter();
+
+  const confirmDeleteIsOpen = ref(false);
+  const confirmCancelIsOpen = ref(false);
+  const showCancelScopeModal = ref(false);
+  const showDeleteScopeModal = ref(false);
+
+  const {
+    mutate: deleteEvent,
+    error: deleteEventError,
+    loading: deleteEventLoading,
+    onDone: onDoneDeleting,
+  } = useMutation(DELETE_EVENT, {
+    variables: { id: eventId.value },
+    update: (cache) => {
+      cache.modify({
+        fields: {
+          events(existingEventRefs = [], { readField }) {
+            return existingEventRefs.filter(
+              (ref: { __ref?: string }) => readField('id', ref) !== eventId.value
+            );
+          },
+        },
+      });
+    },
+  });
+
+  onDoneDeleting(() => {
+    if (channelId.value) {
+      router.push({
+        name: 'forums-forumId-events',
+        params: { forumId: channelId.value },
+      });
+    }
+  });
+
+  const {
+    mutate: cancelEvent,
+    error: cancelEventError,
+    loading: cancelEventLoading,
+    onDone: onDoneCanceling,
+  } = useMutation(CANCEL_EVENT, {
+    variables: {
+      updateEventInput: { canceled: true },
+      eventWhere: { id: eventId.value },
+      channelConnections: [],
+      channelDisconnections: [],
+    },
+  });
+
+  onDoneCanceling(() => {
+    confirmCancelIsOpen.value = false;
+  });
+
+  const {
+    mutate: cancelEventInSeries,
+    error: cancelEventInSeriesError,
+    loading: cancelEventInSeriesLoading,
+    onDone: onDoneCancelingInSeries,
+  } = useMutation(UPDATE_EVENT_IN_SERIES);
+
+  onDoneCancelingInSeries(() => {
+    showCancelScopeModal.value = false;
+  });
+
+  const combinedCancelError = computed(
+    () => cancelEventError.value || cancelEventInSeriesError.value
+  );
+  const combinedCancelLoading = computed(
+    () => cancelEventLoading.value || cancelEventInSeriesLoading.value
+  );
+
+  // Show the scope modal for a series event, otherwise the plain confirm modal.
+  function handleCancelClick() {
+    if (isPartOfSeries.value) {
+      showCancelScopeModal.value = true;
+    } else {
+      confirmCancelIsOpen.value = true;
+    }
+  }
+
+  function handleCancelScopeConfirm(scope: EventEditScope) {
+    cancelEventInSeries({
+      eventId: eventId.value,
+      scope,
+      eventUpdateInput: { canceled: true },
+      channelConnections: [],
+      channelDisconnections: [],
+    });
+  }
+
+  const {
+    mutate: deleteEventInSeriesMutation,
+    error: deleteEventInSeriesError,
+    loading: deleteEventInSeriesLoading,
+    onDone: onDoneDeletingInSeries,
+  } = useMutation(DELETE_EVENT_IN_SERIES);
+
+  onDoneDeletingInSeries(() => {
+    showDeleteScopeModal.value = false;
+    if (channelId.value) {
+      router.push({
+        name: 'forums-forumId-events',
+        params: { forumId: channelId.value },
+      });
+    }
+  });
+
+  const combinedDeleteError = computed(
+    () => deleteEventError.value || deleteEventInSeriesError.value
+  );
+  const combinedDeleteLoading = computed(
+    () => deleteEventLoading.value || deleteEventInSeriesLoading.value
+  );
+
+  function handleDeleteClick() {
+    if (isPartOfSeries.value) {
+      showDeleteScopeModal.value = true;
+    } else {
+      confirmDeleteIsOpen.value = true;
+    }
+  }
+
+  function handleDeleteScopeConfirm(scope: EventEditScope) {
+    deleteEventInSeriesMutation({
+      eventId: eventId.value,
+      scope,
+    });
+  }
+
+  return {
+    confirmDeleteIsOpen,
+    confirmCancelIsOpen,
+    showCancelScopeModal,
+    showDeleteScopeModal,
+    deleteEvent,
+    cancelEvent,
+    deleteEventError,
+    cancelEventError,
+    combinedCancelError,
+    combinedCancelLoading,
+    combinedDeleteError,
+    combinedDeleteLoading,
+    handleCancelClick,
+    handleCancelScopeConfirm,
+    handleDeleteClick,
+    handleDeleteScopeConfirm,
+  };
+}


### PR DESCRIPTION
## Summary

Continuing the component-extraction maintainability work: pull `EventHeader.vue`'s inline event **cancel/delete lifecycle** into a `useEventCancelDelete()` composable, matching the existing `useEventX`/`useCommentX` pattern. **Behavior-preserving** — public props/emits and the template are unchanged. Branched off `main`.

## The change

`EventHeader.vue` (**754 → 632 lines**) inlined the entire cancel/delete flow: four mutations (`DELETE_EVENT`, `CANCEL_EVENT`, and their in-series `UPDATE_EVENT_IN_SERIES` / `DELETE_EVENT_IN_SERIES` variants with `scope`), their `onDone` side effects (navigate to the forum event list, close the confirm/scope modals), the four confirm/scope modal refs, and the combined error/loading computeds. All of it moves into:

**`useEventCancelDelete({ eventId, channelId, isPartOfSeries })`** — owns the modal state and returns the same names the template already binds (`deleteEvent`, `cancelEvent`, `handleDeleteClick`, `confirmDeleteIsOpen`, `combinedDeleteLoading`, …), so the template is untouched.

## Why it's a win

- The 754-line header shrinks, and the destructive-action logic is now readable in one place.
- That flow was previously hard to test while buried in the header. The composable spec covers it directly — **14 tests, 95%**: the standalone-vs-series scope routing, the post-action navigation, the modal-close side effects, and the events-list cache eviction.

## Test plan

- [x] All 19 `EventHeader` unit tests still pass
- [x] New `useEventCancelDelete` spec — 14 tests, 95%
- [x] `pnpm run tsc` — clean (only the pre-existing local `Map.vue` `node_modules` drift; CI unaffected). Ran tsc as the *last* step before commit (per the #326 lesson).
- [x] `pnpm exec eslint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
