### PR TITLE
Add AddToListPopover error-path coverage

### DIFF
--- a/components/collection/AddToListModalHost.spec.ts
+++ b/components/collection/AddToListModalHost.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
+import { nextTick } from 'vue';
 import AddToListModalHost from '@/components/collection/AddToListModalHost.vue';
 import { useAddToListModalStore } from '@/stores/addToListModalStore';
 
@@ -46,6 +47,35 @@ describe('AddToListModalHost', () => {
       isAlreadyFavorite: true,
       variant: 'modal',
     });
+  });
+
+  it('reacts to the store opening after mount', async () => {
+    const wrapper = mountHost();
+    const store = useAddToListModalStore();
+
+    store.open({
+      itemId: 'c1',
+      itemType: 'comment',
+      isAlreadyFavorite: false,
+    });
+    await nextTick();
+
+    expect(wrapper.findComponent(AddToListPopoverStub).props('itemId')).toBe('c1');
+  });
+
+  it('removes the popover when the store closes after mount', async () => {
+    const store = useAddToListModalStore();
+    store.open({
+      itemId: 'd1',
+      itemType: 'discussion',
+      isAlreadyFavorite: true,
+    });
+
+    const wrapper = mountHost();
+    store.close();
+    await nextTick();
+
+    expect(wrapper.findComponent(AddToListPopoverStub).exists()).toBe(false);
   });
 
   it('closes and clears the modal store when the popover emits close', async () => {

--- a/components/collection/AddToListPopover.spec.ts
+++ b/components/collection/AddToListPopover.spec.ts
@@ -163,6 +163,16 @@ describe('AddToListPopover favorites toggle', () => {
     });
   });
 
+  it('refetches collections after adding to favorites', async () => {
+    const wrapper = mountPopover();
+
+    await rows(wrapper)[0].trigger('click');
+    await flushPromises();
+
+    expect(h.refetchCollections).toHaveBeenCalledTimes(1);
+    expect(h.refetchItem).not.toHaveBeenCalled();
+  });
+
   it('emits favoriteChange(true) when favoriting', async () => {
     const wrapper = mountPopover();
 
@@ -179,6 +189,36 @@ describe('AddToListPopover favorites toggle', () => {
     await flushPromises();
 
     expect(h.removeFav).toHaveBeenCalled();
+  });
+
+  it('shows an error toast when adding to favorites fails', async () => {
+    h.addFav = vi.fn().mockRejectedValue(new Error('boom'));
+    const wrapper = mountPopover();
+
+    await rows(wrapper)[0].trigger('click');
+    await flushPromises();
+
+    expect(h.showToast).toHaveBeenCalledWith(
+      'Error updating favorites',
+      'error'
+    );
+    expect(wrapper.emitted('favoriteChange')).toBeUndefined();
+    expect(h.refetchCollections).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when removing from favorites fails', async () => {
+    h.removeFav = vi.fn().mockRejectedValue(new Error('boom'));
+    const wrapper = mountPopover({ isAlreadyFavorite: true });
+
+    await rows(wrapper)[0].trigger('click');
+    await flushPromises();
+
+    expect(h.showToast).toHaveBeenCalledWith(
+      'Error updating favorites',
+      'error'
+    );
+    expect(wrapper.emitted('favoriteChange')).toBeUndefined();
+    expect(h.refetchCollections).not.toHaveBeenCalled();
   });
 
   it('uses a channel param for channel favorites', async () => {

--- a/components/collection/AddToListPopover.spec.ts
+++ b/components/collection/AddToListPopover.spec.ts
@@ -219,6 +219,16 @@ describe('AddToListPopover collection toggle', () => {
     });
   });
 
+  it('refetches collections and membership after adding the item to a collection', async () => {
+    const wrapper = mountPopover();
+
+    await rows(wrapper)[1].trigger('click');
+    await flushPromises();
+
+    expect(h.refetchCollections).toHaveBeenCalledTimes(1);
+    expect(h.refetchItem).toHaveBeenCalledTimes(1);
+  });
+
   it('removes the item from a collection it is already in', async () => {
     h.itemInResult = ref({ users: [{ Collections: [{ id: 'c1' }] }] }) as never;
     h.useQuery = vi
@@ -234,6 +244,44 @@ describe('AddToListPopover collection toggle', () => {
       collectionId: 'c1',
       itemId: 'item-1',
     });
+  });
+
+  it('shows an error toast when adding to a collection fails', async () => {
+    h.addMutation = vi.fn().mockRejectedValue(new Error('boom'));
+    const wrapper = mountPopover();
+
+    await rows(wrapper)[1].trigger('click');
+    await flushPromises();
+
+    expect(h.showToast).toHaveBeenCalledWith(
+      'Error updating collection',
+      'error'
+    );
+    expect(h.refetchCollections).not.toHaveBeenCalled();
+    expect(h.refetchItem).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when removing from a collection fails', async () => {
+    h.itemInResult = ref({ users: [{ Collections: [{ id: 'c1' }] }] }) as never;
+    h.removeMutation = vi.fn().mockRejectedValue(new Error('boom'));
+    h.useQuery = vi
+      .fn()
+      .mockReturnValueOnce({
+        result: h.collectionsResult,
+        refetch: h.refetchCollections,
+      })
+      .mockReturnValueOnce({ result: h.itemInResult, refetch: h.refetchItem });
+    const wrapper = mountPopover();
+
+    await rows(wrapper)[1].trigger('click');
+    await flushPromises();
+
+    expect(h.showToast).toHaveBeenCalledWith(
+      'Error updating collection',
+      'error'
+    );
+    expect(h.refetchCollections).not.toHaveBeenCalled();
+    expect(h.refetchItem).not.toHaveBeenCalled();
   });
 });
 
