### PR TITLE
fix(a11y): P1 — trap focus in the mobile nav drawers

### DIFF
--- a/components/nav/RecentForumsDrawer.spec.ts
+++ b/components/nav/RecentForumsDrawer.spec.ts
@@ -44,6 +44,22 @@ describe('RecentForumsDrawer visibility', () => {
     expect(wrapper.text()).toContain('Recent Forums');
   });
 
+  it('marks the open drawer as a modal dialog labelled by its heading', () => {
+    const wrapper = mountDrawer({ isOpen: true });
+
+    expect({
+      role: wrapper.get('[role="dialog"]').attributes('role'),
+      modal: wrapper.get('[role="dialog"]').attributes('aria-modal'),
+      labelledby: wrapper.get('[role="dialog"]').attributes('aria-labelledby'),
+      titleId: wrapper.get('h3').attributes('id'),
+    }).toEqual({
+      role: 'dialog',
+      modal: 'true',
+      labelledby: 'recent-forums-drawer-title',
+      titleId: 'recent-forums-drawer-title',
+    });
+  });
+
   it('hides the drawer when closed', () => {
     const wrapper = mountDrawer({ isOpen: false });
 

--- a/components/nav/RecentForumsDrawer.vue
+++ b/components/nav/RecentForumsDrawer.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref, watch, toRef } from 'vue';
 import { useRouter } from 'nuxt/app';
 import RecentForumsList from './RecentForumsList.vue';
 import ForumFinder from './ForumFinder.vue';
 import SearchIcon from '@/components/icons/SearchIcon.vue';
+import { useFocusTrap } from '@/composables/useFocusTrap';
 
 type ForumItem = {
   uniqueName: string;
@@ -23,6 +24,14 @@ const emit = defineEmits<{
 const router = useRouter();
 
 const isFindingForum = ref(false);
+
+// Modal drawer: trap focus inside the panel while open, Escape to close, and
+// restore focus to the trigger on close.
+const panelRef = ref<HTMLElement | null>(null);
+useFocusTrap(panelRef, {
+  active: toRef(props, 'isOpen'),
+  onEscape: () => emit('close'),
+});
 
 // Reset back to the recent-forums view whenever the drawer is reopened.
 watch(
@@ -67,13 +76,20 @@ const goToForum = (uniqueName: string) => {
     >
       <div
         v-if="isOpen"
+        ref="panelRef"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="recent-forums-drawer-title"
         class="fixed left-0 top-0 z-40 h-full w-80 overflow-y-auto border-r border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
       >
         <!-- Header -->
         <div
           class="flex items-center justify-between border-b border-gray-200 p-4 dark:border-gray-600"
         >
-          <h3 class="font-semibold text-lg text-gray-900 dark:text-gray-100">
+          <h3
+            id="recent-forums-drawer-title"
+            class="font-semibold text-lg text-gray-900 dark:text-gray-100"
+          >
             Recent Forums
           </h3>
           <button

--- a/components/nav/SiteSidenav.spec.ts
+++ b/components/nav/SiteSidenav.spec.ts
@@ -177,3 +177,30 @@ describe('SiteSidenav auth links', () => {
     expect(wrapper.text()).toContain('Admin Dashboard');
   });
 });
+
+describe('SiteSidenav dialog semantics', () => {
+  it('marks the open drawer panel as a modal dialog', () => {
+    const wrapper = mountNav();
+
+    expect({
+      role: wrapper.get('[role="dialog"]').attributes('role'),
+      modal: wrapper.get('[role="dialog"]').attributes('aria-modal'),
+      label: wrapper.get('[role="dialog"]').attributes('aria-label'),
+    }).toEqual({ role: 'dialog', modal: 'true', label: 'Site navigation' });
+  });
+
+  // The layout remounts SiteSidenav with showDropdown=true when the drawer
+  // opens, so the focus trap must engage on mount (not only on a prop change).
+  it('emits close when Escape is pressed while open', async () => {
+    const wrapper = mountNav();
+    await Promise.resolve();
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    );
+    const closed = wrapper.emitted('close');
+    wrapper.unmount();
+
+    expect(closed).toBeTruthy();
+  });
+});

--- a/components/nav/SiteSidenav.vue
+++ b/components/nav/SiteSidenav.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, toRef } from 'vue';
 import type { Component } from 'vue';
 import { useRouter } from 'nuxt/app';
+import { useFocusTrap } from '@/composables/useFocusTrap';
 import { useQuery } from '@vue/apollo-composable';
 import type { RouteLocationAsRelativeGeneric } from 'vue-router';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
@@ -82,7 +83,7 @@ const navigation: NavigationItem[] = [
   },
 ];
 
