### PR TITLE
fix(a11y): P1 — make FileTypePicker keyboard-operable

### DIFF
--- a/components/FileTypePicker.spec.ts
+++ b/components/FileTypePicker.spec.ts
@@ -93,6 +93,44 @@ describe('FileTypePicker selection', () => {
     expect(wrapper.emitted('setSelectedFileTypes')?.[0]).toEqual([['glb']]);
   });
 
+  it('exposes each chip remove as a labelled button', () => {
+    const wrapper = mountPicker({ selectedFileTypes: ['png'] });
+
+    expect(
+      wrapper.get('button[aria-label="Remove png"]').element.tagName
+    ).toBe('BUTTON');
+  });
+
+  describe('keyboard accessibility', () => {
+    const trigger = (w: ReturnType<typeof mount>) =>
+      w.get('[data-testid="file-type-picker"]');
+
+    it('exposes the trigger as a combobox', () => {
+      const wrapper = mountPicker();
+
+      expect({
+        role: trigger(wrapper).attributes('role'),
+        expanded: trigger(wrapper).attributes('aria-expanded'),
+      }).toEqual({ role: 'combobox', expanded: 'false' });
+    });
+
+    it('opens the list from the trigger with ArrowDown', async () => {
+      const wrapper = mountPicker();
+
+      await trigger(wrapper).trigger('keydown', { key: 'ArrowDown' });
+
+      expect(wrapper.findComponent(listStub).exists()).toBe(true);
+    });
+
+    it('reflects the open state on aria-expanded', async () => {
+      const wrapper = mountPicker();
+
+      await trigger(wrapper).trigger('keydown', { key: 'Enter' });
+
+      expect(trigger(wrapper).attributes('aria-expanded')).toBe('true');
+    });
+  });
+
   it('syncs selection when the prop changes', async () => {
     const wrapper = mountPicker({ selectedFileTypes: ['png'] });
 

--- a/components/FileTypePicker.vue
+++ b/components/FileTypePicker.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, watch } from 'vue';
+import { ref, watch, useId } from 'vue';
 import type { PropType } from 'vue';
 import SearchableFileTypeList from '@/components/SearchableFileTypeList.vue';
 
@@ -22,11 +22,24 @@ const emit = defineEmits(['setSelectedFileTypes']);
 
 const isDropdownOpen = ref(false);
 const selected = ref([...props.selectedFileTypes]);
+// The readonly input doubles as the keyboard-accessible combobox trigger; focus
+// returns to it when the popup closes.
+const triggerRef = ref<HTMLInputElement | null>(null);
+const listId = useId();
 
 const toggleDropdown = () => {
   if (!props.disabled) {
     isDropdownOpen.value = !isDropdownOpen.value;
   }
+};
+
+const openDropdown = () => {
+  if (!props.disabled) isDropdownOpen.value = true;
+};
+
+const closeAndReturnFocus = () => {
+  isDropdownOpen.value = false;
+  triggerRef.value?.focus();
 };
 
 const toggleSelectedFileType = (fileType: string) => {
@@ -82,30 +95,43 @@ const removeSelection = (fileType: string) => {
           :key="index"
           class="mr-2 mt-1 inline-flex items-center rounded-full bg-orange-100 px-2 text-orange-700 dark:bg-orange-700 dark:text-orange-100"
           :class="{ 'opacity-50': disabled }"
-          @click="!disabled && removeSelection(fileType)"
         >
           <span>{{ fileType }}</span>
-          <span
+          <button
             v-if="!disabled"
-            class="ml-1 cursor-pointer"
+            type="button"
+            :aria-label="`Remove ${fileType}`"
+            class="ml-1 cursor-pointer rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
             @click.stop="removeSelection(fileType)"
           >
-            &times;
-          </span>
+            <span aria-hidden="true">&times;</span>
+          </button>
         </div>
         <input
           v-if="!disabled"
+          ref="triggerRef"
           data-testid="file-type-picker"
           class="bg-transparent flex-1 border-none text-sm focus:outline-none dark:text-white"
           placeholder="Search file types..."
+          aria-label="Selected file types"
+          role="combobox"
+          :aria-expanded="isDropdownOpen"
+          aria-haspopup="true"
+          :aria-controls="listId"
           readonly
+          @click.stop="toggleDropdown"
+          @keydown.down.prevent="openDropdown"
+          @keydown.enter.prevent="toggleDropdown"
+          @keydown.escape="closeAndReturnFocus"
         >
       </div>
       <SearchableFileTypeList
         v-if="isDropdownOpen && !disabled"
+        :id="listId"
         v-click-outside="outside"
         :selected-file-types="selected"
         @toggle-selection="toggleSelectedFileType"
+        @keydown.escape="closeAndReturnFocus"
       />
     </div>
   </div>


### PR DESCRIPTION
## Summary

Closes out the last of the P1 keyboard-blocking widgets. `FileTypePicker`'s field was a `<div @click>` — not focusable, so it couldn't be **opened** by keyboard — and each selected chip's remove control was an unfocusable `<span>`. (Its dropdown, `SearchableFileTypeList`, already uses `<label>`-wrapped `@change` checkboxes, so the options themselves were already keyboard-operable.)

## Change

- The readonly field is now a keyboard-accessible **combobox trigger**: `role="combobox"`, `aria-expanded`, `aria-haspopup`, `aria-controls` pointing at the list; **ArrowDown/Enter open** it, **Escape** closes and returns focus. The whole field stays mouse-clickable.
- Each chip's remove control is now a `<button aria-label="Remove <type>">`.

Mirrors the approach in the MultiSelect PR (#356) — native, robust primitives rather than a hand-rolled listbox.

## Testing

- Backward-compatible: the 10 existing tests pass unchanged.
- Adds 4 keyboard-accessibility tests (combobox role/state, open via ArrowDown, `aria-expanded` on Enter, labelled remove button).
- `pnpm run tsc` (fresh `.nuxt`) + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)