### PR TITLE
Preserve SSR discussions through hydration

### DIFF
--- a/components/discussion/list/SitewideDiscussionList.spec.ts
+++ b/components/discussion/list/SitewideDiscussionList.spec.ts
@@ -13,12 +13,21 @@ import { useRoute } from 'nuxt/app';
 // Import after mocks are declared (hoisted) so the component picks them up.
 import SitewideDiscussionList from '@/components/discussion/list/SitewideDiscussionList.vue';
 
+const { mockNuxtState } = vi.hoisted(() => ({
+  mockNuxtState: new Map<string, ReturnType<typeof ref>>(),
+}));
+
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
 }));
 vi.mock('nuxt/app', () => ({
   useRoute: vi.fn(),
-  useState: (_k, init) => ref(init ? init() : undefined),
+  useState: (key: string, init?: () => unknown) => {
+    if (!mockNuxtState.has(key)) {
+      mockNuxtState.set(key, ref(init ? init() : undefined));
+    }
+    return mockNuxtState.get(key);
+  },
 }));
 vi.mock('@/composables/useTheme', () => ({
   useAppTheme: () => ({ theme: ref('light') }),
@@ -86,6 +95,7 @@ const mountList = (route: Record<string, unknown> = {}) => {
 describe('SitewideDiscussionList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockNuxtState.clear();
   });
 
   it('renders a list item per discussion', () => {
@@ -112,6 +122,20 @@ describe('SitewideDiscussionList', () => {
     setupQueries(createQueryMock(null, { loading: ref(true) }));
     const wrapper = mountList();
     expect(wrapper.find('.skeleton-stub').exists()).toBe(true);
+  });
+
+  it('hydrates the SSR discussions while Apollo restores its client cache', () => {
+    mockNuxtState.set(
+      'sitewide-discussions:/discussions',
+      ref([makeDiscussion('ssr')])
+    );
+    mockNuxtState.set('sitewide-discussion-count:/discussions', ref(1));
+    setupQueries(createQueryMock(null, { loading: ref(true) }));
+    const wrapper = mountList({ path: '/discussions', fullPath: '/discussions' });
+    expect({
+      items: wrapper.findAll('.item-stub').length,
+      skeleton: wrapper.find('.skeleton-stub').exists(),
+    }).toEqual({ items: 1, skeleton: false });
   });
 
   // Regression: a query-variable change after hydration (e.g. the logged-in

--- a/components/discussion/list/SitewideDiscussionList.vue
+++ b/components/discussion/list/SitewideDiscussionList.vue
@@ -7,7 +7,7 @@ import DiscussionDetailEmptyState from '@/components/discussion/list/DiscussionD
 import { GET_SITE_WIDE_DISCUSSION_LIST } from '@/graphQLData/discussion/queries';
 import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
 import { useQuery } from '@vue/apollo-composable';
-import { useRoute } from 'nuxt/app';
+import { useRoute, useState } from 'nuxt/app';
 import { getDiscussionFilterValuesFromParams } from '@/utils/getDiscussionFilterValuesFromParams';
 import {
   getSortFromQuery,
@@ -134,11 +134,16 @@ type SiteWideDiscussion = Discussion & { score: number };
 const getLiveDiscussionList = () =>
   discussionResult.value?.getSiteWideDiscussionList ?? null;
 
-const loadedDiscussions = ref<SiteWideDiscussion[]>(
-  getLiveDiscussionList()?.discussions ?? []
+// Component refs are recreated during hydration. Nuxt state is serialized in
+// the SSR payload, so it bridges the gap before Apollo restores its cache.
+const routeStateKey = route.fullPath || route.path || '/discussions';
+const loadedDiscussions = useState<SiteWideDiscussion[]>(
+  `sitewide-discussions:${routeStateKey}`,
+  () => getLiveDiscussionList()?.discussions ?? []
 );
-const loadedAggregateCount = ref(
-  getLiveDiscussionList()?.aggregateDiscussionCount ?? 0
+const loadedAggregateCount = useState<number>(
+  `sitewide-discussion-count:${routeStateKey}`,
+  () => getLiveDiscussionList()?.aggregateDiscussionCount ?? 0
 );
 
 watch(


### PR DESCRIPTION
## Summary
- serialize the server-rendered discussion list and aggregate count through Nuxt state
- keep SSR content in the first client render while Apollo restores its cache
- add a regression test for a null, loading Apollo result with SSR discussions present

## Root cause
The previous fallback used component-local refs. Those refs were populated on the server but recreated empty on the client, so they could not prevent the hydration gap or skeleton flash.

## Testing
- pnpm exec vitest run components/discussion/list/SitewideDiscussionList.spec.ts components/discussion/list/SitewideDiscussionListItem.spec.ts
- pnpm exec eslint components/discussion/list/SitewideDiscussionList.vue components/discussion/list/SitewideDiscussionList.spec.ts
- pnpm run tsc