-defineProps({
+const props = defineProps({
   showDropdown: {
     type: Boolean,
     required: true,
@@ -90,6 +91,17 @@ defineProps({
 });
 
 const emit = defineEmits(['close']);
+
+// The drawer is a modal dialog: trap focus inside the panel while open, close
+// on Escape, and restore focus to the trigger (which unmounts while open, so
+// fall back to the hamburger button) on close.
+const panelRef = ref<HTMLElement | null>(null);
+useFocusTrap(panelRef, {
+  active: toRef(props, 'showDropdown'),
+  onEscape: () => emit('close'),
+  fallbackTrigger: () =>
+    document.querySelector<HTMLElement>('[data-testid="hamburger-menu-button"]'),
+});
 
 const showAllForums = ref(false);
 
@@ -199,7 +211,11 @@ const selectSearchType = (type: SearchType) => {
       @click="outside"
     />
     <div
+      ref="panelRef"
       v-click-outside="outside"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Site navigation"
       class="overlay-shade fixed left-0 top-0 flex h-full w-[275px] flex-col justify-between overflow-y-auto border-gray-300 bg-white py-2 dark:border-gray-200 dark:bg-gray-900"
     >
       <div>

--- a/composables/useFocusTrap.spec.ts
+++ b/composables/useFocusTrap.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { defineComponent, ref, toRef } from 'vue';
+import { flushPromises, mount } from '@vue/test-utils';
+
+import { useFocusTrap } from '@/composables/useFocusTrap';
+
+const Host = defineComponent({
+  props: { active: { type: Boolean, default: false } },
+  setup(props) {
+    const panel = ref<HTMLElement | null>(null);
+    const escapes = ref(0);
+    useFocusTrap(panel, {
+      active: toRef(props, 'active'),
+      onEscape: () => {
+        escapes.value += 1;
+      },
+    });
+    return { panel, escapes };
+  },
+  template: `
+    <div>
+      <button data-testid="outside">outside</button>
+      <div v-if="active" ref="panel" data-testid="panel">
+        <button data-testid="first">first</button>
+        <button data-testid="second">second</button>
+        <button data-testid="last">last</button>
+      </div>
+    </div>
+  `,
+});
+
+const mountHost = () => mount(Host, { attachTo: document.body });
+
+const open = async (wrapper: ReturnType<typeof mountHost>) => {
+  await wrapper.setProps({ active: true });
+  await flushPromises();
+};
+
+const pressKey = (key: string, init: KeyboardEventInit = {}) => {
+  document.dispatchEvent(
+    new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...init })
+  );
+};
+
+const el = (wrapper: ReturnType<typeof mountHost>, testid: string) =>
+  wrapper.get(`[data-testid="${testid}"]`).element as HTMLElement;
+
+describe('useFocusTrap', () => {
+  it('moves focus to the first focusable element when activated', async () => {
+    const wrapper = mountHost();
+    await open(wrapper);
+    const focused = document.activeElement === el(wrapper, 'first');
+    wrapper.unmount();
+
+    expect(focused).toBe(true);
+  });
+
+  it('calls onEscape when Escape is pressed while active', async () => {
+    const wrapper = mountHost();
+    await open(wrapper);
+    pressKey('Escape');
+    const escapes = wrapper.vm.escapes;
+    wrapper.unmount();
+
+    expect(escapes).toBe(1);
+  });
+
+  it('wraps focus from the last element back to the first on Tab', async () => {
+    const wrapper = mountHost();
+    await open(wrapper);
+    el(wrapper, 'last').focus();
+    pressKey('Tab');
+    const focused = document.activeElement === el(wrapper, 'first');
+    wrapper.unmount();
+
+    expect(focused).toBe(true);
+  });
+
+  it('wraps focus from the first element back to the last on Shift+Tab', async () => {
+    const wrapper = mountHost();
+    await open(wrapper);
+    el(wrapper, 'first').focus();
+    pressKey('Tab', { shiftKey: true });
+    const focused = document.activeElement === el(wrapper, 'last');
+    wrapper.unmount();
+
+    expect(focused).toBe(true);
+  });
+
+  it('restores focus to the previously focused element when deactivated', async () => {
+    const wrapper = mountHost();
+    el(wrapper, 'outside').focus();
+    await open(wrapper);
+    await wrapper.setProps({ active: false });
+    await flushPromises();
+    const restored = document.activeElement === el(wrapper, 'outside');
+    wrapper.unmount();
+
+    expect(restored).toBe(true);
+  });
+
+  it('stops trapping focus after it is deactivated', async () => {
+    const wrapper = mountHost();
+    await open(wrapper);
+    await wrapper.setProps({ active: false });
+    await flushPromises();
+    el(wrapper, 'outside').focus();
+    pressKey('Tab');
+    const stillOutside = document.activeElement === el(wrapper, 'outside');
+    wrapper.unmount();
+
+    expect(stillOutside).toBe(true);
+  });
+});

--- a/composables/useFocusTrap.ts
+++ b/composables/useFocusTrap.ts
@@ -52,10 +52,10 @@ export function useFocusTrap(
     if (event.key !== 'Tab') return;
 
     const elements = focusableElements();
-    if (!elements.length) return;
-
     const first = elements[0];
     const last = elements[elements.length - 1];
+    if (!first || !last) return;
+
     const active = document.activeElement as HTMLElement | null;
     const insidePanel = !!active && !!panel.value?.contains(active);
 

--- a/composables/useFocusTrap.ts
+++ b/composables/useFocusTrap.ts
@@ -1,0 +1,105 @@
+import { watch, nextTick, onBeforeUnmount, type Ref } from 'vue';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+type UseFocusTrapOptions = {
+  /** Whether the trap is currently active (i.e. the dialog/drawer is open). */
+  active: Ref<boolean>;
+  /** Called when the user presses Escape while the trap is active. */
+  onEscape: () => void;
+  /**
+   * Optional fallback element to move focus to when the trap deactivates, used
+   * when the element that had focus before opening is gone (e.g. a trigger that
+   * unmounts while the drawer is open).
+   */
+  fallbackTrigger?: () => HTMLElement | null;
+};
+
+/**
+ * Modal focus management for a dialog/drawer: on activate, remember what had
+ * focus and move focus into the panel; while active, keep Tab/Shift+Tab cycling
+ * within the panel and close on Escape; on deactivate, restore focus.
+ *
+ * Guarded on `document` (not `import.meta.client`) so it stays SSR-safe while
+ * still running under jsdom in unit tests.
+ */
+export function useFocusTrap(
+  panel: Ref<HTMLElement | null>,
+  options: UseFocusTrapOptions
+) {
+  let previouslyFocused: HTMLElement | null = null;
+
+  const focusableElements = (): HTMLElement[] => {
+    if (!panel.value) return [];
+    return Array.from(
+      panel.value.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+    ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+  };
+
+  const onKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      options.onEscape();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+
+    const elements = focusableElements();
+    if (!elements.length) return;
+
+    const first = elements[0];
+    const last = elements[elements.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    const insidePanel = !!active && !!panel.value?.contains(active);
+
+    if (event.shiftKey) {
+      if (!insidePanel || active === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (!insidePanel || active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const activate = async () => {
+    if (typeof document === 'undefined') return;
+    previouslyFocused = document.activeElement as HTMLElement | null;
+    document.addEventListener('keydown', onKeydown);
+    await nextTick();
+    focusableElements()[0]?.focus();
+  };
+
+  const deactivate = () => {
+    if (typeof document === 'undefined') return;
+    document.removeEventListener('keydown', onKeydown);
+    const restoreTarget =
+      previouslyFocused && previouslyFocused.isConnected
+        ? previouslyFocused
+        : (options.fallbackTrigger?.() ?? null);
+    restoreTarget?.focus?.();
+    previouslyFocused = null;
+  };
+
+  watch(
+    options.active,
+    (open) => {
+      if (open) activate();
+      else deactivate();
+    },
+    { immediate: true }
+  );
+
+  onBeforeUnmount(deactivate);
+
+  // Exposed for testing / advanced callers.
+  return { focusableElements };
+}


### PR DESCRIPTION
## Summary

Next **P1** item from the accessibility audit: the mobile off-canvas drawers (`SiteSidenav`, `RecentForumsDrawer`) were modal in appearance but had no dialog semantics, **no focus trap**, and **no Escape handling**. Keyboard and screen-reader users could Tab into the page behind the open drawer and had no keyboard way to dismiss it (WCAG 2.1.2 No Keyboard Trap / 2.4.3 Focus Order / 4.1.2).

## Approach

Rather than hand-roll fragile focus logic in two heavy components, added a reusable **`useFocusTrap` composable**:

- On activate: remember what had focus, move focus to the first focusable element in the panel.
- While active: `Tab`/`Shift+Tab` cycle within the panel; `Escape` triggers close.
- On deactivate: restore focus to the previously-focused element, with a `fallbackTrigger` for when the opener unmounts while the drawer is open (the hamburger button does exactly this — it's `v-if="!sideNavIsOpenVar"`).
- Guarded on `typeof document` (not `import.meta.client`) so it's SSR-safe **and** still runs under jsdom, so the behavior is unit-testable.

Applied to both drawers, each panel now `role="dialog"` + `aria-modal="true"` with an accessible name (`SiteSidenav` via `aria-label`, `RecentForumsDrawer` via `aria-labelledby` its heading).

## Testing

- `composables/useFocusTrap.spec.ts` — 6 tests: focus-in on activate, Escape callback, Tab wrap (both directions), focus restore on deactivate, and trap-released after deactivate.
- `SiteSidenav.spec.ts` — dialog semantics + **Escape-on-mount** (covers the layout's remount-on-open via `:key`, so the trap must engage at mount, not only on a prop change).
- `RecentForumsDrawer.spec.ts` — dialog semantics + `aria-labelledby` wiring.
- `vue-tsc --noEmit` clean.

## Scope

Remaining **P1**: SPA route-change focus management, and the keyboard-blocking custom widgets (`MultiSelect`, `FileTypePicker`, `TagComponent`, clickable-`<li>` cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)