### PR TITLE
feat: edit plugin settings during upgrade preview

### DIFF
--- a/components/admin/plugins/PluginUpgradePreviewModal.spec.ts
+++ b/components/admin/plugins/PluginUpgradePreviewModal.spec.ts
@@ -13,13 +13,28 @@ const mountModal = () =>
         reset: ['mode'],
         newDefaults: ['added'],
       },
+      sections: [{
+        title: 'Settings',
+        fields: [{ key: 'endpoint', label: 'Endpoint', type: 'text' }],
+      }],
+      settings: { endpoint: 'https://old.example' },
+      errors: {},
       secrets: [
         { key: 'API_KEY', isSet: true },
         { key: 'NEW_SECRET', isSet: false },
       ],
       installing: false,
     },
-    global: { stubs: { LoadingSpinner: true } },
+    global: {
+      stubs: {
+        LoadingSpinner: true,
+        PluginSettingsForm: {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template: '<button data-test="edit-setting" @click="$emit(\'update:modelValue\', { endpoint: \'https://edited.example\' })">Edit</button>',
+        },
+      },
+    },
   });
 
 describe('PluginUpgradePreviewModal', () => {
@@ -35,6 +50,7 @@ describe('PluginUpgradePreviewModal', () => {
         'New defaults (1)',
         'Reset to default (1)',
         'Removed (1)',
+        'Edit carried configuration',
         'Required secrets',
       ],
       values: [
@@ -58,5 +74,15 @@ describe('PluginUpgradePreviewModal', () => {
     await wrapper.findAll('button').find((button) => button.text().includes(label))!.trigger('click');
 
     expect(wrapper.emitted(event)).toHaveLength(1);
+  });
+
+  it('emits edited settings from the form', async () => {
+    const wrapper = mountModal();
+
+    await wrapper.get('[data-test="edit-setting"]').trigger('click');
+
+    expect(wrapper.emitted('update:settings')?.[0]).toEqual([
+      { endpoint: 'https://edited.example' },
+    ]);
   });
 });

--- a/components/admin/plugins/PluginUpgradePreviewModal.vue
+++ b/components/admin/plugins/PluginUpgradePreviewModal.vue
@@ -1,17 +1,23 @@
 <script setup lang="ts">
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import PluginSettingsForm from '@/components/plugins/PluginSettingsForm.vue';
+import type { PluginFormSection, PluginSettings } from '@/types/pluginForms';
 import type { PluginUpgradeReport } from '@/utils/pluginUpgradeUtils';
 
 defineProps<{
   currentVersion: string;
   targetVersion: string;
   report: PluginUpgradeReport;
+  sections: PluginFormSection[];
+  settings: PluginSettings;
+  errors: Record<string, string>;
   secrets: Array<{ key: string; isSet: boolean }>;
   installing: boolean;
 }>();
 
 const emit = defineEmits<{
   (e: 'carry-over' | 'start-fresh' | 'cancel'): void;
+  (e: 'update:settings', value: PluginSettings): void;
 }>();
 
 const groups = [
@@ -51,6 +57,18 @@ const groups = [
           </ul>
           <p v-else class="mt-2 text-xs text-gray-500 dark:text-gray-400">None</p>
         </div>
+      </div>
+
+      <div v-if="sections.length" class="mt-5 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+        <h3 class="mb-3 text-sm font-semibold text-gray-900 dark:text-white">
+          Edit carried configuration
+        </h3>
+        <PluginSettingsForm
+          :model-value="settings"
+          :sections="sections"
+          :errors="errors"
+          @update:model-value="emit('update:settings', $event)"
+        />
       </div>
 
       <div v-if="secrets.length" class="mt-5 rounded-lg border border-gray-200 p-3 dark:border-gray-700">

--- a/pages/admin/settings/plugins/[pluginId].spec.ts
+++ b/pages/admin/settings/plugins/[pluginId].spec.ts
@@ -72,9 +72,9 @@ const stubs = {
   PluginUpdateBanner: sectionStub('PluginUpdateBanner'),
   PluginUpgradePreviewModal: {
     name: 'PluginUpgradePreviewModal',
-    props: ['currentVersion', 'targetVersion', 'report', 'secrets', 'installing'],
-    emits: ['carry-over', 'start-fresh', 'cancel'],
-    template: '<div data-test="upgrade-preview"><button data-test="carry-upgrade" @click="$emit(\'carry-over\')">Carry</button><button data-test="fresh-upgrade" @click="$emit(\'start-fresh\')">Fresh</button></div>',
+    props: ['currentVersion', 'targetVersion', 'report', 'sections', 'settings', 'errors', 'secrets', 'installing'],
+    emits: ['carry-over', 'start-fresh', 'cancel', 'update:settings'],
+    template: '<div data-test="upgrade-preview"><button data-test="edit-upgrade" @click="$emit(\'update:settings\', { endpoint: \'https://edited.example\', added: true })">Edit</button><button data-test="carry-upgrade" @click="$emit(\'carry-over\')">Carry</button><button data-test="fresh-upgrade" @click="$emit(\'start-fresh\')">Fresh</button></div>',
   },
   PluginInstallSection: {
     name: 'PluginInstallSection',
@@ -332,15 +332,19 @@ describe('Plugin detail page', () => {
     await flushPromises();
     await wrapper.get('[data-test="install"]').trigger('click');
     await flushPromises();
-    const previewProps = wrapper
-      .findComponent({ name: 'PluginUpgradePreviewModal' })
-      .props();
+    const previewProps = JSON.parse(
+      JSON.stringify(
+        wrapper.findComponent({ name: 'PluginUpgradePreviewModal' }).props()
+      )
+    );
+    await wrapper.get('[data-test="edit-upgrade"]').trigger('click');
     await wrapper.get('[data-test="carry-upgrade"]').trigger('click');
     await flushPromises();
 
     expect({
       preview: previewProps,
       installArgs: h.mutations.INSTALL_M?.mutate.mock.calls[0]?.[0],
+      savedSettings: h.mutations.ENABLE_M?.mutate.mock.calls[0]?.[0],
     }).toMatchObject({
       preview: {
         currentVersion: '1.0.0',
@@ -352,11 +356,24 @@ describe('Plugin detail page', () => {
           newDefaults: ['added'],
         },
         secrets: [{ key: 'API_KEY', isSet: true }],
+        settings: {
+          endpoint: 'https://custom.example',
+          added: true,
+        },
       },
       installArgs: {
         pluginId: PLUGIN_ID,
         version: '2.0.0',
         carrySettings: true,
+      },
+      savedSettings: {
+        pluginId: PLUGIN_ID,
+        version: '2.0.0',
+        enabled: false,
+        settingsJson: {
+          endpoint: 'https://edited.example',
+          added: true,
+        },
       },
     });
   });

--- a/pages/admin/settings/plugins/[pluginId].vue
+++ b/pages/admin/settings/plugins/[pluginId].vue
@@ -82,7 +82,10 @@ const pendingUpgrade = ref<{
   version: string;
   report: PluginUpgradeReport;
   secrets: Array<{ key: string; isSet: boolean }>;
+  settings: PluginSettings;
+  sections: PluginFormSection[];
 } | null>(null);
+const upgradeSettingsErrors = ref<Record<string, string>>({});
 
 // Types
 interface PluginSecretStatus {
@@ -578,10 +581,26 @@ const handleInstall = async (versionOverride?: string) => {
             stored.key === secret.key && stored.status !== 'NOT_SET'
         ),
       }));
+    const targetSecretKeys = new Set(
+      (targetManifest.secrets || [])
+        .filter((secret) => !secret.scope || secret.scope === 'server')
+        .map((secret) => secret.key)
+    );
+    const targetSections = getPluginFormSections(targetManifest, 'server')
+      .map((section) => ({
+        ...section,
+        fields: section.fields.filter(
+          (field) => !targetSecretKeys.has(field.key)
+        ),
+      }))
+      .filter((section) => section.fields.length > 0);
+    upgradeSettingsErrors.value = {};
     pendingUpgrade.value = {
       version: versionToInstall,
       report: preview.report,
       secrets: targetSecrets,
+      settings: preview.settings,
+      sections: targetSections,
     };
     return;
   }
@@ -591,11 +610,40 @@ const handleInstall = async (versionOverride?: string) => {
 
 const confirmUpgrade = async (carrySettings: boolean) => {
   if (!pendingUpgrade.value) return;
+  if (carrySettings) {
+    upgradeSettingsErrors.value = validateRequiredSettings(
+      pendingUpgrade.value.sections,
+      pendingUpgrade.value.settings
+    );
+    if (Object.keys(upgradeSettingsErrors.value).length > 0) {
+      toast.error('Complete the required upgrade settings before installing');
+      return;
+    }
+  }
+  const upgrade = pendingUpgrade.value;
   const installed = await performInstall(
-    pendingUpgrade.value.version,
+    upgrade.version,
     carrySettings
   );
-  if (installed) pendingUpgrade.value = null;
+  if (!installed) return;
+
+  if (carrySettings) {
+    try {
+      await enableMutation({
+        pluginId: pluginSlug.value,
+        version: upgrade.version,
+        enabled: false,
+        settingsJson: upgrade.settings,
+      });
+      toast.success('Edited upgrade settings saved successfully');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      installError.value = `Plugin installed, but edited settings could not be saved: ${message}`;
+      return;
+    }
+  }
+
+  pendingUpgrade.value = null;
 };
 
 const handleToggleEnabled = async (enabled: boolean) => {
@@ -850,10 +898,14 @@ const handleSaveSettings = async () => {
             :current-version="installedVersion"
             :target-version="pendingUpgrade.version"
             :report="pendingUpgrade.report"
+            :sections="pendingUpgrade.sections"
+            :settings="pendingUpgrade.settings"
+            :errors="upgradeSettingsErrors"
             :secrets="pendingUpgrade.secrets"
             :installing="installing"
             @carry-over="confirmUpgrade(true)"
             @start-fresh="confirmUpgrade(false)"
+            @update:settings="pendingUpgrade.settings = $event"
             @cancel="pendingUpgrade = null"
           />
         </div>


### PR DESCRIPTION
## Summary

- make carried plugin settings editable in the upgrade preview
- validate required target-version fields before installation
- persist the reviewed settings after carrying configuration into the new version

## Stack

- stacked on #392
- intentionally does not add `renamedFrom` support

## Validation

- 146 plugin/admin frontend tests
- `vue-tsc --noEmit`
- ESLint on changed files