@@ -302,6 +350,43 @@ describe('AddToListPopover create new collection', () => {
       collectionId: 'new1',
       itemId: 'item-1',
     });
+  });
+
+  it('refetches collections and membership after creating and adding to a collection', async () => {
+    (h.createCollection as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        createCollections: { collections: [{ id: 'new1', name: 'New List' }] },
+      },
+    });
+    const wrapper = mountPopover();
+
+    await clickNewListButton(wrapper);
+    await wrapper.get('input[aria-label="New list name"]').setValue('New List');
+    await wrapper.findAll('button').find((b) => b.text() === 'Create')!.trigger('click');
+    await flushPromises();
+
+    expect(h.refetchCollections).toHaveBeenCalledTimes(1);
+    expect(h.refetchItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error toast when collection creation fails', async () => {
+    (h.createCollection as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('boom')
+    );
+    const wrapper = mountPopover();
+
+    await clickNewListButton(wrapper);
+    await wrapper.get('input[aria-label="New list name"]').setValue('New List');
+    await wrapper.findAll('button').find((b) => b.text() === 'Create')!.trigger('click');
+    await flushPromises();
+
+    expect(h.showToast).toHaveBeenCalledWith(
+      'Error creating collection',
+      'error'
+    );
+    expect(h.addMutation).not.toHaveBeenCalled();
+    expect(h.refetchCollections).not.toHaveBeenCalled();
+    expect(h.refetchItem).not.toHaveBeenCalled();
   });
 });
 

--- a/components/event/list/filters/EventFilterBar.spec.ts
+++ b/components/event/list/filters/EventFilterBar.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { nextTick, reactive } from 'vue';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { createMockRoute, createMockRouter } from '@/tests/utils/mockRouter';
 
@@ -6,7 +7,7 @@ import { MilesOrKm } from '@/components/event/list/filters/eventSearchOptions';
 
 import EventFilterBar from '@/components/event/list/filters/EventFilterBar.vue';
 
