### PR TITLE
fix(a11y): correct SortDropdown menu-button state + dismissal (P4)

### DIFF
--- a/components/SortDropdown.spec.ts
+++ b/components/SortDropdown.spec.ts
@@ -2,28 +2,53 @@ import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import SortDropdown from './SortDropdown.vue';
 
+// v-click-outside is a global Nuxt directive; stub it so the component mounts.
+const mountDropdown = () =>
+  mount(SortDropdown, {
+    global: { directives: { 'click-outside': {} } },
+  });
+
 describe('SortDropdown', () => {
   it('hides the menu initially', () => {
-    const wrapper = mount(SortDropdown);
+    const wrapper = mountDropdown();
     expect(wrapper.find('[role="menu"]').exists()).toBe(false);
   });
 
   it('opens the menu when the button is clicked', async () => {
-    const wrapper = mount(SortDropdown);
+    const wrapper = mountDropdown();
     await wrapper.find('#menu-button').trigger('click');
     expect(wrapper.find('[role="menu"]').exists()).toBe(true);
   });
 
   it('renders the sort options when open', async () => {
-    const wrapper = mount(SortDropdown);
+    const wrapper = mountDropdown();
     await wrapper.find('#menu-button').trigger('click');
     expect(wrapper.findAll('[role="menuitem"]')).toHaveLength(3);
   });
 
   it('closes the menu when the button is clicked again', async () => {
-    const wrapper = mount(SortDropdown);
+    const wrapper = mountDropdown();
     await wrapper.find('#menu-button').trigger('click');
     await wrapper.find('#menu-button').trigger('click');
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+  });
+
+  it('reflects the open state in aria-expanded', async () => {
+    const wrapper = mountDropdown();
+    const button = wrapper.find('#menu-button');
+    expect(button.attributes('aria-expanded')).toBe('false');
+
+    await button.trigger('click');
+
+    expect(button.attributes('aria-expanded')).toBe('true');
+  });
+
+  it('closes the menu when Escape is pressed', async () => {
+    const wrapper = mountDropdown();
+    await wrapper.find('#menu-button').trigger('click');
+
+    await wrapper.find('[role="menu"]').trigger('keydown.escape');
+
     expect(wrapper.find('[role="menu"]').exists()).toBe(false);
   });
 });

--- a/components/SortDropdown.vue
+++ b/components/SortDropdown.vue
@@ -2,15 +2,19 @@
 import { ref } from 'vue';
 
 const isOpen = ref(false);
+
+const closeMenu = () => {
+  isOpen.value = false;
+};
 </script>
 <template>
-  <div class="relative inline-block">
+  <div v-click-outside="closeMenu" class="relative inline-block">
     <div class="flex">
       <button
         id="menu-button"
         type="button"
         class="group inline-flex justify-center py-2 text-sm font-medium text-gray-700 hover:text-gray-900"
-        aria-expanded="false"
+        :aria-expanded="isOpen"
         aria-haspopup="true"
         @click="isOpen = !isOpen"
       >
@@ -49,6 +53,7 @@ const isOpen = ref(false);
       aria-orientation="vertical"
       aria-labelledby="menu-button"
       tabindex="-1"
+      @keydown.escape="closeMenu"
     >
       <div class="py-1" role="none">
         <a


### PR DESCRIPTION
## What

`SortDropdown` had a hardcoded `aria-expanded="false"` (so the state never reflected the open menu) and no keyboard/outside-click dismissal.

- `:aria-expanded="isOpen"` — now reflects the actual menu state.
- Close on **Escape** and on **outside click** (`v-click-outside`), so it's dismissible without the mouse.

## Honest note on scope

This component is **currently unused** — it's referenced only by its own spec, and its items are placeholder `<a href="#">` with no handlers. It also duplicates `MenuButton`, which already has a full accessible menu implementation (roving focus, arrow keys, Escape, focus restore, added in the P0 work). Rather than hand-roll a full menu widget into dead code, this PR is a **bounded correctness fix** for the concrete defects the audit flagged. **Recommendation:** replace `SortDropdown` with `MenuButton` or delete it in a follow-up.

## Tests

Spec updated to stub the global `click-outside` directive, with new cases for `aria-expanded` toggling and Escape-to-close (6 tests). `vue-tsc` + ESLint clean.

Part of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).