### PR TITLE
Improve core web vitals by deferring secondary discussion UI

### DIFF
--- a/components/channel/DownloadList.vue
+++ b/components/channel/DownloadList.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, watch } from 'vue';
+import {
+  computed,
+  ref,
+  onMounted,
+  watch,
+  defineAsyncComponent,
+} from 'vue';
 import { useRoute } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import { useUIStore } from '@/stores/uiStore';
@@ -9,7 +15,6 @@ import DownloadSkeletonCard from '@/components/download/DownloadSkeletonCard.vue
 import LoadMore from '../LoadMore.vue';
 import ErrorBanner from '../ErrorBanner.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
-import DiscussionAlbum from '@/components/discussion/detail/DiscussionAlbum.vue';
 import { GET_DISCUSSIONS_WITH_DISCUSSION_CHANNEL_DATA } from '@/graphQLData/discussion/queries';
 import { useUsername } from '@/composables/useAuthState';
 import { provideForumRoleMembership } from '@/composables/useForumRoleMembership';
@@ -20,6 +25,10 @@ import {
 } from '@/utils/getSortFromQuery';
 import { convertUrlParamsToLabelFilters } from '@/utils/downloadFilters';
 import type { Discussion, Album, FilterGroup } from '@/__generated__/graphql';
+
+const DiscussionAlbum = defineAsyncComponent(
+  () => import('@/components/discussion/detail/DiscussionAlbum.vue')
+);
 
 const usernameVar = useUsername();
 

--- a/components/collection/AddToListModalHost.vue
+++ b/components/collection/AddToListModalHost.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import AddToListPopover from '@/components/collection/AddToListPopover.vue';
+import { computed, defineAsyncComponent } from 'vue';
 import { useAddToListModalStore } from '@/stores/addToListModalStore';
+
+const AddToListPopover = defineAsyncComponent(
+  () => import('@/components/collection/AddToListPopover.vue')
+);
 
 const modalStore = useAddToListModalStore();
 

--- a/components/comments/NewEmojiButton.vue
+++ b/components/comments/NewEmojiButton.vue
@@ -1,9 +1,14 @@
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { ref, defineAsyncComponent } from 'vue';
 import VoteButton from '@/components/VoteButton.vue';
-import FloatingDropdown from '@/components/FloatingDropdown.vue';
-import EmojiPicker from '@/components/comments/EmojiPicker.vue';
 import FaceSmileIcon from '@/components/icons/FaceSmileIcon.vue';