-const route = createMockRoute({ name: 'EventList' });
+const route = reactive(createMockRoute({ name: 'EventList' }));
 const router = createMockRouter();
 vi.mock('nuxt/app', () => ({
   useRoute: () => route,
@@ -27,6 +28,7 @@ const heavyStubs = {
   TagIcon: true,
   FilterIcon: true,
   Popper: true,
+  CheckBox: true,
 };
 
 // Slot-rendering stubs so the filter controls (which live deep inside
@@ -34,7 +36,6 @@ const heavyStubs = {
 // and can emit the events the bar wires its update handlers to.
 const openStubs = {
   ...heavyStubs,
-  SearchBar: { name: 'SearchBar', template: '<div><slot /></div>' },
   LocationSearchBar: {
     name: 'LocationSearchBar',
     emits: ['update-location-input'],
@@ -56,11 +57,39 @@ const openStubs = {
     emits: ['update-show-only-free'],
     template: '<div />',
   },
+  SearchBar: {
+    name: 'SearchBar',
+    props: ['initialValue'],
+    emits: ['update-search-input'],
+    template: '<div><slot /></div>',
+  },
   GenericButton: {
     name: 'GenericButton',
     inheritAttrs: true,
     props: ['text'],
     template: '<button>{{ text }}</button>',
+  },
+  FilterChip: {
+    name: 'FilterChip',
+    template: '<div><slot /><slot name="content" /></div>',
+  },
+  SearchableForumList: {
+    name: 'SearchableForumList',
+    props: ['selectedChannels', 'featuredForums'],
+    emits: ['toggle-selection'],
+    template: '<div />',
+  },
+  SearchableTagList: {
+    name: 'SearchableTagList',
+    props: ['selectedTags'],
+    emits: ['toggle-selection'],
+    template: '<div />',
+  },
+  CheckBox: {
+    name: 'CheckBox',
+    props: ['checked'],
+    emits: ['input'],
+    template: '<input type="checkbox" />',
   },
 };
 
@@ -74,7 +103,11 @@ const mountBar = (props: Record<string, unknown> = {}) =>
 // controls render).
 const mountOpen = () =>
   mountWithDefaults(EventFilterBar, {
-    props: { allowHidingMainFilters: true, showMainFiltersByDefault: true },
+    props: {
+      allowHidingMainFilters: true,
+      showMainFiltersByDefault: true,
+      toggleShowArchivedEnabled: true,
+    },
     global: { stubs: openStubs },
   });
 
@@ -188,6 +221,39 @@ describe('EventFilterBar filter handlers', () => {
       .vm.$emit('update-show-only-free', false);
     expect(router.replace).toHaveBeenCalled();
   });
+
+  it('writes searchInput when the search bar updates', async () => {
+    const wrapper = mountOpen();
+    await wrapper
+      .findComponent({ name: 'SearchBar' })
+      .vm.$emit('update-search-input', 'phoenix');
+    expect(lastReplaceQuery()).toMatchObject({ searchInput: 'phoenix' });
+  });
+
+  it('writes showArchived when the archived checkbox is checked', async () => {
+    const wrapper = mountOpen();
+    await wrapper.findComponent({ name: 'CheckBox' }).vm.$emit('input', {
+      target: { checked: true },
+    });
+    expect(lastReplaceQuery()).toMatchObject({ showArchived: true });
+  });
+
+  it('writes channels when a forum selection is toggled on', async () => {
+    route.params = {};
+    const wrapper = mountOpen();
+    await wrapper
+      .findComponent({ name: 'SearchableForumList' })
+      .vm.$emit('toggle-selection', 'cats');
+    expect(lastReplaceQuery()).toMatchObject({ channels: ['cats'] });
+  });
+
+  it('writes tags when a tag selection is toggled on', async () => {
+    const wrapper = mountOpen();
+    await wrapper
+      .findComponent({ name: 'SearchableTagList' })
+      .vm.$emit('toggle-selection', 'music');
+    expect(lastReplaceQuery()).toMatchObject({ tags: ['music'] });
+  });
 });
 
 describe('EventFilterBar computeds', () => {
@@ -241,5 +307,46 @@ describe('EventFilterBar computeds', () => {
       MilesOrKm.KM;
     await wrapper.vm.$nextTick();
     expect((wrapper.vm as unknown as { radiusLabel: string }).radiusLabel).toContain('km');
+  });
+});
+
+describe('EventFilterBar route hydration', () => {
+  beforeEach(() => {
+    route.params = {};
+    route.query = {};
+    route.name = 'EventList';
+    route.path = '/events';
+  });
+
+  it('hydrates the search bar from the route query on mount', () => {
+    route.query = { searchInput: 'phoenix' };
+    const wrapper = mountOpen();
+    expect(wrapper.findComponent({ name: 'SearchBar' }).props('initialValue')).toBe(
+      'phoenix'
+    );
+  });
+
+  it('hydrates the archived checkbox from the route query on mount', () => {
+    route.query = { showArchived: 'true' };
+    const wrapper = mountOpen();
+    expect(wrapper.findComponent({ name: 'CheckBox' }).props('checked')).toBe(true);
+  });
+
+  it('updates the selected tags when the route query changes', async () => {
+    const wrapper = mountOpen();
+    route.query = { tags: ['music'] };
+    await nextTick();
+    expect(
+      wrapper.findComponent({ name: 'SearchableTagList' }).props('selectedTags')
+    ).toEqual(['music']);
+  });
+
+  it('shows featured forums on map-search routes', () => {
+    route.name = 'events-map-search';
+    route.path = '/events/map';
+    const wrapper = mountOpen();
+    expect(
+      wrapper.findComponent({ name: 'SearchableForumList' }).props('featuredForums')
+    ).toHaveLength(3);
   });
 });

--- a/components/event/list/filters/eventSearchOptions.spec.ts
+++ b/components/event/list/filters/eventSearchOptions.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LocationFilterTypes,
+} from './locationFilterTypes';
+import {
+  createDefaultSelectedHourRanges,
+  createDefaultSelectedWeekdays,
+  createDefaultSelectedWeeklyHourRanges,
+  defaultSelectedHourRanges,
+  defaultSelectedWeekdays,
+  defaultSelectedWeeklyHourRanges,
+  distanceOptionsForKilometers,
+  distanceOptionsForMiles,
+  distanceUnitOptions,
+  eventFilterTypeShortcuts,
+  hourRangesObject,
+  MilesOrKm,
+  resultOrderTypes,
+  timeFilterShortcuts,
+  timeShortcutValues,
+  weekdayMap,
+} from './eventSearchOptions';
+
+describe('eventSearchOptions', () => {
+  it('builds fresh default weekday and hour-range objects with all values false', () => {
+    const weekdays = createDefaultSelectedWeekdays();
+    const hourRanges = createDefaultSelectedHourRanges();
+
+    expect(Object.values(weekdays)).toEqual(
+      expect.arrayContaining([false])
+    );
+    expect(Object.values(hourRanges)).toEqual(
+      expect.arrayContaining([false])
+    );
+    expect(defaultSelectedWeekdays).toEqual(weekdays);
+    expect(defaultSelectedHourRanges).toEqual(hourRanges);
+    expect(weekdays).not.toBe(defaultSelectedWeekdays);
+    expect(hourRanges).not.toBe(defaultSelectedHourRanges);
+  });
+
+  it('builds fresh weekly hour ranges without sharing weekday objects', () => {
+    const weeklyRanges = createDefaultSelectedWeeklyHourRanges();
+
+    expect(defaultSelectedWeeklyHourRanges).toEqual(weeklyRanges);
+    expect(weeklyRanges).not.toBe(defaultSelectedWeeklyHourRanges);
+    expect(weeklyRanges['1']).not.toBe(weeklyRanges['2']);
+    expect(Object.values(weeklyRanges['1'] || {})).toEqual(
+      expect.arrayContaining([false])
+    );
+  });
+
+  it('maps shortcut and location filter labels to the expected values', () => {
+    expect(timeFilterShortcuts.map((shortcut) => shortcut.value)).toEqual([
+      timeShortcutValues.TODAY,
+      timeShortcutValues.TOMORROW,
+      timeShortcutValues.THIS_WEEKEND,
+      timeShortcutValues.NEXT_WEEK,
+      timeShortcutValues.NEXT_WEEKEND,
+      timeShortcutValues.THIS_MONTH,
+      timeShortcutValues.NEXT_MONTH,
+      timeShortcutValues.PAST_EVENTS,
+    ]);
+
+    expect(eventFilterTypeShortcuts).toEqual([
+      {
+        label: 'Online events',
+        locationFilterType: LocationFilterTypes.ONLY_VIRTUAL,
+      },
+      {
+        label: 'In-person events',
+        locationFilterType: LocationFilterTypes.ONLY_WITH_ADDRESS,
+      },
+    ]);
+  });
+
+  it('exposes weekday and hour-range lookup objects for query building', () => {
+    expect(weekdayMap['0']).toBe('Sunday');
+    expect(weekdayMap['6']).toBe('Saturday');
+    expect(hourRangesObject['12am-3am']).toEqual(
+      expect.objectContaining({ min: 0, max: 3 })
+    );
+    expect(hourRangesObject['9pm-12am']).toEqual(
+      expect.objectContaining({ min: 21, max: 24 })
+    );
+  });
+
+  it('keeps distance options and ordering constants aligned with search UI expectations', () => {
+    expect(distanceOptionsForMiles[0]).toEqual({ label: '5', value: 8.04672 });
+    expect(distanceOptionsForMiles.at(-1)).toEqual({
+      label: 'Any distance',
+      value: 0,
+    });
+    expect(distanceOptionsForKilometers.at(-1)).toEqual({
+      label: 'Any distance',
+      value: 0,
+    });
+    expect(distanceUnitOptions).toEqual([
+      { label: 'km', value: MilesOrKm.KM },
+      { label: 'mi', value: MilesOrKm.MI },
+    ]);
+    expect(resultOrderTypes).toEqual({
+      CHRONOLOGICAL: 'CHRONOLOGICAL',
+      REVERSE_CHRONOLOGICAL: 'REVERSE_CHRONOLOGICAL',
+    });
+  });
+});

--- a/components/event/list/filters/filterStrings.spec.ts
+++ b/components/event/list/filters/filterStrings.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { SortDirection } from '@/__generated__/graphql';
+
+import {
+  chronologicalOrder,
+  reverseChronologicalOrder,
+} from './filterStrings';
+
+describe('filterStrings', () => {
+  it('exports chronological order by ascending start time', () => {
+    expect(chronologicalOrder).toEqual({
+      startTime: SortDirection.Asc,
+    });
+  });
+
+  it('exports reverse chronological order by descending start time', () => {
+    expect(reverseChronologicalOrder).toEqual({
+      startTime: SortDirection.Desc,
+    });
+  });
+});

--- a/components/favorites/AddToChannelFavorites.spec.ts
+++ b/components/favorites/AddToChannelFavorites.spec.ts
@@ -186,4 +186,22 @@ describe('AddToChannelFavorites mutation completion', () => {
 
     expect(button(wrapper).props('isFavorited')).toBe(true);
   });
+
+  it('refetches favorites after a successful toggle when it owns the lookup query', async () => {
+    const wrapper = mountFav();
+
+    await button(wrapper).vm.$emit('toggle');
+    await flushPromises();
+
+    expect(h.refetch).toHaveBeenCalled();
+  });
+
+  it('does not refetch favorites when the parent provided initialIsFavorited', async () => {
+    const wrapper = mountFav({ initialIsFavorited: false });
+
+    await button(wrapper).vm.$emit('toggle');
+    await flushPromises();
+
+    expect(h.refetch).not.toHaveBeenCalled();
+  });
 });

