### PR TITLE
fix(discussion): dark-mode background for inline comment input

### DIFF
--- a/components/discussion/form/InlineCommentForm.vue
+++ b/components/discussion/form/InlineCommentForm.vue
@@ -450,7 +450,7 @@ const applyModSuggestion = (value: string) => {
           <textarea
             ref="inlineTextarea"
             data-testid="discussion-inline-comment"
-            class="bg-transparent min-h-[44px] flex-1 resize-none text-sm text-gray-900 placeholder-gray-500 outline-none focus:outline-none focus:ring-0 focus-visible:outline-none dark:text-gray-100 dark:placeholder-gray-400"
+            class="min-h-[44px] flex-1 resize-none bg-white text-sm text-gray-900 placeholder-gray-500 outline-none focus:outline-none focus:ring-0 focus-visible:outline-none dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400"
             name="discussionInlineComment"
             :rows="1"
             placeholder="Join the discussion..."
@@ -532,7 +532,7 @@ const applyModSuggestion = (value: string) => {
           class="flex w-full items-center gap-3 rounded-lg border border-orange-400 bg-white px-3 py-2 dark:bg-gray-900"
         >
           <textarea
-            class="bg-transparent min-h-[44px] flex-1 resize-none text-sm text-gray-500 placeholder-gray-500 outline-none focus:outline-none focus:ring-0 focus-visible:outline-none dark:text-gray-400 dark:placeholder-gray-500"
+            class="min-h-[44px] flex-1 resize-none bg-white text-sm text-gray-500 placeholder-gray-500 outline-none focus:outline-none focus:ring-0 focus-visible:outline-none dark:bg-gray-900 dark:text-gray-400 dark:placeholder-gray-500"
             name="discussionInlineComment"
             :rows="1"
             placeholder="Join the discussion..."


### PR DESCRIPTION
## Problem

On the discussion detail page, the **"Join the discussion…" input rendered white in dark mode**.

## Root cause

The `InlineCommentForm` textareas used `bg-transparent` to blend into their dark container. After the Vuetify removal (#332) that class became a no-op:

- `.bg-transparent` **is not generated** in this project's Tailwind build (verified at runtime — no such rule in the loaded stylesheets), so it does nothing.
- `@tailwindcss/forms` injects a base rule `textarea, input, select { background-color: #fff }`, which then wins.

Vuetify's old global CSS reset had been masking this; removing it exposed the white background.

## Fix

Replace `bg-transparent` with `bg-white dark:bg-gray-900` on both the authenticated and unauthenticated textareas, matching their parent containers exactly — seamless in both themes, and the same pattern the search input already uses.

## Verification

Ran the app locally and inspected the live element in dark mode:
- Before: textarea computed background `rgb(255,255,255)` (white) inside a `rgb(13,17,23)` container.
- After: textarea computed background `rgb(13,17,23)`, matching the container.

`tsc`, `eslint`, and the unit suite pass (via the pre-commit `verify` hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)