### PR TITLE
Fix discussion and comment button regressions

### DIFF
--- a/components/ButtonContent.vue
+++ b/components/ButtonContent.vue
@@ -10,15 +10,21 @@ defineProps({
 </script>
 
 <template>
-  <span v-if="!loading" class="justify-center">
+  <span
+    v-if="!loading"
+    class="inline-flex flex-nowrap items-center justify-center whitespace-nowrap"
+  >
     <slot />
   </span>
-  <span v-if="loading" class="justify-center">
+  <span
+    v-if="loading"
+    class="inline-flex flex-nowrap items-center justify-center whitespace-nowrap"
+  >
     <LoadingSpinner />
   </span>
   <span
     v-if="showCount"
-    class="mx-1 justify-center text-xs"
+    class="mx-1 inline-flex flex-nowrap items-center justify-center whitespace-nowrap text-xs"
     aria-live="polite"
   >
     {{ count }}

--- a/components/VoteButton.spec.ts
+++ b/components/VoteButton.spec.ts
@@ -10,7 +10,11 @@ const authButtonStub = {
   template: '<button :data-classes="buttonClasses" @click="$emit(\'click\')"><slot /></button>',
 };
 
-const mountButton = (props: Record<string, unknown> = {}, slot = 'X') =>
+const mountButton = (
+  props: Record<string, unknown> = {},
+  slot = 'X',
+  customStubs: Record<string, unknown> = {}
+) =>
   mount(VoteButton, {
     props,
     slots: { default: slot },
@@ -20,6 +24,7 @@ const mountButton = (props: Record<string, unknown> = {}, slot = 'X') =>
         ClientOnly: { template: '<div><slot /></div>' },
         Tooltip: { template: '<div><slot name="activator" :props="{}" /><slot /></div>' },
         TooltipContent: true,
+        ...customStubs,
       },
     },
   });