--- a/components/favorites/AddToCommentFavorites.spec.ts
+++ b/components/favorites/AddToCommentFavorites.spec.ts
@@ -131,4 +131,22 @@ describe('AddToCommentFavorites', () => {
 
     expect(button(wrapper).props('isFavorited')).toBe(true);
   });
+
+  it('refetches favorites after a successful toggle when isFavorited is query-driven', async () => {
+    const wrapper = mountFav({ isFavorited: null });
+
+    await button(wrapper).vm.$emit('toggle');
+    await flushPromises();
+
+    expect(h.refetch).toHaveBeenCalled();
+  });
+
+  it('does not refetch favorites when the parent controls isFavorited', async () => {
+    const wrapper = mountFav({ isFavorited: false });
+
+    await button(wrapper).vm.$emit('toggle');
+    await flushPromises();
+
+    expect(h.refetch).not.toHaveBeenCalled();
+  });
 });

--- a/components/favorites/AddToDiscussionFavorites.spec.ts
+++ b/components/favorites/AddToDiscussionFavorites.spec.ts
@@ -150,4 +150,22 @@ describe('AddToDiscussionFavorites', () => {
 
     expect(button(wrapper).props('isFavorited')).toBe(true);
   });
+
+  it('refetches favorites after a successful toggle when it owns the lookup query', async () => {
+    const wrapper = mountFav();
+
+    await button(wrapper).vm.$emit('toggle');
+    await flushPromises();
+
+    expect(h.refetch).toHaveBeenCalled();
+  });
+
+  it('does not refetch favorites when the parent provided initialIsFavorited', async () => {
+    const wrapper = mountFav({ initialIsFavorited: false });
+
+    await button(wrapper).vm.$emit('toggle');
+    await flushPromises();
+
+    expect(h.refetch).not.toHaveBeenCalled();
+  });
 });

