### PR TITLE
Fix profile access and active UI styling

### DIFF
--- a/components/VoteButton.spec.ts
+++ b/components/VoteButton.spec.ts
@@ -33,10 +33,12 @@ const authButton = (w: ReturnType<typeof mount>) => w.getComponent(authButtonStu
 const classes = (w: ReturnType<typeof mount>) => authButton(w).props('buttonClasses') as string;
 
 describe('VoteButton classes', () => {
-  it('uses orange styling when active', () => {
+  it('uses outlined, shaded orange styling when active', () => {
     const wrapper = mountButton({ active: true });
 
-    expect(classes(wrapper)).toContain('bg-orange-400');
+    expect(classes(wrapper)).toEqual(
+      expect.stringContaining('border-orange-300 bg-orange-100')
+    );
   });
 
   it('uses gray styling when inactive', () => {

--- a/components/VoteButton.vue
+++ b/components/VoteButton.vue
@@ -52,7 +52,7 @@ const buttonClasses = computed(() => {
 
   if (properties.transparentBackground) {
     const transparentClasses = properties.active
-      ? 'border-orange-400 bg-orange-400 text-black dark:border-orange-500 dark:bg-orange-400 dark:hover:bg-orange-500'
+      ? 'border border-orange-300 bg-orange-100 text-orange-700 ring-1 ring-inset ring-orange-300 dark:border-orange-700/70 dark:bg-orange-950/70 dark:text-orange-200 dark:ring-orange-700/70'
       : 'border-transparent bg-black/5 text-black hover:border-transparent hover:bg-black/10 dark:text-white dark:bg-white/10 dark:hover:bg-white/15';
 
     const externalClass = properties.class || '';
@@ -73,12 +73,14 @@ const buttonClasses = computed(() => {
   }
 
   const defaultClasses = properties.active
-    ? 'border-orange-400 text-black bg-orange-400 dark:border-orange-500 dark:bg-orange-400 dark:hover:bg-orange-500'
+    ? 'border border-orange-300 bg-orange-100 text-orange-700 ring-1 ring-inset ring-orange-300 dark:border-orange-700/70 dark:bg-orange-950/70 dark:text-orange-200 dark:ring-orange-700/70'
     : 'border-gray-200 text-black dark:text-white bg-gray-100 text-black hover:border-orange-400 hover:bg-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600';
 
-  const permalinkClasses = properties.isPermalinked
-    ? 'border-orange-500 hover:bg-orange-300 dark:border-orange-600 dark:hover:bg-orange-600'
-    : 'border-gray-200 dark:border-gray-600 hover:bg-gray-200';
+  const permalinkClasses = properties.active
+    ? ''
+    : properties.isPermalinked
+      ? 'border-orange-500 hover:bg-orange-300 dark:border-orange-600 dark:hover:bg-orange-600'
+      : 'border-gray-200 dark:border-gray-600 hover:bg-gray-200';
 
   // Include external class passed from parent component
   const externalClass = properties.class || '';

--- a/components/comments/Votes.spec.ts
+++ b/components/comments/Votes.spec.ts
@@ -112,10 +112,10 @@ describe('Votes feedback menu', () => {
     expect(labels).toEqual(expect.arrayContaining(['Undo Feedback', 'Edit Feedback']));
   });
 
-  it('uses active styling for the downvote when feedback is given', () => {
+  it('uses outlined, shaded active styling when feedback is given', () => {
     const wrapper = mountVotes({ downvoteActive: true });
 
-    expect(wrapper.html()).toContain('bg-orange-400');
+    expect(wrapper.html()).toContain('border-orange-300 bg-orange-100');
   });
 
   it('uses green styling for a best-answer downvote', () => {

--- a/components/comments/Votes.vue
+++ b/components/comments/Votes.vue
@@ -87,7 +87,7 @@ const downvoteButtonClasses = computed(() => {
 
   const activeClasses = props.isMarkedAsAnswer
     ? 'border-green-500 bg-green-500 dark:border-green-600 dark:bg-green-600 dark:hover:bg-green-500'
-    : 'border-orange-400 text-black bg-orange-400 dark:border-orange-500 dark:bg-orange-400 dark:hover:bg-orange-500';
+    : 'border border-orange-300 bg-orange-100 text-orange-700 ring-1 ring-inset ring-orange-300 dark:border-orange-700/70 dark:bg-orange-950/70 dark:text-orange-200 dark:ring-orange-700/70';
 
   if (props.isPermalinked && !props.downvoteActive) {
     return [
@@ -100,9 +100,11 @@ const downvoteButtonClasses = computed(() => {
     ? 'border-green-200 bg-green-100 text-green-700 hover:border-green-400 hover:bg-green-200 dark:border-green-600 dark:bg-green-800 dark:text-green-300 dark:hover:bg-green-700'
     : 'border-gray-200 text-black dark:text-white bg-gray-100 hover:border-orange-400 hover:bg-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600';
 
-  const permalinkClasses = props.isPermalinked
-    ? 'border-orange-500 hover:bg-orange-300 dark:border-orange-600 dark:hover:bg-orange-600'
-    : 'border-gray-200 dark:border-gray-600 hover:bg-gray-200';
+  const permalinkClasses = props.downvoteActive
+    ? ''
+    : props.isPermalinked
+      ? 'border-orange-500 hover:bg-orange-300 dark:border-orange-600 dark:hover:bg-orange-600'
+      : 'border-gray-200 dark:border-gray-600 hover:bg-gray-200';
 
   return [
     ...baseClasses,

--- a/components/discussion/detail/DiscussionTitleEditForm.vue
+++ b/components/discussion/detail/DiscussionTitleEditForm.vue
@@ -142,7 +142,7 @@ const isDownloadDetailPage = computed(() => {
       <div v-else ref="discussionDetail" class="flex-1">
         <h1
           v-if="!titleEditMode"
-          class="text-wrap px-1 text-lg sm:tracking-tight md:text-2xl"
+          class="text-wrap px-1 text-lg text-black sm:tracking-tight md:text-2xl dark:text-white"
         >
           {{
             discussion && discussion.title

--- a/components/icons/BellIcon.vue
+++ b/components/icons/BellIcon.vue
@@ -1,16 +1,16 @@
-<script setup lang="ts"></script>
 <template>
-  <svg aria-hidden="true"
+  <svg
+    aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
     stroke="currentColor"
-    stroke-width="1.75"
+    stroke-width="2"
   >
     <path
       stroke-linecap="round"
       stroke-linejoin="round"
-      d="M14.857 17.082a23.848 23.848 0 0 1-5.714 0A8.967 8.967 0 0 1 8 12.75V11a4 4 0 1 1 8 0v1.75c0 1.508-.374 2.993-1.143 4.332M9.75 17.5a2.25 2.25 0 0 0 4.5 0"
+      d="M18 8a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"
     />
   </svg>
 </template>

--- a/components/nav/TopNav.vue
+++ b/components/nav/TopNav.vue
@@ -186,7 +186,7 @@ const isOnMapPage = computed(() => {
             :aria-label="notificationCountVar > 0 ? `${notificationCountVar} new notifications` : 'Notifications'"
             class="relative inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-200 hover:text-gray-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white"
           >
-            <BellIcon class="h-[1.05rem] w-[1.05rem]" aria-hidden="true" />
+            <BellIcon class="h-6 w-6" aria-hidden="true" />
             <span
               v-if="notificationCountVar > 0"
               aria-hidden="true"

--- a/components/user/UserProfileSidebar.vue
+++ b/components/user/UserProfileSidebar.vue
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue';
 import type { PropType } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import 'md-editor-v3/lib/style.css';
-import { GET_USER } from '@/graphQLData/user/queries';
+import { GET_PUBLIC_USER_PROFILE } from '@/graphQLData/user/queries';
 import { stableRelativeTime } from '@/utils';
 import type { ServerRoleBadge } from '@/utils/serverRoleBadges';
 import MarkdownPreview from '@/components/MarkdownPreview.vue';
@@ -39,7 +39,7 @@ const {
   loading: getUserLoading,
   error: getUserError,
 } = useQuery(
-  GET_USER,
+  GET_PUBLIC_USER_PROFILE,
   () => ({
     username: username.value,
   }),

--- a/graphQLData/user/queries.js
+++ b/graphQLData/user/queries.js
@@ -60,6 +60,55 @@ export const GET_USER = gql`
   }
 `;
 
+// Public profile data only. Keep owner-only account fields (email, notification
+// preferences, and content settings) in GET_USER so anonymous visitors and
+// other users can load profile sidebars without triggering authorization errors.
+export const GET_PUBLIC_USER_PROFILE = gql`
+  query getPublicUserProfile($username: String!) {
+    getUserWikiEditsCount(username: $username)
+    users(where: { username: $username }) {
+      username
+      commentKarma
+      discussionKarma
+      createdAt
+      displayName
+      profilePicURL
+      location
+      pronouns
+      bio
+      CommentsAggregate(where: { NOT: { archived: true } }) {
+        count
+      }
+      DiscussionsAggregate(
+        where: { OR: [{ hasDownload: false }, { hasDownload: null }] }
+      ) {
+        count
+      }
+      DownloadsAggregate: DiscussionsAggregate(where: { hasDownload: true }) {
+        count
+      }
+      EventsAggregate {
+        count
+      }
+      ImagesAggregate {
+        count
+      }
+      AlbumsAggregate {
+        count
+      }
+      AuthoredWikiPageVersionsAggregate {
+        count
+      }
+      AdminOfChannelsAggregate {
+        count
+      }
+      ModOfChannelsAggregate {
+        count
+      }
+    }
+  }
+`;
+
 export const GET_USER_COMMENTS = gql`
   query getUserComments(
     $username: String!

--- a/pages/u/[username].spec.ts
+++ b/pages/u/[username].spec.ts
@@ -58,7 +58,9 @@ vi.mock('@/composables/useServerRoleMembership', async () => {
 vi.mock('@/config', () => ({
   config: { serverDisplayName: 'Test Server' },
 }));
-vi.mock('@/graphQLData/user/queries', () => ({ GET_USER: 'GET_USER' }));
+vi.mock('@/graphQLData/user/queries', () => ({
+  GET_PUBLIC_USER_PROFILE: 'GET_PUBLIC_USER_PROFILE',
+}));
 
 const makeUser = (overrides: Record<string, unknown> = {}) => ({
   username: 'alice',

--- a/pages/u/[username].vue
+++ b/pages/u/[username].vue
@@ -2,7 +2,7 @@
 import { config } from '@/config';
 import { computed, watchEffect } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
-import { GET_USER } from '@/graphQLData/user/queries';
+import { GET_PUBLIC_USER_PROFILE } from '@/graphQLData/user/queries';
 import UserProfileSidebar from '@/components/user/UserProfileSidebar.vue';
 import { useHead, useRoute } from 'nuxt/app';
 import UserContributionChart from '@/components/charts/UserContributionChart.vue';
@@ -30,7 +30,7 @@ const {
   loading: userLoading,
   error: userError,
 } = useQuery(
-  GET_USER,
+  GET_PUBLIC_USER_PROFILE,
   () => ({
     username: username.value,
   }),

--- a/tests/playwright/mocked/user/userProfile.spec.ts
+++ b/tests/playwright/mocked/user/userProfile.spec.ts
@@ -14,24 +14,38 @@ type MockHandlerInput = {
   };
 };
 
-const getBaseMocks = (loggedInUsername: string) => ({
-  // This query is called with the profile username from route params
-  getBasicUserInfo: ({ body }: MockHandlerInput) => {
-    const username = (body.variables?.username as string) || PROFILE_USERNAME;
-    return {
-      data: {
-        users: [
-          buildBasicUser({
+const getPublicProfile = ({ body }: MockHandlerInput) => {
+  const username = (body.variables?.username as string) || PROFILE_USERNAME;
+  return {
+    data: {
+      users: [
+        {
+          ...buildBasicUser({
             username,
             displayName: username,
             bio: 'Test bio for ' + username,
             commentKarma: 42,
             discussionKarma: 100,
           }),
-        ],
-      },
-    };
-  },
+          AuthoredWikiPageVersionsAggregate: { count: 0 },
+          ModOfChannelsAggregate: { count: 0 },
+        },
+      ],
+      getUserWikiEditsCount: 0,
+    },
+  };
+};
+
+const getBaseMocks = (loggedInUsername: string) => ({
+  // This query is called with the profile username from route params
+  getBasicUserInfo: getPublicProfile,
+  getPublicUserProfile: getPublicProfile,
+  getPublicScratchpadEntries: () => ({
+    data: {
+      scratchpadEntriesAggregate: { count: 0 },
+      scratchpadEntries: [],
+    },
+  }),
   getUser: () => ({
     data: {
       users: [


### PR DESCRIPTION
## What changed

- make discussion titles explicitly black in light mode and white in dark mode
- load public user profiles with a public-only GraphQL query so owner-only account fields cannot block the sidebar for visitors
- enlarge and redraw the top-nav notification icon as a recognizable bell
- replace solid-orange active vote and feedback controls with the outlined, shaded orange treatment used by the vertical navigation in both themes

## Why

Public profile pages were reusing the account-oriented `GET_USER` query, which includes owner-only email and notification settings. Authorization errors from those private fields leaked into public profile UI. The remaining changes correct visual regressions and align active voting controls with the app's navigation language.

## Validation

- `pnpm exec vitest run components/VoteButton.spec.ts components/comments/Votes.spec.ts components/discussion/vote/VoteButtons.spec.ts components/user/UserProfileSidebar.spec.ts components/scratchpad/ProfileKudosPreview.spec.ts components/nav/TopNav.spec.ts pages/u/'[username].spec.ts'` (92 tests)
- `pnpm run tsc`
- targeted ESLint on all changed source and spec files
- `pnpm run build`
- `git diff --check`
