### PR TITLE
fix(a11y): restore keyboard activation on shared buttons (P4)

### DIFF
--- a/components/CancelButton.vue
+++ b/components/CancelButton.vue
@@ -10,6 +10,5 @@ import GenericButton from '@/components/GenericButton.vue';
       'dark:bg-opacity-60', // class for controlling the background opacity in dark mode
     ]"
     class="hover:bg-gray-50 rounded-full border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
-    @keydown.enter.prevent
   />
 </template>

--- a/components/GenericButton.vue
+++ b/components/GenericButton.vue
@@ -30,7 +30,6 @@ withDefaults(
         disabled,
     }"
     class="inline-flex items-center gap-1 whitespace-nowrap rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
-    @keydown.enter.prevent
   >
     <LoadingSpinner v-if="loading" />
     <slot />

--- a/components/GenericSmallButton.vue
+++ b/components/GenericSmallButton.vue
@@ -15,7 +15,6 @@ withDefaults(
     type="button"
     :class="[active ? 'border-orange-500 ring-1 ring-orange-500' : '']"
     class="hover:bg-gray-50 flex inline-flex rounded-full border px-3.5 py-2 text-xs font-medium text-gray-700 focus:border-orange-500 focus:ring-1 focus:ring-orange-500"
-    @keydown.enter.prevent
   >
     <slot />
     <span class="whitespace-nowrap">{{ text }}</span>

--- a/components/RulesEditor.vue
+++ b/components/RulesEditor.vue
@@ -81,6 +81,7 @@ const deleteRule = (index: number) => {
       </div>
     </div>
     <button
+      type="button"
       class="mt-2 rounded border border-orange-500 px-2 py-1 text-orange-500"
       @click="addNewRule"
     >

--- a/components/SaveButton.vue
+++ b/components/SaveButton.vue
@@ -24,7 +24,6 @@ const emit = defineEmits<{
     :disabled="disabled"
     :loading="loading"
     class="border-transparent ml-3 inline-flex justify-center rounded-full border px-4 py-2 text-sm font-medium shadow-sm dark:border-gray-700"
-    @keydown.enter.prevent
     @click="emit('click', $event)"
   />
 </template>


### PR DESCRIPTION
## What

Four shared button components carried an empty `@keydown.enter.prevent`. On a native `<button>`, the click fired for **Enter** is the *default action* of the keydown, so calling `preventDefault()` there cancels it — the button could only be activated with **Space** or the mouse, not Enter. That's a keyboard-operability failure (WCAG 2.1.1).

Removed the no-op handler from:
- `GenericButton.vue`
- `GenericSmallButton.vue`
- `SaveButton.vue`
- `CancelButton.vue`

All four are `type="button"` (directly, or via `PrimaryButton`), so the `.prevent` wasn't guarding against a stray form submit — it was pure breakage.

Also added an explicit `type="button"` to `RulesEditor.vue`'s "+ Add New Rule" control, which otherwise defaults to `type="submit"` and can submit a surrounding form when clicked or activated by keyboard.

## Scope note

The other `@keydown.enter.prevent` occurrences (`SearchBar`, `SiteSidenav` search, `SearchableTagList`, etc.) are on **search inputs** with real handlers, where preventing the Enter default (form submit) and running a search is correct. Two empty ones sit on `<SearchBar>` wrappers, which handle their own Enter internally — left as-is.

## Tests

Existing `SaveButton`, `GenericSmallButton`, and `RulesEditor` specs pass. (Native Enter→click activation is a browser behavior happy-dom doesn't synthesize, so it isn't unit-testable; the fix is the removal of the `preventDefault`.) `vue-tsc` + ESLint clean.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).