### PR TITLE
feat: improve plugin configuration integrity

### DIFF
--- a/components/admin/plugins/PluginSecretsSection.spec.ts
+++ b/components/admin/plugins/PluginSecretsSection.spec.ts
@@ -41,14 +41,22 @@ describe('PluginSecretsSection rendering', () => {
   });
 
   it.each([
-    ['VALID', 'Valid'],
+    ['VALID', '✓ Set and valid'],
     ['INVALID', 'Invalid'],
-    ['SET_UNTESTED', 'Set'],
+    ['SET_UNTESTED', '✓ Set (untested)'],
     ['NOT_SET', 'Not set'],
   ])('shows %s status as "%s"', (status, label) => {
     const wrapper = mountSection({ secrets: [secret({ status })] });
 
     expect(wrapper.text()).toContain(label);
+  });
+
+  it('calls out a required secret that has not been set', () => {
+    const wrapper = mountSection({
+      secrets: [secret({ status: 'NOT_SET', required: true })],
+    });
+
+    expect(wrapper.text()).toContain('Required — not set');
   });
 
   it('labels the toggle "Set Secret" when not set', () => {
@@ -82,7 +90,7 @@ describe('PluginSecretsSection orphaned secrets', () => {
     }).toEqual({
       hasHeading: true,
       hasExplanation: true,
-      item: 'OLD_API_KEYSet',
+      item: 'OLD_API_KEY✓ Set (untested)',
     });
   });
 

--- a/components/admin/plugins/PluginSecretsSection.spec.ts
+++ b/components/admin/plugins/PluginSecretsSection.spec.ts
@@ -19,7 +19,7 @@ const mountSection = (props: Record<string, unknown> = {}) =>
     },
     global: {
       stubs: {
-        FormRow: { props: ['sectionTitle'], template: '<div><slot name="content" /></div>' },
+        FormRow: { props: ['sectionTitle'], template: '<div>{{ sectionTitle }}<slot name="content" /></div>' },
       },
     },
   });
@@ -61,6 +61,40 @@ describe('PluginSecretsSection rendering', () => {
     const wrapper = mountSection({ secrets: [secret({ status: 'VALID' })] });
 
     expect(buttonByText(wrapper, 'Update Secret')).toBeTruthy();
+  });
+});
+
+describe('PluginSecretsSection orphaned secrets', () => {
+  it('shows stored secrets that are unused by the installed version separately', () => {
+    const wrapper = mountSection({
+      secrets: [],
+      orphanedSecrets: [
+        { key: 'OLD_API_KEY', status: 'SET_UNTESTED' },
+      ],
+    });
+
+    expect({
+      hasHeading: wrapper.text().includes('Stored Secrets Not Used by This Version'),
+      hasExplanation: wrapper.text().includes(
+        'These secrets are retained for rollback compatibility.'
+      ),
+      item: wrapper.get('li').text(),
+    }).toEqual({
+      hasHeading: true,
+      hasExplanation: true,
+      item: 'OLD_API_KEYSet',
+    });
+  });
+
+  it('does not offer an edit action for an orphaned secret', () => {
+    const wrapper = mountSection({
+      secrets: [],
+      orphanedSecrets: [
+        { key: 'OLD_API_KEY', status: 'SET_UNTESTED' },
+      ],
+    });
+
+    expect(wrapper.findAll('button')).toHaveLength(0);
   });
 });
 

