### PR TITLE
test: cover four more untested nav/avatar/plugin components

### DIFF
--- a/components/admin/plugins/PluginReadmeSection.spec.ts
+++ b/components/admin/plugins/PluginReadmeSection.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PluginReadmeSection from './PluginReadmeSection.vue';
+
+const stubs = {
+  FormRow: {
+    name: 'FormRow',
+    props: ['sectionTitle'],
+    template: '<div class="form-row"><slot name="content" /></div>',
+  },
+  MarkdownRenderer: {
+    name: 'MarkdownRenderer',
+    props: ['text', 'fontSize'],
+    template: '<div class="markdown">{{ text }}</div>',
+  },
+};
+
+const mountSection = (props: {
+  pluginReadme: string | null;
+  pluginDetailLoading: boolean;
+}) => mount(PluginReadmeSection, { props, global: { stubs } });
+
+describe('PluginReadmeSection', () => {
+  it('renders nothing when there is no readme and it is not loading', () => {
+    const wrapper = mountSection({ pluginReadme: null, pluginDetailLoading: false });
+    expect(wrapper.findComponent({ name: 'FormRow' }).exists()).toBe(false);
+  });
+
+  it('shows the loading state while the readme is loading', () => {
+    const wrapper = mountSection({ pluginReadme: null, pluginDetailLoading: true });
+    expect(wrapper.text()).toContain('Loading documentation');
+  });
+
+  it('renders the readme through the markdown renderer', () => {
+    const wrapper = mountSection({
+      pluginReadme: '# Docs',
+      pluginDetailLoading: false,
+    });
+    expect(wrapper.findComponent({ name: 'MarkdownRenderer' }).props('text')).toBe(
+      '# Docs'
+    );
+  });
+
+  it('shows the readme (not the spinner) when a readme is present even while loading', () => {
+    const wrapper = mountSection({
+      pluginReadme: '# Docs',
+      pluginDetailLoading: true,
+    });
+    expect(wrapper.text()).not.toContain('Loading documentation');
+  });
+});

--- a/components/comments/LoggedInUserAvatar.spec.ts
+++ b/components/comments/LoggedInUserAvatar.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import LoggedInUserAvatar from './LoggedInUserAvatar.vue';
+
+const { query } = vi.hoisted(() => ({ query: { result: { value: null as unknown } } }));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(() => ({ result: query.result })),
+}));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => ref('alice'),
+}));
+
+const AvatarStub = {
+  name: 'AvatarComponent',
+  props: ['text', 'src', 'isSmall'],
+  template: '<div class="avatar" />',
+};
+
+const mountAvatar = () =>
+  mount(LoggedInUserAvatar, {
+    global: { stubs: { AvatarComponent: AvatarStub } },
+  });
+
+const avatar = (wrapper: ReturnType<typeof mountAvatar>) =>
+  wrapper.findComponent({ name: 'AvatarComponent' });
+
+beforeEach(() => {
+  query.result.value = null;
+});
+
+describe('LoggedInUserAvatar', () => {
+  it('passes the current username to the avatar', () => {
+    expect(avatar(mountAvatar()).props('text')).toBe('alice');
+  });
+
+  it('passes the profile picture URL from the query', () => {
+    query.result.value = { users: [{ profilePicURL: 'https://img/pic.png' }] };
+    expect(avatar(mountAvatar()).props('src')).toBe('https://img/pic.png');
+  });
+
+  it('falls back to an empty src when the user has no profile picture', () => {
+    query.result.value = { users: [{ profilePicURL: null }] };
+    expect(avatar(mountAvatar()).props('src')).toBe('');
+  });
+
+  it('falls back to an empty src when the query has no result', () => {
+    expect(avatar(mountAvatar()).props('src')).toBe('');
+  });
+});

