### PR TITLE
Defer auth fallback until hydration completes

### DIFF
--- a/plugins/auth-username-fallback.client.spec.ts
+++ b/plugins/auth-username-fallback.client.spec.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => ({
   setProfilePicURL: vi.fn(),
   setNotificationCount: vi.fn(),
   fetch: vi.fn(),
+  appMounted: undefined as undefined | (() => void),
 }));
 
 vi.mock('nuxt/app', () => ({
@@ -27,8 +28,17 @@ vi.mock('@/composables/useAuthState', () => ({
   setNotificationCount: h.setNotificationCount,
 }));
 
+const start = () => {
+  (plugin as (nuxtApp: { hook: (name: string, callback: () => void) => void }) => void)({
+    hook: (name, callback) => {
+      if (name === 'app:mounted') h.appMounted = callback;
+    },
+  });
+};
+
 const run = async () => {
-  (plugin as () => void)();
+  start();
+  h.appMounted?.();
   await flushPromises();
 };
 
@@ -61,6 +71,7 @@ const fullUser = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  h.appMounted = undefined;
   h.isAuthenticated.value = true;
   h.username.value = '';
   h.fetch.mockResolvedValue(resolvedUser(fullUser));
@@ -68,6 +79,12 @@ beforeEach(() => {
 });
 
 describe('auth-username-fallback plugin: resolves when authenticated but username is empty', () => {
+  it('does not resolve the username before hydration has mounted the app', async () => {
+    start();
+    await flushPromises();
+    expect(h.fetch).not.toHaveBeenCalled();
+  });
+
   it('seeds the username from the backend lookup', async () => {
     await run();
     expect(h.setUsername).toHaveBeenCalledWith('cluse');

--- a/plugins/auth-username-fallback.client.ts
+++ b/plugins/auth-username-fallback.client.ts
@@ -69,16 +69,19 @@ const resolveUsername = async () => {
   }
 };
 
-export default defineNuxtPlugin(() => {
+export default defineNuxtPlugin((nuxtApp) => {
   if (typeof window === 'undefined') return;
 
   const isAuthenticated = useIsAuthenticated();
   const username = useUsername();
 
-  // Nothing to do when anonymous or when SSR already resolved the username.
-  if (!isAuthenticated.value || username.value) return;
-
-  // Fire-and-forget: never block app startup on this network round-trip. The
-  // server session resolves identity server-side.
-  void resolveUsername();
+  // Auth state is part of the SSR payload. Mutating it before Vue finishes
+  // hydration can change Apollo variables and auth-gated DOM midway through
+  // hydration, so defer the fallback until the server tree is fully adopted.
+  nuxtApp.hook('app:mounted', () => {
+    // Re-check after mounting because another source may have resolved the
+    // username while the app was starting.
+    if (!isAuthenticated.value || username.value) return;
+    void resolveUsername();
+  });
 });


### PR DESCRIPTION
## Summary
- defer the client username fallback until Nuxt emits app:mounted
- re-check auth state after mounting before resolving the fallback profile
- prevent auth-state and Apollo-variable mutations while Vue is hydrating SSR markup
- add regression coverage proving no fallback request occurs before mount

## Root cause
When SSR restored an authenticated session but could not resolve its application username, the client fallback immediately started a profile request during plugin startup. A fast response could update the serialized username while Vue was still hydrating. On /discussions that changes loggedInUsername, switches Apollo query keys, and changes auth-dependent row markup midway through hydration, causing the mismatch warning and loading-state flash.

Anonymous capture confirmed the normal Apollo SSR cache is serialized and restored with identical variables, so no duplicate useState cache is needed.

## Testing
- pnpm exec vitest run plugins/auth-username-fallback.client.spec.ts components/discussion/list/SitewideDiscussionList.spec.ts
- pnpm exec eslint plugins/auth-username-fallback.client.ts plugins/auth-username-fallback.client.spec.ts
- pnpm run tsc