### PR TITLE
test: cover four more previously-untested components

### DIFF
--- a/components/channel/ChannelHeaderDesktop.spec.ts
+++ b/components/channel/ChannelHeaderDesktop.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ChannelHeaderDesktop from './ChannelHeaderDesktop.vue';
+
+const mountHeader = (channel: Record<string, unknown>) =>
+  mount(ChannelHeaderDesktop, {
+    props: {
+      adminList: [],
+      channelId: 'cats',
+      channel,
+      route: {},
+      showCreateButton: false,
+    },
+  });
+
+describe('ChannelHeaderDesktop', () => {
+  it('renders the banner image when the channel has a banner URL', () => {
+    const wrapper = mountHeader({ channelBannerURL: 'https://img/banner.png' });
+    expect(wrapper.find('img').attributes('src')).toBe(
+      'https://img/banner.png'
+    );
+  });
+
+  it('renders no banner image when the channel has no banner URL', () => {
+    const wrapper = mountHeader({ channelBannerURL: null });
+    expect(wrapper.find('img').exists()).toBe(false);
+  });
+});

--- a/components/nav/TopNavLink.spec.ts
+++ b/components/nav/TopNavLink.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import TopNavLink from './TopNavLink.vue';
+
+const mountLink = (slot = '') =>
+  mountWithDefaults(TopNavLink, {
+    props: { to: '/forums', label: 'Forums' },
+    slots: slot ? { default: slot } : {},
+  });
+
+describe('TopNavLink', () => {
+  it('renders the label', () => {
+    expect(mountLink().text()).toContain('Forums');
+  });
+
+  it('links to the target route', () => {
+    expect(mountLink().find('a').attributes('href')).toBe('/forums');
+  });
+
+  it('renders the default slot content', () => {
+    expect(mountLink('<span class="icon">icon</span>').find('.icon').exists()).toBe(
+      true
+    );
+  });
+});

--- a/components/text-editor/BotSuggestionsPopover.spec.ts
+++ b/components/text-editor/BotSuggestionsPopover.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import BotSuggestionsPopover from './BotSuggestionsPopover.vue';
+import type { BotSuggestion } from '@/utils/botMentions';
+
+const suggestion = (overrides: Partial<BotSuggestion> = {}): BotSuggestion => ({
+  value: 'bot-1',
+  label: 'Bot One',
+  mention: '@bot-one',
+  displayName: 'Bot One',
+  ...overrides,
+});
+
+const three: BotSuggestion[] = [
+  suggestion({ value: 'a', mention: '@a', displayName: 'Alpha' }),
+  suggestion({ value: 'b', mention: '@b', displayName: 'Bravo' }),
+  suggestion({ value: 'c', mention: '@c', displayName: 'Charlie' }),
+];
+
+const mountPopover = (
+  suggestions: BotSuggestion[] = three,
+  activeIndex?: number
+) =>
+  mount(BotSuggestionsPopover, {
+    props: { suggestions, style: {}, activeIndex },
+  });
+
+describe('BotSuggestionsPopover', () => {
+  it('renders one button per suggestion', () => {
+    expect(mountPopover().findAll('button')).toHaveLength(3);
+  });
+
+  it('shows the mention text for a suggestion', () => {
+    expect(mountPopover().findAll('button')[0]!.text()).toContain('@a');
+  });
+
+  it('shows the display name when present', () => {
+    expect(mountPopover().findAll('button')[0]!.text()).toContain('Alpha');
+  });
+
+  it('omits the display name span when absent', () => {
+    const wrapper = mountPopover([suggestion({ mention: '@x', displayName: null })]);
+    expect(wrapper.findAll('span')).toHaveLength(1);
+  });
+
+  it('emits select with the clicked suggestion', async () => {
+    const wrapper = mountPopover();
+    await wrapper.findAll('button')[1]!.trigger('click');
+    expect(wrapper.emitted('select')![0]).toEqual([three[1]]);
+  });
+
+  it('highlights the active suggestion', () => {
+    const wrapper = mountPopover(three, 1);
+    expect(wrapper.findAll('button')[1]!.classes()).toContain('border-orange-400');
+  });
+
+  it('highlights the first suggestion by default when another is active', () => {
+    const wrapper = mountPopover(three, 1);
+    expect(wrapper.findAll('button')[0]!.classes()).toContain('bg-orange-50');
+  });
+
+  it('renders a non-active, non-first suggestion plainly', () => {
+    const wrapper = mountPopover(three, 1);
+    expect(wrapper.findAll('button')[2]!.classes()).toContain('bg-white');
+  });
+});

