### PR TITLE
Fix channel-scoped rules never loading in BrokenRulesModal (#161)

### DIFF
--- a/components/admin/SelectBrokenRules.spec.ts
+++ b/components/admin/SelectBrokenRules.spec.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { mount } from '@vue/test-utils';
 
 import SelectBrokenRules from '@/components/admin/SelectBrokenRules.vue';
+import { GET_CHANNEL_RULES } from '@/graphQLData/channel/queries';
 
 const h = vi.hoisted(() => ({
   // useQuery is called twice: [0] server rules, [1] channel rules.
@@ -13,13 +14,16 @@ const h = vi.hoisted(() => ({
   channelError: null as unknown,
   channelLoading: null as unknown,
   index: { n: 0 },
+  calls: [] as Array<{ query: unknown; variables: unknown }>,
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
-  useQuery: () =>
-    h.index.n++ === 0
+  useQuery: (query: unknown, variables: unknown) => {
+    h.calls.push({ query, variables });
+    return h.index.n++ === 0
       ? { result: h.serverResult, error: h.serverError, loading: h.serverLoading }
-      : { result: h.channelResult, error: h.channelError, loading: h.channelLoading },
+      : { result: h.channelResult, error: h.channelError, loading: h.channelLoading };
+  },
 }));
 vi.mock('nuxt/app', () => ({ useRoute: () => ({ params: { forumId: 'cats' } }) }));
 
@@ -49,6 +53,7 @@ const buttonByText = (w: ReturnType<typeof mount>, text: string) =>
 beforeEach(() => {
   vi.clearAllMocks();
   h.index.n = 0;
+  h.calls = [];
   h.serverResult = ref({ serverConfigs: [{ rules: ruleJSON(['No spam']) }] });
   h.serverError = ref(null);
   h.serverLoading = ref(false);
@@ -70,6 +75,30 @@ describe('SelectBrokenRules states', () => {
     const wrapper = mountRules();
 
     expect(wrapper.find('.err').text()).toContain('boom');
+  });
+});
+
+describe('SelectBrokenRules channel-rules query wiring', () => {
+  const resolveVariables = (variables: unknown) =>
+    typeof variables === 'function' ? variables() : variables;
+
+  it('invokes the channel-rules query with the forumId as a reactive uniqueName variable', () => {
+    mountRules();
+
+    // useQuery call [1] is the channel rules query (see mock ordering).
+    expect({
+      query: h.calls[1]?.query,
+      variables: resolveVariables(h.calls[1]?.variables),
+    }).toEqual({ query: GET_CHANNEL_RULES, variables: { uniqueName: 'cats' } });
+  });
+
+  it('renders both the forum and server rule sections when both queries return rules', () => {
+    const wrapper = mountRules();
+
+    expect({
+      forum: wrapper.find('[data-testid="forum-rules-section"]').exists(),
+      server: wrapper.text().includes('Server Rules'),
+    }).toEqual({ forum: true, server: true });
   });
 });
 

--- a/components/admin/SelectBrokenRules.vue
+++ b/components/admin/SelectBrokenRules.vue
@@ -39,9 +39,9 @@ const {
   loading: channelRulesLoading,
   error: channelRulesError,
   result: channelRulesResult,
-} = useQuery(GET_CHANNEL_RULES, {
-  uniqueName: forumId,
-});
+} = useQuery(GET_CHANNEL_RULES, () => ({
+  uniqueName: forumId.value,
+}));
 
 const getRules = (rulesJSON: string): RuleOption[] => {
   const rules: RuleOption[] = [];


### PR DESCRIPTION
## Summary

Fixes #161. In `components/admin/SelectBrokenRules.vue`, the channel-scoped rules never loaded in the broken-rules modal — only server rules rendered. The `getChannelRules` query made no network request at all.

**Root cause:** `useQuery(GET_CHANNEL_RULES, ...)` was passed the `forumId` **`ComputedRef`** directly as the `uniqueName` variable:

```ts
useQuery(GET_CHANNEL_RULES, {
  uniqueName: forumId, // ComputedRef, not unwrapped
});
```

Because the ref was never unwrapped, Apollo could not construct a valid `String!` variable and the request was never sent.

**Fix:** switch to the reactive-getter form used everywhere else in the codebase (e.g. `DiscussionDetails.vue`, `ModProfileSidebar.vue`) so the variable resolves to the forum slug:

```ts
useQuery(GET_CHANNEL_RULES, () => ({
  uniqueName: forumId.value,
}));
```

## Why this wasn't caught before

The existing `SelectBrokenRules.spec.ts` mocked `useQuery` with a factory that **discarded its arguments**, so it could not detect wrong query variables. This PR upgrades the mock to record each call and adds tests that:

1. Assert the channel-rules query is invoked with `{ uniqueName: 'cats' }` (fails on the old code, passes only with the reactive-getter fix — a genuine regression guard).
2. Assert both the forum and server rule sections render when both queries return rules.

## Testing

- `pnpm run test:unit` — full suite passes (6886 tests), including the new cases
- `pnpm run tsc` — no type errors
- `pnpm exec eslint` on both changed files — clean

## Files changed

- `components/admin/SelectBrokenRules.vue` — reactive-getter fix (one line)
- `components/admin/SelectBrokenRules.spec.ts` — arg-capturing mock + 2 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzHtVwJgY3x67KbyWuZmnS)_