--- a/components/nav/SiteSidenavLogin.spec.ts
+++ b/components/nav/SiteSidenavLogin.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import SiteSidenavLogin from './SiteSidenavLogin.vue';
+
+const { auth } = vi.hoisted(() => ({ auth: { value: true } }));
+const logoutSpy = vi.fn();
+
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => ref(auth.value),
+  useUsername: () => ref('alice'),
+}));
+vi.mock('@/composables/useServerLogout', () => ({
+  useServerLogout: () => ({ logout: logoutSpy }),
+}));
+
+const mountLogin = () => mountWithDefaults(SiteSidenavLogin);
+
+const link = (wrapper: ReturnType<typeof mountLogin>) =>
+  wrapper.find('[data-testid="sign-out-link"]');
+
+beforeEach(() => {
+  auth.value = true;
+  logoutSpy.mockReset();
+});
+
+describe('SiteSidenavLogin', () => {
+  it('renders the sign-out link when authenticated', () => {
+    expect(link(mountLogin()).text()).toContain('Sign Out');
+  });
+
+  it('renders nothing when not authenticated', () => {
+    auth.value = false;
+    expect(link(mountLogin()).exists()).toBe(false);
+  });
+
+  it('logs out when the link is clicked', async () => {
+    const wrapper = mountLogin();
+    await link(wrapper).trigger('click');
+    expect(logoutSpy).toHaveBeenCalled();
+  });
+});

--- a/components/nav/SiteSidenavLogout.spec.ts
+++ b/components/nav/SiteSidenavLogout.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import SiteSidenavLogout from './SiteSidenavLogout.vue';
+
+const { auth } = vi.hoisted(() => ({ auth: { value: true } }));
+const logoutSpy = vi.fn();
+
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => ref(auth.value),
+  useUsername: () => ref('alice'),
+}));
+vi.mock('@/composables/useServerLogout', () => ({
+  useServerLogout: () => ({ logout: logoutSpy }),
+}));
+
+const mountLogout = (props: Record<string, unknown> = {}) =>
+  mountWithDefaults(SiteSidenavLogout, { props });
+
+const link = (wrapper: ReturnType<typeof mountLogout>) =>
+  wrapper.find('[data-testid="sign-out-link"]');
+
+beforeEach(() => {
+  auth.value = true;
+  logoutSpy.mockReset();
+});
+
+describe('SiteSidenavLogout', () => {
+  it('renders the sign-out link when authenticated', () => {
+    expect(link(mountLogout()).exists()).toBe(true);
+  });
+
+  it('renders nothing when not authenticated', () => {
+    auth.value = false;
+    expect(link(mountLogout()).exists()).toBe(false);
+  });
+
+  it('shows the icon when showIconOnly is set', () => {
+    expect(mountLogout({ showIconOnly: true }).find('svg').exists()).toBe(true);
+  });
+
+  it('shows the text label when not icon-only', () => {
+    expect(mountLogout({ showIconOnly: false }).text()).toContain('Sign Out');
+  });
+
+  it('logs out when the link is clicked', async () => {
+    const wrapper = mountLogout();
+    await link(wrapper).trigger('click');
+    expect(logoutSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Third batch of specs for components that **no spec previously referenced** (found via a static "untested component" census), continuing the push toward 90% combined coverage. Each mounts the real component and drives its own logic. Branched off current `main` (post-Vuetify-removal).

## Components covered

| Component | What's tested |
|---|---|
| `nav/SiteSidenavLogout.vue` | sign-out link shown only when authenticated, icon vs. text (`showIconOnly`), logout on click |
| `nav/SiteSidenavLogin.vue` | sign-out link auth gating + logout on click |
| `comments/LoggedInUserAvatar.vue` | `profilePicURL` computed from the user query (URL / null / no-result fallbacks), username passthrough |
| `admin/plugins/PluginReadmeSection.vue` | hidden (no readme, not loading) / loading-spinner / readme-rendered branches |

All land at **100% lines** (PluginReadmeSection 90% branches — one unreachable `|| ''` fallback).

## Notes

- The two sidenav components mock `useAuthState` / `useServerLogout`; the auth ref is driven by a hoisted holder so both the authenticated and unauthenticated branches render.
- `LoggedInUserAvatar` uses a controllable `useQuery` mock and stubs `AvatarComponent` to assert the props it receives.

## Verification

- `vitest run` — **16/16 pass**.
- `eslint` — clean.
- `tsc` — **0 errors** (full project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)