### PR TITLE
fix(a11y): required + labelled-group semantics on form primitives (P4)

### DIFF
--- a/components/RadioButtons.spec.ts
+++ b/components/RadioButtons.spec.ts
@@ -3,27 +3,50 @@ import { describe, expect, it } from 'vitest';
 
 import RadioButtons from '@/components/RadioButtons.vue';
 
+const options = [
+  { label: 'Small', value: 'small' },
+  { label: 'Large', value: 'large' },
+];
+
+const mountRadios = (props: Record<string, unknown> = {}) =>
+  mount(RadioButtons, {
+    props: { selectedOption: options[0], options, ...props },
+  });
+
 describe('RadioButtons', () => {
   it('checks the selected option and emits the clicked option', async () => {
-    const options = [
-      { label: 'Small', value: 'small' },
-      { label: 'Large', value: 'large' },
-    ];
-    const wrapper = mount(RadioButtons, {
-      props: {
-        selectedOption: options[0],
-        options,
-      },
-    });
+    const wrapper = mountRadios();
+    const radios = wrapper.findAll('input[type="radio"]');
 
-    await wrapper.get('#radio-large').trigger('input');
+    await radios[1]!.trigger('input');
 
     expect({
-      checked: (wrapper.get('#radio-small').element as HTMLInputElement).checked,
+      checked: (radios[0]!.element as HTMLInputElement).checked,
       emitted: wrapper.emitted('updateSelected'),
     }).toEqual({
       checked: true,
       emitted: [[options[1]]],
     });
+  });
+
+  it('renders the legend as the accessible group name', () => {
+    const wrapper = mountRadios({ legend: 'Font Size' });
+
+    expect(wrapper.get('legend').text()).toBe('Font Size');
+  });
+
+  it('gives every radio in the group the same name', () => {
+    const wrapper = mountRadios();
+    const names = wrapper
+      .findAll('input[type="radio"]')
+      .map((r) => r.attributes('name'));
+
+    expect(new Set(names).size).toBe(1);
+  });
+
+  it('omits the legend when none is provided', () => {
+    const wrapper = mountRadios();
+
+    expect(wrapper.find('legend').exists()).toBe(false);
   });
 });

--- a/components/RadioButtons.vue
+++ b/components/RadioButtons.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useId } from 'vue';
 import type { PropType } from 'vue';
 
 type Option = {
@@ -15,22 +16,32 @@ const props = defineProps({
     type: Array as PropType<Option[]>,
     required: true,
   },
+  // Accessible name for the radio group, announced via <legend>.
+  legend: {
+    type: String,
+    default: '',
+  },
 });
 
 const emit = defineEmits(['updateSelected']);
+
+// A unique group name keeps two instances on one page from merging into a
+// single radio group, and namespaces the per-option input ids.
+const groupId = useId();
 </script>
 
 <template>
   <form>
     <fieldset>
+      <legend v-if="legend" class="sr-only">{{ legend }}</legend>
       <div
         v-for="option in props.options"
         :key="option.label"
         class="mt-4 flex items-center"
       >
         <input
-          :id="`radio-${option.value}`"
-          name="showBothVirtualAndInPerson"
+          :id="`radio-${groupId}-${option.value}`"
+          :name="`radio-group-${groupId}`"
           type="radio"
           :checked="selectedOption.value === option.value"
           class="h-4 w-4 border border-gray-300 text-orange-600 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700"
@@ -41,7 +52,7 @@ const emit = defineEmits(['updateSelected']);
           "
         >
         <label
-          :for="`radio-${option.value}`"
+          :for="`radio-${groupId}-${option.value}`"
           class="ml-3 block text-sm font-medium text-gray-700 dark:text-gray-300"
         >
           {{ option.label }}

--- a/components/TextInput.spec.ts
+++ b/components/TextInput.spec.ts
@@ -91,6 +91,24 @@ describe('TextInput validation', () => {
 
     expect(wrapper.find('input').attributes('disabled')).toBeDefined();
   });
