### PR TITLE
fix(a11y): main landmark for the standalone layout-less pages

### DIFF
--- a/pages/create-username.spec.ts
+++ b/pages/create-username.spec.ts
@@ -104,4 +104,12 @@ describe('create-username page', () => {
 
     expect(h.push).toHaveBeenCalledWith('/');
   });
+
+  // This standalone onboarding page renders without the default layout, so it
+  // needs its own main landmark (also the target for route-change focus).
+  it('exposes a main landmark for the page content', async () => {
+    const wrapper = await mountPage();
+
+    expect(wrapper.find('main#main-content').exists()).toBe(true);
+  });
 });

--- a/pages/create-username.vue
+++ b/pages/create-username.vue
@@ -80,7 +80,11 @@ if (isClient) {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center">
+  <main
+    id="main-content"
+    tabindex="-1"
+    class="flex min-h-screen items-center justify-center outline-none"
+  >
     <div class="w-full max-w-md">
       <!-- Show loading state while checking email -->
       <div v-if="loading" class="py-8 text-center">
@@ -107,5 +111,5 @@ if (isClient) {
         </div>
       </client-only>
     </div>
-  </div>
+  </main>
 </template>

--- a/pages/settings.spec.ts
+++ b/pages/settings.spec.ts
@@ -10,4 +10,12 @@ describe('settings page', () => {
       { label: 'Settings', path: 'settings' },
     ]);
   });
+
+  // This standalone page renders without the default layout, so it needs its
+  // own main landmark (also the target for route-change focus).
+  it('exposes a main landmark for the page content', () => {
+    const wrapper = shallowMount(SettingsPage);
+
+    expect(wrapper.find('main#main-content').exists()).toBe(true);
+  });
 });

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -13,12 +13,16 @@ const links = computed(() => {
 </script>
 
 <template>
-  <div class="flex-1 px-10 text-xl font-bold">
+  <main
+    id="main-content"
+    tabindex="-1"
+    class="flex-1 px-10 text-xl font-bold outline-none"
+  >
     <Breadcrumbs :links="links" />
     <h2
-      class="font-extrabold mb-2 ml-2 mt-6 inline text-3xl tracking-tight text-gray-900 sm:block sm:text-4xl"
+      class="font-extrabold mb-2 ml-2 mt-6 inline text-3xl tracking-tight text-gray-900 dark:text-gray-100 sm:block sm:text-4xl"
     >
       Settings
     </h2>
-  </div>
+  </main>
 </template>


### PR DESCRIPTION
## Summary

Completes main-landmark coverage for the few pages that render **without the default layout**.

### Context (correcting an earlier assumption)

I initially suspected the skip link + `<main>` landmark from #345 and the route-focus plugin (#351) only worked on ~27/150 pages. That was wrong — it came from a flaky mocked-server reading. Static routing analysis is authoritative: a page gets the default layout if it, **or any ancestor route file**, wraps in `<NuxtLayout>`. Since parents like `pages/forums/[forumId].vue`, `pages/admin.vue`, and `pages/u/[username].vue` wrap `<NuxtPage/>` in `<NuxtLayout>`, their entire subtrees (all forum discussion/event/download detail pages, admin, profiles, …) inherit `#main-content`.

**147 of 150 pages already have the layout.** So the big `app.vue` refactor I floated is **not needed**.

### The actual gap — 3 pages

- `pages/index.vue` — a pure `navigateTo('/discussions')` redirect that never presents content → left as-is.
- `pages/settings.vue` and `pages/create-username.vue` — standalone pages with real content but no `<main>` landmark and no route-focus target.

### Change

Wrap the content of `settings.vue` and `create-username.vue` in `<main id="main-content" tabindex="-1">`, **preserving their standalone, nav-less design** (no forced TopNav/footer — that stays a product decision). This gives them a proper main landmark (WCAG 1.3.1) and makes the route-change focus plugin work there too. Also adds a `dark:` variant to the Settings heading (an audit contrast item).

## Testing

- Main-landmark assertions added to `settings.spec.ts` and `create-username.spec.ts` (7 tests pass).
- `pnpm run tsc` (fresh `.nuxt`) + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)