### PR TITLE
fix(a11y): P1 — make TagComponent keyboard-operable

### DIFF
--- a/components/TagComponent.spec.ts
+++ b/components/TagComponent.spec.ts
@@ -44,10 +44,14 @@ describe('TagComponent rendering', () => {
 });
 
 describe('TagComponent interaction', () => {
+  // The tag content is a real <button> (first button in the tag); the clear
+  // control, when present, is a separate button with data-testid tag-delete.
+  const selectButton = (w: ReturnType<typeof mountTag>) => w.get('button');
+
   it('emits select when clicked while inactive', async () => {
     const wrapper = mountTag();
 
-    await tagEl(wrapper).trigger('click');
+    await selectButton(wrapper).trigger('click');
 
     expect(wrapper.emitted('select')?.[0]).toEqual(['pets']);
   });
@@ -55,15 +59,35 @@ describe('TagComponent interaction', () => {
   it('emits deselect when clicked while active', async () => {
     const wrapper = mountTag({ active: true });
 
-    await tagEl(wrapper).trigger('click');
+    await selectButton(wrapper).trigger('click');
 
     expect(wrapper.emitted('deselect')?.[0]).toEqual(['pets']);
+  });
+
+  it('renders the tag as a keyboard-operable button', () => {
+    const wrapper = mountTag();
+
+    expect(selectButton(wrapper).element.tagName).toBe('BUTTON');
+  });
+
+  it('exposes the selected state via aria-pressed', () => {
+    const wrapper = mountTag({ active: true });
+
+    expect(selectButton(wrapper).attributes('aria-pressed')).toBe('true');
   });
 
   it('shows the clear icon when clearable', () => {
     const wrapper = mountTag({ clearable: true });
 
     expect(wrapper.find('[data-testid="tag-delete"]').exists()).toBe(true);
+  });
+
+  it('gives the clear control an accessible name', () => {
+    const wrapper = mountTag({ clearable: true });
+
+    expect(wrapper.get('[data-testid="tag-delete"]').attributes('aria-label')).toBe(
+      'Remove pets'
+    );
   });
 
   it('emits delete with the index from the clear icon', async () => {

--- a/components/TagComponent.vue
+++ b/components/TagComponent.vue
@@ -86,23 +86,35 @@ function getButtonStyles() {
     :class="tagClasses"
     @mouseenter="highlightedByMouse = true"
     @mouseleave="highlightedByMouse = false"
-    @click="handleTagClick(props.tag, props.active)"
   >
-    <AvatarComponent
-      v-if="props.channelMode && !props.hideIcon"
-      :class="[props.clearable ? 'mr-1' : '', 'h-6 w-6']"
-      class="inline-flex"
-      :text="props.tag"
-      :src="props.icon"
-      :is-square="true"
-    />
-    {{ props.tag }}
-    <XmarkIcon
+    <!-- Real button so the tag is keyboard-operable; the click still bubbles to
+         the root span, so consumers listening via @click keep working. -->
+    <button
+      type="button"
+      :aria-pressed="props.active"
+      class="inline-flex items-center gap-1 p-0 text-inherit focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-1"
+      @click="handleTagClick(props.tag, props.active)"
+    >
+      <AvatarComponent
+        v-if="props.channelMode && !props.hideIcon"
+        :class="[props.clearable ? 'mr-1' : '', 'h-6 w-6']"
+        class="inline-flex"
+        :text="props.tag"
+        :src="props.icon"
+        :is-square="true"
+      />
+      {{ props.tag }}
+    </button>
+    <button
       v-if="props.clearable"
+      type="button"
       data-testid="tag-delete"
-      class="mr-1 h-4 w-4 cursor-pointer"
-      @click="emits('delete', props.index)"
-    />
+      :aria-label="`Remove ${props.tag}`"
+      class="inline-flex items-center p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+      @click.stop="emits('delete', props.index)"
+    >
+      <XmarkIcon class="mr-1 h-4 w-4" aria-hidden="true" />
+    </button>
   </span>
 </template>
 


### PR DESCRIPTION
## Summary

`TagComponent` (used in ~18 places — filters, cards, channel/discussion/event lists) was a `<span @click>`: not focusable, not keyboard-operable (WCAG 2.1.1), and its clear control was an unlabeled `<XmarkIcon @click>` nested inside.

## Change

- The tag content is now a real **`<button>`** with `aria-pressed` reflecting the selected/filter state and a visible `focus-visible` ring.
- The clear control (when `clearable`) is its own sibling **`<button aria-label="Remove <tag>">`** with `@click.stop`, so removing a tag no longer also fires the tag's select/filter.

### Why this is behaviour-preserving for consumers

I surveyed all usages: **no consumer passes `clearable`, and none listens to `@select`/`@deselect`/`@delete`** — they filter via a fall-through `@click` on `<Tag>` (e.g. `@click="$emit('filterByTag', tag)"`). Since `<button>` clicks still bubble to the root `<span>`, those handlers keep working exactly as before — and now fire on keyboard Enter/Space too. The root `<span>` keeps its `data-testid`, `.tag` class, and pill styling, so visuals are unchanged.

## Testing

- `TagComponent.spec.ts` updated to drive the button; adds assertions for button semantics, `aria-pressed`, and the clear control's accessible name (12 tests pass).
- The 5 consumer specs that render/stub `Tag` still pass (54 tests). Existing e2e that add/remove tags on discussions and channels exercise the real interaction in CI.
- `pnpm run tsc` (fresh `.nuxt`) + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)