+
+  it('marks a required input as required for assistive tech', () => {
+    const wrapper = mountInput({ required: true });
+
+    expect(wrapper.find('input').attributes('aria-required')).toBe('true');
+  });
+
+  it('sets the native required attribute when required', () => {
+    const wrapper = mountInput({ required: true });
+
+    expect(wrapper.find('input').attributes('required')).toBeDefined();
+  });
+
+  it('does not mark an optional input as required', () => {
+    const wrapper = mountInput();
+
+    expect(wrapper.find('input').attributes('required')).toBeUndefined();
+  });
 });
 
 describe('TextInput focus', () => {

--- a/components/TextInput.vue
+++ b/components/TextInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue';
+import { ref, watch, computed, useId } from 'vue';
 import ExclamationTriangleIcon from '@/components/icons/ExclamationIcon.vue';
 
 const props = defineProps({
@@ -16,6 +16,10 @@ const props = defineProps({
     default: '',
   },
   invalid: {
+    type: Boolean,
+    default: false,
+  },
+  required: {
     type: Boolean,
     default: false,
   },
@@ -52,11 +56,13 @@ const props = defineProps({
 const emit = defineEmits(['update']);
 const text = ref(props.value);
 
-// Generate a unique ID if not provided
+// Generate a unique ID if not provided. useId() is SSR-stable (Math.random
+// would mismatch between server and client render and break the label/for tie).
+const generatedId = useId();
 const inputId = computed(() => {
   if (props.id) return props.id;
   if (props.testId) return `input-${props.testId}`;
-  return `input-${Math.random().toString(36).substr(2, 9)}`;
+  return `input-${generatedId}`;
 });
 
 // Use ariaLabel if provided, otherwise fall back to label or placeholder
@@ -110,8 +116,10 @@ const handleInput = (value: string) => {
         :data-testid="testId"
         :disabled="disabled"
         :placeholder="placeholder"
+        :required="required || undefined"
         :aria-label="!label ? accessibleLabel : undefined"
         :aria-invalid="invalid || undefined"
+        :aria-required="required || undefined"
         :aria-describedby="errorMessage ? `${inputId}-error` : undefined"
         type="text"
         @input="handleInput(($event.target as HTMLInputElement).value)"
@@ -125,8 +133,10 @@ const handleInput = (value: string) => {
         :placeholder="placeholder"
         :disabled="disabled"
         :rows="rows"
+        :required="required || undefined"
         :aria-label="!label ? accessibleLabel : undefined"
         :aria-invalid="invalid || undefined"
+        :aria-required="required || undefined"
         :aria-describedby="errorMessage ? `${inputId}-error` : undefined"
         type="text"
         :class="[

--- a/components/channel/FontSizeControl.vue
+++ b/components/channel/FontSizeControl.vue
@@ -37,6 +37,7 @@ const updateFontSize = (option: { label: string; value: string }) => {
       </span>
     </div>
     <RadioButtons
+      legend="Font Size"
       :selected-option="selectedOption"
       :options="options"
       @update-selected="updateFontSize"


### PR DESCRIPTION
## What

Two shared form primitives, so a single edit each reaches every call site.

### `TextInput.vue`
- **Adds a `required` prop** and binds native `required` + `aria-required` on the `<input>`/`<textarea>`. Consumers already passed `required` (e.g. `support.vue`'s email/subject fields), but with no matching prop declared it fell through to the wrapper `<div>` and **never reached the field** — required inputs were unmarked for both native validation and assistive tech (WCAG 3.3.2).
- Generates the fallback id with Vue's **`useId()`** instead of `Math.random()`, so the `label`/`for` tie is SSR-stable (Math.random mismatches between server and client render) and drops the deprecated `substr`.

### `RadioButtons.vue`
- **Adds a `legend` prop** rendered as a `<legend>`, giving the radio group an accessible name (WCAG 1.3.1). `FontSizeControl` now passes `legend="Font Size"` (rendered `sr-only`, since a visible "Font Size" label already sits above it).
- Replaces the **hardcoded `name="showBothVirtualAndInPerson"`** with a `useId()`-based group name and namespaces the per-option ids, so two instances on one page no longer collapse into a single radio group.

## Tests

- `TextInput.spec.ts`: new cases for `required`/`aria-required` present when required and absent when not.
- `RadioButtons.spec.ts`: rewritten to select structurally (ids are now namespaced) with new cases for the legend and the shared group name.
- Full unit suite green (757 files / 6829 tests); `FontSizeControl` spec unaffected. `vue-tsc` + ESLint clean.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).