### PR TITLE
fix(a11y): table header scope + low-contrast text (P4)

### DIFF
--- a/components/admin/ChannelHealthTable.spec.ts
+++ b/components/admin/ChannelHealthTable.spec.ts
@@ -70,6 +70,13 @@ describe('ChannelHealthTable', () => {
     });
   });
 
+  it('marks every column header with scope="col"', () => {
+    const wrapper = mountTable();
+    expect(
+      wrapper.findAll('th').every((th) => th.attributes('scope') === 'col')
+    ).toBe(true);
+  });
+
   it('renders five loading skeleton rows while loading', () => {
     const wrapper = mountTable({ rows: [], loading: true });
     expect(wrapper.findAll('[data-testid="channel-health-loading-row"]')).toHaveLength(5);

--- a/components/admin/ChannelHealthTable.vue
+++ b/components/admin/ChannelHealthTable.vue
@@ -142,6 +142,7 @@ const tableColumnCount = computed(() => {
               <th
                 v-for="column in channelHealthColumns"
                 :key="column.key"
+                scope="col"
                 class="px-4 py-3 font-medium"
                 :aria-sort="column.ariaSort"
                 :title="column.title"
@@ -160,6 +161,7 @@ const tableColumnCount = computed(() => {
               </th>
               <th
                 v-if="detailRouteBase"
+                scope="col"
                 class="px-4 py-3 text-right font-medium"
               >
                 <span class="sr-only">Details</span>

--- a/components/admin/ImageReportsList.vue
+++ b/components/admin/ImageReportsList.vue
@@ -158,7 +158,7 @@ const getIssueLink = (report: {
               </span>
               <span
                 v-else
-                class="text-sm italic text-gray-400 dark:text-gray-500"
+                class="text-sm italic text-gray-500 dark:text-gray-400"
               >
                 (server-scoped)
               </span>

--- a/components/plugins/fields/PluginNumberField.vue
+++ b/components/plugins/fields/PluginNumberField.vue
@@ -111,7 +111,7 @@ const validationError = computed(() => {
     >
     <p
       v-if="rangeHint && !error && !validationError"
-      class="text-xs text-gray-400 dark:text-gray-500"
+      class="text-xs text-gray-500 dark:text-gray-400"
     >
       {{ rangeHint }}
     </p>

--- a/components/plugins/fields/PluginSecretField.vue
+++ b/components/plugins/fields/PluginSecretField.vue
@@ -211,7 +211,7 @@ const validationError = computed(() => {
     </p>
     <p
       v-else-if="secretStatus?.lastValidatedAt"
-      class="text-xs text-gray-400 dark:text-gray-500"
+      class="text-xs text-gray-500 dark:text-gray-400"
     >
       Last validated: {{ new Date(secretStatus.lastValidatedAt).toLocaleString() }}
     </p>

--- a/components/user/NotificationList.vue
+++ b/components/user/NotificationList.vue
@@ -111,7 +111,7 @@ const markAllAsRead = () => {
 </script>
 
 <template>
-  <div class="dak:text-white flex justify-center">
+  <div class="dark:text-white flex justify-center">
     <div class="w-full max-w-5xl">
       <p v-if="notificationLoading">Loading...</p>
       <ErrorBanner

--- a/components/user/UserProfileSidebar.vue
+++ b/components/user/UserProfileSidebar.vue
@@ -115,12 +115,12 @@ const handleReportSuccess = () => {
         {{ username }}
         <span
           v-if="serverRoleBadge === 'serverAdmin'"
-          class="rounded-md border border-orange-500 px-2 py-1 text-xs text-orange-500"
+          class="rounded-md border border-orange-500 px-2 py-1 text-xs text-orange-700 dark:text-orange-500"
           >Server Admin</span
         >
         <span
           v-else-if="serverRoleBadge === 'serverMod'"
-          class="rounded-md border border-orange-500 px-2 py-1 text-xs text-orange-500"
+          class="rounded-md border border-orange-500 px-2 py-1 text-xs text-orange-700 dark:text-orange-500"
           >Server Mod</span
         >
       </h1>


### PR DESCRIPTION
## What

Mechanical, low-risk static fixes.

**Table semantics (WCAG 1.3.1):**
- `admin/ChannelHealthTable.vue` — add `scope="col"` to every column `<th>` (the sortable columns and the Details column) so screen readers correctly associate data cells with their headers.

**Contrast — small text below the 4.5:1 AA threshold (WCAG 1.4.3):**
- `user/NotificationList.vue` — fix a `dak:text-white` typo → `dark:text-white` (the dark-mode text color simply never applied).
- `plugins/fields/PluginNumberField.vue` (range hint), `plugins/fields/PluginSecretField.vue` ("last validated" note), `admin/ImageReportsList.vue` (empty text) — `text-gray-400 dark:text-gray-500` fails in **both** light and dark; swapped to `text-gray-500 dark:text-gray-400`.
- `user/UserProfileSidebar.vue` — the server-role badges used `text-orange-500` (~3:1 on white); now `text-orange-700 dark:text-orange-500` (orange-700 ≈ 5.9:1 on white, orange-500 stays legible on dark).

## Tests

Added a `scope="col"` assertion to `ChannelHealthTable.spec.ts`; all 6 affected specs green (59 tests). `vue-tsc` + ESLint clean.

## Follow-ups (deferred to keep this PR to safe class/attribute changes)

The `<div v-for>` → `<ul role="list">`/`<li>` conversion for `ServerSuspendedModList`/`ServerSuspendedUserList` (structural) will be its own slice.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).