### PR TITLE
Add label_update case to ActivityFeedListItem (#188)

### DIFF
--- a/components/mod/ActivityFeedListItem.spec.ts
+++ b/components/mod/ActivityFeedListItem.spec.ts
@@ -353,6 +353,23 @@ describe('ActivityFeedListItem', () => {
     expect(wrapper.text()).toContain('Server Admin');
   });
 
+  it('renders a dedicated label-update phrase and icon for a label_update action', () => {
+    const wrapper = mountWrapper({
+      activityItem: makeActivityItem({
+        actionType: 'label_update',
+        actionDescription: 'updated the labels on the download',
+        Comment: null,
+        ModerationProfile: { displayName: 'mod-bob' },
+        User: null,
+      }),
+    });
+
+    expect({
+      phrase: wrapper.text().includes('the download labels were updated by'),
+      hasIcon: wrapper.find('svg').exists(),
+    }).toEqual({ phrase: true, hasIcon: true });
+  });
+
   it('shows a suspend button when the activity actor targets the issue mod', () => {
     const wrapper = mountWrapper({
       issue: {

--- a/components/mod/ActivityFeedListItem.vue
+++ b/components/mod/ActivityFeedListItem.vue
@@ -20,6 +20,7 @@ import FlagIcon from '../icons/FlagIcon.vue';
 import XCircleIcon from '../icons/XCircleIcon.vue';
 import PencilIcon from '../icons/PencilIcon.vue';
 import TrashIcon from '../icons/TrashIcon.vue';
+import TagIcon from '../icons/TagIcon.vue';
 import { ActionType } from '@/types/Comment';
 import { useMutation } from '@vue/apollo-composable';
 import { UPDATE_COMMENT } from '@/graphQLData/comment/mutations';
@@ -52,6 +53,7 @@ const actionTypeToIcon: Record<string, Component> = {
   [ActionType.Edit]: PencilIcon,
   edit_content: PencilIcon,
   [ActionType.Delete]: TrashIcon,
+  label_update: TagIcon,
 };
 
 const props = defineProps({
@@ -235,6 +237,8 @@ const actionPhrase = computed(() => {
       return `the ${contentNoun} was unarchived by`;
     case ActionType.Report:
       return `the ${contentNoun} was reported by`;
+    case 'label_update':
+      return `the ${contentNoun} labels were updated by`;
     case ActionType.Comment:
       return 'a comment was added by';
     case ActionType.Suspension:


### PR DESCRIPTION
## Summary

Fixes #188. `components/mod/ActivityFeedListItem.vue` switched on `actionType` for close / edit / archive / report / suspension / etc. but had **no `label_update` case**. Download label-change moderation actions (`actionType: "label_update"`, created by the backend `updateDownloadLabels` resolver) therefore fell through to the `default` branch — no dedicated icon, and the raw `actionDescription` rendered instead of a clear passive phrase.

## Changes

1. **Icon** — import `TagIcon` and add `label_update: TagIcon` to the `actionTypeToIcon` map (following the existing non-enum `edit_content` key pattern).
2. **Phrase** — add a `case 'label_update'` to `actionPhrase` returning `` `the ${contentNoun} labels were updated by` ``, consistent with the passive-phrase style every other moderation action type uses. The content noun ("download", etc.) is derived from the action description via the existing `getContentNoun` helper.
3. **Test** — add a unit test asserting a `label_update` activity item renders the dedicated phrase **and** an icon. (The icon assertion proves the map entry is wired: without it, `<component :is="undefined">` would render no `svg`.)

## Testing

- `pnpm run test:unit` — full suite passes (6887 tests), including the new case
- `pnpm run tsc` — no type errors
- `pnpm exec eslint` on both changed files — clean

## Note on observability

Live end-to-end observability of this action is still blocked until the backend actually creates the `label_update` ModerationAction (gennit-project/multiforum-backend#92). This PR covers the **frontend rendering** and is verified by the unit test — consistent with the issue's "add a `label_update` case + unit test" acceptance criteria.

## Files changed

- `components/mod/ActivityFeedListItem.vue` — icon map entry + `actionPhrase` case
- `components/mod/ActivityFeedListItem.spec.ts` — unit test for a `label_update` item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzHtVwJgY3x67KbyWuZmnS)_