+
+const FloatingDropdown = defineAsyncComponent(
+  () => import('@/components/FloatingDropdown.vue')
+);
+const EmojiPicker = defineAsyncComponent(
+  () => import('@/components/comments/EmojiPicker.vue')
+);
 
 const props = defineProps({
   commentId: {

--- a/components/discussion/detail/DiscussionAlbum.vue
+++ b/components/discussion/detail/DiscussionAlbum.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { PropType } from 'vue';
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, defineAsyncComponent } from 'vue';
 import { useRoute } from 'nuxt/app';
 import LeftArrowIcon from '@/components/icons/LeftArrowIcon.vue';
 import RightArrowIcon from '@/components/icons/RightArrowIcon.vue';
@@ -15,8 +15,11 @@ import { useUsername } from '@/composables/useAuthState';
 import ModelViewer from '@/components/ModelViewer.vue';
 import StlViewer from '@/components/download/StlViewer.vue';
 import CarouselThumbnail from '@/components/discussion/detail/CarouselThumbnail.vue';
-import ImageLightbox from '@/components/discussion/detail/ImageLightbox.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
+
+const ImageLightbox = defineAsyncComponent(
+  () => import('@/components/discussion/detail/ImageLightbox.vue')
+);
 
 const usernameVar = useUsername();
 

--- a/components/discussion/detail/DiscussionDetailContent.vue
+++ b/components/discussion/detail/DiscussionDetailContent.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch, defineAsyncComponent } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
 import {
@@ -28,8 +28,6 @@ import DiscussionChannelLinks from '@/components/discussion/detail/DiscussionCha
 import PageNotFound from '@/components/PageNotFound.vue';
 import { getSortFromQuery } from '@/utils/getSortFromQuery';
 import { useRoute } from 'nuxt/app';
-import DiscussionBodyEditForm from './DiscussionBodyEditForm.vue';
-import AlbumEditForm from './AlbumEditForm.vue';
 import ArchivedDiscussionInfoBanner from './ArchivedDiscussionInfoBanner.vue';
 import DiscussionLayoutManager from './DiscussionLayoutManager.vue';
 import FeedbackModalManager from './FeedbackModalManager.vue';
@@ -40,6 +38,11 @@ import {
   useModProfileName,
   useUsername,
 } from '@/composables/useAuthState';
+
+const DiscussionBodyEditForm = defineAsyncComponent(
+  () => import('./DiscussionBodyEditForm.vue')
+);
+const AlbumEditForm = defineAsyncComponent(() => import('./AlbumEditForm.vue'));
 
 const isAuthenticatedVar = useIsAuthenticated();
 const modProfileNameVar = useModProfileName();

--- a/components/discussion/detail/DiscussionHeader.vue
+++ b/components/discussion/detail/DiscussionHeader.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, computed } from 'vue';
+import { ref, computed, defineAsyncComponent } from 'vue';
 import { useMutation, useQuery } from '@vue/apollo-composable';
 import { useRoute, useRouter } from 'nuxt/app';
 import { DateTime } from 'luxon';
@@ -8,21 +8,17 @@ import {
   DELETE_DISCUSSION,
   UPDATE_DISCUSSION_SENSITIVE_CONTENT,
 } from '@/graphQLData/discussion/mutations';
-import WarningModal from '@/components/WarningModal.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import Notification from '@/components/NotificationComponent.vue';
-import BrokenRulesModal from '@/components/mod/BrokenRulesModal.vue';
 import EllipsisHorizontal from '@/components/icons/EllipsisHorizontal.vue';
 import { getDiscussionHeaderMenuItems } from '@/utils/headerPermissionUtils';
 import { useUsername, useModProfileName } from '@/composables/useAuthState';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
-import UnarchiveModal from '@/components/mod/UnarchiveModal.vue';
 import { GET_CHANNEL } from '@/graphQLData/channel/queries';
 import { USER_IS_MOD_OR_OWNER_IN_CHANNEL } from '@/graphQLData/user/queries';
 import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
 import { config } from '@/config';
 import LinkIcon from '@/components/icons/LinkIcon.vue';
-import EditsDropdown from './activityFeed/EditsDropdown.vue';
 import type { Discussion } from '@/__generated__/graphql';
 import type { RouteLocationRaw } from 'vue-router';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
@@ -30,6 +26,19 @@ import { useForumRoleMembership } from '@/composables/useForumRoleMembership';
 import { getAuthorBadges } from '@/utils/roleBadges';
 import { useModerationOutcomeUI } from '@/composables/useModerationOutcomeUI';
 import { useResolvedModPermissions } from '@/composables/useResolvedModPermissions';
+
+const WarningModal = defineAsyncComponent(
+  () => import('@/components/WarningModal.vue')
+);
+const BrokenRulesModal = defineAsyncComponent(
+  () => import('@/components/mod/BrokenRulesModal.vue')
+);
+const UnarchiveModal = defineAsyncComponent(
+  () => import('@/components/mod/UnarchiveModal.vue')
+);
+const EditsDropdown = defineAsyncComponent(
+  () => import('./activityFeed/EditsDropdown.vue')
+);
 
 const usernameVar = useUsername();
 const modProfileNameVar = useModProfileName();

--- a/components/discussion/detail/FeedbackModalManager.vue
+++ b/components/discussion/detail/FeedbackModalManager.vue
@@ -1,12 +1,20 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
+import { computed, ref, defineAsyncComponent } from 'vue';
 import { useMutation } from '@vue/apollo-composable';
 import { ADD_FEEDBACK_COMMENT_TO_DISCUSSION } from '@/graphQLData/discussion/mutations';
 import type { DiscussionChannel } from '@/__generated__/graphql';
-import GenericFeedbackFormModal from '@/components/GenericFeedbackFormModal.vue';
-import ConfirmUndoDiscussionFeedbackModal from '@/components/discussion/detail/ConfirmUndoDiscussionFeedbackModal.vue';
-import EditFeedbackModal from '@/components/discussion/detail/EditFeedbackModal.vue';
 import Notification from '@/components/NotificationComponent.vue';
+
+const GenericFeedbackFormModal = defineAsyncComponent(
+  () => import('@/components/GenericFeedbackFormModal.vue')
+);
+const ConfirmUndoDiscussionFeedbackModal = defineAsyncComponent(
+  () =>
+    import('@/components/discussion/detail/ConfirmUndoDiscussionFeedbackModal.vue')
+);
+const EditFeedbackModal = defineAsyncComponent(
+  () => import('@/components/discussion/detail/EditFeedbackModal.vue')
+);
 
 const props = defineProps({
   discussionId: {

--- a/components/discussion/detail/ImageLightbox.vue
+++ b/components/discussion/detail/ImageLightbox.vue
@@ -1,16 +1,25 @@
 <script lang="ts" setup>
 import type { PropType } from 'vue';
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import {
+  ref,
+  computed,
+  onMounted,
+  onUnmounted,
+  defineAsyncComponent,
+} from 'vue';
 import { useImageZoom } from '@/composables/useImageZoom';
 import { useLightboxNavigation } from '@/composables/useLightboxNavigation';
 import { useSwipeDetection } from '@/composables/useSwipeDetection';
 import LightboxControls from '@/components/discussion/detail/LightboxControls.vue';
 import LightboxImagePanel from '@/components/discussion/detail/LightboxImagePanel.vue';
 import LightboxInfoPanel from '@/components/discussion/detail/LightboxInfoPanel.vue';
-import BrokenRulesModal from '@/components/mod/BrokenRulesModal.vue';
 import Notification from '@/components/NotificationComponent.vue';
 import { useMutation } from '@vue/apollo-composable';
 import { UPDATE_IMAGE } from '@/graphQLData/discussion/mutations';
+
+const BrokenRulesModal = defineAsyncComponent(
+  () => import('@/components/mod/BrokenRulesModal.vue')
+);
 // Simplified image type for lightbox display
 interface LightboxImage {
   id: string;

--- a/components/discussion/detail/activityFeed/EditsDropdown.vue
+++ b/components/discussion/detail/activityFeed/EditsDropdown.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import {
+  ref,
+  computed,
+  onMounted,
+  onUnmounted,
+  defineAsyncComponent,
+} from 'vue';
 import type { PropType } from 'vue';
 import type { Discussion, TextVersion, User } from '@/__generated__/graphql';
 import {
@@ -7,7 +13,10 @@ import {
   type PopoverPosition,
 } from '@/composables/usePopoverPositioning';
 import { timeAgo } from '@/utils';
-import RevisionDiffModal from './RevisionDiffModal.vue';
+
+const RevisionDiffModal = defineAsyncComponent(
+  () => import('./RevisionDiffModal.vue')
+);
 
 const props = defineProps({
   discussion: {

--- a/components/discussion/list/DiscussionFilterBar.vue
+++ b/components/discussion/list/DiscussionFilterBar.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, defineAsyncComponent } from 'vue';
 import SearchBar from '@/components/SearchBar.vue';
 import FilterChip from '@/components/FilterChip.vue';
 import ChannelIcon from '@/components/icons/ChannelIcon.vue';
 import TagIcon from '@/components/icons/TagIcon.vue';
-import SearchableForumList from '@/components/channel/SearchableForumList.vue';
-import SearchableTagList from '@/components/SearchableTagList.vue';
 import SortButtons from '@/components/SortButtons.vue';
 import CollapseIcon from '@/components/icons/CollapseIcon.vue';
 import { getDiscussionFilterValuesFromParams } from '@/utils/getDiscussionFilterValuesFromParams';
@@ -23,6 +21,13 @@ import {
   DEFAULT_FILTER_LABELS,
 } from '@/composables/useFilterBar';
 import { updateFilters } from '@/utils/routerUtils';
+
+const SearchableForumList = defineAsyncComponent(
+  () => import('@/components/channel/SearchableForumList.vue')
+);
+const SearchableTagList = defineAsyncComponent(
+  () => import('@/components/SearchableTagList.vue')
+);
 
 const emit = defineEmits(['openAbout']);
 

--- a/components/discussion/list/SitewideDownloadList.vue
+++ b/components/discussion/list/SitewideDownloadList.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, defineAsyncComponent } from 'vue';
 import { useRoute, useRouter } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import ErrorBanner from '../../ErrorBanner.vue';
 import LoadMore from '../../LoadMore.vue';
 import SitewideDiscussionSidebar from './SitewideDiscussionSidebar.vue';
 import SitewideDownloadListItem from './SitewideDownloadListItem.vue';
-import DiscussionAlbum from '@/components/discussion/detail/DiscussionAlbum.vue';
 import DownloadSkeletonCard from '@/components/download/DownloadSkeletonCard.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import { GET_SITE_WIDE_DISCUSSION_LIST } from '@/graphQLData/discussion/queries';
@@ -20,6 +19,10 @@ import { config } from '@/config';
 import { useUsername } from '@/composables/useAuthState';
 import type { SearchDiscussionValues } from '@/types/Discussion';
 import type { Album, Discussion } from '@/__generated__/graphql';
+
+const DiscussionAlbum = defineAsyncComponent(
+  () => import('@/components/discussion/detail/DiscussionAlbum.vue')
+);
 
 const usernameVar = useUsername();
 

--- a/components/discussion/vote/DiscussionVotes.vue
+++ b/components/discussion/vote/DiscussionVotes.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
+import { computed, ref, defineAsyncComponent } from 'vue';
 import { useRoute, useRouter } from 'nuxt/app';
 import { useMutation } from '@vue/apollo-composable';
 import type { Reference, StoreObject } from '@apollo/client/core';
@@ -11,11 +11,14 @@ import {
 import VoteButtons from '@/components/discussion/vote/VoteButtons.vue';
 import NewEmojiButton from '@/components/comments/NewEmojiButton.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
-import SuperUpvoteModal from '@/components/superUpvote/SuperUpvoteModal.vue';
 import { UNDO_SUPER_UPVOTE } from '@/graphQLData/scratchpad/mutations';
 import { useUsername, useModProfileName } from '@/composables/useAuthState';
 import SuspensionNotice from '@/components/SuspensionNotice.vue';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
+
+const SuperUpvoteModal = defineAsyncComponent(
+  () => import('@/components/superUpvote/SuperUpvoteModal.vue')
+);
 
 const usernameVar = useUsername();
 const modProfileNameVar = useModProfileName();

--- a/components/favorites/AddToFavoritesButton.vue
+++ b/components/favorites/AddToFavoritesButton.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { ref, computed, nextTick, watch } from 'vue';
+import { ref, computed, nextTick, watch, defineAsyncComponent } from 'vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
-import AddToListPopover from '@/components/collection/AddToListPopover.vue';
+
+const AddToListPopover = defineAsyncComponent(
+  () => import('@/components/collection/AddToListPopover.vue')
+);
 
 const props = defineProps({
   isFavorited: {

--- a/pages/library/[collectionId].vue
+++ b/pages/library/[collectionId].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, defineAsyncComponent } from 'vue';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 import { useHead } from 'nuxt/app';
 import { useRoute, useRouter } from 'vue-router';
@@ -15,9 +15,6 @@ import {
   REORDER_COLLECTION_ITEM,
   SHARE_COLLECTION_AS_DISCUSSION,
 } from '@/graphQLData/collection/mutations';
-import GenericModal from '@/components/GenericModal.vue';
-import WarningModal from '@/components/WarningModal.vue';
-import ForumPicker from '@/components/channel/ForumPicker.vue';
 import { useUsername } from '@/composables/useAuthState';
 import type { Discussion, Comment } from '@/__generated__/graphql';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
@@ -35,6 +32,16 @@ import {
   getCommentContextType,
 } from '@/utils/commentUtils';
 import { isAutoSavedDownloadsCollection } from '@/utils/downloadLibraryCollection';
+
+const GenericModal = defineAsyncComponent(
+  () => import('@/components/GenericModal.vue')
+);
+const WarningModal = defineAsyncComponent(
+  () => import('@/components/WarningModal.vue')
+);
+const ForumPicker = defineAsyncComponent(
+  () => import('@/components/channel/ForumPicker.vue')
+);
 
 const usernameVar = useUsername();
 

--- a/pages/u/[username]/downloads.vue
+++ b/pages/u/[username]/downloads.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, defineAsyncComponent } from 'vue';
 import { GET_USER_DOWNLOADS } from '@/graphQLData/user/queries';
 import { useQuery } from '@vue/apollo-composable';
 import SitewideDownloadListItem from '@/components/discussion/list/SitewideDownloadListItem.vue';
-import DiscussionAlbum from '@/components/discussion/detail/DiscussionAlbum.vue';
 import { useRoute } from 'nuxt/app';
 import type { Album, Discussion } from '@/__generated__/graphql';
 import { useSelectedChannelsFromQuery } from '@/composables/useSelectedChannelsFromQuery';
+
+const DiscussionAlbum = defineAsyncComponent(
+  () => import('@/components/discussion/detail/DiscussionAlbum.vue')
+);
 
 const route = useRoute();
 const { selectedChannels, hasSelectedChannels } = useSelectedChannelsFromQuery();


### PR DESCRIPTION
## Summary
This PR continues the core web vitals work by pushing more interaction-only discussion and library UI behind async boundaries so those code paths do not land in the initial route payload.

## What changed
- Deferred collection popover and album lightbox code used from shared list/card surfaces.
- Deferred discussion filter pickers on the public discussions route.
- Deferred collection-page modal and forum-picker code on library detail pages.
- Deferred discussion-detail header moderation UI and feedback modal stacks.
- Deferred discussion-detail interaction tails including lightbox reporting, revision diff modal, super-upvote modal, and edit-only discussion forms.
- Deferred the emoji picker dropdown internals so the visible reaction affordance can render without pulling in the picker path immediately.

## Impact
- Reduces JavaScript shipped on hot public discussion, download, and library routes.
- Keeps route-critical content rendering separate from click-only moderation, editing, sharing, and picker flows.
- Continues the route-payload trimming work without changing user-visible behavior.

## Validation
- Ran targeted Vitest suites covering the touched discussion-detail, vote, library, filter-bar, favorites, modal-host, and emoji-button components/pages.
- Earlier passes on this branch also passed `npm run tsc` for the affected slices; later passes relied on targeted component validation because repo-wide `vue-tsc --noEmit` was not returning reliably in this environment.