### PR TITLE
Enable production hydration mismatch details

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -443,6 +443,10 @@ export default defineNuxtConfig({
     },
     define: {
       global: 'globalThis',
+      // Keep Vue's production hydration warnings actionable. Without this,
+      // production only reports that a mismatch occurred and omits the server
+      // DOM node and expected client vnode needed to locate the source.
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: true,
     },
     // Allow connections from ngrok for mobile testing
     server: {


### PR DESCRIPTION
## Summary
- enable Vue's production hydration mismatch diagnostics
- preserve current rendering behavior while adding the server DOM node and expected client vnode to production warnings

## Why
The issue only reproduces for authenticated sessions. Direct capture confirmed this sequence:
1. SSR displays 15 discussion rows.
2. Hydration logs a mismatch.
3. Vue replaces the list with 10 skeleton elements and zero rows.
4. Apollo later restores 15 rows.

The authenticated SSR payload already contains the expected sitewide-list cache field for loggedInUsername cluse. The existing production build strips the detailed mismatch warning, so it is impossible to identify which client vnode rejects the SSR subtree.

## Verification
- pnpm run tsc
- pnpm exec eslint nuxt.config.ts
- production pnpm run build