### PR TITLE
feat: delete orphaned plugin secrets

### DIFF
--- a/components/admin/plugins/PluginSecretsSection.spec.ts
+++ b/components/admin/plugins/PluginSecretsSection.spec.ts
@@ -90,11 +90,11 @@ describe('PluginSecretsSection orphaned secrets', () => {
     }).toEqual({
       hasHeading: true,
       hasExplanation: true,
-      item: 'OLD_API_KEY✓ Set (untested)',
+      item: 'OLD_API_KEY✓ Set (untested)Delete',
     });
   });
 
-  it('does not offer an edit action for an orphaned secret', () => {
+  it('confirms the rollback risk before deleting an orphaned secret', async () => {
     const wrapper = mountSection({
       secrets: [],
       orphanedSecrets: [
@@ -102,7 +102,16 @@ describe('PluginSecretsSection orphaned secrets', () => {
       ],
     });
 
-    expect(wrapper.findAll('button')).toHaveLength(0);
+    await buttonByText(wrapper, 'Delete')!.trigger('click');
+
+    expect(wrapper.text()).toContain(
+      'Older plugin versions may need it after a rollback or downgrade.'
+    );
+    expect(wrapper.emitted('delete-secret')).toBeUndefined();
+
+    await buttonByText(wrapper, 'Delete permanently')!.trigger('click');
+
+    expect(wrapper.emitted('delete-secret')?.[0]).toEqual(['OLD_API_KEY']);
   });
 });
 

--- a/components/admin/plugins/PluginSecretsSection.vue
+++ b/components/admin/plugins/PluginSecretsSection.vue
@@ -15,16 +15,19 @@ const props = defineProps<{
   orphanedSecrets?: PluginSecretStatus[];
   secretValues: Record<string, string>;
   showSecretInputs: Record<string, boolean>;
+  deletingSecretKey?: string | null;
 }>();
 
 const emit = defineEmits<{
   (e: 'update:secretValues', value: Record<string, string>): void;
   (e: 'update:showSecretInputs', value: Record<string, boolean>): void;
   (e: 'set-secret', key: string, value: string): void;
+  (e: 'delete-secret', key: string): void;
 }>();
 
 // Track which secret is awaiting confirmation
 const confirmingSecret = ref<string | null>(null);
+const confirmingDeletion = ref<string | null>(null);
 
 const updateSecretValue = (key: string, value: string) => {
   emit('update:secretValues', { ...props.secretValues, [key]: value });
@@ -49,6 +52,11 @@ const cancelConfirmation = () => {
 const confirmAndSave = (key: string) => {
   emit('set-secret', key, props.secretValues[key] || '');
   confirmingSecret.value = null;
+};
+
+const confirmDeletion = (key: string) => {
+  emit('delete-secret', key);
+  confirmingDeletion.value = null;
 };
 
 const getSecretStatusColor = (status: string) => {
@@ -221,17 +229,54 @@ const getSecretStatusText = (secret: PluginSecretStatus) => {
           <li
             v-for="secret in orphanedSecrets"
             :key="secret.key"
-            class="flex items-center justify-between gap-4 p-4"
+            class="p-4"
           >
-            <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">
-              {{ secret.key }}
-            </span>
-            <span
-              class="rounded-full px-2 py-1 text-xs font-semibold"
-              :class="getSecretStatusColor(secret.status)"
+            <div class="flex items-center justify-between gap-4">
+              <div class="flex items-center gap-2">
+                <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">
+                  {{ secret.key }}
+                </span>
+                <span
+                  class="rounded-full px-2 py-1 text-xs font-semibold"
+                  :class="getSecretStatusColor(secret.status)"
+                >
+                  {{ getSecretStatusText(secret) }}
+                </span>
+              </div>
+              <button
+                type="button"
+                class="rounded bg-red-50 px-3 py-1 text-sm text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/50"
+                :disabled="deletingSecretKey === secret.key"
+                @click="confirmingDeletion = secret.key"
+              >
+                {{ deletingSecretKey === secret.key ? 'Deleting…' : 'Delete' }}
+              </button>
+            </div>
+
+            <div
+              v-if="confirmingDeletion === secret.key"
+              class="mt-3 rounded-md border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/30"
             >
-              {{ getSecretStatusText(secret) }}
-            </span>
+              <p class="text-sm text-red-800 dark:text-red-200">
+                Delete this stored secret permanently? Older plugin versions may need it after a rollback or downgrade.
+              </p>
+              <div class="mt-2 flex gap-2">
+                <button
+                  type="button"
+                  class="rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+                  @click="confirmDeletion(secret.key)"
+                >
+                  Delete permanently
+                </button>
+                <button
+                  type="button"
+                  class="rounded bg-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-400 dark:bg-gray-600 dark:text-gray-200 dark:hover:bg-gray-500"
+                  @click="confirmingDeletion = null"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
           </li>
         </ul>
       </div>

--- a/graphQLData/admin/mutations.js
+++ b/graphQLData/admin/mutations.js
@@ -136,6 +136,12 @@ export const SET_SERVER_PLUGIN_SECRET = gql`
   }
 `;
 
+export const DELETE_SERVER_PLUGIN_SECRET = gql`
+  mutation DeleteServerPluginSecret($pluginId: String!, $key: String!) {
+    deleteServerPluginSecret(pluginId: $pluginId, key: $key)
+  }
+`;
+
 export const UPDATE_MOD_CHANNEL_ROLE = gql`
   mutation UpdateModChannelRole(
     $name: String!

--- a/pages/admin/settings/plugins/[pluginId].spec.ts
+++ b/pages/admin/settings/plugins/[pluginId].spec.ts
@@ -27,6 +27,7 @@ vi.mock('@/graphQLData/admin/mutations', () => ({
   INSTALL_PLUGIN_VERSION: 'INSTALL_M',
   ENABLE_SERVER_PLUGIN: 'ENABLE_M',
   SET_SERVER_PLUGIN_SECRET: 'SET_SECRET_M',
+  DELETE_SERVER_PLUGIN_SECRET: 'DELETE_SECRET_M',
 }));
 
 const h = vi.hoisted(() => ({
@@ -84,9 +85,9 @@ const stubs = {
   },
   PluginSecretsSection: {
     name: 'PluginSecretsSection',
-    props: ['secrets', 'orphanedSecrets', 'secretValues', 'showSecretInputs'],
-    emits: ['set-secret', 'update:secretValues', 'update:showSecretInputs'],
-    template: '<button type="button" data-test="set-secret" @click="$emit(\'set-secret\', \'API_KEY\', \'xyz\')">Set secret</button>',
+    props: ['secrets', 'orphanedSecrets', 'secretValues', 'showSecretInputs', 'deletingSecretKey'],
+    emits: ['set-secret', 'delete-secret', 'update:secretValues', 'update:showSecretInputs'],
+    template: '<div><button type="button" data-test="set-secret" @click="$emit(\'set-secret\', \'API_KEY\', \'xyz\')">Set secret</button><button type="button" data-test="delete-secret" @click="$emit(\'delete-secret\', \'OLD_API_KEY\')">Delete secret</button></div>',
   },
   PluginSettingsSection: {
     name: 'PluginSettingsSection',
@@ -397,6 +398,30 @@ describe('Plugin detail page', () => {
       key: 'API_KEY',
       value: 'xyz',
     });
+  });
+
+  it('deletes an orphaned secret and refreshes configuration status', async () => {
+    setInstalledPlugin({ manifest: { secrets: [] } });
+    h.mutations.DELETE_SECRET_M = {
+      mutate: vi.fn().mockResolvedValue({
+        data: { deleteServerPluginSecret: true },
+      }),
+      loading: { value: false },
+    };
+    const wrapper = mountPage();
+
+    await wrapper.get('[data-test="delete-secret"]').trigger('click');
+    await flushPromises();
+
+    expect(h.mutations.DELETE_SECRET_M.mutate).toHaveBeenCalledWith({
+      pluginId: PLUGIN_ID,
+      key: 'OLD_API_KEY',
+    });
+    expect(h.q.SECRETS.refetch).toHaveBeenCalled();
+    expect(h.q.CONFIG_STATUS.refetch).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith(
+      'Secret "OLD_API_KEY" deleted successfully'
+    );
   });
 
   it('blocks saving when required settings are missing', async () => {

--- a/pages/admin/settings/plugins/[pluginId].vue
+++ b/pages/admin/settings/plugins/[pluginId].vue
@@ -57,6 +57,7 @@ import {
   INSTALL_PLUGIN_VERSION,
   ENABLE_SERVER_PLUGIN,
   SET_SERVER_PLUGIN_SECRET,
+  DELETE_SERVER_PLUGIN_SECRET,
 } from '@/graphQLData/admin/mutations';
 
 // @ts-ignore - definePageMeta is auto-imported by Nuxt
@@ -77,6 +78,7 @@ const showSecretInputs = ref<Record<string, boolean>>({});
 const settingsValues = ref<PluginSettings>({});
 const settingsErrors = ref<Record<string, string>>({});
 const savingSettings = ref(false);
+const deletingSecretKey = ref<string | null>(null);
 const installError = ref<string | null>(null);
 const pendingUpgrade = ref<{
   version: string;
@@ -178,6 +180,9 @@ const { mutate: installMutation, loading: installing } = useMutation(
 const { mutate: enableMutation, loading: enabling } =
   useMutation(ENABLE_SERVER_PLUGIN);
 const { mutate: setSecretMutation } = useMutation(SET_SERVER_PLUGIN_SECRET);
+const { mutate: deleteSecretMutation } = useMutation(
+  DELETE_SERVER_PLUGIN_SECRET
+);
 
 // Core computed properties needed for secrets query
 interface PluginFromQuery {
@@ -654,6 +659,31 @@ const handleSetSecret = async (key: string, value: string) => {
   }
 };
 
+const handleDeleteSecret = async (key: string) => {
+  if (!pluginSlug.value) return;
+
+  deletingSecretKey.value = key;
+  try {
+    const result = await deleteSecretMutation({
+      pluginId: pluginSlug.value,
+      key,
+    });
+
+    if (!result?.data?.deleteServerPluginSecret) {
+      throw new Error('Secret was not found');
+    }
+
+    toast.success(`Secret "${key}" deleted successfully`);
+    await refetchSecrets();
+    await refetchConfigStatus();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    toast.error(`Failed to delete secret "${key}": ${message}`);
+  } finally {
+    deletingSecretKey.value = null;
+  }
+};
+
 const handleSaveSettings = async () => {
   if (!installedPlugin.value) return;
   if (!pluginSlug.value) return;
@@ -814,7 +844,9 @@ const handleSaveSettings = async () => {
             v-model:show-secret-inputs="showSecretInputs"
             :secrets="secrets"
             :orphaned-secrets="orphanedSecrets"
+            :deleting-secret-key="deletingSecretKey"
             @set-secret="handleSetSecret"
+            @delete-secret="handleDeleteSecret"
           />
 
           <!-- Loading State for Secrets -->


### PR DESCRIPTION
## Summary

- offer deletion for stored secrets no longer declared by the installed plugin version
- require explicit confirmation and warn that deletion can break rollback or downgrade compatibility
- refresh secret and configuration status after deletion

## Stack

- stacked on #392
- requires backend PR [multiforum-backend#165](https://github.com/gennit-project/multiforum-backend/pull/165)

## Validation

- 146 plugin/admin frontend tests
- `vue-tsc --noEmit`
- ESLint on changed files