### PR TITLE
fix(a11y): proper tab semantics for notification + forum navigation (P4)

### DIFF
--- a/components/channel/ChannelTabs.vue
+++ b/components/channel/ChannelTabs.vue
@@ -320,7 +320,7 @@ const tabs = computed((): Tab[] => {
                   }}
                 </span>
               </div>
-              <i class="fa-solid fa-chevron-down ml-2 h-4 w-4" />
+              <i class="fa-solid fa-chevron-down ml-2 h-4 w-4" aria-hidden="true" />
             </button>
           </template>
 
@@ -334,6 +334,7 @@ const tabs = computed((): Tab[] => {
                   :key="tab.name"
                   :to="tabRoutes[tab.name] || ''"
                   :data-testid="`mobile-dropdown-${tab.name}`"
+                  :aria-current="isTabActive(tab) ? 'page' : undefined"
                   class="flex items-center justify-between px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
                   :class="[
                     isTabActive(tab)

--- a/components/channel/TabButton.spec.ts
+++ b/components/channel/TabButton.spec.ts
@@ -13,8 +13,8 @@ const mountTab = (props: Record<string, unknown> = {}, slot = '') =>
     slots: { default: slot },
     global: {
       stubs: {
-        NuxtLink: { props: ['to'], template: '<a :class="$attrs.class"><slot /></a>' },
-        'nuxt-link': { props: ['to'], template: '<a :class="$attrs.class"><slot /></a>' },
+        NuxtLink: { props: ['to'], template: '<a v-bind="$attrs"><slot /></a>' },
+        'nuxt-link': { props: ['to'], template: '<a v-bind="$attrs"><slot /></a>' },
       },
     },
   });
@@ -74,6 +74,18 @@ describe('TabButton active state', () => {
     const wrapper = mountTab({ isActive: true, vertical: true });
 
     expect(wrapper.find('a').classes()).toContain('bg-gray-100');
+  });
+
+  it('marks the active tab with aria-current="page"', () => {
+    const wrapper = mountTab({ isActive: true });
+
+    expect(wrapper.find('a').attributes('aria-current')).toBe('page');
+  });
+
+  it('omits aria-current on an inactive tab', () => {
+    const wrapper = mountTab({ isActive: false });
+
+    expect(wrapper.find('a').attributes('aria-current')).toBeUndefined();
   });
 });
 

