### PR TITLE
fix(a11y): accessible names for placeholder-only form fields (P4)

### DIFF
--- a/components/admin/ServerMembershipEditor.spec.ts
+++ b/components/admin/ServerMembershipEditor.spec.ts
@@ -148,6 +148,22 @@ describe('ServerMembershipEditor', () => {
       global: { stubs },
     });
 
+  it('gives the admin invite input a distinct accessible name', () => {
+    const wrapper = mountEditor(serverConfig);
+
+    expect(wrapper.findAll('input')[0]!.attributes('aria-label')).toBe(
+      'Username to invite as server admin'
+    );
+  });
+
+  it('gives the moderator invite input a distinct accessible name', () => {
+    const wrapper = mountEditor(serverConfig);
+
+    expect(wrapper.findAll('input')[1]!.attributes('aria-label')).toBe(
+      'Username to invite as server moderator'
+    );
+  });
+
   // --- Remove existing members ---
 
   it('removes a server admin', async () => {

--- a/components/admin/ServerMembershipEditor.vue
+++ b/components/admin/ServerMembershipEditor.vue
@@ -182,6 +182,7 @@ const removeModerator = async (displayName: string) => {
             v-model="newAdminUsername"
             type="text"
             placeholder="Username to invite"
+            aria-label="Username to invite as server admin"
             class="w-full rounded border px-3 py-2 dark:border-gray-700 dark:bg-gray-900"
             @keyup.enter="sendAdminInvite"
           >
@@ -275,6 +276,7 @@ const removeModerator = async (displayName: string) => {
             v-model="newModeratorUsername"
             type="text"
             placeholder="Username to invite"
+            aria-label="Username to invite as server moderator"
             class="w-full rounded border px-3 py-2 dark:border-gray-700 dark:bg-gray-900"
             @keyup.enter="sendModInvite"
           >

--- a/components/admin/plugins/PluginSecretsSection.spec.ts
+++ b/components/admin/plugins/PluginSecretsSection.spec.ts
@@ -81,6 +81,14 @@ describe('PluginSecretsSection input toggle', () => {
     expect(wrapper.find('input[type="password"]').exists()).toBe(true);
   });
 
+  it('names the secret input after its key for assistive tech', () => {
+    const wrapper = mountSection({ showSecretInputs: { API_KEY: true } });
+
+    expect(
+      wrapper.find('input[type="password"]').attributes('aria-label')
+    ).toBe('Value for API_KEY');
+  });
+
   it('emits the updated secret value on input', async () => {
     const wrapper = mountSection({ showSecretInputs: { API_KEY: true } });
 

--- a/components/admin/plugins/PluginSecretsSection.vue
+++ b/components/admin/plugins/PluginSecretsSection.vue
@@ -124,6 +124,7 @@ const getSecretStatusText = (status: string) => {
               :value="secretValues[secret.key] || ''"
               type="password"
               placeholder="Enter secret value"
+              :aria-label="`Value for ${secret.key}`"
               class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
               @input="updateSecretValue(secret.key, ($event.target as HTMLInputElement).value)"
             >

--- a/components/mod/BrokenRulesModal.vue
+++ b/components/mod/BrokenRulesModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, useId } from 'vue';
 import type { PropType } from 'vue';
 import { useRoute } from 'nuxt/app';
 import { useApolloClient, useMutation } from '@vue/apollo-composable';
@@ -139,6 +139,7 @@ const reportText = ref('');
 
 // Holds the chosen suspension length if props.suspendUserEnabled is true
 const suspensionLength = ref<'' | 'two_weeks' | 'one_month' | 'indefinite'>('two_weeks');
+const suspensionLengthId = useId();
 
 const toggleForumRuleSelection = (rule: string) => {
   if (selectedForumRules.value.includes(rule)) {
@@ -702,10 +703,12 @@ const close = () => {
       />
       <div v-if="suspendUserEnabled" class="mt-4">
         <label
+          :for="suspensionLengthId"
           class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-200"
           >Suspend user for</label
         >
         <select
+          :id="suspensionLengthId"
           v-model="suspensionLength"
           class="block w-60 rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
         >
@@ -715,9 +718,9 @@ const close = () => {
           <option value="indefinite">Indefinite</option>
         </select>
       </div>
-      <h2 class="mt-4 text-sm text-gray-500 dark:text-gray-400">
+      <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">
         {{ modalBody }}
-      </h2>
+      </p>
       <TextEditor
         :test-id="`report-${contentType}-input`"
         :initial-value="reportText"


### PR DESCRIPTION
## What

Several inputs relied on a placeholder alone (which is not a label), so assistive tech had no programmatic name — the two invite inputs also share the identical placeholder text, so they're indistinguishable when read out of context (WCAG 3.3.2 Labels or Instructions, 1.3.1 Info and Relationships).

- **`admin/ServerMembershipEditor.vue`** — the admin and moderator invite inputs both had placeholder `"Username to invite"`. Added distinct `aria-label`s: *"Username to invite as server admin"* / *"…as server moderator"*.
- **`admin/plugins/PluginSecretsSection.vue`** — the secret-value `<input type="password">` gets an `aria-label` naming its secret key (`Value for <KEY>`).
- **`mod/BrokenRulesModal.vue`** — associated the *"Suspend user for"* `<label>` with its `<select>` via a `useId()`-based `for`/`id`, and changed the modal-body `<h2>` (which holds prose, not a heading) to a `<p>` so it stops polluting the heading outline.

## Tests

- `ServerMembershipEditor.spec.ts`: asserts each invite input's distinct `aria-label`.
- `PluginSecretsSection.spec.ts`: asserts the secret input is named after its key.
- The `BrokenRulesModal` `for`/`id` + `h2`→`p` changes are inside a slot that its spec renders via `shallow` mount (GenericModal stubbed), so they aren't unit-asserted here; existing specs still pass and `vue-tsc` covers the binding. 41/41 related tests green, ESLint clean (one pre-existing `any` warning in the spec mock, untouched).

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).