### PR TITLE
Improve keyboard and screen-reader accessibility across shared UI

### DIFF
--- a/components/ModelViewer.spec.ts
+++ b/components/ModelViewer.spec.ts
@@ -14,9 +14,9 @@ const mountViewer = (props: Record<string, unknown> = {}) =>
   });
 
 const fullscreenButton = (w: ReturnType<typeof mount>) =>
-  w.find('button[title="View in fullscreen"]');
+  w.find('button[aria-label="View 3D model in fullscreen"]');
 const closeButton = (w: ReturnType<typeof mount>) =>
-  w.find('button[title="Close fullscreen"]');
+  w.find('button[aria-label="Close fullscreen 3D model viewer"]');
 
 beforeEach(() => {
   document.body.style.overflow = '';
@@ -57,6 +57,21 @@ describe('ModelViewer fullscreen', () => {
     expect(closeButton(wrapper).exists()).toBe(true);
   });
 
+  it('exposes the fullscreen viewer as a named modal dialog', async () => {
+    const wrapper = mountViewer();
+
+    await fullscreenButton(wrapper).trigger('click');
+    const dialog = wrapper.get('[role="dialog"]');
+
+    expect({
+      modal: dialog.attributes('aria-modal'),
+      name: wrapper.get(`#${dialog.attributes('aria-labelledby')}`).text(),
+    }).toEqual({
+      modal: 'true',
+      name: 'Fullscreen 3D model viewer',
+    });
+  });
+
   it('locks body scroll while fullscreen', async () => {
     const wrapper = mountViewer();
 
@@ -83,6 +98,16 @@ describe('ModelViewer fullscreen', () => {
     expect(document.body.style.overflow).toBe('');
   });
 
+  it('preserves an existing body overflow value', async () => {
+    document.body.style.overflow = 'clip';
+    const wrapper = mountViewer();
+    await fullscreenButton(wrapper).trigger('click');
+
+    await closeButton(wrapper).trigger('click');
+
+    expect(document.body.style.overflow).toBe('clip');
+  });
+
   it('closes fullscreen on the Escape key', async () => {
     const wrapper = mountViewer();
     await fullscreenButton(wrapper).trigger('click');
@@ -101,5 +126,23 @@ describe('ModelViewer fullscreen', () => {
     await wrapper.vm.$nextTick();
 
     expect(closeButton(wrapper).exists()).toBe(true);
+  });
+
+  it('returns focus to the fullscreen trigger after closing', async () => {
+    const wrapper = mount(ModelViewer, {
+      attachTo: document.body,
+      props: {
+        modelUrl: 'https://x/model.glb',
+        showFullscreenButton: true,
+      },
+    });
+    const trigger = fullscreenButton(wrapper);
+    (trigger.element as HTMLButtonElement).focus();
+    await trigger.trigger('click');
+
+    await closeButton(wrapper).trigger('click');
+
+    expect(document.activeElement).toBe(trigger.element);
+    wrapper.unmount();
   });
 });

--- a/components/ModelViewer.vue
+++ b/components/ModelViewer.vue
@@ -7,11 +7,14 @@
     <!-- Fullscreen button -->
     <button
       v-if="showFullscreenButton !== false"
+      ref="fullscreenButtonRef"
+      type="button"
+      aria-label="View 3D model in fullscreen"
       class="absolute right-2 top-2 z-10 rounded-md bg-black bg-opacity-50 p-2 text-white transition-all duration-200 hover:bg-opacity-70"
-      title="View in fullscreen"
       @click="openFullscreen"
     >
       <svg
+        aria-hidden="true"
         class="h-5 w-5"
         fill="none"
         stroke="currentColor"
@@ -29,7 +32,7 @@
     <model-viewer
       v-if="props.modelUrl"
       :src="props.modelUrl"
-      alt="3D Model Preview"
+      :alt="modelAlt"
       auto-rotate
       camera-controls
       exposure="0.8"
@@ -46,18 +49,26 @@
     <!-- Fullscreen modal -->
     <div
       v-if="isFullscreen"
+      ref="dialogRef"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="dialogTitleId"
       class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-90"
       @click="closeFullscreen"
     >
+      <h2 :id="dialogTitleId" class="sr-only">Fullscreen 3D model viewer</h2>
+
       <!-- Close button -->
       <button
+        type="button"
+        aria-label="Close fullscreen 3D model viewer"
         class="absolute right-4 top-4 z-[100] rounded-md bg-black bg-opacity-50 p-3 text-white transition-all duration-200 hover:bg-opacity-70"
-        title="Close fullscreen"
         @click.stop="closeFullscreen"
         @mousedown.stop
         @touchstart.stop
       >
         <svg
+          aria-hidden="true"
           class="h-6 w-6"
           fill="none"
           stroke="currentColor"
@@ -79,7 +90,7 @@
             props.modelUrl ||
             'https://storage.googleapis.com/listical-dev/models/Tiny_Khopesh_Warrior_Posed_and_Rigged.glb'
           "
-          alt="3D Model Preview - Fullscreen"
+          :alt="`${modelAlt} in fullscreen`"
           camera-controls
           style="width: 100%; height: 95%; border-radius: 8px"
           exposure="0.8"
@@ -93,55 +104,62 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue';
+import { onBeforeUnmount, onMounted, ref, useId } from 'vue';
+import { useFocusTrap } from '@/composables/useFocusTrap';
 
-const props = defineProps<{
-  modelUrl?: string;
-  height?: string;
-  width?: string;
-  showFullscreenButton?: boolean;
-  class?: string;
-  style?: Record<string, string | number>;
-}>();
+const props = withDefaults(
+  defineProps<{
+    modelUrl?: string;
+    modelAlt?: string;
+    height?: string;
+    width?: string;
+    showFullscreenButton?: boolean;
+    class?: string;
+    style?: Record<string, string | number>;
+  }>(),
+  {
+    modelUrl: '',
+    modelAlt: 'Interactive 3D model',
+    height: undefined,
+    width: undefined,
+    showFullscreenButton: true,
+    class: undefined,
+    style: undefined,
+  }
+);
 
 const isFullscreen = ref(false);
-const modelViewer = ref();
+const dialogRef = ref<HTMLElement | null>(null);
+const fullscreenButtonRef = ref<HTMLButtonElement | null>(null);
+const dialogTitleId = useId();
+let previousBodyOverflow = '';
 
 const openFullscreen = () => {
+  previousBodyOverflow = document.body.style.overflow;
   isFullscreen.value = true;
-  // Prevent body scroll when fullscreen is open
   document.body.style.overflow = 'hidden';
 };
 
 const closeFullscreen = () => {
   isFullscreen.value = false;
-  // Restore body scroll
-  document.body.style.overflow = '';
+  document.body.style.overflow = previousBodyOverflow;
 };
 
+useFocusTrap(dialogRef, {
+  active: isFullscreen,
+  onEscape: closeFullscreen,
+  fallbackTrigger: () => fullscreenButtonRef.value,
+});
+
 onMounted(async () => {
-  if (import.meta.env) {
+  if (import.meta.client) {
     await import('@google/model-viewer');
   }
 });
 
-// Close fullscreen on escape key
-onMounted(() => {
-  const handleEscape = (event: KeyboardEvent) => {
-    if (event.key === 'Escape' && isFullscreen.value) {
-      closeFullscreen();
-    }
-  };
-
-  document.addEventListener('keydown', handleEscape);
-
-  // Cleanup on unmount
-  onUnmounted(() => {
-    document.removeEventListener('keydown', handleEscape);
-    // Ensure body scroll is restored if component unmounts while fullscreen
-    if (isFullscreen.value) {
-      document.body.style.overflow = '';
-    }
-  });
+onBeforeUnmount(() => {
+  if (isFullscreen.value) {
+    document.body.style.overflow = previousBodyOverflow;
+  }
 });
 </script>

--- a/components/MultiSelect.spec.ts
+++ b/components/MultiSelect.spec.ts
@@ -13,6 +13,12 @@ const mountSelect = (props: Record<string, unknown> = {}) =>
     props: { options, multiple: true, testId: 'ms', ...props },
   });
 
+const mountAttachedSelect = (props: Record<string, unknown> = {}) =>
+  mountWithDefaults(MultiSelect, {
+    attachTo: document.body,
+    props: { options, multiple: true, testId: 'ms', ...props },
+  });
+
 const clickOutsideDirective = {
   beforeMount(el: HTMLElement, binding: { value: (event: Event) => void }) {
     const handler = (event: Event) => {
@@ -91,13 +97,7 @@ describe('MultiSelect', () => {
   it('toggles an option via its checkbox row when opened', async () => {
     const wrapper = mountSelect({ modelValue: [] });
     await wrapper.get('[data-testid="ms"]').trigger('click');
-    // The row (not the stop-propagating checkbox) carries the click handler.
-    const checkbox = wrapper.get('input[aria-label="Select Apple"]');
-    const row = checkbox.element.closest(
-      '[class*="cursor-pointer"]'
-    ) as HTMLElement;
-    row.click();
-    await wrapper.vm.$nextTick();
+    await clickRow(wrapper, 'Apple');
     expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['a']]);
   });
 
@@ -124,15 +124,14 @@ describe('MultiSelect', () => {
 
   const clickRow = async (wrapper: ReturnType<typeof mountSelect>, label: string) => {
     const row = wrapper
-      .findAll('[class*="cursor-pointer"]')
+      .findAll('button[data-selection-control]')
       .find((r) => r.text().includes(label));
-    (row!.element as HTMLElement).click();
-    await wrapper.vm.$nextTick();
+    await row!.trigger('click');
   };
 
   describe('keyboard accessibility', () => {
     const toggleButton = (wrapper: ReturnType<typeof mountSelect>) =>
-      wrapper.get('button[aria-haspopup="true"]');
+      wrapper.get('button[aria-controls]');
 
     it('exposes a keyboard toggle button for the options popup', () => {
       const wrapper = mountSelect({ modelValue: [] });
@@ -151,11 +150,47 @@ describe('MultiSelect', () => {
       }).toEqual({ expanded: 'true', hasApple: true });
     });
 
-    it('toggles an option from its checkbox change event (keyboard/space)', async () => {
-      const wrapper = mountSelect({ modelValue: [] });
+    it('moves focus to the first option when a non-searchable popup opens', async () => {
+      const wrapper = mountAttachedSelect({ modelValue: [] });
       await toggleButton(wrapper).trigger('click');
 
-      await wrapper.get('input[aria-label="Select Apple"]').trigger('change');
+      expect(wrapper.get('[data-selection-control]').element).toBe(
+        document.activeElement
+      );
+      wrapper.unmount();
+    });
+
+    it('moves focus through options with arrow keys', async () => {
+      const wrapper = mountAttachedSelect({ modelValue: [] });
+      await toggleButton(wrapper).trigger('click');
+      await wrapper
+        .get('[data-selection-control][aria-label="Apple (a)"]')
+        .trigger('keydown', { key: 'ArrowDown' });
+
+      expect((document.activeElement as HTMLElement).getAttribute('aria-label')).toBe(
+        'Banana (b)'
+      );
+      wrapper.unmount();
+    });
+
+    it('moves focus to the final option with End', async () => {
+      const wrapper = mountAttachedSelect({ modelValue: [] });
+      await toggleButton(wrapper).trigger('click');
+      await wrapper
+        .get('[data-selection-control][aria-label="Apple (a)"]')
+        .trigger('keydown', { key: 'End' });
+
+      expect((document.activeElement as HTMLElement).getAttribute('aria-label')).toBe(
+        'Cherry (c)'
+      );
+      wrapper.unmount();
+    });
+
+    it('toggles an option from its checkbox change event (keyboard/space)', async () => {
+      const wrapper = mountAttachedSelect({ modelValue: [] });
+      await toggleButton(wrapper).trigger('click');
+
+      await wrapper.get('button[data-selection-control][aria-label="Apple (a)"]').trigger('click');
 
       expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['a']]);
     });
@@ -173,9 +208,26 @@ describe('MultiSelect', () => {
       await toggleButton(wrapper).trigger('click');
       expect(wrapper.text()).toContain('Apple');
 
-      await wrapper.get('[role="group"]').trigger('keydown.escape');
+      await wrapper
+        .get(
+          `#${wrapper
+            .get('button[aria-controls]')
+            .attributes('aria-controls')}`
+        )
+        .trigger('keydown', { key: 'Escape' });
 
       expect(wrapper.text()).not.toContain('Apple');
+    });
+
+    it('returns focus to the toggle after Escape', async () => {
+      const wrapper = mountAttachedSelect({ modelValue: [] });
+      await toggleButton(wrapper).trigger('click');
+      await wrapper.get('[data-selection-control]').trigger('keydown', {
+        key: 'Escape',
+      });
+
+      expect(document.activeElement).toBe(toggleButton(wrapper).element);
+      wrapper.unmount();
     });
   });
 
@@ -222,15 +274,14 @@ describe('MultiSelect', () => {
     it('select-all selects every option in the section', async () => {
       const wrapper = mountSections({ modelValue: [] });
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      await wrapper.get('input[aria-label="All fruits"]').trigger('click');
+      await wrapper.get('button[data-selection-control][aria-pressed="false"]').trigger('click');
       expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['a', 'b']]);
     });
 
     it('select-all deselects when the section is already fully selected', async () => {
       const wrapper = mountSections({ modelValue: ['a', 'b'] });
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      const selectAll = wrapper.get('input[aria-label="All fruits"]');
-      expect((selectAll.element as HTMLInputElement).checked).toBe(true);
+      const selectAll = wrapper.get('button[data-selection-control][aria-pressed="true"]');
       await selectAll.trigger('click');
       expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([[]]);
     });
@@ -261,7 +312,7 @@ describe('MultiSelect', () => {
       });
 
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      await wrapper.get('input[aria-label="All fruits"]').trigger('click');
+      await wrapper.get('button[data-selection-control]').trigger('click');
       expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['a']]);
     });
   });
@@ -440,8 +491,10 @@ describe('MultiSelect', () => {
     it('deselects every channel when the collection is already fully selected', async () => {
       const wrapper = mountCollection(['x', 'y'], ['x', 'y']);
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      const checkbox = wrapper.get('input[aria-label="Select all forums in My Collection"]');
-      expect((checkbox.element as HTMLInputElement).checked).toBe(true);
+      const checkbox = wrapper.get(
+        'button[data-selection-control][aria-label="Select all forums in My Collection"]'
+      );
+      expect(checkbox.attributes('aria-pressed')).toBe('true');
       await clickRow(wrapper, 'My Collection');
       expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([[]]);
     });

--- a/components/MultiSelect.vue
+++ b/components/MultiSelect.vue
@@ -108,21 +108,29 @@ const isDropdownOpen = ref(false);
 const searchQuery = ref('');
 const selected = ref<MultiSelectValue[]>([...props.modelValue]);
 const searchInputRef = ref<HTMLInputElement | null>(null);
-// Keyboard-accessible toggle button; also the element focus returns to on close.
 const toggleButtonRef = ref<HTMLButtonElement | null>(null);
-const listboxId = useId();
+const popupRef = ref<HTMLElement | null>(null);
+const popupId = useId();
+const descriptionId = useId();
+const errorId = useId();
 const expandedSections = ref<Set<number>>(new Set());
 const expandedCollections = ref<Set<string>>(new Set());
 
 const toggleDropdown = () => {
-  isDropdownOpen.value = !isDropdownOpen.value;
-
-  // Auto-focus the search input when dropdown opens
-  if (isDropdownOpen.value && props.searchable) {
-    nextTick(() => {
-      searchInputRef.value?.focus();
-    });
+  if (isDropdownOpen.value) {
+    closeDropdown();
+    return;
   }
+
+  isDropdownOpen.value = true;
+
+  nextTick(() => {
+    if (props.searchable) {
+      searchInputRef.value?.focus();
+    } else {
+      focusSelectionControl('first');
+    }
+  });
 };
 
 const closeDropdown = () => {
@@ -131,14 +139,28 @@ const closeDropdown = () => {
   searchQuery.value = '';
 };
 
-// Open the dropdown from a keyboard trigger (ArrowDown on the toggle button),
-// then move focus into the search box if there is one.
-const openDropdown = () => {
+const selectionControls = () =>
+  Array.from(
+    popupRef.value?.querySelectorAll<HTMLButtonElement>(
+      '[data-selection-control]:not(:disabled)'
+    ) || []
+  );
+
+const focusSelectionControl = (position: 'first' | 'last') => {
+  const controls = selectionControls();
+  controls[position === 'first' ? 0 : controls.length - 1]?.focus();
+};
+
+const openDropdown = (position: 'first' | 'last' = 'first') => {
   if (isDropdownOpen.value) return;
   isDropdownOpen.value = true;
-  if (props.searchable) {
-    nextTick(() => searchInputRef.value?.focus());
-  }
+  nextTick(() => {
+    if (props.searchable && position === 'first') {
+      searchInputRef.value?.focus();
+    } else {
+      focusSelectionControl(position);
+    }
+  });
 };
 
 // Close the dropdown and return focus to the toggle button (keyboard dismiss).
@@ -147,16 +169,51 @@ const closeAndReturnFocus = () => {
   nextTick(() => toggleButtonRef.value?.focus());
 };
 
-// The search box stops key propagation (so typing doesn't reach parents); make
-// sure Escape still closes the dropdown.
 const onSearchKeydown = (event: KeyboardEvent) => {
-  if (event.key === 'Escape') closeAndReturnFocus();
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeAndReturnFocus();
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    focusSelectionControl('first');
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    focusSelectionControl('last');
+  }
+};
+
+const onPopupKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeAndReturnFocus();
+    return;
+  }
+
+  const target = event.target as HTMLElement;
+  if (!target.matches('[data-selection-control]')) return;
+
+  const controls = selectionControls();
+  const currentIndex = controls.indexOf(target as HTMLButtonElement);
+  let nextIndex: number | undefined;
+
+  if (event.key === 'ArrowDown') nextIndex = (currentIndex + 1) % controls.length;
+  if (event.key === 'ArrowUp') {
+    nextIndex = (currentIndex - 1 + controls.length) % controls.length;
+  }
+  if (event.key === 'Home') nextIndex = 0;
+  if (event.key === 'End') nextIndex = controls.length - 1;
+
+  if (nextIndex !== undefined) {
+    event.preventDefault();
+    controls[nextIndex]?.focus();
+  }
 };
 
 const toggleSelection = (value: MultiSelectValue) => {
   if (!props.multiple) {
     selected.value = selected.value.includes(value) ? [] : [value];
     closeDropdown();
+    nextTick(() => toggleButtonRef.value?.focus());
   } else {
     const index = selected.value.indexOf(value);
     if (index === -1) {
@@ -258,6 +315,12 @@ const updateSearch = (query: string) => {
   emit('search', query);
 };
 
+const optionAriaLabel = (option: MultiSelectOption) => {
+  return option.label === option.value
+    ? option.label
+    : `${option.label} (${option.value})`;
+};
+
 // Combine all options from both legacy options and sections
 const allOptions = computed(() => {
   const optionsFromSections = props.sections.flatMap(
@@ -323,28 +386,50 @@ const selectedOptions = computed(() => {
     .map((value) => getOptionByValue(value))
     .filter(Boolean) as MultiSelectOption[];
 });
+
+const toggleAriaLabel = computed(() => {
+  const valueSummary = selectedOptions.value.length
+    ? selectedOptions.value.map((option) => option.label).join(', ')
+    : 'No selection';
+  return `${props.placeholder} Current selection: ${valueSummary}. ${
+    isDropdownOpen.value ? 'Hide options' : 'Show options'
+  }`;
+});
+
+const describedBy = computed(() => {
+  return [props.description && descriptionId, props.error && errorId]
+    .filter(Boolean)
+    .join(' ') || undefined;
+});
 </script>
 
 <template>
   <div>
-    <div v-if="description" class="py-1 text-sm dark:text-gray-300">
+    <div
+      v-if="description"
+      :id="descriptionId"
+      class="py-1 text-sm dark:text-gray-300"
+    >
       {{ description }}
     </div>
 
-    <div v-if="error" class="mb-2 text-sm text-red-500">
+    <div
+      v-if="error"
+      :id="errorId"
+      role="alert"
+      class="mb-2 text-sm text-red-500"
+    >
       {{ error }}
     </div>
 
     <div v-click-outside="closeDropdown" class="relative">
       <div
-        :data-testid="testId"
         :class="[
-          'flex w-full cursor-pointer rounded-lg border px-4 text-left dark:border-gray-700 dark:bg-gray-700',
+          'flex w-full rounded-lg border px-4 text-left dark:border-gray-700 dark:bg-gray-700',
           showChips
             ? 'min-h-10 flex-wrap items-center'
             : 'min-h-12 items-start py-2',
         ]"
-        @click="toggleDropdown"
       >
         <!-- Selected items as chips -->
         <div
@@ -396,7 +481,7 @@ const selectedOptions = computed(() => {
           v-if="selectedOptions.length === 0"
           class="text-gray-500 dark:text-gray-400"
         >
-          {{ placeholder }}
+          <span>{{ placeholder }}</span>
         </div>
 
         <!-- Clear button and dropdown arrow -->
@@ -413,18 +498,18 @@ const selectedOptions = computed(() => {
             <XmarkIcon class="h-4 w-4" aria-hidden="true" />
           </button>
 
-          <!-- Dropdown toggle: the keyboard-accessible control that opens the
-               options popup (the whole field is also clickable for the mouse). -->
           <button
             ref="toggleButtonRef"
             type="button"
-            :aria-label="isDropdownOpen ? 'Hide options' : 'Show options'"
+            :data-testid="testId"
+            :aria-label="toggleAriaLabel"
+            :aria-describedby="describedBy"
             :aria-expanded="isDropdownOpen"
-            aria-haspopup="true"
-            :aria-controls="listboxId"
-            class="flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
-            @click.stop="toggleDropdown"
-            @keydown.down.prevent="openDropdown"
+            :aria-controls="popupId"
+            class="flex min-h-10 min-w-10 items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+            @click="toggleDropdown"
+            @keydown.down.prevent="openDropdown('first')"
+            @keydown.up.prevent="openDropdown('last')"
           >
             <ChevronDownIcon
               class="h-4 w-4 transition-transform"
@@ -438,15 +523,16 @@ const selectedOptions = computed(() => {
       <!-- Dropdown -->
       <div
         v-if="isDropdownOpen"
-        :id="listboxId"
-        role="group"
-        :aria-label="placeholder"
+        :id="popupId"
+        ref="popupRef"
+        role="region"
+        :aria-label="`${placeholder} options`"
         :class="[
           'absolute z-50 mt-1 w-full rounded-md border bg-white shadow-lg dark:border-gray-600 dark:bg-gray-800',
           dropdownMaxHeight,
           'overflow-y-auto',
         ]"
-        @keydown.escape="closeAndReturnFocus"
+        @keydown="onPopupKeydown"
       >
         <!-- Search bar for dropdown -->
         <div
@@ -461,7 +547,7 @@ const selectedOptions = computed(() => {
             :aria-label="searchPlaceholder"
             class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             @input="updateSearch(searchQuery)"
-            @keydown.stop="onSearchKeydown"
+            @keydown="onSearchKeydown"
             @keyup.stop
             @click.stop
             @focus.stop
@@ -472,6 +558,7 @@ const selectedOptions = computed(() => {
         <!-- Loading state -->
         <div
           v-if="loading"
+          role="status"
           class="p-4 text-center text-gray-500 dark:text-gray-400"
         >
           Loading...
@@ -483,8 +570,8 @@ const selectedOptions = computed(() => {
             v-for="(section, sectionIndex) in filteredSections"
             :key="sectionIndex"
           >
-            <!-- Section title -->
             <div
+              :id="`${popupId}-section-${sectionIndex}`"
               class="bg-gray-50 font-semibold px-4 py-2 text-xs uppercase text-gray-600 dark:bg-gray-900 dark:text-gray-400"
             >
               {{ section.title }}
@@ -492,9 +579,12 @@ const selectedOptions = computed(() => {
 
             <!-- Select All option (if section has selectAllLabel) -->
             <div v-if="section.selectAllLabel && section.options.length > 0">
-              <div
+              <button
+                type="button"
+                data-selection-control
+                :aria-pressed="isSectionFullySelected(section.options)"
                 :class="[
-                  'flex cursor-pointer items-center border-b px-4 py-2 hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700',
+                  'flex w-full items-center border-b px-4 py-2 text-left hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-orange-500 dark:border-gray-600 dark:hover:bg-gray-700',
                   isSectionFullySelected(section.options)
                     ? 'bg-orange-50 dark:bg-orange-900/20'
                     : '',
@@ -503,13 +593,20 @@ const selectedOptions = computed(() => {
               >
                 <!-- Checkbox for select all -->
                 <div class="relative mr-3">
-                  <input
-                    type="checkbox"
-                    :checked="isSectionFullySelected(section.options)"
-                    :aria-label="section.selectAllLabel"
-                    class="h-4 w-4 rounded border border-gray-400 text-orange-600 checked:border-orange-600 checked:bg-orange-600 checked:text-white focus:ring-orange-500 dark:border-gray-500 dark:bg-gray-700"
-                    @click.stop="toggleSelectAll(section.options)"
+                  <span
+                    aria-hidden="true"
+                    :class="[
+                      'flex h-4 w-4 items-center justify-center rounded border',
+                      isSectionFullySelected(section.options)
+                        ? 'border-orange-600 bg-orange-600 text-white'
+                        : 'border-gray-400 dark:border-gray-500',
+                    ]"
                   >
+                    <CheckIcon
+                      v-if="isSectionFullySelected(section.options)"
+                      class="h-3 w-3"
+                    />
+                  </span>
                 </div>
 
                 <!-- Label -->
@@ -525,7 +622,7 @@ const selectedOptions = computed(() => {
                 >
                   {{ selectableOptions(section.options).length }}
                 </span>
-              </div>
+              </button>
 
               <!-- Preview list of forums -->
               <div class="px-4 py-2 text-xs text-gray-600 dark:text-gray-400">
@@ -567,161 +664,188 @@ const selectedOptions = computed(() => {
               <div
                 v-for="collectionOption in section.options"
                 :key="String(collectionOption.value)"
-                :class="[
-                  'flex cursor-pointer items-center border-b px-4 py-2 hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700',
-                  isCollectionFullySelected(
-                    collectionOption.channels || []
-                  )
-                    ? 'bg-orange-50 dark:bg-orange-900/20'
-                    : '',
-                ]"
-                @click="
-                  toggleCollectionChannels(
-                    collectionOption.channels || []
-                  )
-                "
+                class="border-b dark:border-gray-600"
               >
-                <!-- Checkbox -->
-                <div class="relative mr-3">
-                  <input
-                    type="checkbox"
-                    :checked="
-                      isCollectionFullySelected(
-                        collectionOption.channels || []
-                      )
-                    "
-                    :aria-label="`Select all forums in ${collectionOption.label}`"
-                    class="h-4 w-4 rounded border border-gray-400 text-orange-600 checked:border-orange-600 checked:bg-orange-600 checked:text-white focus:ring-orange-500 dark:border-gray-500 dark:bg-gray-700"
-                    @click.stop="
-                      toggleCollectionChannels(
-                        collectionOption.channels || []
-                      )
+                <button
+                  type="button"
+                  data-selection-control
+                  :aria-pressed="
+                    isCollectionFullySelected(
+                      collectionOption.channels || []
+                    )
+                  "
+                  :aria-label="`Select all forums in ${collectionOption.label}`"
+                  :class="[
+                    'flex w-full items-center px-4 py-2 text-left hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-orange-500 dark:hover:bg-gray-700',
+                    isCollectionFullySelected(
+                      collectionOption.channels || []
+                    )
+                      ? 'bg-orange-50 dark:bg-orange-900/20'
+                      : '',
+                  ]"
+                  @click="
+                    toggleCollectionChannels(
+                      collectionOption.channels || []
+                    )
+                  "
+                >
+                  <div class="relative mr-3">
+                    <span
+                      aria-hidden="true"
+                      :class="[
+                        'flex h-4 w-4 items-center justify-center rounded border',
+                        isCollectionFullySelected(collectionOption.channels || [])
+                          ? 'border-orange-600 bg-orange-600 text-white'
+                          : 'border-gray-400 dark:border-gray-500',
+                      ]"
+                    >
+                      <CheckIcon
+                        v-if="
+                        isCollectionFullySelected(
+                          collectionOption.channels || []
+                        )
+                      "
+                        class="h-3 w-3"
+                      />
+                    </span>
+                  </div>
+
+                  <div class="flex-1 text-sm">
+                    <span class="font-medium text-gray-900 dark:text-white">{{
+                      collectionOption.label
+                    }}</span>
+                  </div>
+
+                  <span
+                    class="ml-2 rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-600 dark:text-gray-300"
+                  >
+                    {{ (collectionOption.channels || []).length }}
+                  </span>
+                </button>
+
+                <div class="px-4 pb-2 text-xs text-gray-500 dark:text-gray-400">
+                  <span class="sr-only">
+                    Forums in {{ collectionOption.label }}:
+                  </span>
+                  <span
+                    v-if="(collectionOption.channels || []).length <= 3"
+                  >
+                    {{ (collectionOption.channels || []).join(', ') }}
+                  </span>
+                  <span
+                    v-else-if="
+                      !expandedCollections.has(String(collectionOption.value))
                     "
                   >
-                </div>
-
-                <!-- Collection name and channel preview -->
-                <div class="flex-1 text-sm">
-                  <span class="font-medium text-gray-900 dark:text-white">{{
-                    collectionOption.label
-                  }}</span>
-                  <span class="ml-1 text-gray-500 dark:text-gray-400">
-                    (<span
-                      v-if="
-                        (collectionOption.channels || []).length <= 3
+                    {{
+                      (collectionOption.channels || [])
+                        .slice(0, 3)
+                        .join(', ')
+                    }}
+                    <button
+                      type="button"
+                      class="ml-1 text-orange-600 hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
+                      @click.stop="
+                        toggleCollectionExpansion(
+                          String(collectionOption.value)
+                        )
                       "
-                      >{{
-                        (collectionOption.channels || []).join(', ')
-                      }}</span
-                    ><span
-                      v-else-if="
-                        !expandedCollections.has(String(collectionOption.value))
+                    >
+                      show more
+                    </button>
+                  </span>
+                  <span v-else>
+                    {{ (collectionOption.channels || []).join(', ') }}
+                    <button
+                      type="button"
+                      class="ml-1 text-orange-600 hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
+                      @click.stop="
+                        toggleCollectionExpansion(
+                          String(collectionOption.value)
+                        )
                       "
-                      >{{
-                        (collectionOption.channels || [])
-                          .slice(0, 3)
-                          .join(', ')
-                      }}<button
-                        type="button"
-                        class="ml-1 text-orange-600 hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
-                        @click.stop="
-                          toggleCollectionExpansion(
-                            String(collectionOption.value)
-                          )
-                        "
-                      >
-                        show more
-                      </button></span
-                    ><span v-else
-                      >{{ (collectionOption.channels || []).join(', ')
-                      }}<button
-                        type="button"
-                        class="ml-1 text-orange-600 hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
-                        @click.stop="
-                          toggleCollectionExpansion(
-                            String(collectionOption.value)
-                          )
-                        "
-                      >
-                        show less
-                      </button></span
-                    >)
+                    >
+                      show less
+                    </button>
                   </span>
                 </div>
-
-                <!-- Count badge -->
-                <span
-                  class="ml-2 rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-600 dark:text-gray-300"
-                >
-                  {{ (collectionOption.channels || []).length }}
-                </span>
               </div>
             </div>
 
             <!-- Section options (regular items, not for collections or selectAll sections) -->
-            <div
+            <ul
               v-if="
                 section.options.length > 0 &&
                 !section.selectAllLabel &&
                 !section.isCollectionSection
               "
+              :aria-labelledby="`${popupId}-section-${sectionIndex}`"
               class="py-1"
             >
-              <div
+              <li
                 v-for="option in section.options"
                 :key="String(option.value)"
-                :class="[
-                  'flex cursor-pointer items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700',
-                  selected.includes(option.value)
-                    ? 'bg-orange-50 dark:bg-orange-900/20'
-                    : '',
-                  option.disabled ? 'cursor-not-allowed opacity-50' : '',
-                ]"
-                @click="!option.disabled && toggleSelection(option.value)"
               >
-                <!-- Checkbox for multiple selection -->
-                <div class="relative mr-3">
-                  <input
-                    v-if="multiple"
-                    type="checkbox"
-                    :checked="selected.includes(option.value)"
-                    :disabled="option.disabled"
-                    :aria-label="`Select ${option.label}`"
-                    class="h-4 w-4 rounded border border-gray-400 text-orange-600 checked:border-orange-600 checked:bg-orange-600 checked:text-white focus:ring-orange-500 dark:border-gray-500 dark:bg-gray-700"
-                    @click.stop
-                    @change="toggleSelection(option.value)"
-                  >
-                </div>
-
-                <!-- Compact label: uniqueName (displayName) -->
-                <div class="flex-1 text-sm">
-                  <div>
-                    <span class="font-mono text-gray-900 dark:text-white">
-                      {{ option.value }}
-                    </span>
+                <button
+                  type="button"
+                  data-selection-control
+                  :aria-pressed="selected.includes(option.value)"
+                  :disabled="option.disabled"
+                  :aria-label="optionAriaLabel(option)"
+                  :class="[
+                    'flex w-full items-center px-4 py-2 text-left hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-orange-500 dark:hover:bg-gray-700',
+                    selected.includes(option.value)
+                      ? 'bg-orange-50 dark:bg-orange-900/20'
+                      : '',
+                    option.disabled ? 'cursor-not-allowed opacity-50' : '',
+                  ]"
+                  @click="toggleSelection(option.value)"
+                >
+                  <div v-if="multiple" class="relative mr-3">
                     <span
-                      v-if="option.label && option.label !== option.value"
-                      class="text-gray-500 dark:text-gray-400"
+                      aria-hidden="true"
+                      :class="[
+                        'flex h-4 w-4 items-center justify-center rounded border',
+                        selected.includes(option.value)
+                          ? 'border-orange-600 bg-orange-600 text-white'
+                          : 'border-gray-400 dark:border-gray-500',
+                      ]"
                     >
-                      ({{ option.label }})
+                      <CheckIcon
+                        v-if="selected.includes(option.value)"
+                        class="h-3 w-3"
+                      />
                     </span>
                   </div>
-                  <div
-                    v-if="option.description"
-                    class="text-xs text-gray-500 dark:text-gray-400"
-                  >
-                    {{ option.description }}
-                  </div>
-                </div>
 
-                <!-- Selected indicator for single selection -->
-                <CheckIcon
-                  v-if="!multiple && selected.includes(option.value)"
-                  class="h-4 w-4 text-orange-600"
-                  aria-hidden="true"
-                />
-              </div>
-            </div>
+                  <div class="flex-1 text-sm">
+                    <div>
+                      <span class="font-mono text-gray-900 dark:text-white">
+                        {{ option.value }}
+                      </span>
+                      <span
+                        v-if="option.label && option.label !== option.value"
+                        class="text-gray-500 dark:text-gray-400"
+                      >
+                        ({{ option.label }})
+                      </span>
+                    </div>
+                    <div
+                      v-if="option.description"
+                      class="text-xs text-gray-500 dark:text-gray-400"
+                    >
+                      {{ option.description }}
+                    </div>
+                  </div>
+
+                  <CheckIcon
+                    v-if="!multiple && selected.includes(option.value)"
+                    class="h-4 w-4 text-orange-600"
+                    aria-hidden="true"
+                  />
+                </button>
+              </li>
+            </ul>
 
             <!-- Empty section message (only shown when section has no options and no selectAllLabel) -->
             <div
@@ -738,72 +862,86 @@ const selectedOptions = computed(() => {
         </div>
 
         <!-- Legacy options view (for backwards compatibility) -->
-        <div v-else-if="filteredOptions.length > 0" class="py-1">
-          <div
+        <ul
+          v-else-if="filteredOptions.length > 0"
+          class="py-1"
+        >
+          <li
             v-for="option in filteredOptions"
             :key="String(option.value)"
-            :class="[
-              'flex cursor-pointer items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700',
-              selected.includes(option.value)
-                ? 'bg-orange-50 dark:bg-orange-900/20'
-                : '',
-              option.disabled ? 'cursor-not-allowed opacity-50' : '',
-            ]"
-            @click="!option.disabled && toggleSelection(option.value)"
           >
-            <!-- Checkbox for multiple selection -->
-            <div class="relative mr-3">
-              <input
-                v-if="multiple"
-                type="checkbox"
-                :checked="selected.includes(option.value)"
-                :disabled="option.disabled"
-                :aria-label="`Select ${option.label}`"
-                class="h-4 w-4 rounded border border-gray-400 text-orange-600 checked:border-orange-600 checked:bg-orange-600 checked:text-white focus:ring-orange-500 dark:border-gray-500 dark:bg-gray-700"
-                @click.stop
-                @change="toggleSelection(option.value)"
-              >
-            </div>
-
-            <!-- Avatar -->
-            <img
-              v-if="option.avatar"
-              :src="option.avatar"
-              :alt="option.label"
-              class="mr-3 h-6 w-6 rounded-full"
+            <button
+              type="button"
+              data-selection-control
+              :aria-pressed="selected.includes(option.value)"
+              :disabled="option.disabled"
+              :aria-label="optionAriaLabel(option)"
+              :class="[
+                'flex w-full items-center px-4 py-2 text-left hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-orange-500 dark:hover:bg-gray-700',
+                selected.includes(option.value)
+                  ? 'bg-orange-50 dark:bg-orange-900/20'
+                  : '',
+                option.disabled ? 'cursor-not-allowed opacity-50' : '',
+              ]"
+              @click="toggleSelection(option.value)"
             >
-
-            <!-- Icon -->
-            <i
-              v-else-if="option.icon"
-              :class="[option.icon, 'mr-3']"
-              aria-hidden="true"
-            />
-
-            <!-- Label -->
-            <div class="flex-1 text-sm">
-              <div class="text-gray-900 dark:text-white">
-                {{ option.label }}
+              <div v-if="multiple" class="relative mr-3">
+                <span
+                  aria-hidden="true"
+                  :class="[
+                    'flex h-4 w-4 items-center justify-center rounded border',
+                    selected.includes(option.value)
+                      ? 'border-orange-600 bg-orange-600 text-white'
+                      : 'border-gray-400 dark:border-gray-500',
+                  ]"
+                >
+                  <CheckIcon
+                    v-if="selected.includes(option.value)"
+                    class="h-3 w-3"
+                  />
+                </span>
               </div>
-              <div
-                v-if="option.description"
-                class="text-xs text-gray-500 dark:text-gray-400"
+
+              <img
+                v-if="option.avatar"
+                :src="option.avatar"
+                alt=""
+                class="mr-3 h-6 w-6 rounded-full"
               >
-                {{ option.description }}
-              </div>
-            </div>
 
-            <!-- Selected indicator for single selection -->
-            <CheckIcon
-              v-if="!multiple && selected.includes(option.value)"
-              class="h-4 w-4 text-orange-600"
-              aria-hidden="true"
-            />
-          </div>
-        </div>
+              <i
+                v-else-if="option.icon"
+                :class="[option.icon, 'mr-3']"
+                aria-hidden="true"
+              />
+
+              <div class="flex-1 text-sm">
+                <div class="text-gray-900 dark:text-white">
+                  {{ option.label }}
+                </div>
+                <div
+                  v-if="option.description"
+                  class="text-xs text-gray-500 dark:text-gray-400"
+                >
+                  {{ option.description }}
+                </div>
+              </div>
+
+              <CheckIcon
+                v-if="!multiple && selected.includes(option.value)"
+                class="h-4 w-4 text-orange-600"
+                aria-hidden="true"
+              />
+            </button>
+          </li>
+        </ul>
 
         <!-- No options -->
-        <div v-else class="p-4 text-center text-gray-500 dark:text-gray-400">
+        <div
+          v-else
+          role="status"
+          class="p-4 text-center text-gray-500 dark:text-gray-400"
+        >
           No options available
         </div>
       </div>

--- a/components/collection/AddToListPopover.spec.ts
+++ b/components/collection/AddToListPopover.spec.ts
@@ -128,6 +128,20 @@ describe('AddToListPopover list rendering', () => {
     expect(wrapper.text()).toContain('My List');
   });
 
+  it('renders collection choices as native toggle buttons', () => {
+    const wrapper = mountPopover();
+
+    expect(
+      rows(wrapper).map((row) => ({
+        element: row.element.tagName,
+        pressed: row.attributes('aria-pressed'),
+      }))
+    ).toEqual([
+      { element: 'BUTTON', pressed: 'false' },
+      { element: 'BUTTON', pressed: 'false' },
+    ]);
+  });
+
   it('shows the empty state when there are no collections', () => {
     h.collectionsResult = ref({
       users: [{ Collections: [], FavoriteDiscussions: [] }],
@@ -476,5 +490,28 @@ describe('AddToListPopover modal variant', () => {
     await wrapper.get('.bg-black\\/50').trigger('click');
 
     expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('emits close when Escape is pressed', async () => {
+    const wrapper = mountPopover({ variant: 'modal' });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await flushPromises();
+
+    expect(wrapper.emitted('close')?.length).toBe(1);
+  });
+
+  it('restores focus when the modal closes', async () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    const wrapper = mountPopover({ variant: 'modal' });
+    await flushPromises();
+
+    await wrapper.setProps({ isVisible: false });
+
+    expect(document.activeElement).toBe(trigger);
+    wrapper.unmount();
+    trigger.remove();
   });
 });

--- a/components/collection/AddToListPopover.vue
+++ b/components/collection/AddToListPopover.vue
@@ -15,6 +15,7 @@ import {
   isItemFavorited,
   filterCollectionsBySearch,
 } from '@/utils/collectionFilters';
+import { useFocusTrap } from '@/composables/useFocusTrap';
 
 const usernameVar = useUsername();
 
@@ -193,6 +194,12 @@ const { adjustedPosition } = usePopoverPositioning({
 });
 
 const isModal = computed(() => props.variant === 'modal');
+const modalFocusActive = computed(() => props.isVisible && isModal.value);
+
+useFocusTrap(popoverRef, {
+  active: modalFocusActive,
+  onEscape: () => emit('close'),
+});
 
 const resetCreateCollectionForm = () => {
   isCreatingNew.value = false;
@@ -346,7 +353,7 @@ const handleClickOutside = (event: MouseEvent) => {
 };
 
 const handleKeydown = (event: KeyboardEvent) => {
-  if (event.key === 'Escape' && props.isVisible) {
+  if (event.key === 'Escape' && props.isVisible && !isModal.value) {
     emit('close');
   }
 };
@@ -491,8 +498,10 @@ const popoverStyles = computed(() => {
         <!-- Lists -->
         <div class="max-h-64 space-y-1 overflow-y-auto">
           <!-- Favorites List (Always shown) -->
-          <div
-            class="hover:bg-gray-50 flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm dark:hover:bg-gray-700"
+          <button
+            type="button"
+            :aria-pressed="isItemInFavorites"
+            class="hover:bg-gray-50 flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-gray-700"
             @click.stop="handleToggleInCollection(favoritesList)"
           >
             <div class="flex items-center">
@@ -501,13 +510,18 @@ const popoverStyles = computed(() => {
                 favoritesList.name
               }}</span>
             </div>
-            <input
-              type="checkbox"
-              :checked="isItemInFavorites"
-              class="rounded text-blue-600 focus:ring-blue-500"
-              readonly
+            <span
+              aria-hidden="true"
+              :class="[
+                'flex h-4 w-4 items-center justify-center rounded border text-xs',
+                isItemInFavorites
+                  ? 'border-blue-600 bg-blue-600 text-white'
+                  : 'border-gray-400 dark:border-gray-500',
+              ]"
             >
-          </div>
+              {{ isItemInFavorites ? '✓' : '' }}
+            </span>
+          </button>
 
           <!-- Divider between Favorites and Collections -->
           <div
@@ -526,10 +540,16 @@ const popoverStyles = computed(() => {
           </div>
 
           <!-- Custom Collections -->
-          <div
+          <button
             v-for="collection in filteredCollections"
             :key="collection.id"
-            class="hover:bg-gray-50 flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm dark:hover:bg-gray-700"
+            type="button"
+            :aria-pressed="
+              itemInCollections.some(
+                (c: CollectionListItem) => c.id === collection.id
+              )
+            "
+            class="hover:bg-gray-50 flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-gray-700"
             @click.stop="handleToggleInCollection(collection)"
           >
             <div class="flex items-center">
@@ -540,17 +560,26 @@ const popoverStyles = computed(() => {
                 >({{ collection.itemCount }})</span
               >
             </div>
-            <input
-              type="checkbox"
-              :checked="
+            <span
+              aria-hidden="true"
+              :class="[
+                'flex h-4 w-4 items-center justify-center rounded border text-xs',
                 itemInCollections.some(
                   (c: CollectionListItem) => c.id === collection.id
                 )
-              "
-              class="rounded text-blue-600 focus:ring-blue-500"
-              readonly
+                  ? 'border-blue-600 bg-blue-600 text-white'
+                  : 'border-gray-400 dark:border-gray-500',
+              ]"
             >
-          </div>
+              {{
+                itemInCollections.some(
+                  (c: CollectionListItem) => c.id === collection.id
+                )
+                  ? '✓'
+                  : ''
+              }}
+            </span>
+          </button>
 
           <!-- No Search Results -->
           <div
@@ -683,8 +712,10 @@ const popoverStyles = computed(() => {
       <!-- Lists -->
       <div class="max-h-64 space-y-1 overflow-y-auto">
         <!-- Favorites List (Always shown) -->
-        <div
-          class="hover:bg-gray-50 flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm dark:hover:bg-gray-700"
+        <button
+          type="button"
+          :aria-pressed="isItemInFavorites"
+          class="hover:bg-gray-50 flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-gray-700"
           @click.stop="handleToggleInCollection(favoritesList)"
         >
           <div class="flex items-center">
@@ -693,14 +724,18 @@ const popoverStyles = computed(() => {
               favoritesList.name
             }}</span>
           </div>
-          <input
-            type="checkbox"
-            :checked="isItemInFavorites"
-            :aria-label="`${isItemInFavorites ? 'Remove from' : 'Add to'} ${favoritesList.name}`"
-            class="rounded text-blue-600 focus:ring-blue-500"
-            readonly
+          <span
+            aria-hidden="true"
+            :class="[
+              'flex h-4 w-4 items-center justify-center rounded border text-xs',
+              isItemInFavorites
+                ? 'border-blue-600 bg-blue-600 text-white'
+                : 'border-gray-400 dark:border-gray-500',
+            ]"
           >
-        </div>
+            {{ isItemInFavorites ? '✓' : '' }}
+          </span>
+        </button>
 
         <!-- Divider between Favorites and Collections -->
         <div
@@ -719,10 +754,16 @@ const popoverStyles = computed(() => {
         </div>
 
         <!-- Custom Collections -->
-        <div
+        <button
           v-for="collection in filteredCollections"
           :key="collection.id"
-          class="hover:bg-gray-50 flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm dark:hover:bg-gray-700"
+          type="button"
+          :aria-pressed="
+            itemInCollections.some(
+              (c: CollectionListItem) => c.id === collection.id
+            )
+          "
+          class="hover:bg-gray-50 flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-gray-700"
           @click.stop="handleToggleInCollection(collection)"
         >
           <div class="flex items-center">
@@ -733,18 +774,26 @@ const popoverStyles = computed(() => {
               >({{ collection.itemCount }})</span
             >
           </div>
-          <input
-            type="checkbox"
-            :checked="
+          <span
+            aria-hidden="true"
+            :class="[
+              'flex h-4 w-4 items-center justify-center rounded border text-xs',
               itemInCollections.some(
                 (c: CollectionListItem) => c.id === collection.id
               )
-            "
-            :aria-label="`${itemInCollections.some((c: CollectionListItem) => c.id === collection.id) ? 'Remove from' : 'Add to'} ${collection.name}`"
-            class="rounded text-blue-600 focus:ring-blue-500"
-            readonly
+                ? 'border-blue-600 bg-blue-600 text-white'
+                : 'border-gray-400 dark:border-gray-500',
+            ]"
           >
-        </div>
+            {{
+              itemInCollections.some(
+                (c: CollectionListItem) => c.id === collection.id
+              )
+                ? '✓'
+                : ''
+            }}
+          </span>
+        </button>
 
         <!-- No Search Results -->
         <div

--- a/components/comments/CommentEditsDropdown.spec.ts
+++ b/components/comments/CommentEditsDropdown.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import CommentEditsDropdown from '@/components/comments/CommentEditsDropdown.vue';
@@ -54,6 +54,17 @@ describe('CommentEditsDropdown visibility', () => {
     const wrapper = mountDropdown(makeComment('alice', ['bob']));
 
     expect(wrapper.get('button').text()).toBe('Edits');
+  });
+
+  it('exposes the trigger as a controlled menu button', () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+    const trigger = wrapper.get('button');
+
+    expect({
+      popup: trigger.attributes('aria-haspopup'),
+      expanded: trigger.attributes('aria-expanded'),
+      controls: Boolean(trigger.attributes('aria-controls')),
+    }).toEqual({ popup: 'menu', expanded: 'false', controls: true });
   });
 });
 
@@ -117,7 +128,7 @@ describe('CommentEditsDropdown diff modal', () => {
     const wrapper = mountDropdown(makeComment('alice', ['bob']));
     await open(wrapper);
 
-    await wrapper.get('li').trigger('click');
+    await wrapper.get('[role="menuitem"]').trigger('click');
 
     expect(
       wrapper.findComponent({ name: 'CommentRevisionDiffModal' }).exists()
@@ -127,7 +138,7 @@ describe('CommentEditsDropdown diff modal', () => {
   it('closes the diff modal on the close event', async () => {
     const wrapper = mountDropdown(makeComment('alice', ['bob']));
     await open(wrapper);
-    await wrapper.get('li').trigger('click');
+    await wrapper.get('[role="menuitem"]').trigger('click');
 
     await wrapper
       .findComponent({ name: 'CommentRevisionDiffModal' })
@@ -141,7 +152,7 @@ describe('CommentEditsDropdown diff modal', () => {
   it('closes the diff modal when a revision is deleted', async () => {
     const wrapper = mountDropdown(makeComment('alice', ['bob']));
     await open(wrapper);
-    await wrapper.get('li').trigger('click');
+    await wrapper.get('[role="menuitem"]').trigger('click');
 
     await wrapper
       .findComponent({ name: 'CommentRevisionDiffModal' })
@@ -160,7 +171,7 @@ describe('CommentEditsDropdown current-version flag', () => {
     const wrapper = mountDropdown(makeComment('alice', ['bob', 'carol']));
     await open(wrapper);
 
-    await wrapper.findAll('li')[0].trigger('click');
+    await wrapper.findAll('[role="menuitem"]')[0].trigger('click');
 
     expect(
       wrapper
@@ -173,12 +184,45 @@ describe('CommentEditsDropdown current-version flag', () => {
     const wrapper = mountDropdown(makeComment('alice', ['bob', 'carol']));
     await open(wrapper);
 
-    await wrapper.findAll('li')[1].trigger('click');
+    await wrapper.findAll('[role="menuitem"]')[1].trigger('click');
 
     expect(
       wrapper
         .findComponent({ name: 'CommentRevisionDiffModal' })
         .props('isMostRecent')
     ).toBe(false);
+  });
+});
+
+describe('CommentEditsDropdown keyboard navigation', () => {
+  it('moves to the next revision with ArrowDown', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob', 'carol']));
+    await open(wrapper);
+    const items = wrapper.findAll('[role="menuitem"]');
+    const focus = vi.spyOn(items[1].element as HTMLButtonElement, 'focus');
+
+    await items[0].trigger('keydown', { key: 'ArrowDown' });
+
+    expect(focus).toHaveBeenCalledOnce();
+  });
+
+  it('closes the menu on Escape', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+    await open(wrapper);
+
+    await wrapper.get('[role="menuitem"]').trigger('keydown', { key: 'Escape' });
+
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+  });
+
+  it('returns focus to the trigger on Escape', async () => {
+    const wrapper = mountDropdown(makeComment('alice', ['bob']));
+    const trigger = wrapper.get('button');
+    const focus = vi.spyOn(trigger.element as HTMLButtonElement, 'focus');
+    await open(wrapper);
+
+    await wrapper.get('[role="menuitem"]').trigger('keydown', { key: 'Escape' });
+
+    expect(focus).toHaveBeenCalledOnce();
   });
 });

--- a/components/comments/CommentEditsDropdown.vue
+++ b/components/comments/CommentEditsDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ref, computed, nextTick, onMounted, onUnmounted, useId } from 'vue';
 import type { PropType } from 'vue';
 import type { Comment, TextVersion, User } from '@/__generated__/graphql';
 import {
@@ -23,8 +23,10 @@ const props = defineProps({
 });
 
 const isOpen = ref(false);
-const triggerRef = ref<HTMLElement | null>(null);
+const triggerRef = ref<HTMLButtonElement | null>(null);
 const popoverRef = ref<HTMLElement | null>(null);
+const triggerId = useId();
+const menuId = useId();
 const popoverPosition = ref<PopoverPosition>({
   top: 0,
   left: 0,
@@ -106,11 +108,47 @@ const toggleDropdown = () => {
 
   isOpen.value = true;
   updateAdjustedPosition();
+  nextTick(() => {
+    popoverRef.value
+      ?.querySelector<HTMLButtonElement>('[role="menuitem"]')
+      ?.focus();
+  });
 };
 
 // Close dropdown when clicking outside
 const closeDropdown = () => {
   isOpen.value = false;
+};
+
+const closeDropdownAndReturnFocus = () => {
+  closeDropdown();
+  nextTick(() => triggerRef.value?.focus());
+};
+
+const handleMenuKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeDropdownAndReturnFocus();
+    return;
+  }
+
+  const items = Array.from(
+    popoverRef.value?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') || []
+  );
+  const currentIndex = items.indexOf(event.target as HTMLButtonElement);
+  let nextIndex: number | undefined;
+
+  if (event.key === 'ArrowDown') nextIndex = (currentIndex + 1) % items.length;
+  if (event.key === 'ArrowUp') {
+    nextIndex = (currentIndex - 1 + items.length) % items.length;
+  }
+  if (event.key === 'Home') nextIndex = 0;
+  if (event.key === 'End') nextIndex = items.length - 1;
+
+  if (nextIndex !== undefined) {
+    event.preventDefault();
+    items[nextIndex]?.focus();
+  }
 };
 
 // Close diff modal
@@ -159,7 +197,12 @@ onUnmounted(() => {
   <div v-if="hasEdits" class="relative">
     <!-- Dropdown toggle button -->
     <button
+      :id="triggerId"
       ref="triggerRef"
+      type="button"
+      aria-haspopup="menu"
+      :aria-expanded="isOpen"
+      :aria-controls="menuId"
       class="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
       @click="toggleDropdown"
     >
@@ -170,12 +213,14 @@ onUnmounted(() => {
       <!-- Dropdown content -->
       <div
         v-if="isOpen"
+        :id="menuId"
         ref="popoverRef"
         class="fixed z-[100] w-64 max-w-[calc(100vw-1rem)] rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
         :style="{
           top: `${adjustedPosition.top}px`,
           left: `${adjustedPosition.left}px`,
         }"
+        @keydown="handleMenuKeydown"
       >
         <div
           class="border-b border-gray-200 p-2 text-xs font-medium text-gray-700 dark:border-gray-700 dark:text-gray-300"
@@ -183,14 +228,21 @@ onUnmounted(() => {
           Edited {{ totalEdits }} time{{ totalEdits > 1 ? 's' : '' }}
         </div>
 
-        <ul class="max-h-80 overflow-y-auto py-1">
+        <ul
+          role="menu"
+          :aria-labelledby="triggerId"
+          class="max-h-80 overflow-y-auto py-1"
+        >
           <li
             v-for="edit in allEdits"
             :key="edit.id"
-            class="cursor-pointer px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-            @click="openRevisionDiff(edit)"
           >
-            <div class="flex flex-col">
+            <button
+              type="button"
+              role="menuitem"
+              class="flex w-full flex-col px-3 py-2 text-left hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-orange-500 dark:hover:bg-gray-700"
+              @click="openRevisionDiff(edit)"
+            >
               <div class="flex items-center text-sm">
                 <span class="font-medium text-gray-900 dark:text-gray-200">{{
                   edit.author
@@ -211,7 +263,7 @@ onUnmounted(() => {
                   Most recent
                 </span>
               </div>
-            </div>
+            </button>
           </li>
         </ul>
       </div>

--- a/components/comments/CreateRootCommentForm.spec.ts
+++ b/components/comments/CreateRootCommentForm.spec.ts
@@ -92,4 +92,53 @@ describe('CreateRootCommentForm', () => {
 
     expect(wrapper.find('[data-testid="error-banner"]').exists()).toBe(false);
   });
+
+  it('uses a button to open the authenticated comment editor', async () => {
+    const wrapper = mount(CreateRootCommentForm, {
+      props: {
+        createCommentLoading: false,
+        createFormValues: { text: '', isRootComment: true, depth: 1 },
+        commentEditorOpen: false,
+      },
+      global: {
+        stubs: {
+          RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
+          LoggedInUserAvatar: { template: '<div />' },
+          ErrorBanner: { template: '<div />' },
+          SuspensionNotice: { template: '<div />' },
+        },
+      },
+    });
+
+    await wrapper.get('[data-testid="addComment"]').trigger('click');
+
+    expect({
+      element: wrapper.get('[data-testid="addComment"]').element.tagName,
+      emitted: wrapper.emitted('openCommentEditor')?.length,
+    }).toEqual({ element: 'BUTTON', emitted: 1 });
+  });
+
+  it('uses a named login button for unauthenticated commenters', () => {
+    const wrapper = mount(CreateRootCommentForm, {
+      props: {
+        createCommentLoading: false,
+        createFormValues: { text: '', isRootComment: true, depth: 1 },
+        commentEditorOpen: false,
+      },
+      global: {
+        stubs: {
+          RequireAuth: {
+            template: '<div><slot name="does-not-have-auth" /></div>',
+          },
+          PlaceholderAvatar: { template: '<div />' },
+          ErrorBanner: { template: '<div />' },
+          SuspensionNotice: { template: '<div />' },
+        },
+      },
+    });
+
+    expect(
+      wrapper.get('[aria-label="Log in to write a comment"]').element.tagName
+    ).toBe('BUTTON');
+  });
 });

--- a/components/comments/CreateRootCommentForm.vue
+++ b/components/comments/CreateRootCommentForm.vue
@@ -143,27 +143,29 @@ const showCreateCommentError = computed(() => {
         <template #has-auth>
           <div class="align-items flex w-full gap-2">
             <LoggedInUserAvatar v-if="usernameVar" />
-            <textarea
+            <button
+              type="button"
               data-testid="addComment"
-              class="flex-1 overflow-hidden border"
-              name="addComment"
-              :rows="1"
-              placeholder="Write a comment"
+              class="flex-1 overflow-hidden border px-3 text-left text-gray-500 dark:text-gray-400"
               :class="writeReplyStyle"
               @click="emit('openCommentEditor')"
-            />
+            >
+              Write a comment
+            </button>
           </div>
         </template>
         <template #does-not-have-auth>
           <div class="align-items flex w-full gap-2">
             <PlaceholderAvatar />
-            <textarea
+            <button
               id="addCommentLoginPrompt"
-              name="addComment"
-              :rows="1"
-              placeholder="Write a comment"
+              type="button"
+              aria-label="Log in to write a comment"
+              class="flex-1 overflow-hidden border px-3 text-left text-gray-500 dark:text-gray-400"
               :class="writeReplyStyle"
-            />
+            >
+              Write a comment
+            </button>
           </div>
         </template>
       </RequireAuth>

--- a/components/discussion/detail/CarouselThumbnail.vue
+++ b/components/discussion/detail/CarouselThumbnail.vue
@@ -50,6 +50,8 @@ const sizeStyle = computed(() => ({
     <ModelViewer
       v-if="image && image.url && hasGlbExtension(image.url)"
       :model-url="image.url"
+      :model-alt="image.alt || image.caption || '3D model thumbnail'"
+      :show-fullscreen-button="false"
       :height="`${thumbnailHeight}px`"
       :width="`${thumbnailWidth}px`"
       class="rounded"

--- a/components/discussion/detail/DiscussionAlbum.vue
+++ b/components/discussion/detail/DiscussionAlbum.vue
@@ -294,6 +294,8 @@ onMounted(() => {
           <ModelViewer
             v-if="image && hasGlbExtension(image.url ?? '')"
             :model-url="image.url || ''"
+            :model-alt="image.alt || image.caption || '3D model thumbnail'"
+            :show-fullscreen-button="false"
             height="200px"
             width="100%"
             class="shadow-sm"
@@ -487,6 +489,7 @@ onMounted(() => {
                     hasGlbExtension(activeImage.url)
                   "
                   :model-url="activeImage.url"
+                  :model-alt="activeImage.alt || activeImage.caption || 'Interactive 3D model'"
                   :height="expandedView ? '400px' : '256px'"
                   class="object-contain shadow-sm"
                   :style="{

--- a/components/discussion/detail/ImageLightbox.spec.ts
+++ b/components/discussion/detail/ImageLightbox.spec.ts
@@ -224,10 +224,23 @@ describe('ImageLightbox close', () => {
   it('emits close on the Escape key', async () => {
     const wrapper = mountLightbox();
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     await wrapper.vm.$nextTick();
 
     expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('restores focus when the lightbox unmounts', async () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    const wrapper = mountLightbox();
+    await wrapper.vm.$nextTick();
+
+    wrapper.unmount();
+
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
   });
 });
 
@@ -290,6 +303,16 @@ describe('ImageLightbox reporting', () => {
     await controls(wrapper).vm.$emit('report-image');
 
     expect(reportModal(wrapper).props('open')).toBe(true);
+  });
+
+  it('leaves Escape handling to the nested report modal', async () => {
+    const wrapper = mountLightbox();
+    await controls(wrapper).vm.$emit('report-image');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('close')).toBeUndefined();
   });
 
   it('shows the success notification after a report is submitted', async () => {

--- a/components/discussion/detail/ImageLightbox.vue
+++ b/components/discussion/detail/ImageLightbox.vue
@@ -10,6 +10,7 @@ import {
 import { useImageZoom } from '@/composables/useImageZoom';
 import { useLightboxNavigation } from '@/composables/useLightboxNavigation';
 import { useSwipeDetection } from '@/composables/useSwipeDetection';
+import { useFocusTrap } from '@/composables/useFocusTrap';
 import LightboxControls from '@/components/discussion/detail/LightboxControls.vue';
 import LightboxImagePanel from '@/components/discussion/detail/LightboxImagePanel.vue';
 import LightboxInfoPanel from '@/components/discussion/detail/LightboxInfoPanel.vue';
@@ -63,6 +64,7 @@ const editingCaption = ref('');
 
 // Report modal state
 const showReportModal = ref(false);
+const lightboxRef = ref<HTMLElement | null>(null);
 const showReportSuccess = ref(false);
 
 const openReportModal = () => {
@@ -168,15 +170,20 @@ const closeLightbox = () => {
   emit('close');
 };
 
+const lightboxFocusActive = computed(() => !showReportModal.value);
+
+useFocusTrap(lightboxRef, {
+  active: lightboxFocusActive,
+  onEscape: closeLightbox,
+});
+
 // Keyboard navigation
 const handleKeyDown = (e: KeyboardEvent) => {
-  if (editingCaptionIndex.value !== -1) {
+  if (editingCaptionIndex.value !== -1 || showReportModal.value) {
     return;
   }
 
-  if (e.key === 'Escape') {
-    closeLightbox();
-  } else if (e.key === 'ArrowRight') {
+  if (e.key === 'ArrowRight') {
     nextImage();
   } else if (e.key === 'ArrowLeft') {
     prevImage();
@@ -317,6 +324,7 @@ onUnmounted(() => {
 
 <template>
   <div
+    ref="lightboxRef"
     class="fixed left-0 top-0 z-[1000] flex h-full w-full bg-black transition-all duration-300 ease-in-out"
     role="dialog"
     aria-modal="true"

--- a/components/discussion/detail/LightboxImagePanel.vue
+++ b/components/discussion/detail/LightboxImagePanel.vue
@@ -98,6 +98,7 @@ const handleClick = (event: MouseEvent) => {
         currentImage && currentImage.url && hasGlbExtension(currentImage.url)
       "
       :model-url="currentImage.url"
+      :model-alt="currentImage.alt || currentImage.caption || 'Interactive 3D model'"
       height="100%"
       width="100%"
       class="h-full w-full object-contain transition-all duration-300 ease-in-out"

--- a/components/discussion/detail/activityFeed/EditsDropdown.spec.ts
+++ b/components/discussion/detail/activityFeed/EditsDropdown.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EditsDropdown from '@/components/discussion/detail/activityFeed/EditsDropdown.vue';
@@ -57,6 +57,17 @@ describe('EditsDropdown visibility', () => {
     const wrapper = mountDropdown(makeDiscussion(['alice']));
 
     expect(wrapper.get('button').text()).toBe('Edits');
+  });
+
+  it('exposes the trigger as a controlled menu button', () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice']));
+    const trigger = wrapper.get('button');
+
+    expect({
+      popup: trigger.attributes('aria-haspopup'),
+      expanded: trigger.attributes('aria-expanded'),
+      controls: Boolean(trigger.attributes('aria-controls')),
+    }).toEqual({ popup: 'menu', expanded: 'false', controls: true });
   });
 });
 
@@ -120,7 +131,7 @@ describe('EditsDropdown revision modal', () => {
     const wrapper = mountDropdown(makeDiscussion(['alice']));
     await openDropdown(wrapper);
 
-    await wrapper.get('li').trigger('click');
+    await wrapper.get('[role="menuitem"]').trigger('click');
 
     expect(wrapper.findComponent({ name: 'RevisionDiffModal' }).exists()).toBe(
       true
@@ -130,7 +141,7 @@ describe('EditsDropdown revision modal', () => {
   it('closes the diff modal on the modal close event', async () => {
     const wrapper = mountDropdown(makeDiscussion(['alice']));
     await openDropdown(wrapper);
-    await wrapper.get('li').trigger('click');
+    await wrapper.get('[role="menuitem"]').trigger('click');
 
     await wrapper.findComponent({ name: 'RevisionDiffModal' }).vm.$emit('close');
 
@@ -142,7 +153,7 @@ describe('EditsDropdown revision modal', () => {
   it('closes the diff modal when a revision is deleted', async () => {
     const wrapper = mountDropdown(makeDiscussion(['alice']));
     await openDropdown(wrapper);
-    await wrapper.get('li').trigger('click');
+    await wrapper.get('[role="menuitem"]').trigger('click');
 
     await wrapper
       .findComponent({ name: 'RevisionDiffModal' })
@@ -151,5 +162,32 @@ describe('EditsDropdown revision modal', () => {
     expect(wrapper.findComponent({ name: 'RevisionDiffModal' }).exists()).toBe(
       false
     );
+  });
+});
+
+describe('EditsDropdown keyboard navigation', () => {
+  it('moves to the next revision with ArrowDown', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice', 'bob']));
+    await openDropdown(wrapper);
+    const items = wrapper.findAll('[role="menuitem"]');
+    const focus = vi.spyOn(items[1].element as HTMLButtonElement, 'focus');
+
+    await items[0].trigger('keydown', { key: 'ArrowDown' });
+
+    expect(focus).toHaveBeenCalledOnce();
+  });
+
+  it('closes and returns focus on Escape', async () => {
+    const wrapper = mountDropdown(makeDiscussion(['alice']));
+    const trigger = wrapper.get('button');
+    const focus = vi.spyOn(trigger.element as HTMLButtonElement, 'focus');
+    await openDropdown(wrapper);
+
+    await wrapper.get('[role="menuitem"]').trigger('keydown', { key: 'Escape' });
+
+    expect({
+      open: wrapper.find('[role="menu"]').exists(),
+      restoredFocus: focus.mock.calls.length,
+    }).toEqual({ open: false, restoredFocus: 1 });
   });
 });

--- a/components/discussion/detail/activityFeed/EditsDropdown.vue
+++ b/components/discussion/detail/activityFeed/EditsDropdown.vue
@@ -5,6 +5,8 @@ import {
   onMounted,
   onUnmounted,
   defineAsyncComponent,
+  nextTick,
+  useId,
 } from 'vue';
 import type { PropType } from 'vue';
 import type { Discussion, TextVersion, User } from '@/__generated__/graphql';
@@ -26,8 +28,10 @@ const props = defineProps({
 });
 
 const isOpen = ref(false);
-const triggerRef = ref<HTMLElement | null>(null);
+const triggerRef = ref<HTMLButtonElement | null>(null);
 const popoverRef = ref<HTMLElement | null>(null);
+const triggerId = useId();
+const menuId = useId();
 const popoverPosition = ref<PopoverPosition>({
   top: 0,
   left: 0,
@@ -173,11 +177,47 @@ const toggleDropdown = () => {
 
   isOpen.value = true;
   updateAdjustedPosition();
+  nextTick(() => {
+    popoverRef.value
+      ?.querySelector<HTMLButtonElement>('[role="menuitem"]')
+      ?.focus();
+  });
 };
 
 // Close dropdown when clicking outside
 const closeDropdown = () => {
   isOpen.value = false;
+};
+
+const closeDropdownAndReturnFocus = () => {
+  closeDropdown();
+  nextTick(() => triggerRef.value?.focus());
+};
+
+const handleMenuKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeDropdownAndReturnFocus();
+    return;
+  }
+
+  const items = Array.from(
+    popoverRef.value?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') || []
+  );
+  const currentIndex = items.indexOf(event.target as HTMLButtonElement);
+  let nextIndex: number | undefined;
+
+  if (event.key === 'ArrowDown') nextIndex = (currentIndex + 1) % items.length;
+  if (event.key === 'ArrowUp') {
+    nextIndex = (currentIndex - 1 + items.length) % items.length;
+  }
+  if (event.key === 'Home') nextIndex = 0;
+  if (event.key === 'End') nextIndex = items.length - 1;
+
+  if (nextIndex !== undefined) {
+    event.preventDefault();
+    items[nextIndex]?.focus();
+  }
 };
 
 // Open diff modal for a specific revision
@@ -232,7 +272,12 @@ onUnmounted(() => {
   <div v-if="hasEdits" class="relative">
     <!-- Dropdown toggle button -->
     <button
+      :id="triggerId"
       ref="triggerRef"
+      type="button"
+      aria-haspopup="menu"
+      :aria-expanded="isOpen"
+      :aria-controls="menuId"
       class="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
       @click="toggleDropdown"
     >
@@ -243,12 +288,14 @@ onUnmounted(() => {
       <!-- Dropdown content -->
       <div
         v-if="isOpen"
+        :id="menuId"
         ref="popoverRef"
         class="fixed z-[100] w-64 max-w-[calc(100vw-1rem)] rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
         :style="{
           top: `${adjustedPosition.top}px`,
           left: `${adjustedPosition.left}px`,
         }"
+        @keydown="handleMenuKeydown"
       >
         <div
           class="border-b border-gray-200 p-2 text-xs font-medium text-gray-700 dark:border-gray-700 dark:text-gray-300"
@@ -256,14 +303,21 @@ onUnmounted(() => {
           Edited {{ totalEdits }} time{{ totalEdits > 1 ? 's' : '' }}
         </div>
 
-        <ul class="max-h-80 overflow-y-auto py-1">
+        <ul
+          role="menu"
+          :aria-labelledby="triggerId"
+          class="max-h-80 overflow-y-auto py-1"
+        >
           <li
             v-for="edit in allEdits"
             :key="edit.id"
-            class="cursor-pointer px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-            @click="openRevisionDiff(edit)"
           >
-            <div class="flex flex-col">
+            <button
+              type="button"
+              role="menuitem"
+              class="flex w-full flex-col px-3 py-2 text-left hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-orange-500 dark:hover:bg-gray-700"
+              @click="openRevisionDiff(edit)"
+            >
               <div class="flex items-center text-sm">
                 <span class="font-medium text-gray-900 dark:text-gray-200">{{
                   edit.author
@@ -287,7 +341,7 @@ onUnmounted(() => {
                   Most recent
                 </span>
               </div>
-            </div>
+            </button>
           </li>
         </ul>
       </div>

--- a/components/discussion/form/AlbumImageItem.vue
+++ b/components/discussion/form/AlbumImageItem.vue
@@ -103,6 +103,7 @@ const getUploaderLabel = (image: ImageData) => {
         <ModelViewer
           v-if="image.url && hasGlbExtension(image.url)"
           :model-url="image.url"
+          :model-alt="image.alt || image.caption || 'Interactive 3D model'"
           height="288px"
           width="288px"
           class="w-72"

--- a/components/discussion/form/InlineCommentForm.spec.ts
+++ b/components/discussion/form/InlineCommentForm.spec.ts
@@ -437,11 +437,18 @@ describe('InlineCommentForm — unauthenticated view', () => {
     document.body.innerHTML = '';
   });
 
-  it('renders a disabled composer when the user is not authenticated', () => {
+  it('renders a keyboard-accessible login trigger when unauthenticated', () => {
     const wrapper = buildWrapper({ authSlot: 'does-not-have-auth' });
 
-    expect(
-      (wrapper.find('textarea').element as HTMLTextAreaElement).disabled
-    ).toBe(true);
+    expect({
+      element: wrapper.get('[aria-label="Log in to add a comment"]').element
+        .tagName,
+      name: wrapper
+        .get('[aria-label="Log in to add a comment"]')
+        .attributes('aria-label'),
+    }).toEqual({
+      element: 'BUTTON',
+      name: 'Log in to add a comment',
+    });
   });
 });

--- a/components/discussion/form/InlineCommentForm.vue
+++ b/components/discussion/form/InlineCommentForm.vue
@@ -529,24 +529,23 @@ const applyModSuggestion = (value: string) => {
         </form>
       </template>
       <template #does-not-have-auth>
-        <div
+        <button
+          type="button"
+          aria-label="Log in to add a comment"
           class="flex w-full items-center gap-3 rounded-lg border border-orange-400 bg-white px-3 py-2 dark:bg-gray-900"
         >
-          <textarea
-            class="min-h-[44px] flex-1 resize-none bg-white text-sm text-gray-500 placeholder-gray-500 outline-none focus:outline-none focus:ring-0 focus-visible:outline-none dark:bg-gray-900 dark:text-gray-400 dark:placeholder-gray-500"
-            name="discussionInlineComment"
-            :rows="1"
-            placeholder="Join the discussion..."
-            disabled
-          />
-          <button
-            type="button"
+          <span
+            class="flex min-h-[44px] flex-1 items-center bg-white text-left text-sm text-gray-500 dark:bg-gray-900 dark:text-gray-400"
+          >
+            Join the discussion...
+          </span>
+          <span
+            aria-hidden="true"
             class="font-semibold rounded-md bg-orange-200 px-4 py-2 text-sm text-black dark:bg-orange-950 dark:text-orange-400"
-            disabled
           >
             Post
-          </button>
-        </div>
+          </span>
+        </button>
       </template>
     </RequireAuth>
   </div>

--- a/components/discussion/list/ChannelDiscussionList.vue
+++ b/components/discussion/list/ChannelDiscussionList.vue
@@ -258,9 +258,13 @@ watch(
               </nuxt-link>
             </template>
             <template #does-not-have-auth>
-              <span class="cursor-pointer text-orange-500 underline"
-                >Create one?</span
+              <button
+                type="button"
+                aria-label="Log in to create a discussion"
+                class="cursor-pointer text-orange-500 underline"
               >
+                Create one?
+              </button>
             </template>
           </RequireAuth>
         </p>

--- a/components/discussion/list/SitewideDiscussionList.spec.ts
+++ b/components/discussion/list/SitewideDiscussionList.spec.ts
@@ -176,4 +176,39 @@ describe('SitewideDiscussionList', () => {
       .find((link) => link.text().includes('2 comments'));
     expect(commentLink?.props('to')).toBe('/forums/cats/discussions/1');
   });
+
+  it('opens the About overlay as a modal dialog', async () => {
+    setupQueries(createQueryMock(listResult([])));
+    const wrapper = mountList();
+    const aboutButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'About');
+
+    await aboutButton!.trigger('click');
+    const dialog = wrapper.get('#sitewide-sidebar-drawer');
+
+    expect({
+      role: dialog.attributes('role'),
+      modal: dialog.attributes('aria-modal'),
+      label: dialog.attributes('aria-label'),
+    }).toEqual({
+      role: 'dialog',
+      modal: 'true',
+      label: 'About this forum',
+    });
+  });
+
+  it('closes the About overlay on Escape', async () => {
+    setupQueries(createQueryMock(listResult([])));
+    const wrapper = mountList();
+    const aboutButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'About');
+    await aboutButton!.trigger('click');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await nextTick();
+
+    expect(wrapper.find('#sitewide-sidebar-drawer').exists()).toBe(false);
+  });
 });

--- a/components/discussion/list/SitewideDiscussionList.vue
+++ b/components/discussion/list/SitewideDiscussionList.vue
@@ -20,6 +20,7 @@ import { config } from '@/config';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 import { useUsername } from '@/composables/useAuthState';
 import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
+import { useFocusTrap } from '@/composables/useFocusTrap';
 
 const usernameVar = useUsername();
 const SitewideDiscussionSidebar = defineAsyncComponent(
@@ -48,6 +49,16 @@ const filterValues = ref(
   getDiscussionFilterValuesFromParams({ route, channelId: channelId.value })
 );
 const isSitewideSidebarOpen = ref(false);
+const sitewideSidebarRef = ref<HTMLElement | null>(null);
+
+const closeSitewideSidebar = () => {
+  isSitewideSidebarOpen.value = false;
+};
+
+useFocusTrap(sitewideSidebarRef, {
+  active: isSitewideSidebarOpen,
+  onEscape: closeSitewideSidebar,
+});
 
 const selectedDiscussionId = computed(() => {
   return typeof route.query.selectedDiscussionId === 'string'
@@ -462,12 +473,15 @@ const filterByChannel = (channel: string) => {
         >
           <div
             class="absolute inset-0 bg-black/50"
-            @click="isSitewideSidebarOpen = false"
+            aria-hidden="true"
+            @click="closeSitewideSidebar"
           />
           <div
             id="sitewide-sidebar-drawer"
+            ref="sitewideSidebarRef"
             class="absolute right-0 top-0 h-full w-full max-w-sm overflow-y-auto bg-white shadow-xl dark:bg-gray-900"
             role="dialog"
+            aria-modal="true"
             aria-label="About this forum"
           >
             <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
@@ -477,7 +491,7 @@ const filterByChannel = (channel: string) => {
               <button
                 type="button"
                 class="rounded-md px-2 py-1 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
-                @click="isSitewideSidebarOpen = false"
+                @click="closeSitewideSidebar"
               >
                 Close
               </button>

--- a/components/discussion/list/SitewideDiscussionList.vue
+++ b/components/discussion/list/SitewideDiscussionList.vue
@@ -345,9 +345,13 @@ const filterByChannel = (channel: string) => {
                   </nuxt-link>
                 </template>
                 <template #does-not-have-auth>
-                  <span class="cursor-pointer text-orange-500 underline"
-                    >Create one?</span
+                  <button
+                    type="button"
+                    aria-label="Log in to create a discussion"
+                    class="cursor-pointer text-orange-500 underline"
                   >
+                    Create one?
+                  </button>
                 </template>
               </RequireAuth>
             </p>

--- a/components/discussion/list/SitewideDownloadList.vue
+++ b/components/discussion/list/SitewideDownloadList.vue
@@ -290,9 +290,13 @@ const handleCloseAlbum = () => {
                   </nuxt-link>
                 </template>
                 <template #does-not-have-auth>
-                  <span class="cursor-pointer text-orange-500 underline"
-                    >Create one?</span
+                  <button
+                    type="button"
+                    aria-label="Log in to create a download"
+                    class="cursor-pointer text-orange-500 underline"
                   >
+                    Create one?
+                  </button>
                 </template>
               </RequireAuth>
             </p>

--- a/components/event/form/EditScopeModal.spec.ts
+++ b/components/event/form/EditScopeModal.spec.ts
@@ -25,6 +25,33 @@ describe('EditScopeModal', () => {
     expect(wrapper.emitted('close')).toBeTruthy();
   });
 
+  it('emits close when Escape is pressed', async () => {
+    const wrapper = mountModal();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('restores focus when the modal closes', async () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    const wrapper = mount(EditScopeModal, {
+      attachTo: document.body,
+      props: { isOpen: true },
+      global: { stubs: { Teleport: { template: '<div><slot /></div>' } } },
+    });
+    await wrapper.vm.$nextTick();
+
+    await wrapper.setProps({ isOpen: false });
+
+    expect(document.activeElement).toBe(trigger);
+    wrapper.unmount();
+    trigger.remove();
+  });
+
   it('confirms with the default THIS_ONLY scope', async () => {
     const wrapper = mountModal();
     await wrapper.get('[data-testid="edit-scope-confirm"]').trigger('click');

--- a/components/event/form/EditScopeModal.vue
+++ b/components/event/form/EditScopeModal.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, toRef } from 'vue';
+import { useFocusTrap } from '@/composables/useFocusTrap';
 
 export type EventEditScope = 'THIS_ONLY' | 'THIS_AND_FUTURE' | 'ALL_IN_SERIES';
 
-defineProps({
+const props = defineProps({
   isOpen: {
     type: Boolean,
     required: true,
@@ -20,6 +21,7 @@ const emit = defineEmits<{
 }>();
 
 const selectedScope = ref<EventEditScope>('THIS_ONLY');
+const dialogRef = ref<HTMLElement | null>(null);
 
 const scopeOptions = [
   {
@@ -46,12 +48,18 @@ const handleConfirm = () => {
 const handleClose = () => {
   emit('close');
 };
+
+useFocusTrap(dialogRef, {
+  active: toRef(props, 'isOpen'),
+  onEscape: handleClose,
+});
 </script>
 
 <template>
   <Teleport to="body">
     <div
       v-if="isOpen"
+      ref="dialogRef"
       class="fixed inset-0 z-50 flex items-center justify-center"
       role="dialog"
       aria-modal="true"

--- a/components/image/ImageListItem.vue
+++ b/components/image/ImageListItem.vue
@@ -52,6 +52,8 @@ const getImageAlt = (image: Image) => {
       <ModelViewer
         v-if="props.image.url && hasGlbExtension(props.image.url)"
         :model-url="props.image.url"
+        :model-alt="getImageAlt(props.image)"
+        :show-fullscreen-button="false"
         height="100%"
         width="100%"
         class="h-full w-full object-cover"

--- a/components/plugins/ScopedPipelineView.spec.ts
+++ b/components/plugins/ScopedPipelineView.spec.ts
@@ -182,6 +182,24 @@ describe('ScopedPipelineView', () => {
     expect(wrapper.text()).not.toContain('Server Pipeline');
   });
 
+  it('exposes the collapsible header as a disclosure button', () => {
+    setPipelineStates({ latestPipeline: ref(pipeline()) }, {});
+    const wrapper = mountView({ collapsible: true });
+    const disclosure = wrapper.get('button.cursor-pointer');
+
+    expect({
+      name: disclosure.text().includes('Plugin Pipelines'),
+      expanded: disclosure.attributes('aria-expanded'),
+      controlsExistingContent: wrapper.find(
+        `#${disclosure.attributes('aria-controls')}`
+      ).exists(),
+    }).toEqual({
+      name: true,
+      expanded: 'true',
+      controlsExistingContent: true,
+    });
+  });
+
   it('opens and closes the logs modal from a stage event', async () => {
     setPipelineStates({ latestPipeline: ref(pipeline()) }, {});
     const wrapper = mountView();

--- a/components/plugins/ScopedPipelineView.vue
+++ b/components/plugins/ScopedPipelineView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, toRef, computed } from 'vue';
+import { ref, toRef, computed, useId } from 'vue';
 import { usePluginPipeline, type PipelineRun } from '@/composables/usePluginPipeline';
 import PluginPipelineStage from './PluginPipelineStage.vue';
 import PluginLogsModal from './PluginLogsModal.vue';
@@ -14,6 +14,7 @@ const props = defineProps<{
 const isExpanded = ref(true);
 const selectedRun = ref<PipelineRun | null>(null);
 const showLogsModal = ref(false);
+const pipelineContentId = useId();
 
 // Query server pipelines (file-level)
 const {
@@ -86,9 +87,13 @@ const handleCloseModal = () => {
     class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
   >
     <!-- Header -->
-    <div
+    <component
+      :is="collapsible ? 'button' : 'div'"
+      :type="collapsible ? 'button' : undefined"
+      :aria-expanded="collapsible ? isExpanded : undefined"
+      :aria-controls="collapsible ? pipelineContentId : undefined"
       class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700"
-      :class="{ 'cursor-pointer': collapsible }"
+      :class="{ 'w-full cursor-pointer text-left': collapsible }"
       @click="collapsible && (isExpanded = !isExpanded)"
     >
       <div class="flex items-center space-x-2">
@@ -120,20 +125,20 @@ const handleCloseModal = () => {
         >
           <i class="fa-solid fa-sync fa-spin" />
         </span>
-        <button
+        <span
           v-if="collapsible"
-          type="button"
-          :aria-expanded="isExpanded"
-          :aria-label="isExpanded ? 'Collapse pipeline details' : 'Expand pipeline details'"
+          aria-hidden="true"
           class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
         >
           <i
             :class="isExpanded ? 'fa-solid fa-chevron-up' : 'fa-solid fa-chevron-down'"
             aria-hidden="true"
           />
-        </button>
+        </span>
       </div>
-    </div>
+    </component>
+
+    <div :id="pipelineContentId">
 
     <!-- Loading State -->
     <div
@@ -230,6 +235,7 @@ const handleCloseModal = () => {
       class="p-4 text-center text-sm text-gray-500 dark:text-gray-400"
     >
       No plugin activity for this content.
+    </div>
     </div>
   </div>
 

--- a/pages/u/[username]/images/[imageId].spec.ts
+++ b/pages/u/[username]/images/[imageId].spec.ts
@@ -11,9 +11,12 @@ const h = vi.hoisted(() => ({
   updateImage: vi.fn(),
   useHead: vi.fn(),
   routeParams: { username: 'alice', imageId: 'img1' },
+  isLightboxOpen: null as unknown as { value: boolean },
+  closeLightbox: vi.fn(),
 }));
 
 h.username = ref('alice');
+h.isLightboxOpen = ref(false);
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: h.routeParams }),
@@ -47,7 +50,7 @@ vi.mock('@/composables/useCopyCurrentUrl', () => ({
 
 vi.mock('@/composables/useImageZoomPan', () => ({
   useImageZoomPan: () => ({
-    isLightboxOpen: ref(false),
+    isLightboxOpen: h.isLightboxOpen,
     zoomLevel: ref(1),
     isZoomed: ref(false),
     isDragging: ref(false),
@@ -57,7 +60,7 @@ vi.mock('@/composables/useImageZoomPan', () => ({
     onDrag: vi.fn(),
     stopDrag: vi.fn(),
     openLightbox: vi.fn(),
-    closeLightbox: vi.fn(),
+    closeLightbox: h.closeLightbox,
     zoomIn: vi.fn(),
     zoomOut: vi.fn(),
     resetZoom: vi.fn(),
@@ -85,6 +88,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.username.value = 'alice';
   h.routeParams = { username: 'alice', imageId: 'img1' };
+  h.isLightboxOpen = ref(false);
 });
 
 describe('user image detail page', () => {
@@ -134,5 +138,44 @@ describe('user image detail page', () => {
       imageId: 'img1',
       caption: 'New caption',
     });
+  });
+
+  it('exposes the open lightbox as a named modal dialog', async () => {
+    h.isLightboxOpen.value = true;
+    const wrapper = await mountWith({
+      id: 'img1',
+      url: 'https://img.test/photo.jpg',
+      caption: 'A photo',
+      Uploader: { username: 'alice' },
+      Album: { Images: [], imageOrder: [] },
+    });
+    const dialog = wrapper.get('[role="dialog"]');
+
+    expect({
+      modal: dialog.attributes('aria-modal'),
+      label: dialog.attributes('aria-label'),
+      closeControl: wrapper
+        .get('[aria-label="Close image lightbox"]')
+        .element.tagName,
+    }).toEqual({
+      modal: 'true',
+      label: 'Image lightbox',
+      closeControl: 'BUTTON',
+    });
+    wrapper.unmount();
+  });
+
+  it('closes the lightbox on Escape', async () => {
+    h.isLightboxOpen.value = true;
+    await mountWith({
+      id: 'img1',
+      url: 'https://img.test/photo.jpg',
+      Uploader: { username: 'alice' },
+      Album: { Images: [], imageOrder: [] },
+    });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(h.closeLightbox).toHaveBeenCalledOnce();
   });
 });

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -586,6 +586,7 @@ onUnmounted(() => {
           <ModelViewer
             v-if="image.url && hasGlbExtension(image.url)"
             :model-url="image.url"
+            :model-alt="image.alt || image.caption || 'Interactive 3D model'"
             height="600px"
             width="800px"
             class="h-auto max-w-full"
@@ -1034,6 +1035,7 @@ onUnmounted(() => {
           <ModelViewer
             v-if="image && image.url && hasGlbExtension(image.url)"
             :model-url="image.url"
+            :model-alt="image.alt || image.caption || 'Interactive 3D model'"
             height="100%"
             width="100%"
             class="h-full w-full object-contain transition-all duration-300 ease-in-out"

--- a/pages/u/[username]/images/[imageId].vue
+++ b/pages/u/[username]/images/[imageId].vue
@@ -30,6 +30,7 @@ import AlbumThumbnailGrid from '@/components/album/AlbumThumbnailGrid.vue';
 import { useImageZoomPan } from '@/composables/useImageZoomPan';
 import AddToListPopover from '@/components/collection/AddToListPopover.vue';
 import { useToastStore } from '@/stores/toastStore';
+import { useFocusTrap } from '@/composables/useFocusTrap';
 
 const usernameVar = useUsername();
 const toastStore = useToastStore();
@@ -146,6 +147,8 @@ const { result: albumUsageResult, refetch: refetchAlbumUsage } =
 const showAlbumSaveModal = ref(false);
 const showCollectionSaveModal = ref(false);
 const albumSaveError = ref('');
+const albumSaveModalRef = ref<HTMLElement | null>(null);
+const lightboxRef = ref<HTMLElement | null>(null);
 
 const { mutate: addImageToAlbum, loading: addImageToAlbumLoading } =
   useMutation(ADD_IMAGE_TO_ALBUM);
@@ -291,6 +294,11 @@ const closeAlbumSaveModal = () => {
   albumSaveError.value = '';
 };
 
+useFocusTrap(albumSaveModalRef, {
+  active: showAlbumSaveModal,
+  onEscape: closeAlbumSaveModal,
+});
+
 const openCollectionSaveModal = () => {
   showCollectionSaveModal.value = true;
 };
@@ -389,6 +397,11 @@ const {
     image.value?.url
       ? !hasGlbExtension(image.value.url) && !hasStlExtension(image.value.url)
       : false,
+});
+
+useFocusTrap(lightboxRef, {
+  active: isLightboxOpen,
+  onEscape: closeLightbox,
 });
 
 const downloadImage = (imageUrl: string) => {
@@ -866,6 +879,7 @@ onUnmounted(() => {
 
       <div
         v-if="showAlbumSaveModal"
+        ref="albumSaveModalRef"
         class="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4"
         role="dialog"
         aria-modal="true"
@@ -968,7 +982,11 @@ onUnmounted(() => {
       <!-- Custom lightbox -->
       <div
         v-if="isLightboxOpen"
+        ref="lightboxRef"
         class="fixed left-0 top-0 z-50 flex h-full w-full items-center justify-center bg-black"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Image lightbox"
       >
         <!-- Header controls -->
         <div
@@ -976,6 +994,8 @@ onUnmounted(() => {
         >
           <div class="flex items-center gap-4">
             <button
+              type="button"
+              aria-label="Close image lightbox"
               class="bg-transparent cursor-pointer border-0 text-3xl text-white"
               @click="closeLightbox"
             >
@@ -987,9 +1007,10 @@ onUnmounted(() => {
             <!-- Zoom controls -->
             <div class="flex items-center rounded bg-opacity-10">
               <button
+                type="button"
                 class="cursor-pointer px-2 py-1 text-white transition-colors hover:bg-opacity-20"
                 :class="{ 'cursor-not-allowed opacity-50': zoomLevel <= 1 }"
-                title="Zoom out"
+                aria-label="Zoom out"
                 :disabled="zoomLevel <= 1"
                 @click="zoomOut"
               >
@@ -999,9 +1020,10 @@ onUnmounted(() => {
                 {{ Math.round(zoomLevel * 100) }}%
               </span>
               <button
+                type="button"
                 class="cursor-pointer px-2 py-1 text-white transition-colors hover:bg-opacity-20"
                 :class="{ 'cursor-not-allowed opacity-50': zoomLevel >= 3 }"
-                title="Zoom in"
+                aria-label="Zoom in"
                 :disabled="zoomLevel >= 3"
                 @click="zoomIn"
               >
@@ -1009,8 +1031,9 @@ onUnmounted(() => {
               </button>
               <button
                 v-if="isZoomed"
+                type="button"
                 class="cursor-pointer px-2 py-1 text-white transition-colors hover:bg-opacity-20"
-                title="Reset zoom"
+                aria-label="Reset zoom"
                 @click="resetZoom"
               >
                 Reset
@@ -1020,6 +1043,7 @@ onUnmounted(() => {
             <!-- Download button -->
             <button
               type="button"
+              aria-label="Download image"
               class="flex h-8 w-8 cursor-pointer items-center justify-center rounded text-xl text-white no-underline hover:bg-white hover:bg-opacity-20"
               @click="() => downloadImage(image?.url || '')"
             >

--- a/tests/playwright/mocked/channels/createEditChannels.spec.ts
+++ b/tests/playwright/mocked/channels/createEditChannels.spec.ts
@@ -341,11 +341,13 @@ test('creates and edits a channel', async ({
     await expect(descriptionInput).toBeVisible();
     await descriptionInput.fill(TEST_DESCRIPTION);
 
-    const tagPicker = page.getByTestId('tag-input');
+    const tagPicker = page.getByTestId('tag-picker');
     await tagPicker.click();
-    const tagCheckbox = page.getByLabel(`Select ${TEST_TAG}`);
-    await page.getByText(TEST_TAG, { exact: true }).click();
-    await expect(tagCheckbox).toBeChecked();
+    const tagOption = page.getByRole('button', {
+      name: new RegExp(`${TEST_TAG}$`),
+    });
+    await tagOption.click();
+    await expect(tagOption).toHaveAttribute('aria-pressed', 'true');
     await expect(tagPicker).toHaveAttribute('aria-label', new RegExp(TEST_TAG));
     await page.getByRole('button', { name: 'Save' }).first().click();
     await waitForGraphqlOperation(diagnostics.completedOperations, 'updateChannel');

--- a/tests/playwright/mocked/channels/createEditChannels.spec.ts
+++ b/tests/playwright/mocked/channels/createEditChannels.spec.ts
@@ -346,13 +346,13 @@ test('creates and edits a channel', async ({
     const tagCheckbox = page.getByLabel(`Select ${TEST_TAG}`);
     await page.getByText(TEST_TAG, { exact: true }).click();
     await expect(tagCheckbox).toBeChecked();
-    await expect(tagPicker).toContainText(TEST_TAG);
+    await expect(tagPicker).toHaveAttribute('aria-label', new RegExp(TEST_TAG));
     await page.getByRole('button', { name: 'Save' }).first().click();
     await waitForGraphqlOperation(diagnostics.completedOperations, 'updateChannel');
 
     await expect(page.getByText('Your changes have been saved.')).toBeVisible();
     await expect(descriptionInput).toHaveValue(TEST_DESCRIPTION);
-    await expect(tagPicker).toContainText(TEST_TAG);
+    await expect(tagPicker).toHaveAttribute('aria-label', new RegExp(TEST_TAG));
 
     expect(diagnostics.pageErrors).toEqual([]);
   } finally {

--- a/tests/playwright/mocked/comments/createComment.spec.ts
+++ b/tests/playwright/mocked/comments/createComment.spec.ts
@@ -12,6 +12,29 @@ import {
 
 const ROOT_COMMENT_TEXT = 'Test comment';
 
+test('opens the root comment editor from the keyboard', async ({
+  context,
+  page,
+}) => {
+  const state = createCommentState();
+
+  await installMockAuth(context, page);
+  const diagnostics = await installGraphqlMocks(
+    page,
+    createCommentHandlers(state, DEFAULT_COMMENT_CONFIG)
+  );
+  const discussionUrl = `/forums/${DEFAULT_COMMENT_CONFIG.channelId}/discussions/${DEFAULT_COMMENT_CONFIG.discussionId}`;
+
+  await page.goto(discussionUrl);
+  const openEditor = page.getByRole('button', { name: 'Write a comment' });
+  await expect(openEditor).toBeVisible();
+
+  await openEditor.press('Enter');
+
+  await expect(page.getByTestId('texteditor-textarea')).toBeFocused();
+  expect(diagnostics.pageErrors).toEqual([]);
+});
+
 test('creates a root comment', async ({ context, page }, testInfo) => {
   const state = createCommentState();
 

--- a/tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts
+++ b/tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts
@@ -44,7 +44,10 @@ test('creates, edits and deletes a discussion', async ({
   const channelPicker = page.getByTestId('channel-input');
   await channelPicker.click();
   await page.getByText(TEST_CHANNEL, { exact: true }).click();
-  await expect(channelPicker).toContainText(TEST_CHANNEL);
+  await expect(channelPicker).toHaveAttribute(
+    'aria-label',
+    new RegExp(TEST_CHANNEL)
+  );
   await page.getByTestId('title-input').click();
   await expect(page.getByLabel('Type to search...')).toHaveCount(0);
 
@@ -52,8 +55,8 @@ test('creates, edits and deletes a discussion', async ({
   await tagPicker.click();
   await page.getByText(TAG_ONE, { exact: true }).click();
   await page.getByText(TAG_TWO, { exact: true }).click();
-  await expect(tagPicker).toContainText(TAG_ONE);
-  await expect(tagPicker).toContainText(TAG_TWO);
+  await expect(tagPicker).toHaveAttribute('aria-label', new RegExp(TAG_ONE));
+  await expect(tagPicker).toHaveAttribute('aria-label', new RegExp(TAG_TWO));
 
   await page.getByRole('button', { name: 'Save' }).first().click();
 
@@ -81,9 +84,9 @@ test('creates, edits and deletes a discussion', async ({
   await tagPicker.click();
   await page.getByText(TAG_THREE, { exact: true }).click();
   await page.getByText(TAG_ONE, { exact: true }).click();
-  await expect(tagPicker).toContainText(TAG_TWO);
-  await expect(tagPicker).toContainText(TAG_THREE);
-  await expect(tagPicker).not.toContainText(TAG_ONE);
+  await expect(tagPicker).toHaveAttribute('aria-label', new RegExp(TAG_TWO));
+  await expect(tagPicker).toHaveAttribute('aria-label', new RegExp(TAG_THREE));
+  await expect(tagPicker).not.toHaveAttribute('aria-label', new RegExp(TAG_ONE));
 
   await page.getByRole('button', { name: 'Save' }).first().click();
   await page.goto(`/forums/${TEST_CHANNEL}/discussions/${createdDiscussion.id}`);


### PR DESCRIPTION
## Summary

- refactor MultiSelect into valid, keyboard-operable toggle controls with focus management
- add modal semantics, focus trapping, Escape handling, and focus restoration across model, image, event, collection, and drawer dialogs
- convert revision-history dropdowns to accessible menu-button patterns
- replace dead comment-entry fields and mouse-only authentication prompts with native buttons
- improve disclosure semantics and accessible names for shared controls and 3D model viewers
- add browser coverage for keyboard activation and editor autofocus

## Why

Several shared controls visually behaved like native inputs, menus, and dialogs but used clickable containers, conflicting ARIA patterns, or incomplete focus management. Keyboard and screen-reader users could not reliably open, navigate, dismiss, or return from these interactions.

## Impact

The affected controls now use native interactive elements and coherent ARIA patterns. Modal focus remains contained and returns to the opener, nested dialogs no longer compete for Escape handling, and key comment workflows have browser-level regression coverage.

## Validation

- focused Vitest suites throughout the campaign
- `pnpm run lint:a11y`
- `pnpm run tsc`
- mocked Chromium Playwright comment-creation flow, including keyboard activation and autofocus