### PR TITLE
fix(a11y): per-route document titles (P2, WCAG 2.4.2)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,8 +1,21 @@
 <script setup lang="ts">
 import { useUIStore } from '@/stores/uiStore';
 import { onMounted } from 'vue';
+import { useHead } from 'nuxt/app';
+import { config } from '@/config';
 
 const uiStore = useUIStore();
+
+// Give every page a descriptive, per-route document title (WCAG 2.4.2).
+// Pages set their own title via useHead({ title }); this suffixes it with the
+// server name, and falls back to just the server name when a page sets none
+// (the dedupe guard avoids "Name · Name").
+useHead({
+  titleTemplate: (titleChunk) =>
+    titleChunk && titleChunk !== config.serverDisplayName
+      ? `${titleChunk} · ${config.serverDisplayName}`
+      : config.serverDisplayName,
+});
 
 // Initialize theme class on application load
 onMounted(() => {

--- a/docs/accessibility-audit-2026-07.md
+++ b/docs/accessibility-audit-2026-07.md
@@ -128,10 +128,16 @@ Specific controls that are completely unusable without a mouse, plus global shel
 
 Systemic and mostly sweepable; large screen-reader-orientation impact.
 
-- **Per-route document titles** — 92/150 pages inherit one static title. Add a `titleTemplate`
-  in `nuxt.config.ts` and a per-route `useHead({ title })`. Start with high-traffic pages:
-  `pages/discussions/index.vue`, `pages/downloads/index.vue`, `pages/forums/index.vue`,
-  `pages/settings.vue`, `pages/admin/**`. Serious (WCAG 2.4.2).
+- **Per-route document titles** — ✅ DONE (PR #361). `app.vue` sets a `titleTemplate` that
+  suffixes each page's title with the server name (dedupe guard for title-less pages), and every
+  primary route sets its own `useHead({ title })`. Top-level dynamic detail parents (forum, user,
+  mod, discussion, download, event list) already had titles and cover their nested children;
+  `admin/*` and `server/issues/*` inherit their parent wrapper's baseline title. Collection detail
+  uses a dynamic title from the collection name. Only the event-detail route intentionally keeps its
+  parent forum-name title (a dynamic event title can follow the discussion-detail SEO-head pattern
+  later). Serious (WCAG 2.4.2). Gotcha: `NuxtRouteAnnouncer` now renders each title into a
+  `role="status"` span, so any e2e `getByText('<TitleWord>')` on a titled route can hit a
+  strict-mode double-match — assert by heading role instead.
 - **Exactly one `<h1>` per page** — 104/150 pages render none; several start at `<h2>`
   (`pages/settings.vue:18`, `pages/account_settings.vue`, forum downloads/events index, user
   images index). Meanwhile header/sidebar components each emit their own `<h1>`

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import MarkdownLoader from '@/components/MarkdownLoader.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'About' });
 </script>
 
 <template>

--- a/pages/account_settings.spec.ts
+++ b/pages/account_settings.spec.ts
@@ -38,7 +38,7 @@ vi.mock('vue-i18n', () => ({
   }),
 }));
 
-vi.mock('nuxt/app', () => ({}));
+vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
 
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => ({ value: 'alice' }),

--- a/pages/account_settings.vue
+++ b/pages/account_settings.vue
@@ -13,6 +13,9 @@ import type { UserUpdateInput } from '@/__generated__/graphql';
 import type { EditAccountSettingsFormValues } from '@/types/User';
 import { useUsername } from '@/composables/useAuthState';
 import { config } from '@/config';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'Account Settings' });
 
 const usernameVar = useUsername();
 

