### PR TITLE
fix(a11y): live-region semantics for shared status primitives (P3)

### DIFF
--- a/components/CharCounter.spec.ts
+++ b/components/CharCounter.spec.ts
@@ -41,4 +41,9 @@ describe('CharCounter', () => {
       .find((d) => d.text().includes('Minimum of 5 characters'));
     expect(minWarning && isShown(minWarning.element)).toBe(true);
   });
+
+  it('exposes the counter as a polite live region', () => {
+    const wrapper = mountCounter({ current: 80, max: 100 });
+    expect(wrapper.attributes('aria-live')).toBe('polite');
+  });
 });

--- a/components/CharCounter.vue
+++ b/components/CharCounter.vue
@@ -31,7 +31,7 @@ const showOverLimit = computed(() => charactersRemaining.value < 0);
 </script>
 
 <template>
-  <div :data-testid="testId">
+  <div :data-testid="testId" role="status" aria-live="polite" aria-atomic="true">
     <div
       v-show="showWarning"
       class="mb-4 mt-2 text-right text-sm font-medium text-gray-500 dark:text-gray-300"

--- a/components/ErrorBanner.spec.ts
+++ b/components/ErrorBanner.spec.ts
@@ -20,4 +20,12 @@ describe('ErrorBanner', () => {
     expect(wrapper.classes()).toContain('bg-red-100');
     expect(wrapper.classes()).toContain('text-red-500');
   });
+
+  it('exposes the error as an assertive alert region', () => {
+    const wrapper = mountWithDefaults(ErrorBanner, {
+      props: { text: 'Something went wrong' },
+    });
+
+    expect(wrapper.attributes('role')).toBe('alert');
+  });
 });

--- a/components/ErrorBanner.vue
+++ b/components/ErrorBanner.vue
@@ -9,6 +9,7 @@ defineProps({
 
 <template>
   <div
+    role="alert"
     class="my-2 flex-grow text-wrap rounded bg-red-100 p-3 pl-4 leading-normal text-red-500 dark:bg-red-900 dark:text-red-300"
   >
     {{ text }}

--- a/components/ErrorMessage.spec.ts
+++ b/components/ErrorMessage.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import ErrorMessage from '@/components/ErrorMessage.vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+
+describe('ErrorMessage', () => {
+  it('renders the message text', () => {
+    const wrapper = mountWithDefaults(ErrorMessage, {
+      props: { text: 'This field is required' },
+    });
+
+    expect(wrapper.text()).toContain('This field is required');
+  });
+
+  it('exposes the message as an alert region', () => {
+    const wrapper = mountWithDefaults(ErrorMessage, {
+      props: { text: 'This field is required' },
+    });
+
+    expect(wrapper.attributes('role')).toBe('alert');
+  });
+});

--- a/components/ErrorMessage.vue
+++ b/components/ErrorMessage.vue
@@ -5,7 +5,10 @@ defineProps<{
 </script>
 
 <template>
-  <p class="mb-1 mt-1 h-4 rounded text-sm text-red-500 dark:text-red-400">
+  <p
+    role="alert"
+    class="mb-1 mt-1 h-4 rounded text-sm text-red-500 dark:text-red-400"
+  >
     {{ text }}
   </p>
 </template>

--- a/components/LoadingSpinner.spec.ts
+++ b/components/LoadingSpinner.spec.ts
@@ -15,4 +15,24 @@ describe('LoadingSpinner', () => {
 
     expect(wrapper.classes()).toContain('dark:text-gray-200');
   });
+
+  it('exposes a status role so it announces when it appears', () => {
+    const wrapper = mountWithDefaults(LoadingSpinner);
+
+    expect(wrapper.attributes('role')).toBe('status');
+  });
+
+  it('renders a visually-hidden default loading label', () => {
+    const wrapper = mountWithDefaults(LoadingSpinner);
+
+    expect(wrapper.get('.sr-only').text()).toBe('Loading…');
+  });
+
+  it('uses a custom label when provided', () => {
+    const wrapper = mountWithDefaults(LoadingSpinner, {
+      props: { label: 'Saving…' },
+    });
+
+    expect(wrapper.get('.sr-only').text()).toBe('Saving…');
+  });
 });

--- a/components/LoadingSpinner.vue
+++ b/components/LoadingSpinner.vue
@@ -1,7 +1,21 @@
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+// role="status" makes the spinner announce its label to assistive tech when
+// it appears. Callers that already provide their own status text (e.g.
+// SaveStatus) pass aria-hidden="true", which falls through to the root and
+// suppresses the redundant announcement.
+defineProps({
+  label: {
+    type: String,
+    default: 'Loading…',
+  },
+});
+</script>
 
 <template>
-  <div class="flex items-center justify-center space-x-2 dark:text-gray-200">
+  <div
+    role="status"
+    class="flex items-center justify-center space-x-2 dark:text-gray-200"
+  >
     <svg
       class="h-4 w-4 animate-spin"
       xmlns="http://www.w3.org/2000/svg"
@@ -9,6 +23,7 @@
       fill="none"
       stroke="currentColor"
       stroke-width="4"
+      aria-hidden="true"
     >
       <circle
         cx="12"
@@ -19,6 +34,7 @@
         stroke-linecap="round"
       />
     </svg>
+    <span class="sr-only">{{ label }}</span>
   </div>
 </template>
 

--- a/components/ToastNotification.spec.ts
+++ b/components/ToastNotification.spec.ts
@@ -73,4 +73,18 @@ describe('ToastNotification', () => {
 
     expect(wrapper.text()).toContain('Two');
   });
+
+  it('marks error toasts as an assertive alert region', () => {
+    h.toasts = [{ id: 't1', message: 'Oops', type: 'error' }];
+    const wrapper = mountToasts();
+
+    expect(wrapper.find('[role="alert"]').exists()).toBe(true);
+  });
+
+  it('marks non-error toasts as a polite status region', () => {
+    h.toasts = [{ id: 't1', message: 'Saved', type: 'info' }];
+    const wrapper = mountToasts();
+
+    expect(wrapper.find('[role="status"]').exists()).toBe(true);
+  });
 });

