### PR TITLE
Set dummy NUXT_AUTH0_* env in mocked build Playwright webServer (#227)

### DIFF
--- a/playwright.build.config.ts
+++ b/playwright.build.config.ts
@@ -63,6 +63,17 @@ export default defineConfig({
           VITE_E2E_MOCK_MODE: 'true',
           VITE_GRAPHQL_URL: graphqlURL,
           VITE_SERVER_NAME: 'Playwright Test Server',
+          // Auth is mocked in this suite (VITE_E2E_MOCK_MODE seeds the session
+          // from a cookie, see server/middleware/2.auth-session.ts), but the
+          // @auth0/auth0-nuxt Nitro startup plugin still validates its config
+          // and throws "Auth0 configuration error: Domain is required" on boot
+          // when these are empty. These dummy NUXT_AUTH0_* values only satisfy
+          // that check (runtimeConfig.auth0.*) — they are never used for real
+          // authentication here.
+          NUXT_AUTH0_DOMAIN: 'example.com',
+          NUXT_AUTH0_CLIENT_ID: 'playwright-test-client',
+          NUXT_AUTH0_CLIENT_SECRET: 'playwright-test-secret',
+          NUXT_AUTH0_SESSION_SECRET: 'playwright-test-session-secret',
         },
         url: baseURL,
         reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Summary

Fixes #227. The build-based mocked Playwright suite (`playwright.build.config.ts`) logged `Auth0 configuration error: Domain is required` as an `unhandledRejection` on every run.

**Root cause:** The build config serves a production Nitro build (`node .output/server/index.mjs`). The `@auth0/auth0-nuxt` module registers a **Nitro startup plugin** that validates its config (`runtimeConfig.auth0.*`) and throws when `domain` / `clientId` / `clientSecret` / `sessionSecret` are empty:

```js
// node_modules/@auth0/auth0-nuxt/.../plugins/auth.server.js
if (!options.domain) throw new Error("Auth0 configuration error: Domain is required");
```

Because it throws in a startup plugin — outside the auth middleware's own try/catch — it surfaces as an `unhandledRejection`. The `webServer.env` block set only `VITE_*` / `NITRO_*` vars, leaving those Auth0 fields empty.

**Fix:** Add dummy `NUXT_AUTH0_DOMAIN`, `NUXT_AUTH0_CLIENT_ID`, `NUXT_AUTH0_CLIENT_SECRET`, and `NUXT_AUTH0_SESSION_SECRET` to `webServer.env` (these are the `NUXT_AUTH0_*` names the frontend module reads via runtimeConfig; `appBaseUrl` already has a non-empty default). Auth is fully mocked here — `VITE_E2E_MOCK_MODE` seeds the session from a cookie in `server/middleware/2.auth-session.ts` — so the values only need to satisfy the plugin's presence check and are never used for real authentication.

## Testing

Booted the actual mock-mode node build (`NITRO_PRESET=node_server ... npx nuxt build`, then `node .output/server/index.mjs`) both ways:

- **Without** the vars → boot logs `[unhandledRejection] Error: Auth0 configuration error: Domain is required`
- **With** the vars → server boots clean (`Listening on http://127.0.0.1:...`), no Auth0 error

ESLint passes on the changed file.

## Files changed

- `playwright.build.config.ts` — add four dummy `NUXT_AUTH0_*` vars to the mocked build `webServer.env`, with an explanatory comment.

## Acceptance

- ✅ The mocked build Playwright run no longer logs `Auth0 configuration error: Domain is required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzHtVwJgY3x67KbyWuZmnS)_