### PR TITLE
fix(a11y): P1 — move focus to main content on route change

### DIFF
--- a/plugins/route-focus.client.ts
+++ b/plugins/route-focus.client.ts
@@ -1,0 +1,28 @@
+import { nextTick } from 'vue';
+import { moveFocusToMain } from '@/utils/routeFocus';
+
+// After each client-side navigation, move keyboard focus to the main content
+// region so keyboard/screen-reader users aren't left on the (now-detached) link
+// they activated. See utils/routeFocus.ts.
+export default defineNuxtPlugin(() => {
+  const router = useRouter();
+  let isInitialNavigation = true;
+
+  router.afterEach((to, from) => {
+    // Skip the initial hydration navigation: on first load focus should start
+    // at the top of the page (the skip link), not be pulled into the content.
+    if (isInitialNavigation) {
+      isInitialNavigation = false;
+      return;
+    }
+
+    // Ignore query/hash-only updates (filters, tabs, selected items) — only
+    // move focus when the actual page changes.
+    if (to.path === from.path) return;
+
+    // Wait for the destination page to render before moving focus into it.
+    nextTick(() => {
+      moveFocusToMain();
+    });
+  });
+});

--- a/tests/playwright/mocked/a11y/routeFocus.spec.ts
+++ b/tests/playwright/mocked/a11y/routeFocus.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '../../helpers/testFixture';
+import {
+  createSuperUpvoteState,
+  createSuperUpvoteHandlers,
+} from '../../helpers/mockedSuperUpvoteHandlers';
+
+// After a client-side navigation, keyboard focus should move to the main
+// content region so keyboard/screen-reader users start on the new page's
+// content instead of the (now-detached) link they activated. Navigate between
+// two static pages that both render the default layout (#main-content).
+test('moves focus to main content after client-side navigation', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createSuperUpvoteState({
+    channelId: 'cats',
+    discussionId: 'discussion-1',
+    authorUsername: 'alice',
+    actorUsername: 'cluse',
+  });
+  await setupMockedPage({
+    username: 'cluse',
+    handlers: createSuperUpvoteHandlers(state),
+  });
+
+  await page.goto('/about');
+  await expect(page.locator('#main-content')).toBeAttached();
+
+  // Client-side navigate via the in-layout footer link to another
+  // main-content page.
+  await page.locator('a[href="/terms-of-use"]').first().click();
+
+  await expect(page).toHaveURL(/\/terms-of-use$/);
+  await expect
+    .poll(() => page.evaluate(() => document.activeElement?.id), {
+      timeout: 5000,
+    })
+    .toBe('main-content');
+});

--- a/utils/routeFocus.spec.ts
+++ b/utils/routeFocus.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { moveFocusToMain } from '@/utils/routeFocus';
+
+const setup = (html: string) => {
+  document.body.innerHTML = html;
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('moveFocusToMain', () => {
+  it('moves focus to the main content region', () => {
+    setup(`
+      <a id="link" href="#">nav link</a>
+      <main id="main-content" tabindex="-1"><h1>Page</h1></main>
+    `);
+    document.getElementById('link')!.focus();
+
+    moveFocusToMain(document);
+
+    expect(document.activeElement).toBe(document.getElementById('main-content'));
+  });
+
+  it('returns true when it moved focus', () => {
+    setup('<main id="main-content" tabindex="-1"></main>');
+
+    expect(moveFocusToMain(document)).toBe(true);
+  });
+
+  it('does nothing when there is no main region', () => {
+    setup('<a id="link" href="#">nav link</a>');
+    document.getElementById('link')!.focus();
+
+    expect(moveFocusToMain(document)).toBe(false);
+  });
+
+  it('does not override focus already inside the main region', () => {
+    setup(`
+      <main id="main-content" tabindex="-1">
+        <input id="page-input" />
+      </main>
+    `);
+    document.getElementById('page-input')!.focus();
+
+    const moved = moveFocusToMain(document);
+
+    expect({
+      moved,
+      active: document.activeElement?.id,
+    }).toEqual({ moved: false, active: 'page-input' });
+  });
+});

--- a/utils/routeFocus.ts
+++ b/utils/routeFocus.ts
@@ -1,0 +1,17 @@
+/**
+ * Move keyboard focus to the page's main content region after a client-side
+ * route change. Nuxt's route announcer tells screen-reader users the page
+ * changed, but focus otherwise stays on the link that was activated (often now
+ * detached), leaving keyboard users stranded. Moving focus to `<main>` puts them
+ * at the start of the new page's content.
+ *
+ * No-op (returns false) if there is no main region, or if the destination page
+ * already placed focus inside main (so page-managed focus is never overridden).
+ */
+export function moveFocusToMain(doc: Document = document): boolean {
+  const main = doc.getElementById('main-content');
+  if (!main) return false;
+  if (main.contains(doc.activeElement)) return false;
+  main.focus();
+  return true;
+}


### PR DESCRIPTION
## Summary

Next **P1** item: SPA route-change focus management. Nuxt's `<NuxtRouteAnnouncer>` announces route changes to screen readers, but keyboard **focus** stays on the link that was activated (frequently now detached from the DOM), leaving keyboard users stranded at an arbitrary point. This adds a client plugin that moves focus to the new page's main region after each navigation (WCAG 2.4.3 Focus Order).

## Change

- **`utils/routeFocus.ts`** — `moveFocusToMain()`: focuses `<main id="main-content">`, but only if it exists **and** focus isn't already inside it, so a page that manages its own focus is never overridden. Returns a boolean for testability.
- **`plugins/route-focus.client.ts`** — wires it to `router.afterEach`, skipping the initial hydration navigation (focus should start at the top / skip link on load) and query/hash-only updates (filters, tabs).

## Testing

- `utils/routeFocus.spec.ts` — 4 unit tests: moves focus to main, no-op without a main region, no-op (doesn't override) when focus is already inside main.
- `tests/playwright/mocked/a11y/routeFocus.spec.ts` — real client-side navigation between two default-layout pages (`/about` → `/terms-of-use`) confirms focus lands on `#main-content`.
- `pnpm run tsc` (fresh `.nuxt`) + ESLint clean.

## ⚠️ Important scope note

While building this I found that **`#main-content` (and the skip link added in #345) only exist on ~27 of ~150 pages** — the ones that wrap themselves in `<NuxtLayout>`. `app.vue` renders `<NuxtPage/>` **without** a surrounding `<NuxtLayout>`, so home, forum, and forum-scoped pages (discussions/events/etc.) render **no default layout at all** — no skip link, no `<main>` landmark, and this plugin is a harmless no-op there.

Making the default layout universal (so the skip link, main landmark, and this focus move apply to every page) is a meaningful follow-up — but it's a larger, hydration-sensitive change to `app.vue` + the 27 pages that wrap `<NuxtLayout>` themselves, so it's intentionally **not** in this PR. This plugin is correct and beneficial where `#main-content` exists today, and becomes universally effective once that follow-up lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)