### PR TITLE
Stop test auth from clearing real usernames

### DIFF
--- a/plugins/test-auth.client.spec.ts
+++ b/plugins/test-auth.client.spec.ts
@@ -72,14 +72,19 @@ describe('test-auth client plugin', () => {
     });
   });
 
-  it('still exposes the debug auth helpers when only the token is present', () => {
-    localStorage.setItem('token', 'mock-token');
+  it('does not treat a real token without mock markers as test auth', () => {
+    localStorage.setItem('token', 'real-session-token');
 
     run();
 
-    expect(
-      typeof (window as typeof window & { __SET_AUTH_STATE_DIRECT__?: unknown })
-        .__SET_AUTH_STATE_DIRECT__
-    ).toBe('function');
+    expect({
+      authenticatedWrites: h.setIsAuthenticated.mock.calls,
+      usernameWrites: h.setUsername.mock.calls,
+      emailWrites: h.setEmail.mock.calls,
+    }).toEqual({
+      authenticatedWrites: [],
+      usernameWrites: [],
+      emailWrites: [],
+    });
   });
 });

--- a/plugins/test-auth.client.ts
+++ b/plugins/test-auth.client.ts
@@ -76,6 +76,12 @@ export default defineNuxtPlugin(() => {
     const mockModProfileName = getStorageItem('mock_mod_profile_name');
     const token = getStorageItem('token');
 
+    // A real production session also stores an Apollo token. Only explicit
+    // mock-auth markers authorize this test plugin to overwrite SSR auth state.
+    if (mockUsername === null && mockModProfileName === null) {
+      return;
+    }
+
     if (token) {
       const email = readEmailFromToken(token);
       setIsAuthenticated(true);
@@ -91,9 +97,10 @@ export default defineNuxtPlugin(() => {
   syncMockAuthFromStorage();
 
   // Expose debug functions in dev/test environments
-  // Also expose if mock_username is in localStorage (indicates Playwright tests)
+  // Also expose if an explicit mock-auth marker is in localStorage.
   const hasMockAuth =
-    getStorageItem('mock_username') !== null || !!getStorageItem('token');
+    getStorageItem('mock_username') !== null ||
+    getStorageItem('mock_mod_profile_name') !== null;
   const shouldExpose =
     import.meta.env.DEV ||
     config.environment === 'test' ||


### PR DESCRIPTION
## Summary
- require explicit mock-auth localStorage markers before the test auth plugin mutates auth state
- stop treating every Apollo token as mocked authentication
- add regression coverage for a real session token without mock markers

## Root cause
The production-loaded test-auth.client.ts plugin treated any localStorage token as test auth. Real logged-in users have that token but no mock_username, so the plugin synchronously called setUsername('') before hydration. The SSR Apollo cache was keyed by loggedInUsername: cluse while the client query used null, causing Vue to replace the SSR list with skeletons until the network query completed.

This exactly matches the production diagnostics: server div.p-0 list versus a client comment, and a server comment versus the client loading div. Anonymous users had no token and did not trigger the bug.

## Testing
- pnpm exec vitest run plugins/test-auth.client.spec.ts plugins/auth-username-fallback.client.spec.ts components/discussion/list/SitewideDiscussionList.spec.ts
- pnpm exec eslint plugins/test-auth.client.ts plugins/test-auth.client.spec.ts
- pnpm run tsc