--- a/components/channel/TabButton.vue
+++ b/components/channel/TabButton.vue
@@ -93,6 +93,7 @@ const innerClasses = computed(() => [
   <nuxt-link
     :data-testid="dataTestid"
     :to="to"
+    :aria-current="isActive ? 'page' : undefined"
     class="border-transparent link group inline-flex items-center gap-1 pt-2 font-medium hover:text-gray-600 dark:text-gray-400"
     :class="classes"
     @mouseenter="isHovered = true"

--- a/components/notifications/NotificationTabs.spec.ts
+++ b/components/notifications/NotificationTabs.spec.ts
@@ -200,6 +200,48 @@ describe('NotificationTabs', () => {
     expect(badges.length).toBeGreaterThan(0);
   });
 
+  it('exposes the tabs as an ARIA tablist', () => {
+    const wrapper = mountNotificationTabs();
+
+    expect(wrapper.get('[role="tablist"]').exists()).toBe(true);
+  });
+
+  it('marks the active tab aria-selected and the other not', () => {
+    const wrapper = mountNotificationTabs();
+    const tabs = wrapper.findAll('[role="tab"]');
+
+    expect(tabs.map((t) => t.attributes('aria-selected'))).toEqual([
+      'true',
+      'false',
+    ]);
+  });
+
+  it('gives only the active tab a tabindex of 0 (roving focus)', () => {
+    const wrapper = mountNotificationTabs();
+    const tabs = wrapper.findAll('[role="tab"]');
+
+    expect(tabs.map((t) => t.attributes('tabindex'))).toEqual(['0', '-1']);
+  });
+
+  it('labels the tabpanel with the active tab', () => {
+    const wrapper = mountNotificationTabs();
+    const activeTabId = wrapper.get('[aria-selected="true"]').attributes('id');
+
+    expect(wrapper.get('[role="tabpanel"]').attributes('aria-labelledby')).toBe(
+      activeTabId
+    );
+  });
+
+  it('switches tabs with the ArrowRight key', async () => {
+    const wrapper = mountNotificationTabs();
+
+    await wrapper.get('[role="tablist"]').trigger('keydown', { key: 'ArrowRight' });
+
+    expect(
+      wrapper.findAll('[role="tab"]')[1]!.attributes('aria-selected')
+    ).toBe('true');
+  });
+
   it('renders notification list', () => {
     const wrapper = mountNotificationTabs();
 

--- a/components/notifications/NotificationTabs.vue
+++ b/components/notifications/NotificationTabs.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, useId, nextTick } from 'vue';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 import { useUsername } from '@/composables/useAuthState';
 import { timeAgo } from '@/utils';
@@ -29,6 +29,43 @@ type NotificationTab = 'general' | 'feedback';
 const activeTab = defineModel<NotificationTab>('activeTab', {
   default: 'general',
 });
+
+// ARIA tabs wiring (WAI-ARIA tabs pattern): stable ids tie each tab to the
+// shared panel, and arrow/Home/End keys move between tabs with focus.
+const generalTabId = useId();
+const feedbackTabId = useId();
+const panelId = useId();
+const generalTabRef = ref<HTMLButtonElement | null>(null);
+const feedbackTabRef = ref<HTMLButtonElement | null>(null);
+
+const activeTabId = computed(() =>
+  activeTab.value === 'general' ? generalTabId : feedbackTabId
+);
+
+const selectTab = (tab: NotificationTab) => {
+  activeTab.value = tab;
+  nextTick(() => {
+    (tab === 'general' ? generalTabRef.value : feedbackTabRef.value)?.focus();
+  });
+};
+
+const onTabKeydown = (event: KeyboardEvent) => {
+  switch (event.key) {
+    case 'ArrowRight':
+    case 'ArrowLeft':
+      event.preventDefault();
+      selectTab(activeTab.value === 'general' ? 'feedback' : 'general');
+      break;
+    case 'Home':
+      event.preventDefault();
+      selectTab('general');
+      break;
+    case 'End':
+      event.preventDefault();
+      selectTab('feedback');
+      break;
+  }
+};
 
 const usernameVar = useUsername();
 
@@ -268,8 +305,20 @@ const reachedEnd = computed(() => {
         <h1 class="mb-4 border-b border-gray-500 text-2xl">Notifications</h1>
 
         <!-- Tab navigation -->
-        <div class="mb-4 flex gap-2 border-b border-gray-200 dark:border-gray-700">
+        <div
+          role="tablist"
+          aria-label="Notifications"
+          class="mb-4 flex gap-2 border-b border-gray-200 dark:border-gray-700"
+          @keydown="onTabKeydown"
+        >
           <button
+            :id="generalTabId"
+            ref="generalTabRef"
+            type="button"
+            role="tab"
+            :aria-selected="activeTab === 'general'"
+            :aria-controls="panelId"
+            :tabindex="activeTab === 'general' ? 0 : -1"
             :class="[
               'px-4 py-2 text-sm font-medium',
               activeTab === 'general'
@@ -287,6 +336,13 @@ const reachedEnd = computed(() => {
             </span>
           </button>
           <button
+            :id="feedbackTabId"
+            ref="feedbackTabRef"
+            type="button"
+            role="tab"
+            :aria-selected="activeTab === 'feedback'"
+            :aria-controls="panelId"
+            :tabindex="activeTab === 'feedback' ? 0 : -1"
             :class="[
               'px-4 py-2 text-sm font-medium',
               activeTab === 'feedback'
@@ -306,6 +362,12 @@ const reachedEnd = computed(() => {
         </div>
       </div>
 
+      <div
+        :id="panelId"
+        role="tabpanel"
+        :aria-labelledby="activeTabId"
+        tabindex="0"
+      >
       <p v-if="isLoading" class="px-4">Loading...</p>
 
       <ErrorBanner v-else-if="currentError" :text="currentError.message" />
@@ -402,6 +464,7 @@ const reachedEnd = computed(() => {
             @load-more="loadMore"
           />
         </div>
+      </div>
       </div>
     </div>
   </div>

--- a/tests/playwright/mocked/notifications/notificationTabs.spec.ts
+++ b/tests/playwright/mocked/notifications/notificationTabs.spec.ts
@@ -133,11 +133,11 @@ test.describe('Notification tabs', () => {
       });
 
       // Verify General tab is active by default
-      const generalTab = page.getByRole('button', { name: /General/i });
+      const generalTab = page.getByRole('tab', { name: /General/i });
       await expect(generalTab).toBeVisible();
 
       // Verify Feedback tab exists with unread count
-      const feedbackTab = page.getByRole('button', { name: /Feedback/i });
+      const feedbackTab = page.getByRole('tab', { name: /Feedback/i });
       await expect(feedbackTab).toBeVisible();
 
       // General tab should show general notifications
@@ -210,7 +210,7 @@ test.describe('Notification tabs', () => {
     try {
       await page.goto('/notifications');
 
-      const generalTab = page.getByRole('button', { name: /General/i });
+      const generalTab = page.getByRole('tab', { name: /General/i });
       await expect(generalTab).toBeVisible({ timeout: 30000 });
 
       // The General badge reflects its own aggregate count on load.
@@ -218,7 +218,7 @@ test.describe('Notification tabs', () => {
 
       // The Feedback query is only enabled once its tab is active, so its
       // badge populates after the tab is visited.
-      const feedbackTab = page.getByRole('button', { name: /Feedback/i });
+      const feedbackTab = page.getByRole('tab', { name: /Feedback/i });
       await feedbackTab.click();
       await expect(feedbackTab.locator('span')).toContainText('3');
 


### PR DESCRIPTION
## What

Two tab-like widgets that needed **two different** correct patterns.

### `NotificationTabs` — a real ARIA tabs widget
The General/Feedback toggle swaps content in place, so it's a genuine tab widget (WAI-ARIA Tabs pattern):
- container `role="tablist"` + `aria-label`; each button `role="tab"` with `aria-selected`, `aria-controls`, and **roving tabindex** (`0` for the active tab, `-1` for the rest)
- the content region is wrapped in a `role="tabpanel"` tied back to the active tab via `aria-labelledby`
- **Arrow Left/Right + Home/End** move between tabs and move focus with them

### `ChannelTabs` — route navigation, so `aria-current` (not tablist)
Each forum tab is a **link to a different page**, so `role="tablist"` would be wrong (it implies in-page panel switching and would mislead screen-reader users). Instead:
- the shared `TabButton` link gets `aria-current="page"` when active — this one change covers **every** forum nav tab
- the mobile dropdown links get `aria-current` too; the decorative mobile chevron is `aria-hidden`

## Tests

- `NotificationTabs.spec.ts`: tablist role, `aria-selected` pair, roving `tabindex`, tabpanel `aria-labelledby`, and ArrowRight switching (18 tests).
- `TabButton.spec.ts`: `aria-current="page"` when active / absent when inactive (stub updated to forward all attrs).
- All 3 affected specs green (43 tests). `vue-tsc` + ESLint (incl. `eslint-plugin-vuejs-accessibility`) clean.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).