### PR TITLE
fix(a11y): semantic lists for suspensions + LinkPreview alt fallback (P4)

### DIFF
--- a/components/LinkPreview.spec.ts
+++ b/components/LinkPreview.spec.ts
@@ -67,6 +67,27 @@ describe('LinkPreview', () => {
     expect(wrapper.find('img').exists()).toBe(false);
   });
 
+  it('gives the image a url-based alt when no title is available', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              hybridGraph: { image: 'https://x/og.png' },
+              htmlInferred: {},
+            }),
+        })
+      )
+    );
+    const wrapper = mountPreview('https://example.com/page');
+    await flushPromises();
+
+    expect(wrapper.find('img').attributes('alt')).toBe(
+      'Preview image for https://example.com/page'
+    );
+  });
+
   it('falls back to the url as the title when no title is returned', async () => {
     vi.stubGlobal(
       'fetch',

--- a/components/LinkPreview.vue
+++ b/components/LinkPreview.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import { config } from '@/config';
 
 const props = defineProps<{
@@ -7,6 +7,9 @@ const props = defineProps<{
 }>();
 
 const title = ref('');
+// The image is the only content of its link, so it must never fall back to
+// alt="" (that would leave the link unnamed while the title loads).
+const imageAlt = computed(() => title.value || `Preview image for ${props.url}`);
 const description = ref('');
 const imageUrl = ref('');
 const htmlInferredImages = ref<string[]>([]);
@@ -55,7 +58,7 @@ onMounted(() => {
         v-if="imageUrl && showImage"
         class="m-4 w-20 object-cover"
         :src="imageUrl"
-        :alt="title"
+        :alt="imageAlt"
         @error="showImage = false"
       >
     </a>

--- a/components/admin/ServerSuspendedModList.spec.ts
+++ b/components/admin/ServerSuspendedModList.spec.ts
@@ -84,6 +84,13 @@ describe('ServerSuspendedModList content', () => {
     expect(wrapper.text()).toContain('mod1 (alice)');
   });
 
+  it('renders the suspensions as a semantic list', () => {
+    h.result = ref(withMods([suspension({ id: 'a' }), suspension({ id: 'b' })]));
+    const wrapper = mountList();
+
+    expect(wrapper.findAll('ul[role="list"] > li')).toHaveLength(2);
+  });
+
   it('shows a suspended-until date for a temporary suspension', () => {
     const wrapper = mountList();
 

--- a/components/admin/ServerSuspendedModList.vue
+++ b/components/admin/ServerSuspendedModList.vue
@@ -50,7 +50,8 @@ const humanReadableDate = (dateISO?: string | null): string => {
       <div class="text-sm font-bold">
         {{ `Active Suspensions (${aggregateCount})` }}
       </div>
-      <div
+      <ul role="list">
+      <li
         v-for="suspension in suspensions"
         :key="suspension.id"
         class="flex items-center justify-between rounded p-2 hover:bg-gray-100 dark:hover:bg-gray-700"
@@ -98,7 +99,8 @@ const humanReadableDate = (dateISO?: string | null): string => {
             }}
           </div>
         </div>
-      </div>
+      </li>
+      </ul>
     </div>
   </div>
 </template>

--- a/components/admin/ServerSuspendedUserList.spec.ts
+++ b/components/admin/ServerSuspendedUserList.spec.ts
@@ -85,6 +85,15 @@ describe('ServerSuspendedUserList content', () => {
     expect(wrapper.text()).toContain('alice');
   });
 
+  it('renders the suspensions as a semantic list', () => {
+    h.result = ref(
+      withUsers([suspension({ id: 'a' }), suspension({ id: 'b' })])
+    );
+    const wrapper = mountList();
+
+    expect(wrapper.findAll('ul[role="list"] > li')).toHaveLength(2);
+  });
+
   it('shows a bot badge for a suspended bot', () => {
     h.result = ref({
       serverConfigs: [

--- a/components/admin/ServerSuspendedUserList.vue
+++ b/components/admin/ServerSuspendedUserList.vue
@@ -53,7 +53,8 @@ const humanReadableDate = (dateISO?: string | null): string => {
       <div class="text-sm font-bold">
         {{ `Active Suspensions (${aggregateCount})` }}
       </div>
-      <div
+      <ul role="list">
+      <li
         v-for="suspension in suspendedUsers"
         :key="suspension.id"
         class="flex items-center justify-between rounded p-2 hover:bg-gray-100 dark:hover:bg-gray-700"
@@ -120,7 +121,8 @@ const humanReadableDate = (dateISO?: string | null): string => {
             }}
           </div>
         </div>
-      </div>
+      </li>
+      </ul>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## What

- **`admin/ServerSuspendedModList.vue` / `admin/ServerSuspendedUserList.vue`** — the `<div v-for>` suspension rows are now a real `<ul role="list">` with `<li>` items, so screen readers announce list position and count (WCAG 1.3.1). The explicit `role="list"` is deliberate: Tailwind's `list-style: none` makes Safari/VoiceOver drop list semantics, and `role="list"` restores them (it's not flagged by `no-redundant-roles`).
- **`LinkPreview.vue`** — the preview image is the *only* content of its link, so `:alt="title"` left the link unnamed while the OpenGraph title was still loading (or absent). Now falls back to `Preview image for <url>`.

## Tests

- A semantic-list assertion (`ul[role="list"] > li` count) added to both suspension-list specs.
- A url-based-alt test added to `LinkPreview.spec.ts`.
- All 3 specs green (29 tests); `vue-tsc` + ESLint (incl. `eslint-plugin-vuejs-accessibility`) clean.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).