### PR TITLE
test(a11y): add an axe-core Playwright smoke pass (guardrail)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "vuemoji-picker": "^0.3.2"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@graphql-codegen/cli": "7.2.0",
     "@graphql-codegen/client-preset": "^4.7.0",
     "@nuxt/eslint-config": "^1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2(vue@3.5.39(typescript@6.0.3))
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.61.1)
       '@graphql-codegen/cli':
         specifier: 7.2.0
         version: 7.2.0(@parcel/watcher@2.5.6)(@types/node@24.13.2)(crossws@0.3.5)(graphql@16.14.2)(typescript@6.0.3)
@@ -357,6 +360,11 @@ packages:
 
   '@auth0/auth0-server-js@1.9.0':
     resolution: {integrity: sha512-N381KpwssER5eE2rgT4f6Z+dzwwkpCTuhCH9vSLH6x1GAuznZUnQqh/IZqQ1arbMjSDiHWaKc46+7DNm/6v0eA==}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -8286,6 +8294,11 @@ snapshots:
     dependencies:
       '@auth0/auth0-auth-js': 1.11.0
       jose: 6.2.3
+
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.1
 
   '@babel/code-frame@7.29.7':
     dependencies:

--- a/tests/playwright/helpers/axe.ts
+++ b/tests/playwright/helpers/axe.ts
@@ -1,0 +1,57 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page } from '@playwright/test';
+
+// The rules we actively enforce as a regression guard. These map to the
+// name/role/value and structural issues the accessibility remediation
+// campaign fixed, and they rarely false-positive on well-formed markup.
+//
+// Deliberately NOT enforced yet (noisier / not fully audited across the app):
+// `color-contrast`, `region`/landmark rules. Add them here once those areas
+// have been swept so the guard can only ever get stricter.
+export const ENFORCED_AXE_RULES = [
+  'button-name',
+  'link-name',
+  'image-alt',
+  'input-image-alt',
+  'label',
+  'select-name',
+  'aria-allowed-attr',
+  'aria-command-name',
+  'aria-required-attr',
+  'aria-required-children',
+  'aria-required-parent',
+  'aria-roles',
+  'aria-toggle-field-name',
+  'aria-tooltip-name',
+  'aria-valid-attr',
+  'aria-valid-attr-value',
+  'document-title',
+  'html-has-lang',
+  'list',
+  'listitem',
+  'definition-list',
+  'dlitem',
+  'duplicate-id-aria',
+  'tabindex',
+] as const;
+
+// Run axe against the current page for the enforced rule set and assert there
+// are no violations. On failure the assertion message lists each violated rule
+// and the offending selectors so the report is actionable.
+export async function expectNoAxeViolations(page: Page): Promise<void> {
+  const results = await new AxeBuilder({ page })
+    .withRules([...ENFORCED_AXE_RULES])
+    .analyze();
+
+  const summary = results.violations.map((v) => ({
+    id: v.id,
+    impact: v.impact,
+    help: v.help,
+    nodes: v.nodes.map((n) => n.target.join(' ')),
+  }));
+
+  expect(
+    summary,
+    `axe found accessibility violations:\n${JSON.stringify(summary, null, 2)}`
+  ).toEqual([]);
+}

--- a/tests/playwright/mocked/a11y/axeSmoke.spec.ts
+++ b/tests/playwright/mocked/a11y/axeSmoke.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '../../helpers/testFixture';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import { expectNoAxeViolations } from '../../helpers/axe';
+
+// Smoke-level axe pass over a few representative pages: a static content page,
+// a form page, and the sitewide discussion list. This is a regression guard
+// for the name/role/value + structural rules the a11y campaign fixed (see
+// ENFORCED_AXE_RULES); it is intentionally a small, fast set rather than a full
+// site crawl. Expand the page list / rule set as more areas are audited.
+const PAGES = [
+  { name: 'about', path: '/about' },
+  { name: 'support', path: '/support' },
+  { name: 'sitewide discussions', path: '/discussions' },
+];
+
+for (const { name, path } of PAGES) {
+  test(`${name} page has no axe violations for the enforced rules`, async ({
+    page,
+    setupMockedPage,
+  }) => {
+    await setupMockedPage({ handlers: createBaseHandlers() });
+
+    await page.goto(path);
+    // Let the app hydrate and the main content render before scanning.
+    await expect(page.locator('#main-content')).toBeAttached();
+
+    await expectNoAxeViolations(page);
+  });
+}


### PR DESCRIPTION
## What

Adds a runtime accessibility guardrail: [`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm) plus a mocked e2e (`tests/playwright/mocked/a11y/axeSmoke.spec.ts`) that runs axe against a few representative pages and asserts **zero violations** for a curated rule set.

- **Pages scanned:** `/about` (static content + app shell), `/support` (a form — exercises the label rule), `/discussions` (shell + filter/list components).
- **Enforced rules** (`ENFORCED_AXE_RULES` in `tests/playwright/helpers/axe.ts`): name/role/value + structural checks — `button-name`, `link-name`, `image-alt`, `label`, `select-name`, the `aria-*` validity/name rules, `document-title`, `html-has-lang`, `list`/`listitem`, `tabindex`, `duplicate-id-aria`, etc. These are exactly the classes of issue the campaign fixed, and they rarely false-positive on well-formed markup.
- **Deliberately excluded for now:** `color-contrast` and landmark/`region` rules — noisier and not yet fully swept app-wide. The helper is structured so the rule list and page list can only ever be *widened*, never silently narrowed.

## Why this shape

A whole-page `wcag2aa` scan would fail immediately on pre-existing contrast/landmark noise and force either a broad baseline-suppression file or disabling the guard. Enforcing a high-confidence subset lands green **today**, genuinely catches regressions in what we fixed, and leaves a clear path to tighten.

This complements the **`eslint-plugin-vuejs-accessibility`** rules already enforced at lint time (author-time static checks) with a runtime DOM check.

## Validation

Built the mocked app and ran the spec locally — **all 3 pages pass** for the enforced rules. `vue-tsc` + ESLint clean. The lockfile is updated for the new devDependency.

Closes the guardrail item from `docs/accessibility-audit-2026-07.md`.