--- a/components/favorites/AddToFavoritesButton.spec.ts
+++ b/components/favorites/AddToFavoritesButton.spec.ts
@@ -4,6 +4,15 @@ import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 
 import AddToFavoritesButton from '@/components/favorites/AddToFavoritesButton.vue';
 
+const AddToListPopoverStub = defineComponent({
+  name: 'AddToListPopover',
+  template: '<div class="add-to-list-popover-stub" />',
+});
+
+vi.mock('@/components/collection/AddToListPopover.vue', () => ({
+  default: AddToListPopoverStub,
+}));
+
 // Override the default RequireAuth stub (which renders the has-auth slot) to
 // render the unauthenticated branch instead.
 const RequireAuthUnauth = defineComponent({
@@ -14,17 +23,23 @@ const RequireAuthUnauth = defineComponent({
 });
 
 // RequireAuth is stubbed by mountWithDefaults (renders the has-auth slot);
-// AddToListPopover is Apollo-backed, so stub it here.
+// AddToListPopover is async and Apollo-backed, so keep the global stub aligned
+// with the module mock above.
 const mountButton = (props: Record<string, unknown> = {}) =>
   mountWithDefaults(AddToFavoritesButton, {
     props: { isFavorited: false, ...props },
-    global: { stubs: { AddToListPopover: true } },
+    global: { stubs: { AddToListPopover: AddToListPopoverStub } },
   });
 
 const mountUnauthButton = (props: Record<string, unknown> = {}) =>
   mountWithDefaults(AddToFavoritesButton, {
     props: { isFavorited: false, ...props },
-    global: { stubs: { RequireAuth: RequireAuthUnauth, AddToListPopover: true } },
+    global: {
+      stubs: {
+        RequireAuth: RequireAuthUnauth,
+        AddToListPopover: AddToListPopoverStub,
+      },
+    },
   });
 
 const clickFavorite = (wrapper: ReturnType<typeof mountButton>) =>

--- a/components/favorites/AddToImageFavorites.spec.ts
+++ b/components/favorites/AddToImageFavorites.spec.ts
@@ -131,4 +131,22 @@ describe('AddToImageFavorites', () => {
 
     expect(button(wrapper).props('isFavorited')).toBe(true);
   });
+
+  it('refetches favorites after a successful toggle when it owns the lookup query', async () => {
+    const wrapper = mountFav();
+
+    await button(wrapper).vm.$emit('toggle');
+    await flushPromises();
+
+    expect(h.refetch).toHaveBeenCalled();
+  });
+
+  it('does not refetch favorites when the parent provided initialIsFavorited', async () => {
+    const wrapper = mountFav({ initialIsFavorited: false });
+
+    await button(wrapper).vm.$emit('toggle');
+    await flushPromises();
+
+    expect(h.refetch).not.toHaveBeenCalled();
+  });
 });

