### PR TITLE
fix: defer v-click-outside so click-mounted dropdowns don't self-close

### DIFF
--- a/plugins/click-outside.client.ts
+++ b/plugins/click-outside.client.ts
@@ -8,9 +8,17 @@ export default defineNuxtPlugin((nuxtApp) => {
           binding.value(event);
         }
       };
-      document.addEventListener('click', el.clickOutsideEvent);
+      // Defer attaching the listener until after the current event loop tick.
+      // When the element is mounted *by* a click (e.g. the click that opens a
+      // dropdown/emoji picker), that same click keeps propagating to document;
+      // attaching synchronously would let it immediately fire the outside-click
+      // handler and close the thing that just opened.
+      el.clickOutsideTimer = setTimeout(() => {
+        document.addEventListener('click', el.clickOutsideEvent);
+      }, 0);
     },
     unmounted(el) {
+      clearTimeout(el.clickOutsideTimer);
       document.removeEventListener('click', el.clickOutsideEvent);
     },
   });

--- a/tests/playwright/mocked/reactions/emojiPickerOpens.spec.ts
+++ b/tests/playwright/mocked/reactions/emojiPickerOpens.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../../helpers/testFixture';
+import {
+  createSuperUpvoteState,
+  createSuperUpvoteHandlers,
+} from '../../helpers/mockedSuperUpvoteHandlers';
+
+const CHANNEL = 'cats';
+const DISCUSSION_ID = 'discussion-1';
+
+// Regression: the emoji "React" button opens a FloatingDropdown containing the
+// emoji picker. The picker's own v-click-outside handler used to fire on the
+// very click that opened the dropdown, closing it again immediately, so the
+// picker never appeared. See plugins/click-outside.client.ts.
+test('clicking the React button opens the emoji picker', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createSuperUpvoteState({
+    channelId: CHANNEL,
+    discussionId: DISCUSSION_ID,
+    authorUsername: 'alice',
+    actorUsername: 'cluse',
+  });
+  await setupMockedPage({
+    username: 'cluse',
+    handlers: createSuperUpvoteHandlers(state),
+  });
+
+  await page.goto(`/forums/${CHANNEL}/discussions/${DISCUSSION_ID}`);
+
+  const reactButton = page.getByTestId('emoji-button').first();
+  await expect(reactButton).toBeVisible();
+  await expect(reactButton).toHaveAttribute('aria-expanded', 'false');
+
+  await reactButton.click();
+
+  // The regression: the emoji picker's own v-click-outside used to fire on the
+  // opening click and close the dropdown again immediately. The dropdown's open
+  // state is reflected on the trigger via aria-expanded; assert it opens AND
+  // stays open a beat later (rather than snapping back to false). This is
+  // independent of the emoji-data CDN, which is blocked in the sandbox.
+  await expect(reactButton).toHaveAttribute('aria-expanded', 'true');
+  await page.waitForTimeout(600);
+  await expect(reactButton).toHaveAttribute('aria-expanded', 'true');
+});


### PR DESCRIPTION
## Summary

Hardens the `v-click-outside` directive so an element mounted **by** a click can't immediately close itself.

### The bug

`v-click-outside` attached its `document` `click` listener synchronously in `beforeMount`. When an element is mounted as a *result* of a click — e.g. the emoji **React** button opens a `FloatingDropdown` whose content (`EmojiPicker`) uses `v-click-outside` — that same click keeps propagating up to `document`, where the freshly-registered handler fires and treats it as an "outside click", emitting `close`. The dropdown opens and slams shut in the same tick, so the emoji picker never appears.

I reproduced this on pre-#341 code (React click → `FloatingDropdown` `isOpen` goes `true` then immediately `false`, with the close coming from `EmojiPicker`'s `v-click-outside → emit('close')`).

### Why it's not currently visible on `main`

#341 (`c33b6e3d`, "Defer emoji picker dropdown UI") lazy-loads the picker via `defineAsyncComponent`. That async mount happens to register the listener a tick after the opening click, so the self-close no longer occurs. **This PR is therefore not fixing an active regression on `main`** — it removes the underlying footgun so the behavior doesn't depend on that incidental async timing, and it protects the other click-mounted dropdowns that use the directive (`MultiSelect`, `FileTypePicker`, `SiteSidenav`).

### The fix

Attach the `document` listener on the next tick (`setTimeout(…, 0)`) so the opening click finishes propagating first; clear the timer on unmount. One-line behavioral change, no API change.

## Testing

- New Playwright test `tests/playwright/mocked/reactions/emojiPickerOpens.spec.ts`: clicking React opens the picker and it **stays** open (asserted via the trigger's `aria-expanded`, which is independent of the emoji-data CDN that's blocked in the sandbox).
- Unit specs for all four `v-click-outside` consumers pass (`MultiSelect`, `FileTypePicker`, `EmojiPicker`, `NewEmojiButton`, `FloatingDropdown` — 52 tests).
- `vue-tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)