--- a/components/text-editor/ModSuggestionsPopover.spec.ts
+++ b/components/text-editor/ModSuggestionsPopover.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ModSuggestionsPopover from './ModSuggestionsPopover.vue';
+import type { ModSuggestion } from '@/utils/modMentions';
+
+const suggestion = (overrides: Partial<ModSuggestion> = {}): ModSuggestion => ({
+  value: 'mod-1',
+  label: 'Mod One',
+  mention: '@mod-one',
+  username: 'modone',
+  ...overrides,
+});
+
+const three: ModSuggestion[] = [
+  suggestion({ value: 'a', mention: '@a', username: 'alpha' }),
+  suggestion({ value: 'b', mention: '@b', username: 'bravo' }),
+  suggestion({ value: 'c', mention: '@c', username: 'charlie' }),
+];
+
+const mountPopover = (
+  suggestions: ModSuggestion[] = three,
+  activeIndex?: number
+) =>
+  mount(ModSuggestionsPopover, {
+    props: { suggestions, style: {}, activeIndex },
+  });
+
+describe('ModSuggestionsPopover', () => {
+  it('renders one button per suggestion', () => {
+    expect(mountPopover().findAll('button')).toHaveLength(3);
+  });
+
+  it('shows the mention text for a suggestion', () => {
+    expect(mountPopover().findAll('button')[0]!.text()).toContain('@a');
+  });
+
+  it('shows the username when present', () => {
+    expect(mountPopover().findAll('button')[0]!.text()).toContain('@alpha');
+  });
+
+  it('omits the username span when absent', () => {
+    const wrapper = mountPopover([suggestion({ mention: '@x', username: null })]);
+    expect(wrapper.findAll('span')).toHaveLength(1);
+  });
+
+  it('emits select with the clicked suggestion', async () => {
+    const wrapper = mountPopover();
+    await wrapper.findAll('button')[1]!.trigger('click');
+    expect(wrapper.emitted('select')![0]).toEqual([three[1]]);
+  });
+
+  it('highlights the active suggestion', () => {
+    const wrapper = mountPopover(three, 1);
+    expect(wrapper.findAll('button')[1]!.classes()).toContain('border-blue-400');
+  });
+
+  it('highlights the first suggestion by default when another is active', () => {
+    const wrapper = mountPopover(three, 1);
+    expect(wrapper.findAll('button')[0]!.classes()).toContain('bg-blue-50');
+  });
+
+  it('renders a non-active, non-first suggestion plainly', () => {
+    const wrapper = mountPopover(three, 1);
+    expect(wrapper.findAll('button')[2]!.classes()).toContain('bg-white');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #334 — adds unit specs for four more components that **no spec previously referenced**, continuing the push toward 90% combined coverage. Each mounts the real component and drives its own logic. Rebased on current `main` (post-Vuetify-removal #332).

## Components covered

| Component | What's tested |
|---|---|
| `text-editor/BotSuggestionsPopover.vue` | one button per suggestion, `select` emit on click, optional `displayName` label, and the active / first-by-default / plain styling branches |
| `text-editor/ModSuggestionsPopover.vue` | same, with the `@username` secondary label |
| `channel/ChannelHeaderDesktop.vue` | banner image shown/hidden by `channelBannerURL` |
| `nav/TopNavLink.vue` | label, target href, default slot |

All four land at **100%** statements / lines / functions / branches.

## Verification

- `vitest run` — **21/21 pass**.
- `eslint` — clean.
- `tsc` — **0 errors** (full project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)