### PR TITLE
fix(a11y): P1 app shell — skip link, main landmark, search + hamburger ARIA

### DIFF
--- a/components/SearchBar.spec.ts
+++ b/components/SearchBar.spec.ts
@@ -70,6 +70,26 @@ describe('SearchBar', () => {
     });
   });
 
+  it('associates the visually-hidden label with the input', () => {
+    const wrapper = mount(SearchBar, {
+      props: { autoFocus: false, initialValue: '', testId: 'search' },
+      global: { stubs: { SearchIcon: true } },
+    });
+
+    expect(wrapper.get('label').attributes('for')).toBe(
+      input(wrapper).attributes('id')
+    );
+  });
+
+  it('gives the input a non-empty id for the label association', () => {
+    const wrapper = mount(SearchBar, {
+      props: { autoFocus: false, initialValue: '', testId: 'search' },
+      global: { stubs: { SearchIcon: true } },
+    });
+
+    expect(input(wrapper).attributes('id')).toBeTruthy();
+  });
+
   it('exposes focus and getValue helpers', async () => {
     const wrapper = mount(SearchBar, {
       props: { autoFocus: false, initialValue: 'needle', testId: 'search' },

--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted, nextTick } from 'vue';
+import { ref, onMounted, nextTick, useId } from 'vue';
 import SearchIcon from '@/components/icons/SearchIcon.vue';
 import XmarkIcon from '@/components/icons/XmarkIcon.vue';
+
+// Unique per instance so the label association stays correct when more than one
+// SearchBar renders on a page (the previous hard-coded id="search" collided).
+const inputId = useId();
 
 // Props
 const props = defineProps({
@@ -115,6 +119,7 @@ defineExpose({ focus, getValue });
         <SearchIcon />
       </div>
       <input
+        :id="inputId"
         ref="searchInputRef"
         :value="input"
         name="search"
@@ -143,7 +148,7 @@ defineExpose({ focus, getValue });
         />
       </button>
       <slot />
-      <label for="search" class="sr-only">Search</label>
+      <label :for="inputId" class="sr-only">Search</label>
     </div>
   </div>
 </template>

--- a/components/nav/HamburgerMenuButton.spec.ts
+++ b/components/nav/HamburgerMenuButton.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import HamburgerMenuButton from '@/components/nav/HamburgerMenuButton.vue';
+
+describe('HamburgerMenuButton', () => {
+  it('has an accessible name for the icon-only control', () => {
+    const wrapper = mount(HamburgerMenuButton);
+
+    expect(wrapper.get('button').text()).toContain('navigation menu');
+  });
+
+  it('reports collapsed state by default', () => {
+    const wrapper = mount(HamburgerMenuButton);
+
+    expect(wrapper.get('button').attributes('aria-expanded')).toBe('false');
+  });
+
+  it('reflects the expanded prop in aria-expanded', () => {
+    const wrapper = mount(HamburgerMenuButton, { props: { expanded: true } });
+
+    expect(wrapper.get('button').attributes('aria-expanded')).toBe('true');
+  });
+
+  it('points aria-controls at the mobile menu region', () => {
+    const wrapper = mount(HamburgerMenuButton);
+
+    expect(wrapper.get('button').attributes('aria-controls')).toBe('mobile-menu');
+  });
+});

--- a/components/nav/HamburgerMenuButton.vue
+++ b/components/nav/HamburgerMenuButton.vue
@@ -1,5 +1,13 @@
 <script lang="ts" setup>
 // HamburgerMenuButton component - mobile navigation toggle
+defineProps({
+  // Open/closed state of the mobile nav this button controls, exposed to
+  // assistive tech via aria-expanded (was previously hard-coded to false).
+  expanded: {
+    type: Boolean,
+    default: false,
+  },
+});
 </script>
 
 <template>
@@ -8,7 +16,7 @@
     type="button"
     class="inline-flex items-center justify-center rounded-md border border-gray-600 bg-gray-800 p-2 text-gray-300 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-gray-600"
     aria-controls="mobile-menu"
-    aria-expanded="false"
+    :aria-expanded="expanded"
   >
     <span class="sr-only">Open site-wide navigation menu</span>
     <svg

--- a/components/nav/TopNav.vue
+++ b/components/nav/TopNav.vue
@@ -91,6 +91,7 @@ const isOnMapPage = computed(() => {
           v-if="!sideNavIsOpenVar"
           data-testid="menu-button"
           class="fixed-menu-button cursor-pointer md:ml-1 lg:hidden"
+          :expanded="sideNavIsOpenVar"
           @click="$emit('toggleDropdown')"
         />
 

--- a/layouts/default.spec.ts
+++ b/layouts/default.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+
+import DefaultLayout from '@/layouts/default.vue';
+
+vi.mock('nuxt/app', () => ({
+  useHead: vi.fn(),
+  useRoute: () => ({ name: 'home', query: {} }),
+}));
+
+vi.mock('@/composables/useDisplay', () => ({
+  useDisplay: () => ({ lgAndUp: ref(true), mdAndUp: ref(true) }),
+}));
+
+vi.mock('@/composables/useTestAuthHelpers', () => ({
+  useTestAuthHelpers: vi.fn(),
+}));
+
+vi.mock('@/config', () => ({
+  config: { environment: 'test' },
+}));
+
+vi.mock('@/cache', () => ({
+  sideNavIsOpenVar: ref(false),
+  setSideNavIsOpenVar: vi.fn(),
+}));
+
+const mountLayout = () =>
+  shallowMount(DefaultLayout, {
+    slots: { default: '<p data-testid="page">Page content</p>' },
+    global: {
+      stubs: { ClientOnly: { template: '<div><slot /></div>' } },
+    },
+  });
+
+describe('default layout landmarks', () => {
+  it('renders a skip link that targets the main content region', () => {
+    const wrapper = mountLayout();
+
+    expect(wrapper.find('a[href="#main-content"]').exists()).toBe(true);
+  });
+
+  it('exposes exactly one main landmark', () => {
+    const wrapper = mountLayout();
+
+    expect(wrapper.findAll('main')).toHaveLength(1);
+  });
+
+  it('gives the main landmark the skip-link target id', () => {
+    const wrapper = mountLayout();
+
+    expect(wrapper.get('main').attributes('id')).toBe('main-content');
+  });
+
+  it('renders the page slot inside the main landmark', () => {
+    const wrapper = mountLayout();
+
+    expect(wrapper.get('main').find('[data-testid="page"]').exists()).toBe(true);
+  });
+
+  it('keeps the banner header outside the main landmark', () => {
+    const wrapper = mountLayout();
+
+    expect(wrapper.get('main').find('header').exists()).toBe(false);
+  });
+
+  it('keeps the footer outside the main landmark', () => {
+    const wrapper = mountLayout();
+
+    expect(wrapper.get('main').find('footer').exists()).toBe(false);
+  });
+
+  it('keeps navigation landmarks outside the main landmark', () => {
+    const wrapper = mountLayout();
+
+    expect(wrapper.get('main').find('nav').exists()).toBe(false);
+  });
+});

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -103,10 +103,16 @@ onMounted(() => {
 
 <template>
   <div>
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[1000] focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-black focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-orange-500 dark:focus:bg-gray-800 dark:focus:text-white"
+    >
+      Skip to main content
+    </a>
     <DevOverlay v-if="isDevelopment" />
     <ToastNotification />
     <AddToListModalHost />
-    <main class="flex min-h-screen flex-col">
+    <div class="flex min-h-screen flex-col">
       <div
         class="flex flex-grow list-disc flex-col bg-gray-200 dark:bg-black dark:text-gray-200"
       >
@@ -145,11 +151,13 @@ onMounted(() => {
             </nav>
           </ClientOnly>
 
-          <div
-            class="flex min-w-0 flex-1 flex-col bg-white dark:bg-black lg:pl-20"
+          <main
+            id="main-content"
+            tabindex="-1"
+            class="flex min-w-0 flex-1 flex-col bg-white outline-none dark:bg-black lg:pl-20"
           >
             <slot />
-          </div>
+          </main>
           <!-- Intentionally NO #fallback slot (see the mobile-nav note above):
                a ClientOnly #fallback's fragment-boundary markers cause a
                hydration mismatch that re-renders the page content. -->
@@ -164,6 +172,6 @@ onMounted(() => {
           </ClientOnly>
         </div>
       </div>
-    </main>
+    </div>
   </div>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -142,7 +142,7 @@ onMounted(() => {
                fallback, ClientOnly renders one placeholder element that matches on
                both sides. -->
           <ClientOnly>
-            <nav v-if="!lgAndUp" aria-label="Mobile navigation">
+            <nav v-if="!lgAndUp" id="mobile-menu" aria-label="Mobile navigation">
               <SiteSidenav
                 :key="`${sideNavIsOpenVar}`"
                 :show-dropdown="sideNavIsOpenVar"


### PR DESCRIPTION
## Summary

First slice of **P1** from the accessibility audit (`docs/accessibility-audit-2026-07.md`) — the app-shell items. Small, global, low-risk fixes to `layouts/default.vue` and the nav/search primitives.

### 1. Skip-to-content link
There was no way for keyboard users to bypass the top nav + vertical rail on every page. Added a visually-hidden-until-focused **"Skip to main content"** link as the first focusable element, targeting the page region.

### 2. `<main>` landmark scoping
`layouts/default.vue` wrapped the entire app — `<header>`, both `<nav>`s, the page slot, and `<footer>` — in one `<main>`, so banner/navigation/contentinfo were nested inside `main`. Retagged so **`<main id="main-content">` wraps only the page slot**; the former outer `<main>` is now a plain `<div>`. header/navs/footer are siblings of `main`.

> This layout is historically sensitive to hydration flashes, so the change is **tag-renames only** (plus the static skip link) — the DOM tree shape is preserved. Verified no hydration regressions: layout landmark unit tests pass and mocked E2E that load real pages through this layout report `pageErrors === []`.

### 3. Global search input name
`SearchBar`'s `<label for="search">` pointed at an id the `<input>` never had, so the top-nav search field had **no accessible name**. Gave the input a per-instance `useId()` and bound both the input `id` and the label `for` (a hard-coded id would also collide when multiple SearchBars render on a page).

### 4. Hamburger menu ARIA
`HamburgerMenuButton` had a hard-coded `aria-expanded="false"` and an `aria-controls="mobile-menu"` that referenced a nonexistent element. Made `aria-expanded` a prop bound to the mobile nav's open state (wired from `TopNav`), and gave the mobile `<nav>` `id="mobile-menu"` so `aria-controls` resolves.

## Testing

- New `layouts/default.spec.ts` (skip link present; exactly one `main#main-content`; header/nav/footer outside `main`; slot inside `main`).
- New `components/nav/HamburgerMenuButton.spec.ts` (accessible name; `aria-expanded` reflects prop; valid `aria-controls`).
- `SearchBar.spec.ts` extended (label `for` matches input `id`).
- Existing `TopNav.spec.ts` still passes. `vue-tsc --noEmit` clean.

## Scope

App-shell only. Remaining **P1** items are separate follow-ups: mobile-drawer focus trap (`SiteSidenav`/`RecentForumsDrawer`), SPA route-change focus management, and the keyboard-blocking custom widgets (`MultiSelect`, `FileTypePicker`, `TagComponent`, clickable-`<li>` cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)