### PR TITLE
fix(a11y): text alternative for the contribution line chart (P4)

### DIFF
--- a/components/charts/ContributionLineChart.spec.ts
+++ b/components/charts/ContributionLineChart.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { defineComponent } from 'vue';
+
+import ContributionLineChart from '@/components/charts/ContributionLineChart.vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+
+// Stub the canvas-rendering chart so the test exercises only the accessible
+// text alternatives, not chart.js/canvas (unavailable in happy-dom).
+const LineStub = defineComponent({
+  name: 'Line',
+  props: ['data', 'options'],
+  template: '<canvas class="line-stub" />',
+});
+
+// One day with 2 comments + 1 discussion, another with 1 comment + 0
+// discussions → totals of 3 comments and 1 discussion.
+const dayData = [
+  {
+    date: '2024-01-02',
+    activities: [{ Comments: [{}, {}], Discussions: [{}] }],
+  },
+  { date: '2024-01-01', activities: [{ Comments: [{}], Discussions: [] }] },
+];
+
+const mountChart = () =>
+  mountWithDefaults(ContributionLineChart, {
+    props: { dayData },
+    global: { stubs: { Line: LineStub } },
+  });
+
+describe('ContributionLineChart', () => {
+  it('exposes the chart as an image with a data summary label', () => {
+    const wrapper = mountChart();
+
+    expect(wrapper.get('[role="img"]').attributes('aria-label')).toContain(
+      '3 comments and 1 discussions'
+    );
+  });
+
+  it('renders a visually-hidden data-table alternative', () => {
+    const wrapper = mountChart();
+
+    expect(wrapper.get('table').classes()).toContain('sr-only');
+  });
+
+  it('lists one table row per day of data', () => {
+    const wrapper = mountChart();
+
+    expect(wrapper.findAll('tbody tr').length).toBe(2);
+  });
+});

--- a/components/charts/ContributionLineChart.vue
+++ b/components/charts/ContributionLineChart.vue
@@ -78,6 +78,32 @@ const chartData = computed(() => {
   };
 });
 
+// Canvas charts are invisible to assistive tech, so we expose the same data
+// two accessible ways (WCAG 1.1.1): a summary via role="img"/aria-label on the
+// chart, and a visually-hidden data table with the exact per-day numbers.
+const tableRows = computed(() => {
+  const labels = chartData.value.labels;
+  const comments = chartData.value.datasets[0]?.data ?? [];
+  const discussions = chartData.value.datasets[1]?.data ?? [];
+  return labels.map((label, i) => ({
+    label,
+    comments: comments[i] ?? 0,
+    discussions: discussions[i] ?? 0,
+  }));
+});
+
+const chartSummary = computed(() => {
+  const rows = tableRows.value;
+  const first = rows[0];
+  const last = rows[rows.length - 1];
+  if (!first || !last) {
+    return 'Line chart of contribution activity. No data yet.';
+  }
+  const totalComments = rows.reduce((sum, r) => sum + r.comments, 0);
+  const totalDiscussions = rows.reduce((sum, r) => sum + r.discussions, 0);
+  return `Line chart of contribution activity from ${first.label} to ${last.label}: ${totalComments} comments and ${totalDiscussions} discussions.`;
+});
+
 const chartOptions = computed(() => ({
   responsive: true,
   maintainAspectRatio: false,
@@ -127,7 +153,29 @@ const chartOptions = computed(() => ({
 </script>
 
 <template>
-  <div class="h-64">
-    <Line :data="chartData" :options="chartOptions" />
+  <div>
+    <div class="h-64" role="img" :aria-label="chartSummary">
+      <Line :data="chartData" :options="chartOptions" />
+    </div>
+    <!-- Text alternative for screen readers; visually hidden. -->
+    <table v-if="tableRows.length" class="sr-only">
+      <caption>
+        {{ chartSummary }}
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">Date</th>
+          <th scope="col">Comments</th>
+          <th scope="col">Discussions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in tableRows" :key="row.label">
+          <th scope="row">{{ row.label }}</th>
+          <td>{{ row.comments }}</td>
+          <td>{{ row.discussions }}</td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </template>


### PR DESCRIPTION
## What

The `<canvas>` that `vue-chartjs` renders for the contribution chart is invisible to assistive tech — a screen-reader user gets nothing (WCAG 1.1.1 Non-text Content).

`ContributionLineChart.vue` now exposes the same data two accessible ways:
- The chart container is `role="img"` with an `aria-label` summarizing the date range and the comment/discussion totals (e.g. *"Line chart of contribution activity from Jan 1 to Jan 30: 42 comments and 9 discussions."*).
- A visually-hidden (`sr-only`) **data table** gives the exact per-day numbers, with a `<caption>` and `scope="col"`/`scope="row"` headers.

This also covers `ChannelContributionChart.vue`, which just wraps this component.

## Tests

New `ContributionLineChart.spec.ts` (stubs the canvas `Line` component, which chart.js can't render in happy-dom) verifies the `role="img"` summary label, the `sr-only` table, and one row per day. Existing `ChannelContributionChart` and `contributors` page specs still pass. `vue-tsc` + ESLint clean.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).