@@ -100,6 +105,22 @@ describe('VoteButton rendering', () => {
 
   it('emits vote from the tooltip activator button', async () => {
     const wrapper = mountButton({ tooltipText: 'Upvote this' });
+
+    await authButton(wrapper).trigger('click');
+
+    expect(wrapper.emitted('vote')).toBeTruthy();
+  });
+
+  it('emits vote from the tooltip fallback button', async () => {
+    const wrapper = mountButton(
+      { tooltipText: 'Upvote this' },
+      'Upvote',
+      {
+        ClientOnly: {
+          template: '<div><slot name="fallback" /></div>',
+        },
+      }
+    );
 
     await authButton(wrapper).trigger('click');
 

--- a/components/VoteButton.vue
+++ b/components/VoteButton.vue
@@ -136,6 +136,7 @@ const mergedButtonProps = computed(() => {
           :loading="loading"
           :show-count="showCount"
           :count="count"
+          @click="emit('vote')"
         >
           <slot />
         </AuthButton>

--- a/components/comments/EmojiButtons.vue
+++ b/components/comments/EmojiButtons.vue
@@ -168,11 +168,11 @@ function getDefaultVariant(emojiLabel: string) {
           }
         "
       >
-        <span class="flex items-center gap-1">
+        <span class="flex flex-nowrap items-center gap-1 whitespace-nowrap">
           <span
             v-for="unicode in Object.keys(getVariants(emojiLabel))"
             :key="unicode"
-            class="text-lg"
+            class="shrink-0 text-lg"
             aria-hidden="true"
           >
             {{ unicode }}

--- a/components/comments/NewEmojiButton.vue
+++ b/components/comments/NewEmojiButton.vue
@@ -90,8 +90,8 @@ function handleClick() {
           :transparent-background="transparentBackground"
           @vote="handleClick"
         >
-          <span class="flex items-center gap-1">
-            <FaceSmileIcon class="h-4 w-4" aria-hidden="true" />
+          <span class="flex flex-nowrap items-center gap-1 whitespace-nowrap">
+            <FaceSmileIcon class="h-4 w-4 shrink-0" aria-hidden="true" />
             <span class="text-xs">React</span>
           </span>
         </VoteButton>

--- a/components/comments/Votes.spec.ts
+++ b/components/comments/Votes.spec.ts
@@ -34,6 +34,16 @@ describe('Votes upvote', () => {
     expect(button(wrapper, 'upvote-comment-button').text()).toContain('5');
   });
 
+  it('keeps the upvote icon, count, and label on one line', () => {
+    const wrapper = mountVotes({ upvoteCount: 5 });
+
+    expect(
+      button(wrapper, 'upvote-comment-button').get('button > span').classes()
+    ).toEqual(
+      expect.arrayContaining(['flex-nowrap', 'whitespace-nowrap'])
+    );
+  });
+
   it('hides the upvote button when showUpvote is false', () => {
     const wrapper = mountVotes({ showUpvote: false });
 

--- a/components/comments/Votes.vue
+++ b/components/comments/Votes.vue
@@ -192,9 +192,11 @@ function viewFeedback() {
       :transparent-background="isPermalinked"
       @vote="clickUpvote"
     >
-      <UpArrowIcon class="h-4 w-4" aria-hidden="true" />
-      <span class="text-xs">{{ upvoteCount }}</span>
-      <span class="text-xs">{{ upvoteActive ? 'Undo' : 'Upvote' }}</span>
+      <span class="flex flex-nowrap items-center gap-1 whitespace-nowrap">
+        <UpArrowIcon class="h-4 w-4 shrink-0" aria-hidden="true" />
+        <span class="text-xs">{{ upvoteCount }}</span>
+        <span class="text-xs">{{ upvoteActive ? 'Undo' : 'Upvote' }}</span>
+      </span>
     </VoteButton>
 
     <!-- Super Upvote button - visible when user has upvoted and not own content -->
@@ -210,9 +212,12 @@ function viewFeedback() {
       :class="superUpvoteActive ? '' : 'super-upvote-button'"
       @vote="superUpvoteActive ? emit('undoSuperUpvote') : emit('superUpvote')"
     >
-      <span class="flex items-center gap-1 text-xs font-medium" :class="superUpvoteActive ? '' : 'rainbow-star'">
+      <span
+        class="flex flex-nowrap items-center gap-1 whitespace-nowrap text-xs font-medium"
+        :class="superUpvoteActive ? '' : 'rainbow-star'"
+      >
         <StarIcon
-          class="h-4 w-4"
+          class="h-4 w-4 shrink-0"
           :class="superUpvoteActive ? 'fill-current' : ''"
           :filled="superUpvoteActive"
           aria-hidden="true"

--- a/components/discussion/vote/VoteButtons.spec.ts
+++ b/components/discussion/vote/VoteButtons.spec.ts
@@ -50,6 +50,16 @@ describe('VoteButtons (authenticated)', () => {
     expect(button(wrapper, 'upvote-discussion-button').text()).toContain('7');
   });
 
+  it('keeps the upvote icon, count, and label on one line', () => {
+    const wrapper = mountButtons({ upvoteCount: 7 });
+
+    expect(
+      button(wrapper, 'upvote-discussion-button').get('button > span').classes()
+    ).toEqual(
+      expect.arrayContaining(['flex-nowrap', 'whitespace-nowrap'])
+    );
+  });
+
   it('hides the upvote button when showUpvote is false', () => {
     const wrapper = mountButtons({ showUpvote: false });
 

--- a/components/discussion/vote/VoteButtons.vue
+++ b/components/discussion/vote/VoteButtons.vue
@@ -184,20 +184,20 @@ const showHeartFilledIcon = computed(
           "
           @vote="clickUp"
         >
-          <span class="flex items-center gap-1">
+          <span class="flex flex-nowrap items-center gap-1 whitespace-nowrap">
             <UpArrowIcon
               v-if="showArrowUpIcon"
-              class="h-4 w-4"
+              class="h-4 w-4 shrink-0"
               aria-hidden="true"
             />
             <HeartIcon
               v-else-if="showHeartOutlineIcon"
-              class="h-4 w-4"
+              class="h-4 w-4 shrink-0"
               aria-hidden="true"
             />
             <HeartIcon
               v-else-if="showHeartFilledIcon"
-              class="h-4 w-4 fill-current"
+              class="h-4 w-4 shrink-0 fill-current"
               filled
               aria-hidden="true"
             />
@@ -218,9 +218,12 @@ const showHeartFilledIcon = computed(
           :class="superUpvoteActive ? '' : 'super-upvote-button'"
           @vote="superUpvoteActive ? clickUndoSuperUpvote() : clickSuperUpvote()"
         >
-          <span class="flex items-center gap-1 text-xs font-medium" :class="superUpvoteActive ? '' : 'rainbow-star'">
+          <span
+            class="flex flex-nowrap items-center gap-1 whitespace-nowrap text-xs font-medium"
+            :class="superUpvoteActive ? '' : 'rainbow-star'"
+          >
             <StarIcon
-              class="h-4 w-4"
+              class="h-4 w-4 shrink-0"
               :class="superUpvoteActive ? 'fill-current' : ''"
               :filled="superUpvoteActive"
             />
@@ -246,7 +249,9 @@ const showHeartFilledIcon = computed(
               :test-id="'downvote-discussion-button'"
               :button-props="activatorProps"
             >
-              <span class="flex items-center gap-1 text-xs font-medium">
+              <span
+                class="flex flex-nowrap items-center gap-1 whitespace-nowrap text-xs font-medium"
+              >
                 <FlagIcon class="h-4 w-4" />
                 <span>Feedback</span>
               </span>
@@ -266,20 +271,20 @@ const showHeartFilledIcon = computed(
           :test-id="'upvote-discussion-button'"
           :tooltip-text="upvoteTooltipUnauthenticated"
         >
-          <span class="flex items-center gap-1">
+          <span class="flex flex-nowrap items-center gap-1 whitespace-nowrap">
             <UpArrowIcon
               v-if="showArrowUpIcon"
-              class="h-4 w-4"
+              class="h-4 w-4 shrink-0"
               aria-hidden="true"
             />
             <HeartIcon
               v-else-if="showHeartOutlineIcon"
-              class="h-4 w-4"
+              class="h-4 w-4 shrink-0"
               aria-hidden="true"
             />
             <HeartIcon
               v-else-if="showHeartFilledIcon"
-              class="h-4 w-4 fill-current"
+              class="h-4 w-4 shrink-0 fill-current"
               filled
               aria-hidden="true"
             />
@@ -304,7 +309,9 @@ const showHeartFilledIcon = computed(
               :tooltip-text="'Give semi-anonymous feedback'"
               :button-props="activatorProps"
             >
-              <span class="flex items-center gap-1 text-xs font-medium">
+              <span
+                class="flex flex-nowrap items-center gap-1 whitespace-nowrap text-xs font-medium"
+              >
                 <FlagIcon class="h-4 w-4" />
                 <span>Feedback</span>
               </span>


### PR DESCRIPTION
## Summary
Fix the recent discussion/comment button regressions by restoring emoji-button click handling in the shared vote button path and keeping vote button contents on one line.

## What changed
- forward clicks from `VoteButton`'s tooltip fallback branch so tooltip-wrapped buttons still emit `vote`
- make shared button content render as an inline non-wrapping row
- add explicit non-wrapping layout classes to discussion/comment vote and reaction button content
- add regression specs for the shared tooltip fallback click path and the discussion/comment upvote layout wrappers

## Root cause
The shared `VoteButton` component had a `client-only` fallback path that rendered the button without forwarding `@click`, so controls relying on that path could appear inert. Separately, the vote/reaction button contents did not enforce a non-wrapping inline layout, which allowed the icon and label to split across lines in tight layouts.

## Validation
- `npm run tsc`
- `npx vitest run components/VoteButton.spec.ts components/comments/Votes.spec.ts components/discussion/vote/VoteButtons.spec.ts components/comments/NewEmojiButton.spec.ts components/comments/EmojiButtons.spec.ts components/comments/CommentButtons.spec.ts components/discussion/vote/DiscussionVotes.spec.ts`

## Impact
Discussion detail and comment reaction/upvote controls should behave correctly again, and the added tests should catch regressions in both the shared button wrapper and the affected vote layouts.