### PR TITLE
Add next-tier coverage for issues and downloads

### DIFF
--- a/composables/useServerIssueList.spec.ts
+++ b/composables/useServerIssueList.spec.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { defineComponent, h, nextTick, ref, reactive } from 'vue';
+import { mount } from '@vue/test-utils';
+
+const hState = vi.hoisted(() => ({
+  route: {
+    params: { forumId: 'cats' as string | undefined },
+    query: {} as Record<string, unknown>,
+    path: '/admin/issues',
+  },
+  router: { replace: vi.fn() },
+  isAuthenticated: null as unknown as { value: boolean },
+  selectedIssueNumber: null as unknown as { value: number | null },
+  setSelectedIssueSelection: vi.fn(),
+  clearSelectedIssueSelection: vi.fn(),
+  refetch: vi.fn(),
+  queryResult: null as unknown as {
+    value: { getSiteWideIssueList: { issues: Array<{ id: string }> } };
+  },
+  queryLoading: null as unknown as { value: boolean },
+  queryError: null as unknown as { value: Error | null },
+  queryCalls: [] as Array<{
+    variables: { value: Record<string, unknown> };
+    options: Record<string, unknown>;
+  }>,
+}));
+
+hState.isAuthenticated = ref(true);
+hState.selectedIssueNumber = ref<number | null>(null);
+hState.queryResult = ref({
+  getSiteWideIssueList: { issues: [{ id: 'issue-1' }] },
+});
+hState.queryLoading = ref(false);
+hState.queryError = ref<Error | null>(null);
+
+const route = reactive(hState.route);
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => route,
+  useRouter: () => hState.router,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: (
+    _doc: unknown,
+    variables: { value: Record<string, unknown> },
+    options: Record<string, unknown>
+  ) => {
+    hState.queryCalls.push({ variables, options });
+    return {
+      result: hState.queryResult,
+      error: hState.queryError,
+      loading: hState.queryLoading,
+      refetch: hState.refetch,
+    };
+  },
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useIsAuthenticated: () => hState.isAuthenticated,
+}));
+
+vi.mock('@/stores/uiStore', () => ({
+  useUIStore: () => ({
+    selectedIssueNumber: hState.selectedIssueNumber,
+    setSelectedIssueSelection: hState.setSelectedIssueSelection,
+    clearSelectedIssueSelection: hState.clearSelectedIssueSelection,
+  }),
+}));
+
+vi.mock('pinia', () => ({
+  storeToRefs: (store: { selectedIssueNumber: typeof hState.selectedIssueNumber }) => ({
+    selectedIssueNumber: store.selectedIssueNumber,
+  }),
+}));
+
+vi.mock('@/utils', () => ({
+  getChannelLabel: (channels: string[]) =>
+    channels.length ? channels.join(', ') : 'All Forums',
+}));
+
+vi.mock('@/utils/issueSortOptions', () => ({
+  issueSortValues: {
+    NEWEST: 'newest',
+    OLDEST: 'oldest',
+    MOST_REPORTS: 'mostReports',
+  },
+  defaultIssueSort: 'newest',
+  getIssueSortFromQuery: (query: Record<string, unknown>) => {
+    return query.sort === 'oldest' || query.sort === 'mostReports'
+      ? String(query.sort)
+      : 'newest';
+  },
+  getIssueSortLabel: (value: string) => `label:${value}`,
+}));
+
+vi.mock('@/utils/routerUtils', () => ({
+  updateFilters: vi.fn(),
+}));
+
+const mountComposable = async (options: {
+  isOpen: boolean;
+  scopedToForum?: boolean;
+}) => {
+  const { useServerIssueList } = await import('./useServerIssueList');
+  let api!: ReturnType<typeof useServerIssueList>;
+
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        api = useServerIssueList(options);
+        return () => h('div');
+      },
+    })
+  );
+
+  return { wrapper, api };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  route.params = { forumId: 'cats' };
+  route.query = {};
+  route.path = '/admin/issues';
+  hState.isAuthenticated.value = true;
+  hState.selectedIssueNumber.value = null;
+  hState.queryResult.value = {
+    getSiteWideIssueList: { issues: [{ id: 'issue-1' }] },
+  };
+  hState.queryLoading.value = false;
+  hState.queryError.value = null;
+  hState.queryCalls = [];
+});
+
+describe('useServerIssueList', () => {
+  it('uses the forum id and cache-and-network fetches in forum scope', async () => {
+    route.query = {
+      channels: ['dogs'],
+      showOnlyServerRuleViolations: 'true',
+      filterCreatedByMe: 'true',
+    };
+
+    const { wrapper } = await mountComposable({
+      isOpen: true,
+      scopedToForum: true,
+    });
+    const firstCall = hState.queryCalls[0];
+    wrapper.unmount();
+
+    expect({
+      variables: firstCall.variables.value,
+      fetchPolicy: firstCall.options.fetchPolicy,
+    }).toEqual({
+      variables: {
+        searchInput: '',
+        selectedChannels: ['cats'],
+        startDate: null,
+        endDate: null,
+        showOnlyServerRuleViolations: false,
+        isOpen: true,
+        filterCreatedByMe: true,
+        filterIAmOP: false,
+        filterIReported: false,
+        options: { sort: 'newest' },
+      },
+      fetchPolicy: 'cache-and-network',
+    });
+  });
+
+  it('drops involvement filters from query variables when the viewer is unauthenticated', async () => {
+    hState.isAuthenticated.value = false;
+    route.query = {
+      filterCreatedByMe: 'true',
+      filterIAmOP: 'true',
+      filterIReported: 'true',
+    };
+
+    const { wrapper } = await mountComposable({ isOpen: false });
+    const firstCall = hState.queryCalls[0];
+    wrapper.unmount();
+
+    expect(firstCall.variables.value).toMatchObject({
+      filterCreatedByMe: false,
+      filterIAmOP: false,
+      filterIReported: false,
+      isOpen: false,
+      selectedChannels: [],
+      showOnlyServerRuleViolations: true,
+    });
+  });
+
+  it('syncs route query changes back into state and refetches', async () => {
+    const { wrapper, api } = await mountComposable({ isOpen: true });
+
+    route.query = {
+      channels: ['cats', 'dogs'],
+      searchInput: 'spam',
+      sort: 'oldest',
+      filterIReported: 'true',
+    };
+    await nextTick();
+
+    expect({
+      selectedChannels: api.selectedChannels.value,
+      searchInput: api.searchInput.value,
+      selectedSort: api.selectedSort.value,
+      filterIReported: api.filterIReported.value,
+      refetchVariables: hState.refetch.mock.calls.at(-1)?.[0],
+    }).toEqual({
+      selectedChannels: ['cats', 'dogs'],
+      searchInput: 'spam',
+      selectedSort: 'oldest',
+      filterIReported: true,
+      refetchVariables: {
+        searchInput: 'spam',
+        selectedChannels: ['cats', 'dogs'],
+        startDate: null,
+        endDate: null,
+        showOnlyServerRuleViolations: true,
+        isOpen: true,
+        filterCreatedByMe: false,
+        filterIAmOP: false,
+        filterIReported: true,
+        options: { sort: 'oldest' },
+      },
+    });
+
+    wrapper.unmount();
+  });
+
+  it('clears the selected issue when the forum changes in forum scope', async () => {
+    const { wrapper } = await mountComposable({
+      isOpen: true,
+      scopedToForum: true,
+    });
+
+    route.params = { forumId: 'dogs' };
+    await nextTick();
+    wrapper.unmount();
+
+    expect(hState.clearSelectedIssueSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates filter updates and issue selection through the shared helpers', async () => {
+    const { updateFilters } = await import('@/utils/routerUtils');
+    const { wrapper, api } = await mountComposable({ isOpen: true });
+
+    api.updateSearchInput('abuse');
+    api.updateSort('mostReports');
+    api.updateShowOnlyServerRuleViolations(false);
+    api.toggleSelectedChannel('cats');
+    api.updateInvolvementFilter({ key: 'filterCreatedByMe', value: true });
+    api.handleSelectIssue({
+      issueNumber: 7,
+      title: 'Needs review',
+      channelId: 'cats',
+    });
+    wrapper.unmount();
+
+    expect({
+      searchCall: (updateFilters as ReturnType<typeof vi.fn>).mock.calls[0]?.[0],
+      sortCall: (updateFilters as ReturnType<typeof vi.fn>).mock.calls[1]?.[0],
+      ruleCall: (updateFilters as ReturnType<typeof vi.fn>).mock.calls[2]?.[0],
+      channelCall: (updateFilters as ReturnType<typeof vi.fn>).mock.calls[3]?.[0],
+      involvementCall: (updateFilters as ReturnType<typeof vi.fn>).mock.calls[4]?.[0],
+      selectionCall: hState.setSelectedIssueSelection.mock.calls[0]?.[0],
+    }).toEqual({
+      searchCall: {
+        router: hState.router,
+        route,
+        params: { searchInput: 'abuse' },
+      },
+      sortCall: {
+        router: hState.router,
+        route,
+        params: { sort: 'mostReports' },
+      },
+      ruleCall: {
+        router: hState.router,
+        route,
+        params: { showOnlyServerRuleViolations: false },
+      },
+      channelCall: {
+        router: hState.router,
+        route,
+        params: { channels: ['cats'] },
+      },
+      involvementCall: {
+        router: hState.router,
+        route,
+        params: { filterCreatedByMe: true },
+      },
+      selectionCall: {
+        issueNumber: 7,
+        title: 'Needs review',
+        channelId: 'cats',
+      },
+    });
+  });
+});

--- a/composables/useServerIssueList.spec.ts
+++ b/composables/useServerIssueList.spec.ts
@@ -144,7 +144,7 @@ describe('useServerIssueList', () => {
       isOpen: true,
       scopedToForum: true,
     });
-    const firstCall = hState.queryCalls[0];
+    const firstCall = hState.queryCalls[0]!;
     wrapper.unmount();
 
     expect({
@@ -176,7 +176,7 @@ describe('useServerIssueList', () => {
     };
 
     const { wrapper } = await mountComposable({ isOpen: false });
-    const firstCall = hState.queryCalls[0];
+    const firstCall = hState.queryCalls[0]!;
     wrapper.unmount();
 
     expect(firstCall.variables.value).toMatchObject({

--- a/pages/forums/[forumId]/downloads/index.spec.ts
+++ b/pages/forums/[forumId]/downloads/index.spec.ts
@@ -54,22 +54,25 @@ const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 const mountWith = async (opts: {
   channelDownloadsEnabled?: boolean;
   serverDownloadsEnabled?: boolean;
+  channelError?: Error | null;
+  serverError?: Error | null;
+  filterGroups?: Array<{ key: string }>;
 }) => {
   const channel = {
     downloadsEnabled: opts.channelDownloadsEnabled ?? true,
-    FilterGroups: [{ key: 'type' }],
+    FilterGroups: opts.filterGroups ?? [{ key: 'type' }],
   };
   const serverConfig = { enableDownloads: opts.serverDownloadsEnabled ?? true };
   mockedUseQuery
     .mockReturnValueOnce({
       result: ref({ channels: [channel] }),
       loading: ref(false),
-      error: ref(null),
+      error: ref(opts.channelError ?? null),
     })
     .mockReturnValueOnce({
       result: ref({ serverConfigs: [serverConfig] }),
       loading: ref(false),
-      error: ref(null),
+      error: ref(opts.serverError ?? null),
     });
   const Page = (await import('./index.vue')).default;
   return shallowMount(Page);
@@ -86,6 +89,13 @@ describe('downloads index page', () => {
     expect(wrapper.text()).toContain('Downloads Not Available');
   });
 
+  it('shows the server-disabled explanation when downloads are disabled server-wide', async () => {
+    const wrapper = await mountWith({ serverDownloadsEnabled: false });
+    expect(wrapper.text()).toContain(
+      'Contact the server administrators to enable downloads server-wide.'
+    );
+  });
+
   it('hides the not-available message when downloads are enabled', async () => {
     const wrapper = await mountWith({});
     expect(wrapper.text()).not.toContain('Downloads Not Available');
@@ -98,6 +108,19 @@ describe('downloads index page', () => {
       expect.objectContaining({
         query: expect.not.objectContaining({ filter_old: expect.anything() }),
       })
+    );
+  });
+
+  it('does not rewrite the route when every filter query key is still allowed', async () => {
+    h.route.query = { filter_type: 'pdf' };
+    await mountWith({});
+    expect(h.router.replace).not.toHaveBeenCalled();
+  });
+
+  it('shows the shared configuration error message when a backing query fails', async () => {
+    const wrapper = await mountWith({ serverError: new Error('boom') });
+    expect(wrapper.text()).toContain(
+      'Unable to load forum or server configuration.'
     );
   });
 });

--- a/tests/unit/composables/usePopoverPositioning.spec.ts
+++ b/tests/unit/composables/usePopoverPositioning.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { ref, defineComponent, h } from 'vue';
+import { ref, defineComponent, h, nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { usePopoverPositioning } from '@/composables/usePopoverPositioning';
 
@@ -22,9 +22,15 @@ const createPopoverRef = (rect: Rect) =>
   } as unknown as HTMLElement);
 
 const mountPopoverComposable = (options: {
-  position: { top: number; left: number; placement?: 'above' | 'below'; triggerRect?: any };
+  position: {
+    top: number;
+    left: number;
+    placement?: 'above' | 'below';
+    triggerRect?: { top: number; bottom: number; height: number; width: number };
+  };
   rect: Rect;
   isVisible?: boolean;
+  contentDependencies?: Array<ReturnType<typeof ref>>;
 }) => {
   const popoverRef = createPopoverRef(options.rect);
   const position = ref(options.position);
@@ -33,7 +39,12 @@ const mountPopoverComposable = (options: {
 
   const wrapper = mount(defineComponent({
     setup() {
-      api = usePopoverPositioning({ popoverRef, position, isVisible });
+      api = usePopoverPositioning({
+        popoverRef,
+        position,
+        isVisible,
+        contentDependencies: options.contentDependencies,
+      });
       return () => h('div');
     },
   }));
@@ -115,5 +126,34 @@ describe('usePopoverPositioning', () => {
     wrapper.unmount();
 
     expect(adjustedPosition.value).toEqual({ top: 122, left: 20 });
+  });
+
+  it('does not reposition when the popover is hidden', async () => {
+    const { wrapper, api } = mountPopoverComposable({
+      position: { top: 190, left: 250 },
+      rect: { width: 200, height: 80 },
+      isVisible: false,
+    });
+    await api.updateAdjustedPosition();
+    const adjustedPosition = api.adjustedPosition;
+    wrapper.unmount();
+
+    expect(adjustedPosition.value).toEqual({ top: 190, left: 250 });
+  });
+
+  it('repositions when a content dependency changes while visible', async () => {
+    const contentSize = ref('small');
+    const { wrapper, api } = mountPopoverComposable({
+      position: { top: 190, left: 250 },
+      rect: { width: 200, height: 80 },
+      contentDependencies: [contentSize],
+    });
+
+    contentSize.value = 'large';
+    await nextTick();
+    const adjustedPosition = api.adjustedPosition;
+    wrapper.unmount();
+
+    expect(adjustedPosition.value).toEqual({ top: 108, left: 88 });
   });
 });

--- a/utils/arrayHelpers.spec.ts
+++ b/utils/arrayHelpers.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { toggleInArray } from './arrayHelpers';
+
+describe('toggleInArray', () => {
+  it('appends a value that is not present', () => {
+    expect(toggleInArray(['a'], 'b')).toEqual(['a', 'b']);
+  });
+
+  it('removes a value that is already present', () => {
+    expect(toggleInArray(['a', 'b', 'c'], 'b')).toEqual(['a', 'c']);
+  });
+
+  it('only removes the first matching item position via filter result', () => {
+    expect(toggleInArray(['a', 'b', 'a'], 'a')).toEqual(['b', 'a']);
+  });
+});

--- a/utils/isEventSearchRoute.spec.ts
+++ b/utils/isEventSearchRoute.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isEventSearchRoute } from './isEventSearchRoute';
+
+describe('isEventSearchRoute', () => {
+  it('returns false for nullish routes', () => {
+    expect(isEventSearchRoute(null)).toBe(false);
+  });
+
+  it('matches routes by name prefix', () => {
+    expect(isEventSearchRoute({ name: 'events-list-search-eventId' })).toBe(
+      true
+    );
+  });
+
+  it('matches routes by path prefix when the name is absent', () => {
+    expect(isEventSearchRoute({ path: '/events/list/search/abc' })).toBe(true);
+  });
+
+  it('returns false for unrelated route names and paths', () => {
+    expect(
+      isEventSearchRoute({
+        name: 'events-map-search',
+        path: '/events/map',
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add direct coverage for `useServerIssueList` query shaping, route sync, and forum-scope selection clearing
- extend download index page coverage for server-disabled, query-error, and no-op stale-filter paths
- extend popover positioning coverage and add direct specs for small event-search and array helpers

## Verification
- pnpm exec eslint tests/unit/composables/usePopoverPositioning.spec.ts composables/useServerIssueList.spec.ts 'pages/forums/[forumId]/downloads/index.spec.ts' utils/isEventSearchRoute.spec.ts utils/arrayHelpers.spec.ts
- npx vitest run tests/unit/composables/usePopoverPositioning.spec.ts composables/useServerIssueList.spec.ts 'pages/forums/[forumId]/downloads/index.spec.ts' utils/isEventSearchRoute.spec.ts utils/arrayHelpers.spec.ts