### PR TITLE
test: de-flake the giveSuperUpvote e2e

### DIFF
--- a/tests/playwright/mocked/superUpvote/giveSuperUpvote.spec.ts
+++ b/tests/playwright/mocked/superUpvote/giveSuperUpvote.spec.ts
@@ -41,15 +41,23 @@ test('user can give and undo a super upvote on another user\'s discussion', asyn
   await expect(upvoteButton).toBeVisible();
   await expect(superUpvoteButton).toHaveCount(0);
 
-  // Upvote alice's discussion.
-  await upvoteButton.click();
-  await page.waitForResponse(
-    (response) =>
-      response.url().includes('/graphql') && response.request().method() === 'POST'
-  );
+  // Upvote alice's discussion. Register the response listener *before* the
+  // click (Promise.all) so a fast GraphQL POST can't resolve before we start
+  // listening — the "click then waitForResponse" ordering races and, when the
+  // response lands first, waitForResponse waits for a POST that never comes and
+  // times out (the source of this test's flakiness).
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.url().includes('/graphql') &&
+        response.request().method() === 'POST'
+    ),
+    upvoteButton.click(),
+  ]);
 
-  // The super upvote button now appears, in its inactive state.
-  await expect(superUpvoteButton).toBeVisible();
+  // The super upvote button now appears, in its inactive state. Give it a
+  // generous timeout for cold-start CI where the mutation round-trip is slow.
+  await expect(superUpvoteButton).toBeVisible({ timeout: 15_000 });
   await expect(superUpvoteButton).not.toContainText('Undo');
 
   // Open the super upvote modal.


### PR DESCRIPTION
## Summary

The `giveSuperUpvote` mocked e2e has been failing intermittently on cold-start CI — it flaked on nearly every recent PR (#340, #345, #355, #357) and required manual job re-runs each time.

## Root cause

Classic Playwright ordering race:

```ts
await upvoteButton.click();
await page.waitForResponse(/* graphql POST */);
```

The click fires the upvote mutation; its response can return **before** `waitForResponse` registers its listener. When that happens, `waitForResponse` waits for the *next* matching POST — which never comes — and hits the 60s timeout.

## Fix

Register the listener **before** the click with `Promise.all`, and give the follow-up "super upvote button is visible" assertion a generous timeout for slow cold-start mutation round-trips:

```ts
await Promise.all([
  page.waitForResponse(/* graphql POST */),
  upvoteButton.click(),
]);
await expect(superUpvoteButton).toBeVisible({ timeout: 15_000 });
```

Passes 3× in a row locally. Not an accessibility change — spun off separately as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)