--- a/pages/admin.spec.ts
+++ b/pages/admin.spec.ts
@@ -10,6 +10,7 @@ const routeRef: { name: string } = { name: 'admin-issues' };
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => routeRef,
+  useHead: vi.fn(),
 }));
 
 vi.mock('@vue/apollo-composable', () => ({

--- a/pages/admin.vue
+++ b/pages/admin.vue
@@ -1,11 +1,13 @@
 <script lang="ts" setup>
 import { useQuery } from '@vue/apollo-composable';
 import { computed } from 'vue';
-import { useRoute } from 'nuxt/app';
+import { useRoute, useHead } from 'nuxt/app';
 import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
 import { config } from '@/config';
 import ServerTabs from '@/components/admin/ServerTabs.vue';
 import ServerIssueSplitView from '@/components/mod/ServerIssueSplitView.vue';
+
+useHead({ title: 'Admin' });
 
 const route = useRoute();
 const { result: getServerResult, error: getServerError } = useQuery(

--- a/pages/collections/[collectionId].spec.ts
+++ b/pages/collections/[collectionId].spec.ts
@@ -6,6 +6,7 @@ import ErrorBanner from '@/components/ErrorBanner.vue';
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { collectionId: 'col-1' } }),
+  useHead: vi.fn(),
 }));
 
 vi.mock('@vue/apollo-composable', () => ({

--- a/pages/collections/[collectionId].vue
+++ b/pages/collections/[collectionId].vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { useRoute } from 'nuxt/app';
+import { useRoute, useHead } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import type { Discussion } from '@/__generated__/graphql';
 import { GET_PUBLIC_COLLECTION_BY_ID } from '@/graphQLData/collection/queries';
@@ -36,6 +36,10 @@ const { result, loading, error, refetch } = useQuery(
 );
 
 const collection = computed(() => result.value?.collections?.[0] || null);
+
+useHead({
+  title: computed(() => collection.value?.name || 'Collection'),
+});
 
 watch(
   () => result.value,

--- a/pages/create-username.vue
+++ b/pages/create-username.vue
@@ -11,6 +11,9 @@ import {
 } from '@/composables/useAuthState';
 import CreateUsernameForm from '@/components/auth/CreateUsernameForm.vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'Choose a username' });
 
 const usernameVar = useUsername();
 const isAuthenticatedVar = useIsAuthenticated();

--- a/pages/discussions/create.vue
+++ b/pages/discussions/create.vue
@@ -1,5 +1,8 @@
 <script lang="ts" setup>
 import CreateDiscussion from '@/components/discussion/form/CreateDiscussion.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'New discussion' });
 </script>
 <template>
   <NuxtLayout>

--- a/pages/discussions/index.vue
+++ b/pages/discussions/index.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import SearchDiscussions from '@/components/discussion/list/SearchDiscussions.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'Discussions' });
 </script>
 
 <template>

--- a/pages/downloads/index.vue
+++ b/pages/downloads/index.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import SitewideDownloadList from '@/components/discussion/list/SitewideDownloadList.vue';
 import DiscussionFilterBar from '@/components/discussion/list/DiscussionFilterBar.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'Downloads' });
 </script>
 
 <template>

--- a/pages/events/create.vue
+++ b/pages/events/create.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import CreateEvent from '@/components/event/form/CreateEvent.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'New event' });
 </script>
 <template>
   <NuxtLayout>

--- a/pages/forums/create.spec.ts
+++ b/pages/forums/create.spec.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock('nuxt/app', () => ({
   useRouter: () => ({ push: h.push }),
+  useHead: vi.fn(),
 }));
 
 vi.mock('@vue/apollo-composable', async () => {

--- a/pages/forums/create.vue
+++ b/pages/forums/create.vue
@@ -12,8 +12,10 @@ import type {
 } from '@/__generated__/graphql';
 import type { CreateEditChannelFormValues } from '@/types/Channel';
 import { useUsername } from '@/composables/useAuthState';
-import { useRouter } from 'nuxt/app';
+import { useRouter, useHead } from 'nuxt/app';
 import { useServerSuspensionNotice } from '@/composables/useSuspensionNotice';
+
+useHead({ title: 'New forum' });
 
 const usernameVar = useUsername();
 

--- a/pages/forums/index.spec.ts
+++ b/pages/forums/index.spec.ts
@@ -7,6 +7,7 @@ import ChannelList from '@/components/channel/ChannelList.vue';
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ query: {} }),
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useHead: vi.fn(),
 }));
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => ref('viewer'),

--- a/pages/forums/index.vue
+++ b/pages/forums/index.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { computed, ref, watchEffect } from 'vue';
-import { useRoute, useRouter } from 'nuxt/app';
+import { useRoute, useRouter, useHead } from 'nuxt/app';
 import { useQuery } from '@vue/apollo-composable';
 import ChannelList from '@/components/channel/ChannelList.vue';
 import {
@@ -23,6 +23,8 @@ import {
 import type { LocationQueryValue } from 'vue-router';
 import type { Channel } from '@/__generated__/graphql';
 import { useUsername } from '@/composables/useAuthState';
+
+useHead({ title: 'Forums' });
 
 const route = useRoute();
 const router = useRouter();

--- a/pages/logout.spec.ts
+++ b/pages/logout.spec.ts
@@ -8,6 +8,7 @@ const setUsername = vi.fn();
 
 vi.mock('nuxt/app', () => ({
   useRouter: () => ({ push }),
+  useHead: vi.fn(),
 }));
 
 vi.mock('@/composables/useAuthState', () => ({

--- a/pages/logout.vue
+++ b/pages/logout.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { useRouter } from 'nuxt/app';
+import { useRouter, useHead } from 'nuxt/app';
 import { onMounted, ref } from 'vue';
 import { setIsAuthenticated, setUsername } from '@/composables/useAuthState';
+
+useHead({ title: 'Log out' });
 
 const router = useRouter();
 const error = ref(false);

--- a/pages/map/search.vue
+++ b/pages/map/search.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import MapView from '@/components/event/map/MapView.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'Map' });
 </script>
 <template>
   <NuxtLayout>

--- a/pages/notifications/index.vue
+++ b/pages/notifications/index.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import NotificationTabs from '@/components/notifications/NotificationTabs.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'Notifications' });
 </script>
 
 <template>

--- a/pages/privacy-policy.vue
+++ b/pages/privacy-policy.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import MarkdownLoader from '@/components/MarkdownLoader.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'Privacy Policy' });
 </script>
 
 <template>

--- a/pages/server/issues.spec.ts
+++ b/pages/server/issues.spec.ts
@@ -8,6 +8,7 @@ const routeRef: { name: string } = { name: 'server-issues' };
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => routeRef,
+  useHead: vi.fn(),
 }));
 
 const NuxtLayoutStub = defineComponent({

--- a/pages/server/issues.vue
+++ b/pages/server/issues.vue
@@ -6,9 +6,11 @@
 // new issue still requires a logged-in account (handled by ServerIssueTabNav's
 // RequireAuth), matching the GitHub issues model.
 import { computed } from 'vue';
-import { useRoute } from 'nuxt/app';
+import { useRoute, useHead } from 'nuxt/app';
 import ServerIssueTabNav from '@/components/mod/ServerIssueTabNav.vue';
 import ServerIssueSplitView from '@/components/mod/ServerIssueSplitView.vue';
+
+useHead({ title: 'Issues' });
 
 const route = useRoute();
 

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import Breadcrumbs from '@/components/nav/Breadcrumbs.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'Settings' });
 
 const links = computed(() => {
   return [

--- a/pages/support.spec.ts
+++ b/pages/support.spec.ts
@@ -8,7 +8,7 @@ const h = vi.hoisted(() => ({
   mutate: null as unknown as ReturnType<typeof vi.fn>,
 }));
 
-vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
+vi.mock('nuxt/app', () => ({ useRoute: () => h.route, useHead: vi.fn() }));
 
 vi.mock('@vue/apollo-composable', async () => {
   const { ref } = await import('vue');

--- a/pages/support.vue
+++ b/pages/support.vue
@@ -9,8 +9,10 @@ import NotificationComponent from '@/components/NotificationComponent.vue';
 import FormComponent from '@/components/FormComponent.vue';
 import FormRow from '@/components/FormRow.vue';
 import { useUsername } from '@/composables/useAuthState';
-import { useRoute } from 'nuxt/app';
+import { useRoute, useHead } from 'nuxt/app';
 import { getSupportReportContent } from '@/utils/supportReportMode';
+
+useHead({ title: 'Support' });
 
 const usernameVar = useUsername();
 

--- a/pages/terms-of-use.vue
+++ b/pages/terms-of-use.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import MarkdownLoader from '@/components/MarkdownLoader.vue';
+import { useHead } from 'nuxt/app';
+
+useHead({ title: 'Terms of Use' });
 </script>
 
 <template>

--- a/tests/playwright/mocked/collections/collectionDetail.spec.ts
+++ b/tests/playwright/mocked/collections/collectionDetail.spec.ts
@@ -85,7 +85,9 @@ test.describe('Public collection detail', () => {
     try {
       await page.goto(`/collections/${COLLECTION_ID}`);
 
-      await expect(page.getByText('My Favorite Models')).toBeVisible();
+      await expect(
+        page.getByRole('heading', { name: 'My Favorite Models' })
+      ).toBeVisible();
       await expect(
         page.getByText('A public collection of 3D models.')
       ).toBeVisible();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -100,4 +100,5 @@ vi.mock('nuxt/app', () => ({
   navigateTo: vi.fn(),
   defineNuxtPlugin: (fn: unknown) => fn,
   useRuntimeConfig: () => ({ public: {} }),
+  useHead: vi.fn(),
 }));


### PR DESCRIPTION
## What

Give every primary route a descriptive, unique `<title>` (WCAG 2.4.2 Page Titled).

`app.vue` adds a `titleTemplate` that suffixes each page's own title with the server display name — e.g. `Discussions · Topical` — with a dedupe guard so a page that sets no title still renders just the server name (never `Name · Name`).

Each primary page then sets its own title via `useHead({ title })`:

- **Static routes**: About, Privacy Policy, Terms of Use, Support, Notifications, Discussions, Downloads, Forums, Settings, Account Settings, Map, Issues, Admin, New discussion / New event / New forum, Choose a username, Log out
- **Collection detail** (`collections/[collectionId]`): dynamic title from the collection name (falls back to `Collection`)

## Scope notes

- Top-level **dynamic detail parents** already set titles and stay mounted while their child routes render, so they cover the nested tree: `forums/[forumId]`, `u/[username]`, `mod/[modId]`, `discussions/[discussionId]`, `downloads/[discussionId]`, and the events list.
- `admin/*` and `server/issues/*` child routes inherit their parent wrapper's baseline title (`Admin` / `Issues`).
- The event-detail route (`forums/[forumId]/events/[eventId]`) intentionally keeps the forum-name title from its parent rather than adding a duplicate `GET_EVENT` query solely for the title; a dynamic event title can follow the discussion-detail SEO-head pattern in a later pass.

## Tests

- `useHead` added to the global `nuxt/app` mock in `tests/setup.ts`, and to the per-file `nuxt/app` mocks of the 8 affected page specs.
- Full unit suite green (`vitest run`), `vue-tsc` clean, ESLint clean.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).