### PR TITLE
fix(a11y): visible focus rings on remaining bare outline-none controls (P5)

### DIFF
--- a/components/FileTypePicker.spec.ts
+++ b/components/FileTypePicker.spec.ts
@@ -34,6 +34,14 @@ describe('FileTypePicker display', () => {
     expect(wrapper.text()).toContain('Select allowed file types');
   });
 
+  // Regression: the combobox input uses focus:outline-none, so the container
+  // must show a focus-within ring or keyboard focus is invisible (WCAG 2.4.7).
+  it('shows a focus-within ring on the combobox container', () => {
+    const wrapper = mountPicker();
+
+    expect(box(wrapper).classes()).toContain('focus-within:ring-2');
+  });
+
   it('shows the disabled hint when disabled', () => {
     const wrapper = mountPicker({ disabled: true });
 

--- a/components/FileTypePicker.vue
+++ b/components/FileTypePicker.vue
@@ -76,7 +76,7 @@ const removeSelection = (fileType: string) => {
     </div>
     <div class="relative">
       <div
-        class="flex min-h-10 w-full cursor-text flex-wrap items-center rounded-lg border px-4 text-left text-sm dark:border-gray-700 dark:bg-gray-700"
+        class="flex min-h-10 w-full cursor-text flex-wrap items-center rounded-lg border px-4 text-left text-sm focus-within:ring-2 focus-within:ring-orange-500 dark:border-gray-700 dark:bg-gray-700"
         :class="{
           'cursor-not-allowed opacity-50': disabled,
           'cursor-text': !disabled,

--- a/components/IconButtonDropdown.spec.ts
+++ b/components/IconButtonDropdown.spec.ts
@@ -8,7 +8,7 @@ const h = vi.hoisted(() => ({ push: vi.fn() }));
 vi.mock('nuxt/app', () => ({ useRouter: () => ({ push: h.push }) }));
 vi.mock('@headlessui/vue', () => ({
   Menu: { name: 'Menu', template: '<div><slot /></div>' },
-  MenuButton: { name: 'MenuButton', template: '<button class="menu-button"><slot /></button>' },
+  MenuButton: { name: 'MenuButton', template: '<button class="menu-button" v-bind="$attrs"><slot /></button>' },
   MenuItems: { name: 'MenuItems', template: '<div><slot /></div>' },
   MenuItem: { name: 'MenuItem', template: '<div class="menu-item"><slot :active="false" /></div>' },
 }));
@@ -31,6 +31,16 @@ describe('IconButtonDropdown rendering', () => {
     const wrapper = mountDropdown({ items: [{ value: '/a', label: 'Item A' }] });
 
     expect(wrapper.text()).toContain('Item A');
+  });
+
+  // Regression: the trigger paired focus:outline-none with no ring width,
+  // leaving keyboard focus invisible (WCAG 2.4.7).
+  it('renders a focus ring width on the trigger', () => {
+    const wrapper = mountDropdown();
+
+    expect(wrapper.get('.menu-button').classes()).toContain(
+      'focus-visible:ring-2'
+    );
   });
 
   it('renders a divider item', () => {

--- a/components/IconButtonDropdown.vue
+++ b/components/IconButtonDropdown.vue
@@ -51,7 +51,7 @@ const handleItemClick = (item: MenuItemType) => {
     <Menu as="div" class="relative flex items-center text-left">
       <MenuButton
         :class="[
-          'font-semibold inline-flex h-10 w-full items-center justify-center gap-x-1.5 rounded-full px-2 text-sm text-black focus:outline-none dark:text-gray-300 dark:hover:text-white',
+          'font-semibold inline-flex h-10 w-full items-center justify-center gap-x-1.5 rounded-full px-2 text-sm text-black focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 dark:text-gray-300 dark:hover:text-white',
           darkBackground ? 'text-gray-200 hover:text-white' : '',
         ]"
         :aria-label="props.ariaLabel"
@@ -107,7 +107,7 @@ const handleItemClick = (item: MenuItemType) => {
     </Menu>
     <template #fallback>
       <button
-        class="font-semibold inline-flex h-10 w-full items-center justify-center gap-x-1.5 rounded-full px-2 text-sm text-black focus:outline-none dark:text-white"
+        class="font-semibold inline-flex h-10 w-full items-center justify-center gap-x-1.5 rounded-full px-2 text-sm text-black focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 dark:text-white"
         :aria-label="props.ariaLabel"
       >
         <i v-if="menuButtonIcon" :class="` ${menuButtonIcon} `" aria-hidden="true" />

--- a/components/TextButtonDropdown.spec.ts
+++ b/components/TextButtonDropdown.spec.ts
@@ -5,7 +5,7 @@ import TextButtonDropdown from '@/components/TextButtonDropdown.vue';
 
 vi.mock('@headlessui/vue', () => ({
   Menu: { name: 'Menu', template: '<div><slot /></div>' },
-  MenuButton: { name: 'MenuButton', template: '<button class="menu-button"><slot /></button>' },
+  MenuButton: { name: 'MenuButton', template: '<button class="menu-button" v-bind="$attrs"><slot /></button>' },
   MenuItems: { name: 'MenuItems', template: '<div><slot /></div>' },
   MenuItem: { name: 'MenuItem', template: '<div class="menu-item"><slot :active="false" /></div>' },
 }));
@@ -23,6 +23,16 @@ describe('TextButtonDropdown', () => {
     const wrapper = mountDropdown({ label: 'Sort' });
 
     expect(wrapper.text()).toContain('Sort');
+  });
+
+  // Regression: the trigger paired focus:outline-none with no ring width,
+  // leaving keyboard focus invisible (WCAG 2.4.7).
+  it('renders a focus ring width on the trigger', () => {
+    const wrapper = mountDropdown({ label: 'Sort' });
+
+    expect(wrapper.get('.menu-button').classes()).toContain(
+      'focus-visible:ring-2'
+    );
   });
 
   it('renders the menu items', () => {

--- a/components/TextButtonDropdown.vue
+++ b/components/TextButtonDropdown.vue
@@ -39,7 +39,7 @@ function handleClick(item: MenuItemType) {
       <div>
         <MenuButton
           :data-testid="`text-dropdown-${label}`"
-          class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-100 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
+          class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
         >
           <SortIcon v-if="showSortIcon" class="h-4 w-4" aria-hidden="true" />
           {{ label }}
@@ -87,7 +87,7 @@ function handleClick(item: MenuItemType) {
     <template #fallback>
       <button
         :data-testid="`text-dropdown-${label}`"
-        class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-200 focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
+        class="inline-flex w-full items-center justify-center gap-x-1.5 rounded-md border border-gray-300 bg-white py-2 pl-3 pr-4 text-xs text-gray-700 transition-colors duration-200 hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 dark:border-gray-600 dark:bg-gray-900 dark:text-white hover:dark:bg-gray-800"
       >
         <SortIcon v-if="showSortIcon" class="h-4 w-4" aria-hidden="true" />
         {{ label }}

--- a/components/nav/RecentForumsDrawer.vue
+++ b/components/nav/RecentForumsDrawer.vue
@@ -126,7 +126,7 @@ const goToForum = (uniqueName: string) => {
               </span>
               <button
                 type="button"
-                class="text-xs text-gray-500 hover:text-gray-700 focus:outline-none dark:text-gray-400 dark:hover:text-gray-200"
+                class="rounded text-xs text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 dark:text-gray-400 dark:hover:text-gray-200"
                 @click="isFindingForum = false"
               >
                 Cancel


### PR DESCRIPTION
## What

The final sweep for **P5** — interactive controls that stripped the focus outline (`focus:outline-none`) without adding a replacement, so keyboard focus was invisible (WCAG 2.4.7 Focus Visible). Added the app's standard focus-visible ring:

- `IconButtonDropdown` — the `MenuButton` trigger **and** its client-only fallback `<button>`
- `TextButtonDropdown` — the `MenuButton` trigger **and** fallback `<button>`
- `nav/RecentForumsDrawer` — the "Cancel" button

`FileTypePicker`'s combobox `<input>` is intentionally borderless, so its focus indicator goes on the **container** via `focus-within:ring` instead of on the input.

## Not changed (intentional `outline-none`)

- Dropdown menu **panels** (`role="menu"`, `tabindex="-1"`) in IconButtonDropdown / TextButtonDropdown / SelectComponent / CreateAnythingButton / EventNotificationsMenu / SortDropdown — focus lands on their menu-item descendants, not the container.
- The **route-focus** `#main-content` regions (`admin.vue`, `forums/[forumId].vue`, discussion/download detail pages, `server/issues.vue`) — these receive focus programmatically after navigation via `tabindex="-1"` and shouldn't paint a full-region outline.

## Tests

Focus-ring regression tests added for the two dropdown triggers and the FileTypePicker container, matching the existing `ThemeSwitcher`/`SearchButton`/`CreateAnythingButton` pattern (stubs updated to forward `$attrs`). All 4 affected specs green (37 tests). `vue-tsc` + ESLint clean.

This closes **P5** — the last phase of the app-wide WCAG remediation campaign (`docs/accessibility-audit-2026-07.md`).