### PR TITLE
Add forum quick switcher

### DIFF
--- a/components/nav/ForumQuickSwitcher.spec.ts
+++ b/components/nav/ForumQuickSwitcher.spec.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, nextTick, ref } from 'vue';
+import type { ComputedRef } from 'vue';
+import { mount } from '@vue/test-utils';
+import ForumQuickSwitcher from '@/components/nav/ForumQuickSwitcher.vue';
+
+const h = vi.hoisted(() => ({
+  username: null as unknown as ReturnType<typeof ref<string>>,
+  routerPush: vi.fn(),
+  getRecentForums: vi.fn(),
+  queryCall: 0,
+  enabled: [] as Array<ComputedRef<boolean>>,
+  variables: [] as Array<ComputedRef<Record<string, unknown>>>,
+  channelsResult: null as unknown as ReturnType<
+    typeof ref<Record<string, unknown>>
+  >,
+  favoritesResult: null as unknown as ReturnType<
+    typeof ref<Record<string, unknown>>
+  >,
+  collectionsResult: null as unknown as ReturnType<
+    typeof ref<Record<string, unknown>>
+  >,
+}));
+
+vi.mock('@floating-ui/vue', () => ({
+  autoUpdate: vi.fn(),
+  flip: vi.fn(),
+  offset: vi.fn(),
+  shift: vi.fn(),
+  useFloating: () => ({ floatingStyles: ref({}) }),
+}));
+
+vi.mock('nuxt/app', () => ({
+  useRouter: () => ({ push: h.routerPush }),
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => h.username,
+}));
+
+vi.mock('@/utils/localStorageUtils', () => ({
+  getLocalStorageItem: h.getRecentForums,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: (
+    _query: unknown,
+    variables: ComputedRef<Record<string, unknown>>,
+    options: { enabled: ComputedRef<boolean> }
+  ) => {
+    const call = h.queryCall++;
+    h.variables.push(variables);
+    h.enabled.push(options.enabled);
+    return {
+      result: [h.channelsResult, h.favoritesResult, h.collectionsResult][call],
+      loading: ref(false),
+    };
+  },
+}));
+
+const SearchBarStub = defineComponent({
+  name: 'SearchBar',
+  emits: ['updateSearchInput', 'submit'],
+  methods: { focus() {} },
+  template:
+    '<input data-testid="search-stub" @input="$emit(\'updateSearchInput\', $event.target.value)" />',
+});
+
+const mountSwitcher = () =>
+  mount(ForumQuickSwitcher, {
+    props: { currentForumId: 'cats' },
+    attachTo: document.body,
+    global: {
+      stubs: {
+        AvatarComponent: true,
+        ChevronDownIcon: true,
+        SearchBar: SearchBarStub,
+      },
+    },
+  });
+
+beforeEach(() => {
+  h.username = ref('alice');
+  h.routerPush.mockReset();
+  h.routerPush.mockResolvedValue(undefined);
+  h.getRecentForums.mockReset();
+  h.getRecentForums.mockReturnValue([]);
+  h.queryCall = 0;
+  h.enabled = [];
+  h.variables = [];
+  h.channelsResult = ref({ channels: [] });
+  h.favoritesResult = ref({ users: [] });
+  h.collectionsResult = ref({ users: [] });
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('ForumQuickSwitcher lazy loading', () => {
+  it('keeps the forum popover out of the initial render', () => {
+    mountSwitcher();
+
+    expect(
+      document.querySelector('[data-testid="forum-quick-switcher"]')
+    ).toBeNull();
+  });
+
+  it('does not read recent forums during the initial render', () => {
+    mountSwitcher();
+
+    expect(h.getRecentForums).not.toHaveBeenCalled();
+  });
+
+  it('disables all queries before the switcher opens', () => {
+    mountSwitcher();
+
+    expect(h.enabled.map((enabled) => enabled.value)).toEqual([
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it('enables all queries for an authenticated user after opening', async () => {
+    const wrapper = mountSwitcher();
+
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+
+    expect(h.enabled.map((enabled) => enabled.value)).toEqual([
+      true,
+      true,
+      true,
+    ]);
+  });
+
+  it('reads recent forums only when the switcher opens', async () => {
+    const wrapper = mountSwitcher();
+
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+
+    expect(h.getRecentForums).toHaveBeenCalledWith('recentForums', []);
+  });
+
+  it('keeps account-specific queries disabled for a signed-out user', async () => {
+    h.username.value = '';
+    const wrapper = mountSwitcher();
+
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+
+    expect(h.enabled.map((enabled) => enabled.value)).toEqual([
+      true,
+      false,
+      false,
+    ]);
+  });
+});
+
+describe('ForumQuickSwitcher content', () => {
+  it('shows recent, favorite, collection, and top-forum sections', async () => {
+    h.getRecentForums.mockReturnValue([
+      { uniqueName: 'recent', displayName: 'Recent Forum', timestamp: 2 },
+    ]);
+    h.channelsResult.value = {
+      channels: [{ uniqueName: 'top', displayName: 'Top Forum' }],
+    };
+    h.favoritesResult.value = {
+      users: [
+        {
+          FavoriteChannels: [
+            { uniqueName: 'favorite', displayName: 'Favorite Forum' },
+          ],
+        },
+      ],
+    };
+    h.collectionsResult.value = {
+      users: [
+        {
+          Collections: [
+            {
+              id: 'list-1',
+              name: 'My Forums',
+              Channels: [{ uniqueName: 'listed', displayName: 'Listed Forum' }],
+            },
+          ],
+        },
+      ],
+    };
+    const wrapper = mountSwitcher();
+
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+
+    expect(document.body.textContent).toEqual(
+      expect.stringContaining('Recent forums')
+    );
+  });
+
+  it('renders data from each forum source', async () => {
+    h.getRecentForums.mockReturnValue([
+      { uniqueName: 'recent', displayName: 'Recent Forum', timestamp: 2 },
+    ]);
+    h.channelsResult.value = {
+      channels: [{ uniqueName: 'top', displayName: 'Top Forum' }],
+    };
+    h.favoritesResult.value = {
+      users: [
+        {
+          FavoriteChannels: [
+            { uniqueName: 'favorite', displayName: 'Favorite Forum' },
+          ],
+        },
+      ],
+    };
+    h.collectionsResult.value = {
+      users: [
+        {
+          Collections: [
+            {
+              id: 'list-1',
+              name: 'My Forums',
+              Channels: [{ uniqueName: 'listed', displayName: 'Listed Forum' }],
+            },
+          ],
+        },
+      ],
+    };
+    const wrapper = mountSwitcher();
+
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+
+    expect(document.body.textContent).toEqual(
+      expect.stringMatching(
+        /Recent Forum.*Favorite Forum.*My Forums.*Top Forum/s
+      )
+    );
+  });
+
+  it('expands a forum collection', async () => {
+    h.collectionsResult.value = {
+      users: [
+        {
+          Collections: [
+            {
+              id: 'list-1',
+              name: 'My Forums',
+              Channels: [{ uniqueName: 'listed', displayName: 'Listed Forum' }],
+            },
+          ],
+        },
+      ],
+    };
+    const wrapper = mountSwitcher();
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+
+    const collectionButton = Array.from(
+      document.querySelectorAll('button')
+    ).find((button) =>
+      button.textContent?.includes('My Forums')
+    ) as HTMLButtonElement;
+    collectionButton.click();
+    await nextTick();
+
+    expect(document.body.textContent).toContain('Listed Forum');
+  });
+
+  it('updates the all-forums query from the search input', async () => {
+    const wrapper = mountSwitcher();
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+
+    const input = document.querySelector(
+      '[data-testid="search-stub"]'
+    ) as HTMLInputElement;
+    input.value = 'cats';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await nextTick();
+
+    expect(h.variables[0].value).toEqual({
+      channelWhere: { uniqueName_MATCHES: '(?i).*cats.*' },
+    });
+  });
+
+  it('navigates immediately when a forum is selected', async () => {
+    h.channelsResult.value = {
+      channels: [{ uniqueName: 'dogs', displayName: 'Dogs' }],
+    };
+    const wrapper = mountSwitcher();
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+
+    (
+      document.querySelector(
+        '[data-testid="forum-quick-switcher-option-dogs"]'
+      ) as HTMLButtonElement
+    ).click();
+    await nextTick();
+
+    expect(h.routerPush).toHaveBeenCalledWith({
+      name: 'forums-forumId-discussions',
+      params: { forumId: 'dogs' },
+    });
+  });
+});

--- a/components/nav/ForumQuickSwitcher.vue
+++ b/components/nav/ForumQuickSwitcher.vue
@@ -1,0 +1,378 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue';
+import { useRouter } from 'nuxt/app';
+import SearchBar from '@/components/SearchBar.vue';
+import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue';
+import ForumQuickSwitcherOption from '@/components/nav/ForumQuickSwitcherOption.vue';
+import {
+  GET_CHANNEL_NAMES,
+  GET_USER_FAVORITE_CHANNELS,
+} from '@/graphQLData/channel/queries';
+import { GET_USER_CHANNEL_COLLECTIONS_WITH_CHANNELS } from '@/graphQLData/collection/queries';
+import { useUsername } from '@/composables/useAuthState';
+import { createCaseInsensitivePattern } from '@/utils/searchUtils';
+import { getLocalStorageItem } from '@/utils/localStorageUtils';
+import type { ForumItem } from '@/types/forum';
+
+type ForumOption = {
+  uniqueName: string;
+  displayName: string;
+  channelIconURL: string;
+};
+
+type ForumSource = {
+  uniqueName: string;
+  displayName?: string | null;
+  channelIconURL?: string | null;
+};
+
+type ForumCollection = {
+  id: string;
+  name: string;
+  Channels?: ForumSource[] | null;
+};
+
+defineProps<{
+  currentForumId: string;
+}>();
+
+const router = useRouter();
+const username = useUsername();
+const isOpen = ref(false);
+const searchInput = ref('');
+const recentForums = ref<ForumOption[]>([]);
+const expandedCollectionIds = ref<Set<string>>(new Set());
+const triggerRef = ref<HTMLElement | null>(null);
+const floatingRef = ref<HTMLElement | null>(null);
+const searchBarRef = ref<InstanceType<typeof SearchBar> | null>(null);
+
+const { floatingStyles } = useFloating(triggerRef, floatingRef, {
+  placement: 'bottom-start',
+  strategy: 'fixed',
+  middleware: [offset(6), flip(), shift({ padding: 8 })],
+  whileElementsMounted: autoUpdate,
+});
+
+const queryEnabled = computed(() => isOpen.value);
+const authenticatedQueryEnabled = computed(
+  () => isOpen.value && Boolean(username.value)
+);
+
+const { result: channelsResult, loading: channelsLoading } = useQuery(
+  GET_CHANNEL_NAMES,
+  computed(() => ({
+    channelWhere: {
+      uniqueName_MATCHES:
+        createCaseInsensitivePattern(searchInput.value) || '.*',
+    },
+  })),
+  {
+    enabled: queryEnabled,
+    fetchPolicy: 'cache-first',
+  }
+);
+
+const { result: favoritesResult } = useQuery(
+  GET_USER_FAVORITE_CHANNELS,
+  computed(() => ({ username: username.value })),
+  {
+    enabled: authenticatedQueryEnabled,
+    fetchPolicy: 'cache-first',
+  }
+);
+
+const { result: collectionsResult } = useQuery(
+  GET_USER_CHANNEL_COLLECTIONS_WITH_CHANNELS,
+  computed(() => ({ username: username.value })),
+  {
+    enabled: authenticatedQueryEnabled,
+    fetchPolicy: 'cache-first',
+  }
+);
+
+const normalizeForum = (forum: ForumSource): ForumOption => ({
+  uniqueName: forum.uniqueName,
+  displayName: forum.displayName || forum.uniqueName,
+  channelIconURL: forum.channelIconURL || '',
+});
+
+const normalizedSearch = computed(() => searchInput.value.trim().toLowerCase());
+
+const forumMatchesSearch = (forum: ForumOption) => {
+  if (!normalizedSearch.value) return true;
+  return (
+    forum.uniqueName.toLowerCase().includes(normalizedSearch.value) ||
+    forum.displayName.toLowerCase().includes(normalizedSearch.value)
+  );
+};
+
+const visibleRecentForums = computed(() =>
+  recentForums.value.filter(forumMatchesSearch)
+);
+
+const favoriteForums = computed<ForumOption[]>(() => {
+  const favorites: ForumSource[] =
+    favoritesResult.value?.users?.[0]?.FavoriteChannels || [];
+  return favorites.map(normalizeForum).filter(forumMatchesSearch);
+});
+
+const forumCollections = computed(() => {
+  const collections: ForumCollection[] =
+    collectionsResult.value?.users?.[0]?.Collections || [];
+
+  return collections
+    .map((collection) => ({
+      id: collection.id,
+      name: collection.name,
+      forums: (collection.Channels || [])
+        .map(normalizeForum)
+        .filter(forumMatchesSearch),
+    }))
+    .filter((collection) => collection.forums.length > 0);
+});
+
+const allForums = computed<ForumOption[]>(() => {
+  const forums: ForumSource[] = channelsResult.value?.channels || [];
+  return forums.map(normalizeForum);
+});
+
+const loadRecentForums = () => {
+  const storedForums = getLocalStorageItem<ForumItem[]>('recentForums', []);
+  recentForums.value = [...storedForums]
+    .filter((forum) => forum && typeof forum.uniqueName === 'string')
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, 5)
+    .map(normalizeForum);
+};
+
+const close = () => {
+  isOpen.value = false;
+  searchInput.value = '';
+  expandedCollectionIds.value = new Set();
+};
+
+const toggle = async () => {
+  if (isOpen.value) {
+    close();
+    return;
+  }
+
+  // This only runs after a user interaction, so browser-persisted recents can
+  // never change the server-rendered or initial hydration markup.
+  loadRecentForums();
+  isOpen.value = true;
+  await nextTick();
+  searchBarRef.value?.focus();
+};
+
+const goToForum = async (uniqueName: string) => {
+  close();
+  await router.push({
+    name: 'forums-forumId-discussions',
+    params: { forumId: uniqueName },
+  });
+};
+
+const toggleCollection = (collectionId: string) => {
+  const nextIds = new Set(expandedCollectionIds.value);
+  if (nextIds.has(collectionId)) {
+    nextIds.delete(collectionId);
+  } else {
+    nextIds.add(collectionId);
+  }
+  expandedCollectionIds.value = nextIds;
+};
+
+const collectionIsExpanded = (collectionId: string) =>
+  Boolean(normalizedSearch.value) ||
+  expandedCollectionIds.value.has(collectionId);
+
+const handleSearch = (value: string) => {
+  searchInput.value = value;
+};
+
+const onDocumentPointerDown = (event: PointerEvent) => {
+  const target = event.target as Node;
+  if (
+    triggerRef.value?.contains(target) ||
+    floatingRef.value?.contains(target)
+  ) {
+    return;
+  }
+  close();
+};
+
+const onDocumentKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    close();
+    triggerRef.value?.focus();
+  }
+};
+
+watch(isOpen, (open) => {
+  if (!import.meta.client) return;
+  if (open) {
+    document.addEventListener('pointerdown', onDocumentPointerDown, true);
+    document.addEventListener('keydown', onDocumentKeydown);
+  } else {
+    document.removeEventListener('pointerdown', onDocumentPointerDown, true);
+    document.removeEventListener('keydown', onDocumentKeydown);
+  }
+});
+
+onBeforeUnmount(() => {
+  if (!import.meta.client) return;
+  document.removeEventListener('pointerdown', onDocumentPointerDown, true);
+  document.removeEventListener('keydown', onDocumentKeydown);
+});
+</script>
+
+<template>
+  <div class="min-w-0">
+    <button
+      ref="triggerRef"
+      type="button"
+      data-testid="forum-quick-switcher-trigger"
+      class="hover:text-gray-950 flex min-w-0 max-w-[9.5rem] items-center gap-1 rounded-md px-1 py-1 text-gray-700 transition-colors hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white sm:max-w-[13.5rem] lg:max-w-[17.5rem]"
+      aria-haspopup="dialog"
+      :aria-expanded="isOpen"
+      aria-label="Switch forum"
+      @click="toggle"
+    >
+      <span class="truncate">{{ currentForumId }}</span>
+      <ChevronDownIcon
+        class="h-3.5 w-3.5 shrink-0 transition-transform"
+        :class="{ 'rotate-180': isOpen }"
+        aria-hidden="true"
+      />
+    </button>
+
+    <Teleport to="body">
+      <div
+        v-if="isOpen"
+        ref="floatingRef"
+        :style="floatingStyles"
+        class="z-[10000] w-[min(24rem,calc(100vw-1rem))] overflow-hidden rounded-lg border border-gray-200 bg-white text-gray-900 shadow-xl dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+        role="dialog"
+        aria-label="Switch forum"
+        data-testid="forum-quick-switcher"
+      >
+        <div class="border-b border-gray-200 p-3 dark:border-gray-700">
+          <SearchBar
+            ref="searchBarRef"
+            :initial-value="searchInput"
+            search-placeholder="Search forums"
+            test-id="forum-quick-switcher-search"
+            :debounce-ms="200"
+            @update-search-input="handleSearch"
+            @submit="handleSearch"
+          />
+        </div>
+
+        <div class="max-h-[min(32rem,calc(100vh-6rem))] overflow-y-auto p-2">
+          <section v-if="visibleRecentForums.length > 0" class="mb-2">
+            <h2
+              class="font-semibold px-2 py-1 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400"
+            >
+              Recent forums
+            </h2>
+            <ForumQuickSwitcherOption
+              v-for="forum in visibleRecentForums"
+              :key="`recent-${forum.uniqueName}`"
+              :forum="forum"
+              :active="forum.uniqueName === currentForumId"
+              @select="goToForum"
+            />
+          </section>
+
+          <section v-if="favoriteForums.length > 0" class="mb-2">
+            <h2
+              class="font-semibold px-2 py-1 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400"
+            >
+              Favorite forums
+            </h2>
+            <ForumQuickSwitcherOption
+              v-for="forum in favoriteForums"
+              :key="`favorite-${forum.uniqueName}`"
+              :forum="forum"
+              :active="forum.uniqueName === currentForumId"
+              @select="goToForum"
+            />
+          </section>
+
+          <section v-if="forumCollections.length > 0" class="mb-2">
+            <h2
+              class="font-semibold px-2 py-1 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400"
+            >
+              Forum lists
+            </h2>
+            <div v-for="collection in forumCollections" :key="collection.id">
+              <button
+                type="button"
+                class="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-700"
+                :aria-expanded="collectionIsExpanded(collection.id)"
+                @click="toggleCollection(collection.id)"
+              >
+                <span class="truncate">{{ collection.name }}</span>
+                <span
+                  class="ml-2 flex shrink-0 items-center gap-2 text-xs text-gray-500 dark:text-gray-400"
+                >
+                  {{ collection.forums.length }}
+                  <ChevronDownIcon
+                    class="h-3 w-3 transition-transform"
+                    :class="{
+                      'rotate-180': collectionIsExpanded(collection.id),
+                    }"
+                    aria-hidden="true"
+                  />
+                </span>
+              </button>
+              <div
+                v-if="collectionIsExpanded(collection.id)"
+                class="ml-3 border-l border-gray-200 pl-1 dark:border-gray-700"
+              >
+                <ForumQuickSwitcherOption
+                  v-for="forum in collection.forums"
+                  :key="`${collection.id}-${forum.uniqueName}`"
+                  :forum="forum"
+                  :active="forum.uniqueName === currentForumId"
+                  compact
+                  @select="goToForum"
+                />
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h2
+              class="font-semibold px-2 py-1 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400"
+            >
+              {{ normalizedSearch ? 'Search results' : 'Top forums' }}
+            </h2>
+            <div
+              v-if="channelsLoading && allForums.length === 0"
+              class="px-2 py-3 text-sm text-gray-500 dark:text-gray-400"
+            >
+              Loading forums...
+            </div>
+            <div
+              v-else-if="allForums.length === 0"
+              class="px-2 py-3 text-sm text-gray-500 dark:text-gray-400"
+            >
+              No forums found
+            </div>
+            <ForumQuickSwitcherOption
+              v-for="forum in allForums"
+              :key="`all-${forum.uniqueName}`"
+              :forum="forum"
+              :active="forum.uniqueName === currentForumId"
+              @select="goToForum"
+            />
+          </section>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/components/nav/ForumQuickSwitcherOption.vue
+++ b/components/nav/ForumQuickSwitcherOption.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import AvatarComponent from '@/components/AvatarComponent.vue';
+
+defineProps<{
+  forum: {
+    uniqueName: string;
+    displayName: string;
+    channelIconURL: string;
+  };
+  active?: boolean;
+  compact?: boolean;
+}>();
+
+const emit = defineEmits<{
+  select: [uniqueName: string];
+}>();
+</script>
+
+<template>
+  <button
+    type="button"
+    :data-testid="`forum-quick-switcher-option-${forum.uniqueName}`"
+    class="group flex w-full items-center gap-2 rounded-md px-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+    :class="compact ? 'py-1.5' : 'py-2'"
+    @click="emit('select', forum.uniqueName)"
+  >
+    <AvatarComponent
+      class="shrink-0 border border-gray-200 shadow-sm dark:border-gray-700"
+      :class="compact ? 'h-6 w-6' : 'h-7 w-7'"
+      :text="forum.uniqueName"
+      :src="forum.channelIconURL"
+      :is-small="true"
+      :is-square="false"
+      :is-decorative="true"
+    />
+    <span class="min-w-0 flex-1">
+      <span class="block truncate font-medium">{{ forum.displayName }}</span>
+      <span
+        v-if="forum.displayName !== forum.uniqueName"
+        class="block truncate font-mono text-xs text-gray-500 dark:text-gray-400"
+      >
+        {{ forum.uniqueName }}
+      </span>
+    </span>
+    <svg
+      v-if="active"
+      class="h-4 w-4 shrink-0 text-orange-600 dark:text-orange-400"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-label="Current forum"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M16.704 5.292a1 1 0 0 1 .004 1.416l-8 8a1 1 0 0 1-1.416 0l-4-4a1 1 0 1 1 1.416-1.416L8 12.584l7.292-7.292a1 1 0 0 1 1.412 0Z"
+        clip-rule="evenodd"
+      />
+    </svg>
+  </button>
+</template>

--- a/components/nav/TopNav.spec.ts
+++ b/components/nav/TopNav.spec.ts
@@ -11,7 +11,9 @@ const h = vi.hoisted(() => ({
   smAndDown: null as unknown,
 }));
 
-vi.mock('@/composables/useDisplay', () => ({ useDisplay: () => ({ smAndDown: h.smAndDown }) }));
+vi.mock('@/composables/useDisplay', () => ({
+  useDisplay: () => ({ smAndDown: h.smAndDown }),
+}));
 vi.mock('nuxt/app', () => ({ useRoute: () => h.route }));
 vi.mock('@/cache', () => ({ sideNavIsOpenVar: false }));
 vi.mock('@/composables/useAuthState', () => ({
@@ -25,11 +27,27 @@ const mountNav = () =>
   mount(TopNav, {
     global: {
       stubs: {
-        HamburgerMenuButton: { name: 'HamburgerMenuButton', emits: ['click'], template: '<button class="hamburger" @click="$emit(\'click\')" />' },
-        UserProfileDropdownMenu: { name: 'UserProfileDropdownMenu', template: '<div class="profile" />' },
+        HamburgerMenuButton: {
+          name: 'HamburgerMenuButton',
+          emits: ['click'],
+          template: '<button class="hamburger" @click="$emit(\'click\')" />',
+        },
+        UserProfileDropdownMenu: {
+          name: 'UserProfileDropdownMenu',
+          template: '<div class="profile" />',
+        },
         ThemeSwitcher: true,
         CreateAnythingButton: true,
-        AddToChannelFavorites: { name: 'AddToChannelFavorites', template: '<div class="fav" />' },
+        AddToChannelFavorites: {
+          name: 'AddToChannelFavorites',
+          template: '<div class="fav" />',
+        },
+        ForumQuickSwitcher: {
+          name: 'ForumQuickSwitcher',
+          props: ['currentForumId'],
+          template:
+            '<button class="forum-switcher">{{ currentForumId }}</button>',
+        },
         TopNavSearch: true,
         LoginButton: true,
         ClientOnly: { template: '<div><slot /></div>' },
@@ -69,6 +87,13 @@ describe('TopNav branding', () => {
     const wrapper = mountNav();
 
     expect(wrapper.find('.fav').exists()).toBe(true);
+  });
+
+  it('passes the active forum to the quick switcher', () => {
+    h.route = { params: { forumId: 'cats' }, name: 'forums-forumId' };
+    const wrapper = mountNav();
+
+    expect(wrapper.get('.forum-switcher').text()).toBe('cats');
   });
 });
 
@@ -128,7 +153,9 @@ describe('TopNav actions', () => {
     h.notificationCount = ref(5);
     const wrapper = mountNav();
 
-    expect(wrapper.find('[data-testid="notification-bell"]').text()).toContain('5');
+    expect(wrapper.find('[data-testid="notification-bell"]').text()).toContain(
+      '5'
+    );
   });
 
   it('shows the profile menu when logged in', () => {

--- a/components/nav/TopNav.vue
+++ b/components/nav/TopNav.vue
@@ -9,6 +9,7 @@ import CreateAnythingButton from '@/components/nav/CreateAnythingButton.vue';
 import AddToChannelFavorites from '@/components/favorites/AddToChannelFavorites.vue';
 import TopNavSearch from '@/components/nav/TopNavSearch.vue';
 import BellIcon from '@/components/icons/BellIcon.vue';
+import ForumQuickSwitcher from '@/components/nav/ForumQuickSwitcher.vue';
 // import LogoIcon from "@/components/icons/LogoIcon.vue"; // Unused for now
 import { useRoute } from 'nuxt/app';
 import LoginButton from './LoginButton.vue';
@@ -113,12 +114,7 @@ const isOnMapPage = computed(() => {
               class="h-1.5 w-1.5 shrink-0 rounded-full bg-gray-400 dark:bg-gray-500"
               aria-hidden="true"
             />
-            <nuxt-link
-              :to="`/forums/${channelId}`"
-              class="max-w-[8rem] truncate text-gray-700 transition-colors hover:text-gray-950 sm:max-w-[12rem] lg:max-w-[16rem] dark:text-gray-300 dark:hover:text-white"
-            >
-              {{ channelId }}
-            </nuxt-link>
+            <ForumQuickSwitcher :current-forum-id="channelId" />
             <AddToChannelFavorites
               :channel-unique-name="channelId"
               :allow-add-to-list="true"


### PR DESCRIPTION
## Summary

- replace the active forum link in the top navigation with a quick-switcher trigger
- show recent forums, favorite forums, collapsible forum collections, and searchable top-forum results
- navigate immediately when a forum is selected, with outside-click and Escape dismissal
- lazy-load browser recents and GraphQL queries only after the switcher opens

## Why

Users who participate across several forums need a fast way to move between them without returning to the forum index. Reusing the existing forum data sources gives the switcher access to personal favorites and collections while keeping navigation semantics distinct from the form-oriented multi-select picker.

The popover stays closed during SSR and the client's initial hydration pass. Local storage is read only after a user opens it, and all forum queries remain disabled until then, preventing client-only recent-forum state from changing the initial markup.

## User impact

The active forum name in the desktop top navigation now has a caret. Opening it provides quick access to recent and saved forums plus a global forum search.

## Validation

- `vitest run components/nav/ForumQuickSwitcher.spec.ts components/nav/TopNav.spec.ts` — 30 tests passed
- `vue-tsc --noEmit`
- targeted ESLint checks for the changed Vue and test files
- `git diff --check`