### PR TITLE
fix(a11y): accessible names for icon-only controls + hide decorative icons (P4)

### DIFF
--- a/components/PlaceholderAvatar.vue
+++ b/components/PlaceholderAvatar.vue
@@ -25,6 +25,7 @@ const sizeClasses: Record<string, string> = {
     <User
       class="text-gray-500 dark:text-gray-400"
       :size="size === 'sm' ? 16 : size === 'md' ? 20 : 24"
+      aria-hidden="true"
     />
   </div>
 </template>

--- a/components/admin/ServerTabs.vue
+++ b/components/admin/ServerTabs.vue
@@ -163,7 +163,7 @@ const activeTab = computed(() => {
                 <component :is="activeTab?.icon" class="h-5 w-5 shrink-0" />
                 <span>{{ activeTab?.label }}</span>
               </div>
-              <i class="fa-solid fa-chevron-down ml-2 h-4 w-4" />
+              <i class="fa-solid fa-chevron-down ml-2 h-4 w-4" aria-hidden="true" />
             </button>
           </template>
 

--- a/components/filter/FilterOptionManager.vue
+++ b/components/filter/FilterOptionManager.vue
@@ -658,9 +658,10 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
               class="px-1 py-1 text-xs text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
               :disabled="disabled"
               title="Move up"
+              aria-label="Move option up"
               @click="moveOption(option.id, 'up')"
             >
-              ↑
+              <span aria-hidden="true">↑</span>
             </button>
             <button
               v-if="
@@ -671,9 +672,10 @@ const moveOption = (optionId: string, direction: 'up' | 'down') => {
               class="px-1 py-1 text-xs text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
               :disabled="disabled"
               title="Move down"
+              aria-label="Move option down"
               @click="moveOption(option.id, 'down')"
             >
-              ↓
+              <span aria-hidden="true">↓</span>
             </button>
             <button
               type="button"

--- a/components/layout/SiteFooter.vue
+++ b/components/layout/SiteFooter.vue
@@ -45,8 +45,9 @@ const links = [
       <a
         class="ml-1 text-orange-400 underline"
         target="_blank"
+        rel="noopener noreferrer"
         href="https://github.com/gennit-project/multiforum-nuxt/issues"
-        >GitHub repo</a
+        >GitHub repo<span class="sr-only"> (opens in a new tab)</span></a
       >, or email support at
       <a class="ml-1 text-orange-400 underline" href="mailto:gennitdev@gmail.com"
         >gennitdev@gmail.com</a

--- a/components/nav/Breadcrumbs.spec.ts
+++ b/components/nav/Breadcrumbs.spec.ts
@@ -55,6 +55,14 @@ describe('Breadcrumbs', () => {
     expect(wrapper.findAll('a')).toHaveLength(1);
   });
 
+  it('marks the current crumb with aria-current="page"', () => {
+    const wrapper = mountCrumbs([
+      { path: 'library', label: 'Library' },
+      { label: 'Saved Comments', current: true },
+    ]);
+    expect(wrapper.get('[aria-current="page"]').text()).toBe('Saved Comments');
+  });
+
   it('does not render a chevron before the first crumb', () => {
     const wrapper = mountCrumbs([{ path: 'forums', label: 'Forums' }]);
     expect(wrapper.find('svg').exists()).toBe(false);

--- a/components/nav/Breadcrumbs.vue
+++ b/components/nav/Breadcrumbs.vue
@@ -55,6 +55,7 @@ const buildTarget = (link: Link) => {
           </nuxt-link>
           <span
             v-else
+            aria-current="page"
             class="text-xs font-medium text-gray-700 dark:text-gray-300"
           >
             {{ link.label }}

--- a/components/nav/SiteLogo.spec.ts
+++ b/components/nav/SiteLogo.spec.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import SiteLogo from '@/components/nav/SiteLogo.vue';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+
+vi.mock('@/config', () => ({
+  config: { serverDisplayName: 'Test Forum' },
+}));
 
 describe('SiteLogo', () => {
   it('renders both mobile and desktop logo images', () => {
@@ -10,12 +14,12 @@ describe('SiteLogo', () => {
     expect(wrapper.findAll('img')).toHaveLength(2);
   });
 
-  it('uses the Workflow alt text on both logos', () => {
+  it('names both logos after the server for assistive tech', () => {
     const wrapper = mountWithDefaults(SiteLogo);
 
-    expect(wrapper.findAll('img').every((img) => img.attributes('alt') === 'Workflow')).toBe(
-      true
-    );
+    expect(
+      wrapper.findAll('img').every((img) => img.attributes('alt') === 'Test Forum logo')
+    ).toBe(true);
   });
 
   it('applies the responsive visibility classes to the two logos', () => {

--- a/components/nav/SiteLogo.vue
+++ b/components/nav/SiteLogo.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 // SiteLogo component - displays the site logo
+import { config } from '@/config';
 </script>
 
 <template>
@@ -7,12 +8,12 @@
     <img
       class="block h-8 w-auto lg:hidden"
       src="https://tailwindui.com/img/logos/workflow-mark-orange-500.svg"
-      alt="Workflow"
+      :alt="`${config.serverDisplayName} logo`"
     >
     <img
       class="hidden h-8 w-auto lg:block"
       src="https://tailwindui.com/img/logos/workflow-logo-orange-500-mark-white-text.svg"
-      alt="Workflow"
+      :alt="`${config.serverDisplayName} logo`"
     >
   </div>
 </template>

--- a/components/nav/SiteSidenavLogout.spec.ts
+++ b/components/nav/SiteSidenavLogout.spec.ts
@@ -43,6 +43,12 @@ describe('SiteSidenavLogout', () => {
     expect(mountLogout({ showIconOnly: false }).text()).toContain('Sign Out');
   });
 
+  it('gives the icon-only link an accessible name', () => {
+    expect(
+      link(mountLogout({ showIconOnly: true })).attributes('aria-label')
+    ).toBe('Sign Out');
+  });
+
   it('logs out when the link is clicked', async () => {
     const wrapper = mountLogout();
     await link(wrapper).trigger('click');

--- a/components/nav/SiteSidenavLogout.vue
+++ b/components/nav/SiteSidenavLogout.vue
@@ -25,6 +25,7 @@ const { logout: handleLogout } = useServerLogout();
     data-testid="sign-out-link"
     to="/"
     :class="navLinkClasses"
+    :aria-label="showIconOnly ? 'Sign Out' : undefined"
     @click="handleLogout"
   >
     <svg
@@ -33,6 +34,7 @@ const { logout: handleLogout } = useServerLogout();
       fill="none"
       stroke="currentColor"
       viewBox="0 0 24 24"
+      aria-hidden="true"
     >
       <path
         stroke-linecap="round"

--- a/components/plugins/PipelineVisualEditor.vue
+++ b/components/plugins/PipelineVisualEditor.vue
@@ -243,9 +243,10 @@ const eventDescription = computed(() => {
                 type="button"
                 class="p-2 text-gray-400 hover:text-red-500"
                 title="Remove step"
+                aria-label="Remove step"
                 @click="removeStep(index)"
               >
-                <i class="fa-solid fa-times" />
+                <i class="fa-solid fa-times" aria-hidden="true" />
               </button>
             </div>
           </div>

--- a/components/plugins/PluginLogsModal.vue
+++ b/components/plugins/PluginLogsModal.vue
@@ -122,10 +122,11 @@ const formatTimestamp = (isoString: string) => {
                     </div>
                     <button
                       type="button"
+                      aria-label="Close"
                       class="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
                       @click="emit('close')"
                     >
-                      <i class="fa-solid fa-times text-lg" />
+                      <i class="fa-solid fa-times text-lg" aria-hidden="true" />
                     </button>
                   </div>
                 </div>

--- a/components/plugins/PluginPipeline.vue
+++ b/components/plugins/PluginPipeline.vue
@@ -81,10 +81,13 @@ const handleCloseModal = () => {
         <button
           v-if="collapsible"
           type="button"
+          :aria-expanded="isExpanded"
+          :aria-label="isExpanded ? 'Collapse pipeline details' : 'Expand pipeline details'"
           class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
         >
           <i
             :class="isExpanded ? 'fa-solid fa-chevron-up' : 'fa-solid fa-chevron-down'"
+            aria-hidden="true"
           />
         </button>
       </div>

--- a/components/plugins/ScopedPipelineView.vue
+++ b/components/plugins/ScopedPipelineView.vue
@@ -123,10 +123,13 @@ const handleCloseModal = () => {
         <button
           v-if="collapsible"
           type="button"
+          :aria-expanded="isExpanded"
+          :aria-label="isExpanded ? 'Collapse pipeline details' : 'Expand pipeline details'"
           class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
         >
           <i
             :class="isExpanded ? 'fa-solid fa-chevron-up' : 'fa-solid fa-chevron-down'"
+            aria-hidden="true"
           />
         </button>
       </div>

--- a/components/plugins/fields/PluginSecretField.spec.ts
+++ b/components/plugins/fields/PluginSecretField.spec.ts
@@ -34,4 +34,23 @@ describe('PluginSecretField', () => {
     const wrapper = mountField({ secretStatus: { status: 'VALID' } });
     expect(wrapper.get('input').attributes('placeholder')).toContain('encrypted');
   });
+
+  it('exposes the reveal toggle as an unpressed labelled button', () => {
+    const wrapper = mountField();
+    expect(
+      wrapper
+        .get('button[aria-label="Show secret value"]')
+        .attributes('aria-pressed')
+    ).toBe('false');
+  });
+
+  it('marks the toggle pressed after revealing the value', async () => {
+    const wrapper = mountField();
+    await wrapper.get('button[aria-label="Show secret value"]').trigger('click');
+    expect(
+      wrapper
+        .get('button[aria-label="Hide secret value"]')
+        .attributes('aria-pressed')
+    ).toBe('true');
+  });
 });

--- a/components/plugins/fields/PluginSecretField.vue
+++ b/components/plugins/fields/PluginSecretField.vue
@@ -154,6 +154,8 @@ const validationError = computed(() => {
           type="button"
           class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
           :title="showValue ? 'Hide' : 'Show'"
+          :aria-label="showValue ? 'Hide secret value' : 'Show secret value'"
+          :aria-pressed="showValue"
           @click="showValue = !showValue"
         >
           <svg
@@ -162,6 +164,7 @@ const validationError = computed(() => {
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
             <path
               stroke-linecap="round"
@@ -176,6 +179,7 @@ const validationError = computed(() => {
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
             <path
               stroke-linecap="round"


### PR DESCRIPTION
## What

Icon-only controls that relied on a `title` (or nothing at all) now carry a real accessible name, and purely decorative icons are hidden from assistive tech (WCAG 4.1.2 Name, Role, Value / 1.1.1 Non-text Content).

**Icon-only controls → accessible name (+ state where relevant):**
- `plugins/PluginLogsModal.vue` close, `plugins/PipelineVisualEditor.vue` remove-step — `aria-label` + `aria-hidden` glyph.
- `plugins/fields/PluginSecretField.vue` show/hide — `aria-label` + `aria-pressed` reflecting the reveal state; both eye SVGs `aria-hidden`.
- `plugins/ScopedPipelineView.vue` / `plugins/PluginPipeline.vue` collapse chevrons — `aria-label` + `aria-expanded`. The native `<button>` already toggles via the header's click handler (activation bubbles), so keyboard operation works; chevron `aria-hidden`.
- `filter/FilterOptionManager.vue` per-option reorder — `aria-label` on the ↑/↓ buttons, arrow glyphs wrapped `aria-hidden`.
- `nav/SiteSidenavLogout.vue` icon-only variant — `aria-label="Sign Out"`, svg hidden.

**Decorative icons → hidden:**
- `PlaceholderAvatar.vue` user glyph, `admin/ServerTabs.vue` mobile chevron — `aria-hidden`.

**Link / label polish:**
- `nav/SiteLogo.vue` — replace the leftover Tailwind-template `alt="Workflow"` with the server display name.
- `nav/Breadcrumbs.vue` — `aria-current="page"` on the current crumb.
- `layout/SiteFooter.vue` — `rel="noopener noreferrer"` + an `sr-only` "(opens in a new tab)" hint on the external GitHub link.

## Tests

New assertions for the logout `aria-label`, breadcrumb `aria-current`, secret-toggle `aria-pressed` (before/after reveal), and the server-named logo `alt` (spec now mocks `@/config`). All 12 affected component specs green (107 tests); `vue-tsc` + ESLint clean.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).