--- a/components/ToastNotification.vue
+++ b/components/ToastNotification.vue
@@ -15,9 +15,17 @@ const toastStore = useToastStore();
         leave-from-class="translate-y-0 opacity-100"
         leave-to-class="translate-y-2 opacity-0"
       >
+        <!--
+          Each toast is its own live region so it announces on insertion:
+          role="alert" (assertive) for errors, role="status" (polite)
+          otherwise. Per-toast roles avoid nesting live regions inside a
+          single aria-live container (which double-announces).
+        -->
         <div
           v-for="toast in toastStore.toasts"
           :key="toast.id"
+          :role="toast.type === 'error' ? 'alert' : 'status'"
+          :aria-live="toast.type === 'error' ? 'assertive' : 'polite'"
           class="flex min-w-[200px] max-w-[420px] items-center justify-between gap-3 rounded-lg bg-gray-900 px-4 py-3 text-white shadow-lg"
           :class="{
             'bg-gray-900': toast.type === 'info' || !toast.type,


### PR DESCRIPTION
## What

First slice of **P3 — announcements, status & error semantics**. The app had almost no `aria-live` regions, so async loading / error / status text swapped silently for screen-reader users. This adds live-region semantics to the shared primitives, so a single edit each covers every call site (WCAG 4.1.3 Status Messages, 3.3.1 Error Identification).

| Component | Change | Reach |
|---|---|---|
| `ToastNotification.vue` | Each toast is its own live region — `role="alert"` (assertive) for errors, `role="status"` (polite) otherwise | all toasts |
| `ErrorBanner.vue` | `role="alert"` | 184 call sites |
| `ErrorMessage.vue` | `role="alert"` | 11 call sites |
| `LoadingSpinner.vue` | `role="status"` + visually-hidden `Loading…` label (customizable via `label` prop); SVG `aria-hidden` | 65 call sites |
| `CharCounter.vue` | Polite live region for the remaining/over-limit count | 28 call sites |

### Design notes

- **Per-toast roles, not a wrapping `aria-live` container** — nesting live regions inside one `aria-live` parent double-announces. Each toast node carries its own role so it announces once on insertion, with errors assertive and everything else polite.
- **LoadingSpinner suppression path** — callers that already render their own status text (e.g. `settings/SaveStatus.vue`, which shows "Saving…"/"Saved") pass `aria-hidden="true"`; it falls through to the spinner root and removes the redundant "Loading…" announcement.

## Tests

- Added role/live-region assertions to `ErrorBanner`, `LoadingSpinner`, `CharCounter`, `ToastNotification` specs and a new `ErrorMessage.spec.ts`.
- Full unit suite green (757 files / 6829 tests) — the spinner's new `sr-only` text causes no text-equality regressions across its 65 call sites. `vue-tsc` + ESLint clean.

## Not in this PR (remaining P3, tracked in the audit doc)

The ~45 mod/admin loading/empty/error blocks and the per-component `role="status"` rollout (`NotificationList`, `NotificationTabs`, `SearchableForumList`, plugin editors, etc.). `settings/SaveStatus.vue` already has correct roles. These are follow-ups.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).