--- a/components/admin/plugins/PluginSecretsSection.vue
+++ b/components/admin/plugins/PluginSecretsSection.vue
@@ -11,6 +11,7 @@ interface PluginSecretStatus {
 
 const props = defineProps<{
   secrets: PluginSecretStatus[];
+  orphanedSecrets?: PluginSecretStatus[];
   secretValues: Record<string, string>;
   showSecretInputs: Record<string, boolean>;
 }>();
@@ -195,6 +196,43 @@ const getSecretStatusText = (status: string) => {
             </button>
           </div>
         </div>
+      </div>
+    </template>
+  </FormRow>
+
+  <FormRow
+    v-if="orphanedSecrets?.length"
+    section-title="Stored Secrets Not Used by This Version"
+  >
+    <template #content>
+      <div class="space-y-3">
+        <div
+          class="rounded-md border border-sky-200 bg-sky-50 p-3 text-sm text-sky-900 dark:border-sky-700 dark:bg-sky-900/30 dark:text-sky-200"
+        >
+          <p class="font-medium">These secrets are retained for rollback compatibility.</p>
+          <p class="mt-1">
+            The installed plugin version no longer declares them. They are not required
+            for enablement and will not be removed automatically.
+          </p>
+        </div>
+
+        <ul class="divide-y divide-gray-200 rounded-lg border border-gray-200 dark:divide-gray-700 dark:border-gray-700">
+          <li
+            v-for="secret in orphanedSecrets"
+            :key="secret.key"
+            class="flex items-center justify-between gap-4 p-4"
+          >
+            <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">
+              {{ secret.key }}
+            </span>
+            <span
+              class="rounded-full px-2 py-1 text-xs font-semibold"
+              :class="getSecretStatusColor(secret.status)"
+            >
+              {{ getSecretStatusText(secret.status) }}
+            </span>
+          </li>
+        </ul>
       </div>
     </template>
   </FormRow>

--- a/components/admin/plugins/PluginSecretsSection.vue
+++ b/components/admin/plugins/PluginSecretsSection.vue
@@ -7,6 +7,7 @@ interface PluginSecretStatus {
   status: 'NOT_SET' | 'SET_UNTESTED' | 'VALID' | 'INVALID';
   lastValidatedAt?: string;
   validationError?: string;
+  required?: boolean;
 }
 
 const props = defineProps<{
@@ -63,22 +64,22 @@ const getSecretStatusColor = (status: string) => {
   }
 };
 
-const getSecretStatusText = (status: string) => {
-  switch (status) {
+const getSecretStatusText = (secret: PluginSecretStatus) => {
+  switch (secret.status) {
     case 'VALID':
-      return 'Valid';
+      return '✓ Set and valid';
     case 'INVALID':
       return 'Invalid';
     case 'SET_UNTESTED':
-      return 'Set';
+      return '✓ Set (untested)';
     default:
-      return 'Not set';
+      return secret.required ? 'Required — not set' : 'Not set';
   }
 };
 </script>
 
 <template>
-  <FormRow v-if="secrets.length > 0" section-title="Required Secrets">
+  <FormRow v-if="secrets.length > 0" section-title="Plugin Secrets">
     <template #content>
       <div class="space-y-4">
         <!-- Security warning banner -->
@@ -93,7 +94,7 @@ const getSecretStatusText = (status: string) => {
         </div>
 
         <p class="text-sm text-gray-600 dark:text-gray-400">
-          Configure server-wide secrets required by this plugin.
+          Configure server-wide secrets declared by this plugin.
         </p>
 
         <div
@@ -115,7 +116,7 @@ const getSecretStatusText = (status: string) => {
                 class="font-semibold rounded-full px-2 py-1 text-xs"
                 :class="getSecretStatusColor(secret.status)"
               >
-                {{ getSecretStatusText(secret.status) }}
+                {{ getSecretStatusText(secret) }}
               </span>
             </div>
           </div>
@@ -229,7 +230,7 @@ const getSecretStatusText = (status: string) => {
               class="rounded-full px-2 py-1 text-xs font-semibold"
               :class="getSecretStatusColor(secret.status)"
             >
-              {{ getSecretStatusText(secret.status) }}
+              {{ getSecretStatusText(secret) }}
             </span>
           </li>
         </ul>

--- a/components/admin/plugins/PluginStatusCards.spec.ts
+++ b/components/admin/plugins/PluginStatusCards.spec.ts
@@ -56,10 +56,25 @@ describe('PluginStatusCards disabled state', () => {
     expect(wrapper.emitted('toggle-enabled')?.[0]).toEqual([true]);
   });
 
-  it('prompts to configure secrets when it cannot be enabled', () => {
+  it('prompts to complete required configuration when it cannot be enabled', () => {
     const wrapper = mountCards({ isEnabled: false, canEnable: false });
 
-    expect(wrapper.text()).toContain('Configure required secrets first');
+    expect(wrapper.text()).toContain('Complete required configuration first');
+  });
+
+  it('lists every blocking configuration field', () => {
+    const wrapper = mountCards({
+      canEnable: false,
+      blockingConfigFields: [
+        { key: 'url', label: 'Service URL', kind: 'SETTING' },
+        { key: 'key', label: 'API key', kind: 'SECRET' },
+      ],
+    });
+
+    expect(wrapper.findAll('li').map((item) => item.text())).toEqual([
+      'Service URL (setting)',
+      'API key (secret)',
+    ]);
   });
 
   it('hides the Enable button when it cannot be enabled', () => {

--- a/components/admin/plugins/PluginStatusCards.vue
+++ b/components/admin/plugins/PluginStatusCards.vue
@@ -6,6 +6,12 @@ defineProps<{
   installedVersion?: string | null;
   canEnable: boolean;
   enabling: boolean;
+  blockingConfigFields?: Array<{
+    key: string;
+    label: string;
+    kind: 'SETTING' | 'SECRET';
+    message?: string | null;
+  }>;
 }>();
 
 const emit = defineEmits<{
@@ -78,7 +84,7 @@ const emit = defineEmits<{
           Plugin Disabled
         </p>
         <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-          {{ canEnable ? 'Ready to enable' : 'Configure required secrets first' }}
+          {{ canEnable ? 'Ready to enable' : 'Complete required configuration first' }}
         </p>
         <button
           v-if="canEnable"
@@ -95,10 +101,22 @@ const emit = defineEmits<{
           <i class="fa-solid fa-info-circle mr-1" />
           After enabling, restart the backend for changes to take effect
         </p>
-        <p v-else class="mt-3 text-xs text-gray-500 dark:text-gray-400">
-          <i class="fa-solid fa-lock mr-1" />
-          Configure secrets below to enable
-        </p>
+        <div
+          v-else
+          class="mt-3 w-full rounded-lg border border-amber-300 bg-amber-50 p-3 text-left text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200"
+        >
+          <p class="font-medium">
+            <i class="fa-solid fa-lock mr-1" />
+            Required before enabling
+          </p>
+          <ul v-if="blockingConfigFields?.length" class="mt-2 list-disc space-y-1 pl-5">
+            <li v-for="field in blockingConfigFields" :key="`${field.kind}:${field.key}`">
+              {{ field.label }}
+              <span class="text-xs opacity-80">({{ field.kind.toLowerCase() }})</span>
+            </li>
+          </ul>
+          <p v-else class="mt-1 text-xs">Configure the required fields below.</p>
+        </div>
       </div>
     </div>
   </div>

--- a/components/admin/plugins/PluginUpgradePreviewModal.spec.ts
+++ b/components/admin/plugins/PluginUpgradePreviewModal.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PluginUpgradePreviewModal from './PluginUpgradePreviewModal.vue';
+
+const mountModal = () =>
+  mount(PluginUpgradePreviewModal, {
+    props: {
+      currentVersion: '1.0.0',
+      targetVersion: '2.0.0',
+      report: {
+        carried: ['endpoint'],
+        dropped: ['removed'],
+        reset: ['mode'],
+        newDefaults: ['added'],
+      },
+      secrets: [
+        { key: 'API_KEY', isSet: true },
+        { key: 'NEW_SECRET', isSet: false },
+      ],
+      installing: false,
+    },
+    global: { stubs: { LoadingSpinner: true } },
+  });
+
+describe('PluginUpgradePreviewModal', () => {
+  it('summarizes configuration and secret changes', () => {
+    const wrapper = mountModal();
+
+    expect({
+      groups: wrapper.findAll('h3').map((heading) => heading.text()),
+      values: wrapper.findAll('li').map((item) => item.text()),
+    }).toEqual({
+      groups: [
+        'Carried over (1)',
+        'New defaults (1)',
+        'Reset to default (1)',
+        'Removed (1)',
+        'Required secrets',
+      ],
+      values: [
+        'endpoint',
+        'added',
+        'mode',
+        'removed',
+        'API_KEYAlready set ✓',
+        'NEW_SECRETNeeds setting',
+      ],
+    });
+  });
+
+  it.each([
+    ['Carry over and install', 'carry-over'],
+    ['Start fresh', 'start-fresh'],
+    ['Cancel', 'cancel'],
+  ])('emits %s choice', async (label, event) => {
+    const wrapper = mountModal();
+
+    await wrapper.findAll('button').find((button) => button.text().includes(label))!.trigger('click');
+
+    expect(wrapper.emitted(event)).toHaveLength(1);
+  });
+});

--- a/components/admin/plugins/PluginUpgradePreviewModal.vue
+++ b/components/admin/plugins/PluginUpgradePreviewModal.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import type { PluginUpgradeReport } from '@/utils/pluginUpgradeUtils';
+
+defineProps<{
+  currentVersion: string;
+  targetVersion: string;
+  report: PluginUpgradeReport;
+  secrets: Array<{ key: string; isSet: boolean }>;
+  installing: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'carry-over' | 'start-fresh' | 'cancel'): void;
+}>();
+
+const groups = [
+  { key: 'carried', label: 'Carried over' },
+  { key: 'newDefaults', label: 'New defaults' },
+  { key: 'reset', label: 'Reset to default' },
+  { key: 'dropped', label: 'Removed' },
+] as const;
+</script>
+
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <section
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="plugin-upgrade-preview-title"
+      class="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-white p-6 shadow-xl dark:bg-gray-900"
+    >
+      <h2 id="plugin-upgrade-preview-title" class="text-xl font-semibold text-gray-900 dark:text-white">
+        Preview upgrade to v{{ targetVersion }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+        Review configuration changes from v{{ currentVersion }} before installing.
+      </p>
+
+      <div class="mt-5 grid gap-3 sm:grid-cols-2">
+        <div
+          v-for="group in groups"
+          :key="group.key"
+          class="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+        >
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-white">
+            {{ group.label }} ({{ report[group.key].length }})
+          </h3>
+          <ul v-if="report[group.key].length" class="mt-2 list-disc pl-5 text-sm text-gray-700 dark:text-gray-300">
+            <li v-for="key in report[group.key]" :key="key" class="font-mono">{{ key }}</li>
+          </ul>
+          <p v-else class="mt-2 text-xs text-gray-500 dark:text-gray-400">None</p>
+        </div>
+      </div>
+
+      <div v-if="secrets.length" class="mt-5 rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Required secrets</h3>
+        <ul class="mt-2 space-y-1 text-sm">
+          <li v-for="secret in secrets" :key="secret.key" class="flex justify-between gap-4">
+            <span class="font-mono text-gray-800 dark:text-gray-200">{{ secret.key }}</span>
+            <span :class="secret.isSet ? 'text-green-700 dark:text-green-300' : 'text-amber-700 dark:text-amber-300'">
+              {{ secret.isSet ? 'Already set ✓' : 'Needs setting' }}
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <button type="button" class="rounded-md px-4 py-2 text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800" :disabled="installing" @click="emit('cancel')">
+          Cancel
+        </button>
+        <button type="button" class="rounded-md border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800" :disabled="installing" @click="emit('start-fresh')">
+          Start fresh
+        </button>
+        <button type="button" class="rounded-md bg-orange-700 px-4 py-2 font-medium text-white hover:bg-orange-800 disabled:opacity-50" :disabled="installing" @click="emit('carry-over')">
+          <LoadingSpinner v-if="installing" class="mr-2 inline-flex" />
+          Carry over and install
+        </button>
+      </div>
+    </section>
+  </div>
+</template>

--- a/graphQLData/admin/mutations.js
+++ b/graphQLData/admin/mutations.js
@@ -78,8 +78,16 @@ export const DISALLOW_PLUGIN = gql`
 `;
 
 export const INSTALL_PLUGIN_VERSION = gql`
-  mutation InstallPluginVersion($pluginId: String!, $version: String!) {
-    installPluginVersion(pluginId: $pluginId, version: $version) {
+  mutation InstallPluginVersion(
+    $pluginId: String!
+    $version: String!
+    $carrySettings: Boolean
+  ) {
+    installPluginVersion(
+      pluginId: $pluginId
+      version: $version
+      carrySettings: $carrySettings
+    ) {
       plugin {
         id
         name
@@ -88,6 +96,7 @@ export const INSTALL_PLUGIN_VERSION = gql`
       scope
       enabled
       settingsJson
+      carryOverReport
     }
   }
 `;

--- a/graphQLData/admin/queries.js
+++ b/graphQLData/admin/queries.js
@@ -583,6 +583,32 @@ export const GET_SERVER_PLUGIN_SECRETS = gql`
   }
 `;
 
+export const GET_PLUGIN_CONFIG_STATUS = gql`
+  query GetPluginConfigStatus(
+    $pluginId: String!
+    $version: String!
+    $scope: String
+  ) {
+    getPluginConfigStatus(
+      pluginId: $pluginId
+      version: $version
+      scope: $scope
+    ) {
+      isFullyConfigured
+      fields {
+        key
+        label
+        scope
+        kind
+        required
+        isSet
+        isValid
+        message
+      }
+    }
+  }
+`;
+
 export const GET_PLUGIN_MANAGEMENT_DATA = gql`
   query GetPluginManagementData($serverName: String!) {
     plugins {

--- a/pages/admin/settings/plugins/[pluginId].spec.ts
+++ b/pages/admin/settings/plugins/[pluginId].spec.ts
@@ -78,7 +78,7 @@ const stubs = {
   },
   PluginSecretsSection: {
     name: 'PluginSecretsSection',
-    props: ['secrets', 'secretValues', 'showSecretInputs'],
+    props: ['secrets', 'orphanedSecrets', 'secretValues', 'showSecretInputs'],
     emits: ['set-secret', 'update:secretValues', 'update:showSecretInputs'],
     template: '<button type="button" data-test="set-secret" @click="$emit(\'set-secret\', \'API_KEY\', \'xyz\')">Set secret</button>',
   },
@@ -204,6 +204,20 @@ describe('Plugin detail page', () => {
       secrets: [{ key: 'API_KEY', status: 'NOT_SET' }],
       fields: [{ key: 'serviceUrl', label: 'Service URL', type: 'text' }],
     });
+  });
+
+  it('separates stored secrets that the installed version no longer declares', () => {
+    setInstalledPlugin({ manifest: { secrets: [] } });
+    h.q.SECRETS.result.value = {
+      getServerPluginSecrets: [
+        { key: 'OLD_API_KEY', status: 'SET_UNTESTED' },
+      ],
+    };
+    const wrapper = mountPage();
+
+    expect(
+      wrapper.findComponent({ name: 'PluginSecretsSection' }).props('orphanedSecrets')
+    ).toEqual([{ key: 'OLD_API_KEY', status: 'SET_UNTESTED' }]);
   });
 
   it('hides the installed-only sections for an uninstalled plugin', () => {

--- a/pages/admin/settings/plugins/[pluginId].spec.ts
+++ b/pages/admin/settings/plugins/[pluginId].spec.ts
@@ -207,7 +207,7 @@ describe('Plugin detail page', () => {
       secrets: wrapper.findComponent({ name: 'PluginSecretsSection' }).props('secrets'),
       fields: wrapper.findComponent({ name: 'PluginSettingsSection' }).props('sections')[0].fields,
     }).toEqual({
-      secrets: [{ key: 'API_KEY', status: 'NOT_SET' }],
+      secrets: [{ key: 'API_KEY', status: 'NOT_SET', required: true }],
       fields: [{ key: 'serviceUrl', label: 'Service URL', type: 'text' }],
     });
   });

--- a/pages/admin/settings/plugins/[pluginId].spec.ts
+++ b/pages/admin/settings/plugins/[pluginId].spec.ts
@@ -70,6 +70,12 @@ const stubs = {
   PluginDetailHeader: { name: 'PluginDetailHeader', props: ['pluginDisplayName'], template: '<div class="header">{{ pluginDisplayName }}</div>' },
   PluginStatusCards: { name: 'PluginStatusCards', props: ['isEnabled', 'canEnable', 'enabling', 'blockingConfigFields'], emits: ['toggle-enabled'], template: '<button type="button" data-test="toggle-enabled" @click="$emit(\'toggle-enabled\', false)" />' },
   PluginUpdateBanner: sectionStub('PluginUpdateBanner'),
+  PluginUpgradePreviewModal: {
+    name: 'PluginUpgradePreviewModal',
+    props: ['currentVersion', 'targetVersion', 'report', 'secrets', 'installing'],
+    emits: ['carry-over', 'start-fresh', 'cancel'],
+    template: '<div data-test="upgrade-preview"><button data-test="carry-upgrade" @click="$emit(\'carry-over\')">Carry</button><button data-test="fresh-upgrade" @click="$emit(\'start-fresh\')">Fresh</button></div>',
+  },
   PluginInstallSection: {
     name: 'PluginInstallSection',
     props: ['modelValue', 'canInstall', 'compatibilityByVersion'],
@@ -285,6 +291,74 @@ describe('Plugin detail page', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('Plugin version not found in registry.');
+  });
+
+  it('previews an upgrade and carries settings only after confirmation', async () => {
+    setInstalledPlugin({
+      version: '1.0.0',
+      settingsJson: { endpoint: 'https://custom.example', removed: true },
+    });
+    setAvailablePlugin({ Versions: [{ version: '1.0.0' }, { version: '2.0.0' }] });
+    h.q.DETAIL.result.value = {
+      plugins: [{
+        id: PLUGIN_ID,
+        Versions: [{
+          version: '2.0.0',
+          manifest: {
+            secrets: [{ key: 'API_KEY', scope: 'server', required: true }],
+            settingsDefaults: { server: { endpoint: 'default', added: true } },
+            ui: {
+              forms: {
+                server: [{
+                  title: 'Settings',
+                  fields: [
+                    { key: 'endpoint', label: 'Endpoint', type: 'text' },
+                    { key: 'added', label: 'Added', type: 'toggle' },
+                  ],
+                }],
+              },
+            },
+          },
+        }],
+      }],
+    };
+    h.q.SECRETS.result.value = {
+      getServerPluginSecrets: [{ key: 'API_KEY', status: 'SET_UNTESTED' }],
+    };
+    const wrapper = mountPage();
+    const installSection = wrapper.findComponent({ name: 'PluginInstallSection' });
+
+    installSection.vm.$emit('update:modelValue', '2.0.0');
+    await flushPromises();
+    await wrapper.get('[data-test="install"]').trigger('click');
+    await flushPromises();
+    const previewProps = wrapper
+      .findComponent({ name: 'PluginUpgradePreviewModal' })
+      .props();
+    await wrapper.get('[data-test="carry-upgrade"]').trigger('click');
+    await flushPromises();
+
+    expect({
+      preview: previewProps,
+      installArgs: h.mutations.INSTALL_M?.mutate.mock.calls[0]?.[0],
+    }).toMatchObject({
+      preview: {
+        currentVersion: '1.0.0',
+        targetVersion: '2.0.0',
+        report: {
+          carried: ['endpoint'],
+          dropped: ['removed'],
+          reset: [],
+          newDefaults: ['added'],
+        },
+        secrets: [{ key: 'API_KEY', isSet: true }],
+      },
+      installArgs: {
+        pluginId: PLUGIN_ID,
+        version: '2.0.0',
+        carrySettings: true,
+      },
+    });
   });
 
   it('toggles enabled state via the status cards', async () => {

--- a/pages/admin/settings/plugins/[pluginId].spec.ts
+++ b/pages/admin/settings/plugins/[pluginId].spec.ts
@@ -20,6 +20,7 @@ vi.mock('@/graphQLData/admin/queries', () => ({
   GET_AVAILABLE_PLUGINS: 'AVAILABLE',
   GET_INSTALLED_PLUGINS: 'INSTALLED',
   GET_SERVER_PLUGIN_SECRETS: 'SECRETS',
+  GET_PLUGIN_CONFIG_STATUS: 'CONFIG_STATUS',
   GET_PLUGIN_DETAIL: 'DETAIL',
 }));
 vi.mock('@/graphQLData/admin/mutations', () => ({
@@ -48,6 +49,7 @@ vi.mock('@vue/apollo-composable', async () => {
     INSTALLED: { result: ref(null), loading: ref(false), error: ref(null), refetch: vi.fn() },
     DETAIL: { result: ref(null), loading: ref(false), error: ref(null), refetch: vi.fn() },
     SECRETS: { result: ref(null), loading: ref(false), error: ref(null), refetch: vi.fn() },
+    CONFIG_STATUS: { result: ref(null), loading: ref(false), error: ref(null), refetch: vi.fn() },
   };
   return {
     useQuery: (doc: keyof typeof h.q) => h.q[doc],
@@ -66,7 +68,7 @@ vi.mock('@/composables/useToast', () => ({ useToast: () => toast }));
 const sectionStub = (name: string) => ({ name, template: `<div data-stub="${name}" />` });
 const stubs = {
   PluginDetailHeader: { name: 'PluginDetailHeader', props: ['pluginDisplayName'], template: '<div class="header">{{ pluginDisplayName }}</div>' },
-  PluginStatusCards: { name: 'PluginStatusCards', props: ['isEnabled', 'canEnable', 'enabling'], emits: ['toggle-enabled'], template: '<button type="button" data-test="toggle-enabled" @click="$emit(\'toggle-enabled\', false)" />' },
+  PluginStatusCards: { name: 'PluginStatusCards', props: ['isEnabled', 'canEnable', 'enabling', 'blockingConfigFields'], emits: ['toggle-enabled'], template: '<button type="button" data-test="toggle-enabled" @click="$emit(\'toggle-enabled\', false)" />' },
   PluginUpdateBanner: sectionStub('PluginUpdateBanner'),
   PluginInstallSection: {
     name: 'PluginInstallSection',
@@ -133,6 +135,9 @@ const setInstalledPlugin = (overrides: Record<string, unknown> = {}) => {
     ],
   };
   h.q.SECRETS.result.value = { getServerPluginSecrets: [] };
+  h.q.CONFIG_STATUS.result.value = {
+    getPluginConfigStatus: { isFullyConfigured: true, fields: [] },
+  };
 };
 
 beforeEach(() => {
@@ -171,6 +176,34 @@ describe('Plugin detail page', () => {
     const wrapper = mountPage();
 
     expect(wrapper.findComponent({ name: 'PluginStatusCards' }).exists()).toBe(true);
+  });
+
+  it('renders a declared missing secret once and removes its duplicate form field', () => {
+    setInstalledPlugin({
+      manifest: {
+        secrets: [{ key: 'API_KEY', scope: 'server', required: true }],
+        ui: {
+          forms: {
+            server: [{
+              title: 'Settings',
+              fields: [
+                { key: 'API_KEY', label: 'API key', type: 'secret' },
+                { key: 'serviceUrl', label: 'Service URL', type: 'text' },
+              ],
+            }],
+          },
+        },
+      },
+    });
+    const wrapper = mountPage();
+
+    expect({
+      secrets: wrapper.findComponent({ name: 'PluginSecretsSection' }).props('secrets'),
+      fields: wrapper.findComponent({ name: 'PluginSettingsSection' }).props('sections')[0].fields,
+    }).toEqual({
+      secrets: [{ key: 'API_KEY', status: 'NOT_SET' }],
+      fields: [{ key: 'serviceUrl', label: 'Service URL', type: 'text' }],
+    });
   });
 
   it('hides the installed-only sections for an uninstalled plugin', () => {

--- a/pages/admin/settings/plugins/[pluginId].vue
+++ b/pages/admin/settings/plugins/[pluginId].vue
@@ -8,6 +8,7 @@ import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import PluginDetailHeader from '@/components/admin/plugins/PluginDetailHeader.vue';
 import PluginStatusCards from '@/components/admin/plugins/PluginStatusCards.vue';
 import PluginUpdateBanner from '@/components/admin/plugins/PluginUpdateBanner.vue';
+import PluginUpgradePreviewModal from '@/components/admin/plugins/PluginUpgradePreviewModal.vue';
 import PluginInstallSection from '@/components/admin/plugins/PluginInstallSection.vue';
 import PluginSecretsSection from '@/components/admin/plugins/PluginSecretsSection.vue';
 import PluginSettingsSection from '@/components/admin/plugins/PluginSettingsSection.vue';
@@ -36,6 +37,10 @@ import {
   getPluginFormSections,
   stringifyManifest,
 } from '@/utils/pluginManifestUtils';
+import {
+  buildPluginUpgradePreview,
+  type PluginUpgradeReport,
+} from '@/utils/pluginUpgradeUtils';
 import type {
   PluginFormSection,
   PluginSecretStatus as PluginSecretStatusType,
@@ -73,6 +78,11 @@ const settingsValues = ref<PluginSettings>({});
 const settingsErrors = ref<Record<string, string>>({});
 const savingSettings = ref(false);
 const installError = ref<string | null>(null);
+const pendingUpgrade = ref<{
+  version: string;
+  report: PluginUpgradeReport;
+  secrets: Array<{ key: string; isSet: boolean }>;
+} | null>(null);
 
 // Types
 interface PluginSecretStatus {
@@ -189,6 +199,7 @@ interface PluginFromQuery {
     sourceCommit?: string | null;
     minServerVersion?: string | null;
     apiVersion?: string | null;
+    manifest?: PluginManifest;
   }>;
 }
 
@@ -306,11 +317,13 @@ const pluginLicense = computed(() => pluginMeta.value.license);
 const pluginTags = computed(() => pluginMeta.value.tags);
 
 // Get versions with full details from the plugin detail query
-const pluginDetailVersions = computed(() => {
+const pluginDetailVersions = computed(
+  (): NonNullable<PluginFromQuery['Versions']> => {
   const plugins = pluginDetailResult.value?.plugins || [];
   const pluginDetail = plugins.find((p: PluginFromQuery) => p.id === pluginId);
   return pluginDetail?.Versions || [];
-});
+  }
+);
 
 const pluginReadme = computed(() =>
   resolvePluginReadme({
@@ -477,26 +490,15 @@ watch(
 );
 
 // Methods
-const handleInstall = async (versionOverride?: string) => {
-  const versionToInstall = versionOverride || selectedVersion.value;
-  if (!versionToInstall) {
-    installError.value = 'No version selected';
-    return;
-  }
-
-  const compatibility = compatibilityByVersion.value[versionToInstall];
-  if (compatibility?.compatible === false) {
-    installError.value = compatibility.reason;
-    return;
-  }
-
-  // Clear any previous error
-  installError.value = null;
-
+const performInstall = async (
+  versionToInstall: string,
+  carrySettings: boolean
+): Promise<boolean> => {
   try {
     const result = await installMutation({
       pluginId,
       version: versionToInstall,
+      carrySettings,
     });
 
     // Check for GraphQL errors in the result
@@ -505,7 +507,7 @@ const handleInstall = async (versionOverride?: string) => {
         .map((e: { message: string }) => e.message)
         .join(', ');
       installError.value = `Installation failed: ${errorMsg}`;
-      return;
+      return false;
     }
 
     toast.success(
@@ -519,11 +521,75 @@ const handleInstall = async (versionOverride?: string) => {
     await refetchInstalled();
     await refetchSecrets();
     await refetchConfigStatus();
+    return true;
   } catch (err: unknown) {
     console.error('Install error:', err);
     const errorMessage = err instanceof Error ? err.message : '';
     installError.value = mapInstallErrorMessage(errorMessage);
+    return false;
   }
+};
+
+const handleInstall = async (versionOverride?: string) => {
+  const versionToInstall = versionOverride || selectedVersion.value;
+  if (!versionToInstall) {
+    installError.value = 'No version selected';
+    return;
+  }
+
+  const compatibility = compatibilityByVersion.value[versionToInstall];
+  if (compatibility?.compatible === false) {
+    installError.value = compatibility.reason;
+    return;
+  }
+
+  installError.value = null;
+
+  if (installedPlugin.value && versionToInstall !== installedVersion.value) {
+    const targetManifest = pluginDetailVersions.value.find(
+      (candidate) => candidate.version === versionToInstall
+    )?.manifest;
+    if (!targetManifest) {
+      installError.value =
+        'Upgrade preview is unavailable because the target manifest has not loaded.';
+      return;
+    }
+
+    const preview = buildPluginUpgradePreview({
+      oldSettings: installedPlugin.value.settingsJson || {},
+      newManifest: targetManifest,
+    });
+    const targetSecrets = (targetManifest.secrets || [])
+      .filter(
+        (secret) =>
+          (!secret.scope || secret.scope === 'server') &&
+          secret.required !== false
+      )
+      .map((secret) => ({
+        key: secret.key,
+        isSet: storedSecrets.value.some(
+          (stored) =>
+            stored.key === secret.key && stored.status !== 'NOT_SET'
+        ),
+      }));
+    pendingUpgrade.value = {
+      version: versionToInstall,
+      report: preview.report,
+      secrets: targetSecrets,
+    };
+    return;
+  }
+
+  await performInstall(versionToInstall, false);
+};
+
+const confirmUpgrade = async (carrySettings: boolean) => {
+  if (!pendingUpgrade.value) return;
+  const installed = await performInstall(
+    pendingUpgrade.value.version,
+    carrySettings
+  );
+  if (installed) pendingUpgrade.value = null;
 };
 
 const handleToggleEnabled = async (enabled: boolean) => {
@@ -771,6 +837,18 @@ const handleSaveSettings = async () => {
           <PluginReadmeSection
             :plugin-readme="pluginReadme"
             :plugin-detail-loading="pluginDetailLoading"
+          />
+
+          <PluginUpgradePreviewModal
+            v-if="pendingUpgrade && installedVersion"
+            :current-version="installedVersion"
+            :target-version="pendingUpgrade.version"
+            :report="pendingUpgrade.report"
+            :secrets="pendingUpgrade.secrets"
+            :installing="installing"
+            @carry-over="confirmUpgrade(true)"
+            @start-fresh="confirmUpgrade(false)"
+            @cancel="pendingUpgrade = null"
           />
         </div>
       </template>

--- a/pages/admin/settings/plugins/[pluginId].vue
+++ b/pages/admin/settings/plugins/[pluginId].vue
@@ -23,7 +23,6 @@ import {
 import {
   resolvePluginMetadata,
   resolvePluginReadme,
-  canEnablePlugin,
   sortVersionsDescending,
   hasNewerVersions as hasNewerVersionsUtil,
   mapInstallErrorMessage,
@@ -46,6 +45,7 @@ import {
   GET_AVAILABLE_PLUGINS,
   GET_INSTALLED_PLUGINS,
   GET_SERVER_PLUGIN_SECRETS,
+  GET_PLUGIN_CONFIG_STATUS,
   GET_PLUGIN_DETAIL,
 } from '@/graphQLData/admin/queries';
 import {
@@ -82,6 +82,17 @@ interface PluginSecretStatus {
   validationError?: string;
 }
 
+interface PluginConfigFieldStatus {
+  key: string;
+  label: string;
+  scope: string;
+  kind: 'SETTING' | 'SECRET';
+  required: boolean;
+  isSet: boolean;
+  isValid: boolean;
+  message?: string | null;
+}
+
 interface PluginMetadata {
   id: string;
   name: string;
@@ -95,6 +106,11 @@ interface PluginMetadata {
 }
 
 interface PluginManifest {
+  secrets?: Array<{
+    key: string;
+    scope?: string;
+    required?: boolean;
+  }>;
   ui?: {
     forms?: {
       server?: PluginFormSection[];
@@ -207,12 +223,58 @@ const {
   enabled: computed(() => !!pluginSlug.value),
 });
 
-const secrets = computed((): PluginSecretStatus[] => {
+const storedSecrets = computed((): PluginSecretStatus[] => {
   return secretsResult.value?.getServerPluginSecrets || [];
 });
 
+const declaredServerSecretKeys = computed(() =>
+  new Set(
+    (installedPlugin.value?.manifest?.secrets || [])
+      .filter((secret) => !secret.scope || secret.scope === 'server')
+      .map((secret) => secret.key)
+  )
+);
+
+const secrets = computed((): PluginSecretStatus[] =>
+  [...declaredServerSecretKeys.value].map((key) =>
+    storedSecrets.value.find((secret) => secret.key === key) || {
+      key,
+      status: 'NOT_SET',
+    }
+  )
+);
+
 const isInstalled = computed(() => !!installedPlugin.value);
 const isEnabled = computed(() => installedPlugin.value?.enabled ?? false);
+const installedVersion = computed(() => installedPlugin.value?.version);
+
+const configStatusQueryVars = computed(() => ({
+  pluginId: pluginSlug.value,
+  version: installedVersion.value || '',
+  scope: 'server',
+}));
+
+const { result: configStatusResult, refetch: refetchConfigStatus } = useQuery(
+  GET_PLUGIN_CONFIG_STATUS,
+  configStatusQueryVars,
+  {
+    enabled: computed(
+      () => !!pluginSlug.value && !!installedVersion.value
+    ),
+    fetchPolicy: 'cache-and-network',
+  }
+);
+
+const configStatus = computed(() =>
+  configStatusResult.value?.getPluginConfigStatus || null
+);
+
+const blockingConfigFields = computed((): PluginConfigFieldStatus[] =>
+  (configStatus.value?.fields || []).filter(
+    (field: PluginConfigFieldStatus) =>
+      field.required && (!field.isSet || !field.isValid)
+  )
+);
 
 // Only show full-page loading on initial load, not during refetches
 // Check if we're loading AND don't have any data yet
@@ -255,6 +317,13 @@ const pluginReadme = computed(() =>
 // Extract server settings form sections from the plugin manifest
 const serverSettingsSections = computed((): PluginFormSection[] =>
   getPluginFormSections(installedPlugin.value?.manifest, 'server')
+    .map((section) => ({
+      ...section,
+      fields: section.fields.filter(
+        (field) => !declaredServerSecretKeys.value.has(field.key)
+      ),
+    }))
+    .filter((section) => section.fields.length > 0)
 );
 
 // Convert secrets array to the format expected by PluginSecretField
@@ -307,9 +376,9 @@ const pluginApiVersion = computed(
   () => installedPlugin.value?.apiVersion || selectedVersionMetadata.value?.apiVersion
 );
 
-const canEnable = computed(() =>
-  canEnablePlugin({ isInstalled: isInstalled.value, secrets: secrets.value })
-);
+const canEnable = computed(() => {
+  return isInstalled.value && configStatus.value?.isFullyConfigured === true;
+});
 
 const availableVersions = computed(() =>
   sortVersionsDescending(plugin.value?.Versions || [])
@@ -324,10 +393,6 @@ const compatibilityByVersion = computed(() =>
     {} as Record<string, PluginVersionCompatibility>
   )
 );
-
-const installedVersion = computed(() => {
-  return installedPlugin.value?.version;
-});
 
 const isSelectedVersionInstalled = computed(() => {
   return installedVersion.value === selectedVersion.value;
@@ -447,6 +512,7 @@ const handleInstall = async (versionOverride?: string) => {
     // Refetch data
     await refetchInstalled();
     await refetchSecrets();
+    await refetchConfigStatus();
   } catch (err: unknown) {
     console.error('Install error:', err);
     const errorMessage = err instanceof Error ? err.message : '';
@@ -470,12 +536,15 @@ const handleToggleEnabled = async (enabled: boolean) => {
       `Plugin ${plugin.value?.name} ${enabled ? 'enabled' : 'disabled'} successfully`
     );
     await refetchInstalled();
+    await refetchConfigStatus();
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : '';
     if (message.includes('Missing required secrets')) {
       toast.error('Cannot enable: missing required secrets');
     } else if (message.includes('PLUGIN_MISCONFIGURED_REQUIRED_SECRET_MISSING')) {
       toast.error('Plugin misconfigured: required secrets missing');
+    } else if (message.includes('PLUGIN_CONFIG_INCOMPLETE')) {
+      toast.error('Cannot enable: complete all required plugin configuration');
     } else {
       toast.error(`${enabled ? 'Enable' : 'Disable'} failed: ${message || 'Unknown error'}`);
     }
@@ -500,6 +569,7 @@ const handleSetSecret = async (key: string, value: string) => {
 
     // Refetch secrets to update status
     await refetchSecrets();
+    await refetchConfigStatus();
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     toast.error(`Failed to set secret "${key}": ${message}`);
@@ -561,6 +631,7 @@ const handleSaveSettings = async () => {
 
     await refetchInstalled();
     await refetchSecrets();
+    await refetchConfigStatus();
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     toast.error(`Failed to save settings: ${message}`);
@@ -624,6 +695,7 @@ const handleSaveSettings = async () => {
             :is-enabled="isEnabled"
             :installed-version="installedVersion"
             :can-enable="canEnable"
+            :blocking-config-fields="blockingConfigFields"
             :enabling="enabling"
             @toggle-enabled="handleToggleEnabled"
           />

--- a/pages/admin/settings/plugins/[pluginId].vue
+++ b/pages/admin/settings/plugins/[pluginId].vue
@@ -244,6 +244,12 @@ const secrets = computed((): PluginSecretStatus[] =>
   )
 );
 
+const orphanedSecrets = computed((): PluginSecretStatus[] =>
+  storedSecrets.value.filter(
+    (secret) => !declaredServerSecretKeys.value.has(secret.key)
+  )
+);
+
 const isInstalled = computed(() => !!installedPlugin.value);
 const isEnabled = computed(() => installedPlugin.value?.enabled ?? false);
 const installedVersion = computed(() => installedPlugin.value?.version);
@@ -735,6 +741,7 @@ const handleSaveSettings = async () => {
             v-model:secret-values="secretValues"
             v-model:show-secret-inputs="showSecretInputs"
             :secrets="secrets"
+            :orphaned-secrets="orphanedSecrets"
             @set-secret="handleSetSecret"
           />
 

--- a/pages/admin/settings/plugins/[pluginId].vue
+++ b/pages/admin/settings/plugins/[pluginId].vue
@@ -88,6 +88,7 @@ const pendingUpgrade = ref<{
 interface PluginSecretStatus {
   key: string;
   status: 'NOT_SET' | 'SET_UNTESTED' | 'VALID' | 'INVALID';
+  required?: boolean;
   lastValidatedAt?: string;
   validationError?: string;
 }
@@ -238,21 +239,26 @@ const storedSecrets = computed((): PluginSecretStatus[] => {
   return secretsResult.value?.getServerPluginSecrets || [];
 });
 
-const declaredServerSecretKeys = computed(() =>
-  new Set(
-    (installedPlugin.value?.manifest?.secrets || [])
-      .filter((secret) => !secret.scope || secret.scope === 'server')
-      .map((secret) => secret.key)
+const declaredServerSecrets = computed(() =>
+  (installedPlugin.value?.manifest?.secrets || []).filter(
+    (secret) => !secret.scope || secret.scope === 'server'
   )
 );
 
+const declaredServerSecretKeys = computed(
+  () => new Set(declaredServerSecrets.value.map((secret) => secret.key))
+);
+
 const secrets = computed((): PluginSecretStatus[] =>
-  [...declaredServerSecretKeys.value].map((key) =>
-    storedSecrets.value.find((secret) => secret.key === key) || {
-      key,
-      status: 'NOT_SET',
-    }
-  )
+  declaredServerSecrets.value.map((declaration) => ({
+    ...(storedSecrets.value.find(
+      (secret) => secret.key === declaration.key
+    ) || {
+      key: declaration.key,
+      status: 'NOT_SET' as const,
+    }),
+    required: declaration.required !== false,
+  }))
 );
 
 const orphanedSecrets = computed((): PluginSecretStatus[] =>

--- a/tests/playwright/mocked/admin/pluginDetail.spec.ts
+++ b/tests/playwright/mocked/admin/pluginDetail.spec.ts
@@ -91,6 +91,9 @@ const getBaseMocks = (username: string) => ({
   GetInstalledPlugins: () => ({ data: { getInstalledPlugins: [] } }),
   GetPluginDetail: () => ({ data: { plugins: [buildPlugin()] } }),
   GetServerPluginSecrets: () => ({ data: { getServerPluginSecrets: [] } }),
+  GetPluginConfigStatus: () => ({
+    data: { getPluginConfigStatus: { isFullyConfigured: true, fields: [] } },
+  }),
 });
 
 test.describe('Server plugin detail', () => {

--- a/tests/unit/utils/pluginUpgradeUtils.spec.ts
+++ b/tests/unit/utils/pluginUpgradeUtils.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildPluginUpgradePreview } from '@/utils/pluginUpgradeUtils';
+
+const manifest = {
+  settingsDefaults: { server: { endpoint: 'default', mode: 'safe', added: true } },
+  ui: {
+    forms: {
+      server: [{
+        title: 'Settings',
+        fields: [
+          { key: 'endpoint', label: 'Endpoint', type: 'text' as const },
+          { key: 'mode', label: 'Mode', type: 'select' as const, options: [{ value: 'safe', label: 'Safe' }] },
+          { key: 'added', label: 'Added', type: 'toggle' as const },
+        ],
+      }],
+    },
+  },
+};
+
+describe('buildPluginUpgradePreview', () => {
+  it('reports carried, dropped, reset, and new-default settings', () => {
+    const result = buildPluginUpgradePreview({
+      oldSettings: { endpoint: 'custom', mode: 'legacy', removed: true },
+      newManifest: manifest,
+    });
+
+    expect(result).toEqual({
+      settings: { endpoint: 'custom', mode: 'safe', added: true },
+      report: {
+        carried: ['endpoint'],
+        dropped: ['removed'],
+        reset: ['mode'],
+        newDefaults: ['added'],
+      },
+    });
+  });
+});

--- a/tests/unit/utils/pluginUpgradeUtils.spec.ts
+++ b/tests/unit/utils/pluginUpgradeUtils.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { buildPluginUpgradePreview } from '@/utils/pluginUpgradeUtils';
 
 const manifest = {
-  settingsDefaults: { server: { endpoint: 'default', mode: 'safe', added: true } },
+  settingsDefaults: { server: { endpoint: 'default', mode: 'safe', added: true, profiles: [] } },
   ui: {
     forms: {
       server: [{
@@ -20,14 +20,14 @@ const manifest = {
 describe('buildPluginUpgradePreview', () => {
   it('reports carried, dropped, reset, and new-default settings', () => {
     const result = buildPluginUpgradePreview({
-      oldSettings: { endpoint: 'custom', mode: 'legacy', removed: true },
+      oldSettings: { endpoint: 'custom', mode: 'legacy', removed: true, profiles: [{ id: 'custom' }] },
       newManifest: manifest,
     });
 
     expect(result).toEqual({
-      settings: { endpoint: 'custom', mode: 'safe', added: true },
+      settings: { endpoint: 'custom', mode: 'safe', added: true, profiles: [{ id: 'custom' }] },
       report: {
-        carried: ['endpoint'],
+        carried: ['endpoint', 'profiles'],
         dropped: ['removed'],
         reset: ['mode'],
         newDefaults: ['added'],

--- a/utils/pluginUpgradeUtils.ts
+++ b/utils/pluginUpgradeUtils.ts
@@ -70,9 +70,17 @@ export function buildPluginUpgradePreview(params: {
 
   for (const [key, value] of Object.entries(oldSettings)) {
     const field = fieldsByKey.get(key);
-    if (!field) {
+    const hasDefault = Object.prototype.hasOwnProperty.call(defaults, key);
+    if (!field && !hasDefault) {
       report.dropped.push(key);
-    } else if (!isCompatibleValue(field, value)) {
+    } else if (
+      field
+        ? !isCompatibleValue(field, value)
+        : defaults[key] !== null &&
+          (Array.isArray(defaults[key])
+            ? !Array.isArray(value)
+            : typeof defaults[key] !== typeof value)
+    ) {
       report.reset.push(key);
     } else {
       settings[key] = value;

--- a/utils/pluginUpgradeUtils.ts
+++ b/utils/pluginUpgradeUtils.ts
@@ -1,0 +1,84 @@
+import type { PluginField, PluginFormSection } from '@/types/pluginForms';
+
+export interface PluginUpgradeReport {
+  carried: string[];
+  dropped: string[];
+  reset: string[];
+  newDefaults: string[];
+}
+
+export interface PluginUpgradePreview {
+  settings: Record<string, unknown>;
+  report: PluginUpgradeReport;
+}
+
+interface UpgradeManifest {
+  settingsDefaults?: Record<string, unknown>;
+  ui?: { forms?: { server?: PluginFormSection[] } };
+}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const isCompatibleValue = (field: PluginField, value: unknown): boolean => {
+  if (value === undefined || value === null) return true;
+  if (field.type === 'number' && (typeof value !== 'number' || !Number.isFinite(value))) return false;
+  if ((field.type === 'boolean' || field.type === 'toggle') && typeof value !== 'boolean') return false;
+  if ((field.type === 'text' || field.type === 'textarea') && typeof value !== 'string') return false;
+  if (field.type === 'select' && !field.options?.some((option) => Object.is(option.value, value))) return false;
+
+  const validation = field.validation || {};
+  if (typeof value === 'number') {
+    if (typeof validation.min === 'number' && value < validation.min) return false;
+    if (typeof validation.max === 'number' && value > validation.max) return false;
+  }
+  if (typeof value === 'string') {
+    if (typeof validation.minLength === 'number' && value.length < validation.minLength) return false;
+    if (typeof validation.maxLength === 'number' && value.length > validation.maxLength) return false;
+    if (validation.pattern) {
+      try {
+        if (!new RegExp(validation.pattern).test(value)) return false;
+      } catch {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+export function buildPluginUpgradePreview(params: {
+  oldSettings: Record<string, unknown>;
+  newManifest?: UpgradeManifest | null;
+}): PluginUpgradePreview {
+  const { oldSettings, newManifest } = params;
+  const defaults = asRecord(newManifest?.settingsDefaults?.server);
+  const fields = (newManifest?.ui?.forms?.server || [])
+    .flatMap((section) => section.fields)
+    .filter((field) => field.type !== 'secret');
+  const fieldsByKey = new Map(fields.map((field) => [field.key, field]));
+  const settings = { ...defaults };
+  const report: PluginUpgradeReport = {
+    carried: [],
+    dropped: [],
+    reset: [],
+    newDefaults: Object.keys(defaults).filter(
+      (key) => !Object.prototype.hasOwnProperty.call(oldSettings, key)
+    ),
+  };
+
+  for (const [key, value] of Object.entries(oldSettings)) {
+    const field = fieldsByKey.get(key);
+    if (!field) {
+      report.dropped.push(key);
+    } else if (!isCompatibleValue(field, value)) {
+      report.reset.push(key);
+    } else {
+      settings[key] = value;
+      report.carried.push(key);
+    }
+  }
+
+  return { settings, report };
+}


### PR DESCRIPTION
## Summary

- consume the shared configuration-completeness status and hard-gate Enable
- list every required setting or secret that blocks enablement
- render declared-but-unset secrets and dedupe secrets from ordinary settings forms
- separate stored secrets unused by the installed version without deleting them
- clarify valid, untested, invalid, and required-not-set secret states
- preview upgrade reconciliation and offer **Carry over** or **Start fresh**
- show carried, new-default, reset, dropped, and required-secret status before upgrade

## Why

Plugin configuration state was ambiguous and distributed across independent UI checks. Misconfigured fail-closed plugins could be enabled, secrets could render twice, obsolete secrets looked required, and upgrades discarded settings.

## Validation

- 233 plugin-management tests across 20 files
- Vue TypeScript type-check
- ESLint on changed files

## Companion PRs

- Backend: https://github.com/gennit-project/multiforum-backend/pull/164
- Scanner manifest: https://github.com/gennit-project/multiforum-plugin-security-attachment-scan/pull/3

Implements the frontend portion of #330.