### PR TITLE
fix(a11y): P1 — keyboard-operable profile discussion/event cards

### DIFF
--- a/components/user/DiscussionItemInProfile.spec.ts
+++ b/components/user/DiscussionItemInProfile.spec.ts
@@ -31,8 +31,14 @@ const mountItem = (props: Record<string, unknown> = {}) =>
         HighlightedSearchTerms: highlightStub,
         Tag: tagStub,
         TagComponent: tagStub,
-        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
-        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+        NuxtLink: {
+          props: ['to'],
+          template: `<a :href="typeof to === 'string' ? to : ''"><slot /></a>`,
+        },
+        'nuxt-link': {
+          props: ['to'],
+          template: `<a :href="typeof to === 'string' ? to : ''"><slot /></a>`,
+        },
       },
     },
   });
@@ -76,28 +82,31 @@ describe('DiscussionItemInProfile content', () => {
 });
 
 describe('DiscussionItemInProfile navigation', () => {
-  it('navigates to the discussion on click', async () => {
+  const titleLink = (wrapper: ReturnType<typeof mountItem>) =>
+    wrapper.findAll('a').find((a) => a.text().includes('A discussion'));
+
+  it('links the keyboard-focusable title to the discussion', () => {
     const wrapper = mountItem();
 
-    await wrapper.find('li').trigger('click');
-
-    expect(h.push).toHaveBeenCalledWith('/forums/cats/discussions/d1');
+    expect(titleLink(wrapper)?.attributes('href')).toBe(
+      '/forums/cats/discussions/d1'
+    );
   });
 
-  it('navigates to the download path for a download', async () => {
+  it('links the title to the download path for a download', () => {
     const wrapper = mountItem({ discussion: discussion({ hasDownload: true }) });
 
-    await wrapper.find('li').trigger('click');
-
-    expect(h.push).toHaveBeenCalledWith('/forums/cats/downloads/d1');
+    expect(titleLink(wrapper)?.attributes('href')).toBe(
+      '/forums/cats/downloads/d1'
+    );
   });
 
-  it('does not navigate without a channel', async () => {
-    const wrapper = mountItem({ discussion: discussion({ DiscussionChannels: [] }) });
+  it('renders the title without a link when there is no channel', () => {
+    const wrapper = mountItem({
+      discussion: discussion({ DiscussionChannels: [] }),
+    });
 
-    await wrapper.find('li').trigger('click');
-
-    expect(h.push).not.toHaveBeenCalled();
+    expect(titleLink(wrapper)).toBeUndefined();
   });
 
   it('shows a download view link for downloads', () => {

--- a/components/user/DiscussionItemInProfile.vue
+++ b/components/user/DiscussionItemInProfile.vue
@@ -4,7 +4,6 @@ import { relativeTime } from '@/utils';
 import Tag from '@/components/TagComponent.vue';
 import HighlightedSearchTerms from '@/components/HighlightedSearchTerms.vue';
 import type { Discussion } from '@/__generated__/graphql';
-import { useRouter } from 'nuxt/app';
 
 const props = defineProps({
   discussion: {
@@ -27,8 +26,6 @@ const props = defineProps({
 
 defineEmits(['filterByTag']);
 
-const router = useRouter();
-
 const defaultUniqueName = computed(() => {
   if (
     !props.discussion.DiscussionChannels ||
@@ -41,6 +38,14 @@ const defaultUniqueName = computed(() => {
 
 const isDownload = computed(() => !!props.discussion.hasDownload);
 
+// Primary link target for the card title, so it is reachable by keyboard
+// instead of relying on a click handler on the whole <li>.
+const titleLink = computed(() => {
+  if (!defaultUniqueName.value) return '';
+  const basePath = isDownload.value ? 'downloads' : 'discussions';
+  return `/forums/${defaultUniqueName.value}/${basePath}/${props.discussion.id}`;
+});
+
 const title = props.discussion.title;
 const relativeTimeText = relativeTime(props.discussion.createdAt);
 const authorUsername = props.discussion.Author
@@ -51,19 +56,16 @@ const tags = (props.discussion.Tags ?? []).map((tag) => tag.text);
 
 <template>
   <li
-    class="relative cursor-pointer list-none rounded-lg bg-gray-100 p-4 dark:bg-gray-800 dark:text-white"
-    @click="
-      () => {
-        if (defaultUniqueName) {
-          const basePath = isDownload ? 'downloads' : 'discussions';
-          router.push(
-            `/forums/${defaultUniqueName}/${basePath}/${discussion.id}`
-          );
-        }
-      }
-    "
+    class="relative list-none rounded-lg bg-gray-100 p-4 dark:bg-gray-800 dark:text-white"
   >
-    <HighlightedSearchTerms :text="title" :search-input="searchInput" />
+    <nuxt-link
+      v-if="titleLink"
+      :to="titleLink"
+      class="font-medium hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+    >
+      <HighlightedSearchTerms :text="title" :search-input="searchInput" />
+    </nuxt-link>
+    <HighlightedSearchTerms v-else :text="title" :search-input="searchInput" />
 
     <p
       class="mt-1 flex space-x-1 text-sm font-medium text-gray-600 hover:no-underline"

--- a/components/user/EventItemInProfile.spec.ts
+++ b/components/user/EventItemInProfile.spec.ts
@@ -30,8 +30,14 @@ const mountItem = (props: Record<string, unknown> = {}) =>
         HighlightedSearchTerms: highlightStub,
         Tag: tagStub,
         TagComponent: tagStub,
-        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
-        'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
+        NuxtLink: {
+          props: ['to'],
+          template: `<a :href="typeof to === 'string' ? to : ''"><slot /></a>`,
+        },
+        'nuxt-link': {
+          props: ['to'],
+          template: `<a :href="typeof to === 'string' ? to : ''"><slot /></a>`,
+        },
       },
     },
   });
@@ -81,19 +87,18 @@ describe('EventItemInProfile content', () => {
 });
 
 describe('EventItemInProfile navigation', () => {
-  it('navigates to the event on click', async () => {
+  const titleLink = (wrapper: ReturnType<typeof mountItem>) =>
+    wrapper.findAll('a').find((a) => a.text().includes('An event'));
+
+  it('links the keyboard-focusable title to the event', () => {
     const wrapper = mountItem();
 
-    await wrapper.find('li').trigger('click');
-
-    expect(h.push).toHaveBeenCalledWith('/forums/cats/events/e1');
+    expect(titleLink(wrapper)?.attributes('href')).toBe('/forums/cats/events/e1');
   });
 
-  it('does not navigate without a channel', async () => {
+  it('renders the title without a link when there is no channel', () => {
     const wrapper = mountItem({ event: event({ EventChannels: [] }) });
 
-    await wrapper.find('li').trigger('click');
-
-    expect(h.push).not.toHaveBeenCalled();
+    expect(titleLink(wrapper)).toBeUndefined();
   });
 });

--- a/components/user/EventItemInProfile.vue
+++ b/components/user/EventItemInProfile.vue
@@ -5,7 +5,6 @@ import Tag from '@/components/TagComponent.vue';
 import HighlightedSearchTerms from '@/components/HighlightedSearchTerms.vue';
 import type { Event } from '@/__generated__/graphql';
 import type { TagData } from '../../types/Tag';
-import { useRouter } from 'nuxt/app';
 
 const props = defineProps({
   event: {
@@ -28,8 +27,6 @@ const props = defineProps({
 
 defineEmits(['filterByTag']);
 
-const router = useRouter();
-
 // Computed property for defaultUniqueName
 const defaultUniqueName = computed(() => {
   if (!props.event.EventChannels || !props.event.EventChannels[0]) {
@@ -37,6 +34,14 @@ const defaultUniqueName = computed(() => {
   }
   return props.event.EventChannels[0].channelUniqueName;
 });
+
+// Primary link target for the card title, so it is keyboard-reachable instead
+// of relying on a click handler on the whole <li>.
+const titleLink = computed(() =>
+  defaultUniqueName.value
+    ? `/forums/${defaultUniqueName.value}/events/${props.event.id}`
+    : ''
+);
 
 const title = props.event.title;
 const relativeTimeText = relativeTime(props.event.createdAt);
@@ -46,17 +51,21 @@ const tags = (props.event.Tags ?? []).map((tag: TagData) => tag.text);
 
 <template>
   <li
-    class="relative cursor-pointer list-none rounded-lg bg-gray-100 p-4 dark:bg-gray-800 dark:text-white"
-    @click="
-      () => {
-        if (defaultUniqueName) {
-          router.push(`/forums/${defaultUniqueName}/events/${event.id}`);
-        }
-      }
-    "
+    class="relative list-none rounded-lg bg-gray-100 p-4 dark:bg-gray-800 dark:text-white"
   >
     <p class="text-md">
-      <HighlightedSearchTerms :text="title" :search-input="searchInput" />
+      <nuxt-link
+        v-if="titleLink"
+        :to="titleLink"
+        class="font-medium hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+      >
+        <HighlightedSearchTerms :text="title" :search-input="searchInput" />
+      </nuxt-link>
+      <HighlightedSearchTerms
+        v-else
+        :text="title"
+        :search-input="searchInput"
+      />
     </p>
 
     <p


### PR DESCRIPTION
## Summary

Next **P1** slice from the accessibility audit: the discussion and event cards on user profile pages (`DiscussionItemInProfile`, `EventItemInProfile`) put the primary navigation on a `@click` handler on the whole `<li>`. That made the card **mouse-only** — keyboard and screen-reader users had no focusable control for the card's main action (WCAG 2.1.1 Keyboard) — and, as a side effect, clicking a tag inside the card also triggered the card navigation.

## Change

- Make the card **title** a real `<nuxt-link>` (keyboard-focusable, with a visible `focus-visible` ring) pointing at the discussion/event, and remove the `<li>` click handler (and the now-unused `useRouter`).
- Falls back to plain title text when there's no channel to link to (unchanged behavior for that edge case).

This also fixes the incidental bug where clicking a filter tag inside the card double-fired navigation.

## Testing

- Updated both component specs to assert the title link's target (`href`) instead of the removed `router.push`-on-`<li>`-click, plus the no-channel fallback.
- `pnpm run tsc` (fresh `.nuxt`) and ESLint clean.

## Scope / deferred

Kept intentionally out of this batch because they need dedicated care and cross-site verification, not a quick pass:
- **`TagComponent`** — the tag is a select-toggle that also contains a delete control; making both keyboard-operable requires restructuring nested-interactive into siblings and re-checking its many call sites.
- **`EventListItem`** — its `<li>` click drives real preview/select logic (`openPreview`), not just navigation, so removing it is a UX-behavior decision.
- **`MultiSelect` / `FileTypePicker`** — full combobox/listbox keyboard rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)