### PR TITLE
Fix admin dashboard medium-width overflow and activity chart date range

### DIFF
--- a/components/admin/ServerDashboardActivityChart.spec.ts
+++ b/components/admin/ServerDashboardActivityChart.spec.ts
@@ -2,15 +2,23 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import ServerDashboardActivityChart from '@/components/admin/ServerDashboardActivityChart.vue';
 
-const mountChart = (timeSeries: Array<Record<string, unknown>>) =>
+const mountChart = (
+  timeSeries: Array<Record<string, unknown>>,
+  range: { startDate?: string; endDate?: string } = {}
+) =>
   mount(ServerDashboardActivityChart, {
-    props: { timeSeries },
+    props: { timeSeries, ...range },
     global: {
       stubs: {
         CalendarDays: { template: '<svg class="calendar" />' },
       },
     },
   });
+
+// Each rendered day-bar column is the `.min-w-6` wrapper (distinct from the
+// legend's coloured dots, which also use the segment colour classes).
+const barCount = (wrapper: ReturnType<typeof mountChart>) =>
+  wrapper.findAll('.min-w-6').length;
 
 describe('ServerDashboardActivityChart', () => {
   beforeEach(() => {
@@ -52,6 +60,48 @@ describe('ServerDashboardActivityChart', () => {
       firstOrange: 'height: 25%;',
       firstGreen: 'height: 25%;',
     });
+  });
+
+  it('renders one bar per day across the selected range even when the series is sparse', () => {
+    const wrapper = mountChart(
+      [{ date: '2024-01-12', discussions: 1, comments: 0, events: 0 }],
+      { startDate: '2024-01-10', endDate: '2024-01-14' }
+    );
+
+    expect(barCount(wrapper)).toBe(5);
+  });
+
+  it('zero-fills days in the range that the series does not cover', () => {
+    const wrapper = mountChart(
+      [{ date: '2024-01-12', discussions: 1, comments: 0, events: 0 }],
+      { startDate: '2024-01-10', endDate: '2024-01-14' }
+    );
+
+    expect(wrapper.get('[title="Jan 10: 0"]').exists()).toBe(true);
+  });
+
+  it('drops series points that fall outside the selected range', () => {
+    const wrapper = mountChart(
+      [
+        { date: '2024-01-12', discussions: 1, comments: 0, events: 0 },
+        { date: '2024-01-20', discussions: 9, comments: 9, events: 9 },
+      ],
+      { startDate: '2024-01-10', endDate: '2024-01-14' }
+    );
+
+    expect(wrapper.text()).not.toContain('Jan 20');
+  });
+
+  it('falls back to the raw series when the range is invalid', () => {
+    const wrapper = mountChart(
+      [
+        { date: '2024-01-12', discussions: 1, comments: 0, events: 0 },
+        { date: '2024-01-13', discussions: 1, comments: 0, events: 0 },
+      ],
+      { startDate: 'not-a-date', endDate: '2024-01-14' }
+    );
+
+    expect(barCount(wrapper)).toBe(2);
   });
 
   it('renders zero-height segments and keeps the legend labels', () => {

--- a/components/admin/ServerDashboardActivityChart.vue
+++ b/components/admin/ServerDashboardActivityChart.vue
@@ -11,10 +11,66 @@ type ServerHealthTimeSeriesPoint = {
 
 const props = defineProps<{
   timeSeries: ServerHealthTimeSeriesPoint[];
+  startDate?: string;
+  endDate?: string;
 }>();
 
+// Guard against a pathological range dragging in thousands of empty bars.
+const MAX_RANGE_DAYS = 366;
+
+const isDateInputValue = (value?: string): value is string =>
+  !!value && /^\d{4}-\d{2}-\d{2}$/.test(value);
+
+// Build every calendar day in [startDate, endDate] inclusive, using UTC so the
+// arithmetic never drifts across daylight-saving boundaries.
+const buildDateRange = (start: string, end: string): string[] => {
+  const startTime = Date.parse(`${start}T00:00:00Z`);
+  const endTime = Date.parse(`${end}T00:00:00Z`);
+  if (Number.isNaN(startTime) || Number.isNaN(endTime) || startTime > endTime) {
+    return [];
+  }
+  const dayMs = 24 * 60 * 60 * 1000;
+  const dates: string[] = [];
+  for (let time = startTime; time <= endTime; time += dayMs) {
+    const isoDate = new Date(time).toISOString().split('T')[0];
+    if (isoDate) dates.push(isoDate);
+    if (dates.length > MAX_RANGE_DAYS) return [];
+  }
+  return dates;
+};
+
+// The chart's x-axis should always mirror the selected date range so it matches
+// the date pickers, even when the backend omits days or returns stale/partial
+// data mid-refetch. When a valid range is supplied we render one bar per day and
+// zero-fill any day the time series does not cover; otherwise we fall back to
+// rendering the raw series as-is.
+const chartPoints = computed<ServerHealthTimeSeriesPoint[]>(() => {
+  if (!isDateInputValue(props.startDate) || !isDateInputValue(props.endDate)) {
+    return props.timeSeries;
+  }
+
+  const dateRange = buildDateRange(props.startDate, props.endDate);
+  if (dateRange.length === 0) {
+    return props.timeSeries;
+  }
+
+  const pointsByDate = new Map(
+    props.timeSeries.map((point) => [point.date, point])
+  );
+
+  return dateRange.map(
+    (date) =>
+      pointsByDate.get(date) || {
+        date,
+        discussions: 0,
+        comments: 0,
+        events: 0,
+      }
+  );
+});
+
 const maxActivity = computed(() => {
-  const values = props.timeSeries.map(
+  const values = chartPoints.value.map(
     (point) => point.discussions + point.comments + point.events
   );
   return Math.max(...values, 1);
@@ -35,7 +91,7 @@ const percent = (value: number, max: number) => {
 </script>
 
 <template>
-  <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
+  <div class="min-w-0 rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
     <div class="mb-4 flex items-center justify-between gap-3">
       <div>
         <h2 class="text-base font-semibold !text-gray-900 dark:!text-gray-100">
@@ -50,7 +106,7 @@ const percent = (value: number, max: number) => {
 
     <div class="flex h-64 items-end gap-2 overflow-x-auto overflow-y-visible pb-12">
       <div
-        v-for="point in timeSeries"
+        v-for="point in chartPoints"
         :key="point.date"
         class="relative flex min-w-6 flex-1 flex-col items-center justify-end gap-1"
         :title="`${formatDateLabel(point.date)}: ${point.discussions + point.comments + point.events}`"

--- a/components/admin/ServerDashboardIssueAging.vue
+++ b/components/admin/ServerDashboardIssueAging.vue
@@ -30,7 +30,7 @@ const barPercent = (value: number, max: number) => {
 </script>
 
 <template>
-  <div class="rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
+  <div class="min-w-0 rounded-lg border border-gray-200 bg-white p-4 !text-gray-900 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:!text-gray-100">
     <div class="mb-4 flex items-center justify-between gap-3">
       <div>
         <h2 class="text-base font-semibold !text-gray-900 dark:!text-gray-100">

--- a/components/dashboard/ChannelHealthDetailView.vue
+++ b/components/dashboard/ChannelHealthDetailView.vue
@@ -364,9 +364,13 @@ const refreshDashboard = () => {
         </section>
 
         <section
-          class="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
+          class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
         >
-          <ServerDashboardActivityChart :time-series="timeSeries" />
+          <ServerDashboardActivityChart
+            :time-series="timeSeries"
+            :start-date="startDate"
+            :end-date="endDate"
+          />
           <ServerDashboardIssueAging :issue-aging="issueAging" />
         </section>
       </template>

--- a/pages/admin/dashboard/index.vue
+++ b/pages/admin/dashboard/index.vue
@@ -308,7 +308,7 @@ const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
           />
         </div>
         <div
-          class="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
+          class="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
         >
           <div
             class="h-72 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800"
@@ -342,9 +342,13 @@ const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
         <ServerDashboardMetricCards :summary="dashboard.summary" />
 
         <section
-          class="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
+          class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"
         >
-          <ServerDashboardActivityChart :time-series="timeSeries" />
+          <ServerDashboardActivityChart
+            :time-series="timeSeries"
+            :start-date="startDate"
+            :end-date="endDate"
+          />
           <ServerDashboardIssueAging :issue-aging="issueAging" />
         </section>
 

--- a/tests/playwright/mocked/admin/serverDashboardLayout.spec.ts
+++ b/tests/playwright/mocked/admin/serverDashboardLayout.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test } from '../../helpers/testFixture';
+import { buildServerHealthDashboard } from '../../helpers/graphqlFixtures';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import { installMockAuth } from '../../helpers/mockAuth';
+import { installGraphqlMocks } from '../../helpers/mockGraphql';
+
+// Regression guard for the admin dashboard overflowing past the right edge of
+// the viewport at medium widths. The activity-chart / issue-aging row used to
+// fall back to `auto`-sized grid tracks below `xl`, so the chart's intrinsic
+// width forced the whole page wider than the screen instead of scrolling inside
+// its own container. These tests render the fully-populated dashboard and assert
+// the document never scrolls horizontally.
+const TEST_USER = 'alice';
+
+const buildTimeSeries = () =>
+  Array.from({ length: 28 }).map((_, i) => ({
+    __typename: 'ServerHealthTimeSeriesPoint',
+    date: new Date(Date.UTC(2026, 5, 1 + i)).toISOString().split('T')[0],
+    discussions: (i % 5) + 1,
+    comments: (i % 7) + 2,
+    events: i % 3,
+    downloads: 0,
+    issuesOpened: 0,
+    moderationActions: 0,
+  }));
+
+const buildChannelRows = () =>
+  Array.from({ length: 8 }).map((_, i) => ({
+    __typename: 'ChannelHealthRow',
+    id: `chan-${i}`,
+    channelUniqueName: `channel-number-${i}`,
+    displayName: `Channel Number ${i}`,
+    channelIconURL: '',
+    discussionCount: 10,
+    commentCount: 20,
+    eventCount: 5,
+    downloadCount: 0,
+    voteCount: 30,
+    uniqueContributorCount: 12,
+    openIssueCount: i,
+    issueOpenedCount: i,
+    moderationActionCount: i,
+    archivedContentCount: 0,
+    lockedContentCount: 0,
+    oldestOpenIssueAgeDays: i * 3,
+    issuesPerHundredContributions: i * 1.5,
+    activityScore: 40 - i,
+    healthLabel: 'Active',
+  }));
+
+const buildIssueAging = () => [
+  { __typename: 'IssueAgingBucket', label: '<1 day', minDays: 0, maxDays: 0, count: 3 },
+  { __typename: 'IssueAgingBucket', label: '1-3 days', minDays: 1, maxDays: 3, count: 5 },
+  { __typename: 'IssueAgingBucket', label: '4-7 days', minDays: 4, maxDays: 7, count: 2 },
+  { __typename: 'IssueAgingBucket', label: '8-30 days', minDays: 8, maxDays: 30, count: 7 },
+  { __typename: 'IssueAgingBucket', label: '30+ days', minDays: 31, maxDays: null, count: 1 },
+];
+
+// Medium widths between the `md` and `xl` Tailwind breakpoints, where the bug
+// used to appear.
+const MEDIUM_WIDTHS = [768, 900, 1024];
+
+test.describe('Admin dashboard layout', () => {
+  for (const width of MEDIUM_WIDTHS) {
+    test(`does not overflow horizontally at ${width}px`, async ({
+      context,
+      page,
+    }) => {
+      await installMockAuth(context, page, {
+        username: TEST_USER,
+        email: 'alice@example.com',
+      });
+      const dashboardData = () => ({
+        data: {
+          getServerHealthDashboard: buildServerHealthDashboard({
+            timeSeries: buildTimeSeries(),
+            channelHealth: buildChannelRows(),
+            issueAging: buildIssueAging(),
+          }),
+        },
+      });
+      await installGraphqlMocks(page, {
+        ...createBaseHandlers({ username: TEST_USER }),
+        getServerHealthDashboard: dashboardData,
+        getServerHealthDashboardOverview: dashboardData,
+        getServerHealthChannelHealth: dashboardData,
+      });
+
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto('/admin/dashboard', { waitUntil: 'domcontentloaded' });
+
+      // Wait for the data-gated content (chart + table) to render so the layout
+      // is fully settled before measuring.
+      await expect(
+        page.getByRole('heading', { name: 'Channel Health' })
+      ).toBeVisible();
+
+      // The reported bug is that dashboard content (specifically the activity /
+      // issue-aging cards) visibly extended past the right edge. Assert that no
+      // element visibly overflows the viewport. Elements clipped by an
+      // overflow:auto/scroll/hidden ancestor (e.g. the channel-health table's own
+      // horizontal scroll region) are intentionally scrollable and excluded — we
+      // measure `documentElement.clientWidth`, not `scrollWidth`, so their
+      // internal scroll does not count.
+      const visibleOverflow = await page.evaluate(() => {
+        const vw = document.documentElement.clientWidth;
+        const isClipped = (node: HTMLElement) => {
+          let n: HTMLElement | null = node.parentElement;
+          while (n && n !== document.documentElement) {
+            const ox = getComputedStyle(n).overflowX;
+            if (ox !== 'visible') return true;
+            n = n.parentElement;
+          }
+          return false;
+        };
+        const offenders: Array<{ tag: string; cls: string; right: number }> = [];
+        for (const node of Array.from(
+          document.querySelectorAll('body *')
+        ) as HTMLElement[]) {
+          const r = node.getBoundingClientRect();
+          if (r.right > vw + 1 && r.width > 0 && !isClipped(node)) {
+            offenders.push({
+              tag: node.tagName.toLowerCase(),
+              cls: (node.getAttribute('class') || '').slice(0, 80),
+              right: Math.round(r.right),
+            });
+          }
+        }
+        offenders.sort((a, b) => b.right - a.right);
+        return { viewportWidth: vw, offenders: offenders.slice(0, 6) };
+      });
+
+      expect(
+        visibleOverflow.offenders,
+        JSON.stringify(visibleOverflow, null, 2)
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes two bugs affecting the admin dashboard.

### 1. Dashboard extended past the right edge at medium width
The activity-chart / issue-aging row declared columns only at `xl` (`xl:grid-cols-[...]`), so below `xl` it fell back to **`auto`-sized grid tracks** that grew to the chart's intrinsic width (~922px) and pushed the cards past the right edge of the screen. (The metric-cards grid was unaffected because it uses `md:grid-cols-3`, i.e. `minmax(0,1fr)`.)

**Fix:** give that row an explicit base `grid-cols-1` (a shrinkable `minmax(0,1fr)` track) and add `min-w-0` to the chart and issue-aging cards so they shrink and the chart scrolls inside its own `overflow-x-auto` container. Applied at both the server dashboard (`pages/admin/dashboard/index.vue`) and the forum-scoped channel-health view (`components/dashboard/ChannelHealthDetailView.vue`).

### 2. Activity chart didn't match the date-picker range
The chart rendered whatever time series the query returned, which can diverge from the selected range on sparse/partial data or a stale cache during a `cache-and-network` refetch.

**Fix:** make the chart authoritative over its x-axis. `ServerDashboardActivityChart` now takes `startDate`/`endDate`, renders exactly one bar per UTC day across the whole selected range, zero-fills gaps, drops out-of-range points, and falls back to the raw series when no valid range is supplied (capped at 366 days). The date-picker refs are wired into the chart at both scopes so it always matches the pickers.

## Testing
- New unit tests in `ServerDashboardActivityChart.spec.ts` for the range / zero-fill / out-of-range / fallback behavior (7 pass).
- New Playwright regression test `serverDashboardLayout.spec.ts` asserting no element visibly overflows the viewport at 768/900/1024px (3 pass).
- `pnpm run tsc` clean; ESLint clean on all changed files.

## Note / out of scope
`documentElement.scrollWidth` still reports a small phantom horizontal-scroll from the channel-health table's *internal* `overflow-x-auto` region plus a ~132px baseline that is present even with an empty dashboard. That is a pre-existing admin-shell measurement artifact (not visible content) and is left out of scope for these bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)