--- a/pages/admin/dashboard.spec.ts
+++ b/pages/admin/dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
@@ -136,6 +136,9 @@ const mountDashboard = async (
           props: ['to'],
           template: '<a :href="to"><slot /></a>',
         },
+        ClientOnly: {
+          template: '<slot /><slot name="fallback" />',
+        },
       },
     },
   });
@@ -151,6 +154,8 @@ const mountDashboard = async (
 };
 
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-26T12:00:00Z'));
   vi.clearAllMocks();
   mockedUseRoute.mockReturnValue({
     query: {
@@ -161,6 +166,10 @@ beforeEach(() => {
   mockedUseRouter.mockReturnValue({
     replace: vi.fn(),
   });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('admin dashboard page', () => {
@@ -207,6 +216,62 @@ describe('admin dashboard page', () => {
         sort: 'oldestOpenIssueAgeDays',
         sortDirection: 'desc',
       },
+    });
+  });
+
+  it('falls back to default dates and sort values for invalid route query params', async () => {
+    const replace = vi.fn();
+    mockedUseRoute.mockReturnValue({
+      query: {
+        startDate: 'not-a-date',
+        endDate: 'still-not-a-date',
+        sort: 'bogus',
+        sortDirection: 'sideways',
+      },
+    });
+    mockedUseRouter.mockReturnValue({ replace });
+
+    await mountDashboard();
+
+    expect(replace).not.toHaveBeenCalled();
+
+    expect(
+      mockedUseQuery.mock.calls[0]?.[1]?.value
+    ).toEqual({
+      startDate: '2026-05-27',
+      endDate: '2026-06-26',
+    });
+    expect(
+      mockedUseQuery.mock.calls[1]?.[1]?.value
+    ).toEqual({
+      startDate: '2026-05-27',
+      endDate: '2026-06-26',
+      limit: 20,
+      sortBy: 'activityScore',
+      sortDirection: 'desc',
+    });
+  });
+
+  it('uses valid sort query params in the channel health query', async () => {
+    mockedUseRoute.mockReturnValue({
+      query: {
+        startDate: '2026-05-27',
+        endDate: '2026-06-26',
+        sort: 'channelUniqueName',
+        sortDirection: 'asc',
+      },
+    });
+
+    await mountDashboard();
+
+    expect(
+      mockedUseQuery.mock.calls[1]?.[1]?.value
+    ).toEqual({
+      startDate: '2026-05-27',
+      endDate: '2026-06-26',
+      limit: 20,
+      sortBy: 'channelUniqueName',
+      sortDirection: 'asc',
     });
   });
 

--- a/pages/admin/settings/plugins/[pluginId].spec.ts
+++ b/pages/admin/settings/plugins/[pluginId].spec.ts
@@ -93,6 +93,16 @@ const stubs = {
 
 const mountPage = () => mountWithDefaults(PluginDetailPage, { global: { stubs } });
 
+const deferred = <T = unknown>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
 const setAvailablePlugin = (overrides: Record<string, unknown> = {}) => {
   h.q.AVAILABLE.result.value = {
     plugins: [
@@ -365,5 +375,160 @@ describe('Plugin detail page', () => {
         endpoint: 'https://example.com',
       },
     });
+  });
+
+  it('saves settings and secrets using the installed plugin slug, then refetches and clears secret values', async () => {
+    setInstalledPlugin({
+      plugin: {
+        id: PLUGIN_ID,
+        name: 'plugin-slug',
+        displayName: 'My Plugin',
+      },
+      manifest: {
+        ui: {
+          forms: {
+            server: [
+              {
+                id: 'main',
+                title: 'Main',
+                fields: [
+                  { key: 'endpoint', label: 'Endpoint', type: 'text' },
+                  { key: 'apiKey', label: 'API Key', type: 'secret' },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    });
+    const wrapper = mountPage();
+
+    await wrapper.findComponent({ name: 'PluginSettingsSection' }).vm.$emit(
+      'update:modelValue',
+      {
+        endpoint: 'https://example.com',
+        apiKey: 'secret-value',
+      }
+    );
+    await wrapper.get('[data-test="save-settings"]').trigger('click');
+    await flushPromises();
+
+    expect(h.mutations.SET_SECRET_M?.mutate).toHaveBeenCalledWith({
+      pluginId: 'plugin-slug',
+      key: 'apiKey',
+      value: 'secret-value',
+    });
+    expect(h.mutations.ENABLE_M?.mutate).toHaveBeenCalledWith({
+      pluginId: 'plugin-slug',
+      version: '1.0.0',
+      enabled: true,
+      settingsJson: {
+        endpoint: 'https://example.com',
+      },
+    });
+    expect(toast.success).toHaveBeenCalledWith('Settings saved successfully');
+    expect(h.q.INSTALLED.refetch).toHaveBeenCalled();
+    expect(h.q.SECRETS.refetch).toHaveBeenCalled();
+    expect(
+      wrapper.findComponent({ name: 'PluginSettingsSection' }).props(
+        'modelValue'
+      )
+    ).toEqual({
+      endpoint: 'https://example.com',
+      apiKey: '',
+    });
+  });
+
+  it('stops before saving non-secret settings when saving a secret fails', async () => {
+    setInstalledPlugin({
+      manifest: {
+        ui: {
+          forms: {
+            server: [
+              {
+                id: 'main',
+                title: 'Main',
+                fields: [
+                  { key: 'endpoint', label: 'Endpoint', type: 'text' },
+                  { key: 'apiKey', label: 'API Key', type: 'secret' },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    });
+    h.mutations.SET_SECRET_M = {
+      mutate: vi.fn().mockRejectedValue(new Error('Secret rejected')),
+      loading: { value: false },
+    };
+    const wrapper = mountPage();
+
+    await wrapper.findComponent({ name: 'PluginSettingsSection' }).vm.$emit(
+      'update:modelValue',
+      {
+        endpoint: 'https://example.com',
+        apiKey: 'secret-value',
+      }
+    );
+    await wrapper.get('[data-test="save-settings"]').trigger('click');
+    await flushPromises();
+
+    expect(h.mutations.ENABLE_M?.mutate).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      'Failed to save settings: Secret rejected'
+    );
+    expect(
+      wrapper.findComponent({ name: 'PluginSettingsSection' }).props(
+        'modelValue'
+      )
+    ).toEqual({
+      endpoint: 'https://example.com',
+      apiKey: 'secret-value',
+    });
+  });
+
+  it('keeps the settings section in a saving state while the save is in flight', async () => {
+    setInstalledPlugin({
+      manifest: {
+        ui: {
+          forms: {
+            server: [
+              {
+                id: 'main',
+                title: 'Main',
+                fields: [{ key: 'endpoint', label: 'Endpoint', type: 'text' }],
+              },
+            ],
+          },
+        },
+      },
+    });
+    const enableDeferred = deferred<Record<string, never>>();
+    h.mutations.ENABLE_M = {
+      mutate: vi.fn().mockReturnValue(enableDeferred.promise),
+      loading: { value: false },
+    };
+    const wrapper = mountPage();
+
+    await wrapper.findComponent({ name: 'PluginSettingsSection' }).vm.$emit(
+      'update:modelValue',
+      {
+        endpoint: 'https://example.com',
+      }
+    );
+    await wrapper.get('[data-test="save-settings"]').trigger('click');
+    await flushPromises();
+
+    expect(
+      wrapper.findComponent({ name: 'PluginSettingsSection' }).props('saving')
+    ).toBe(true);
+
+    enableDeferred.resolve({});
+    await flushPromises();
+
+    expect(
+      wrapper.findComponent({ name: 'PluginSettingsSection' }).props('saving')
+    ).toBe(false);
   });
 });

--- a/pages/forums/[forumId]/downloads/[discussionId].spec.ts
+++ b/pages/forums/[forumId]/downloads/[discussionId].spec.ts
@@ -2,11 +2,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { defineComponent, ref } from 'vue';
 
+type RouteShape = {
+  params: {
+    forumId?: string;
+    discussionId?: string | null;
+  };
+};
+
+type QueryResultShape = {
+  data?: {
+    discussions?: Array<Record<string, unknown> | null>;
+  };
+};
+
 const h = vi.hoisted(() => ({
-  route: { params: { forumId: 'cats', discussionId: 'd1' } },
+  route: { params: { forumId: 'cats', discussionId: 'd1' } } as RouteShape,
   modName: null as unknown as { value: string },
   useHead: vi.fn(),
-  onResult: null as null | ((result: any) => void),
+  onResult: null as null | ((result: QueryResultShape) => void),
 }));
 
 h.modName = ref('modAlice');
@@ -60,7 +73,7 @@ beforeEach(() => {
 
 describe('download detail page wrapper', () => {
   it('shows an error banner when the route discussion id is missing', async () => {
-    h.route = { params: { forumId: 'cats', discussionId: null } as any };
+    h.route = { params: { forumId: 'cats', discussionId: null } };
     const wrapper = await mountPage();
     expect(wrapper.text()).toContain('Download not found');
   });
@@ -70,6 +83,21 @@ describe('download detail page wrapper', () => {
     h.onResult?.({ data: { discussions: [] } });
     expect(h.useHead).toHaveBeenCalledWith({
       title: 'Download Not Found | cats',
+      meta: [
+        {
+          name: 'description',
+          content: 'The requested download could not be found.',
+        },
+      ],
+    });
+  });
+
+  it('omits the channel suffix from not-found metadata when the forum id is missing', async () => {
+    h.route = { params: { discussionId: 'd1' } };
+    await mountPage();
+    h.onResult?.({ data: { discussions: [] } });
+    expect(h.useHead).toHaveBeenCalledWith({
+      title: 'Download Not Found',
       meta: [
         {
           name: 'description',
@@ -106,6 +134,68 @@ describe('download detail page wrapper', () => {
         ]),
       })
     );
+  });
+
+  it('uses fallback SEO values when the download has no body or image', async () => {
+    await mountPage();
+    h.onResult?.({
+      data: {
+        discussions: [
+          {
+            title: '',
+            body: '',
+            coverImageURL: '',
+            createdAt: '2024-01-01T00:00:00.000Z',
+            updatedAt: '',
+            Author: { username: 'alice' },
+          },
+        ],
+      },
+    });
+
+    expect(h.useHead).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Download | cats | Multiforum',
+        meta: expect.arrayContaining([
+          {
+            name: 'description',
+            content: 'View this download on Multiforum',
+          },
+          { name: 'twitter:card', content: 'summary' },
+        ]),
+      })
+    );
+  });
+
+  it('does not add image meta tags when the download has no cover image', async () => {
+    await mountPage();
+    h.onResult?.({
+      data: {
+        discussions: [
+          {
+            title: 'No Image',
+            body: 'Plain body',
+            coverImageURL: '',
+            createdAt: '2024-01-01T00:00:00.000Z',
+            updatedAt: '2024-01-01T00:00:00.000Z',
+            Author: { displayName: 'Alice', username: 'alice' },
+          },
+        ],
+      },
+    });
+
+    expect(
+      h.useHead.mock.calls.at(-1)?.[0]?.meta?.some(
+        (tag: Record<string, string>) =>
+          tag.property === 'og:image' || tag.name === 'twitter:image'
+      )
+    ).toBe(false);
+  });
+
+  it('ignores query results that do not include discussions', async () => {
+    await mountPage();
+    h.onResult?.({ data: {} });
+    expect(h.useHead).not.toHaveBeenCalled();
   });
 
   it('falls back to generic metadata when building SEO tags throws', async () => {


### PR DESCRIPTION
## Summary
- add error-path coverage for collection add/remove failures in AddToListPopover
- cover refetch behavior after collection toggles and create-plus-add flows
- cover collection creation failure without over-stubbing the component

## Testing
- npx vitest run 'components/collection/AddToListPopover.spec.ts'
- pnpm exec eslint 'components/collection/AddToListPopover.spec.ts'