### PR TITLE
Add download scan review controls

### DIFF
--- a/components/admin/DownloadScanReviewQueue.spec.ts
+++ b/components/admin/DownloadScanReviewQueue.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import DownloadScanReviewQueue from './DownloadScanReviewQueue.vue';
+
+const mockClear = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const mockRefetch = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(() => ({
+    result: ref({
+      getDownloadScanReviewQueue: [{
+        downloadableFileId: 'file-1',
+        fileName: 'asset.zip',
+        scanStatus: 'SUSPICIOUS',
+        scanReason: 'Archive contains an installer',
+        reviewRequestedAt: '2026-07-19T00:00:00Z',
+        reviewRequestReason: 'This is source code only',
+        uploaderUsername: 'alice',
+        discussionId: 'discussion-1',
+        discussionTitle: 'Asset pack',
+        channelUniqueName: 'general',
+      }],
+    }),
+    loading: ref(false),
+    error: ref(null),
+    refetch: mockRefetch,
+  })),
+  useMutation: vi.fn(() => ({
+    mutate: mockClear,
+    loading: ref(false),
+    error: ref(null),
+  })),
+}));
+
+const mountQueue = () => mount(DownloadScanReviewQueue, {
+  global: {
+    stubs: {
+      NuxtLink: {
+        props: ['to'],
+        template: '<a :href="to"><slot /></a>',
+      },
+    },
+  },
+});
+
+describe('DownloadScanReviewQueue', () => {
+  it('renders scanner context and the creator review request', () => {
+    const wrapper = mountQueue();
+
+    expect(wrapper.text()).toContain(
+      'Creator requested human review: This is source code only'
+    );
+  });
+
+  it('clears a reviewed file and refreshes the queue', async () => {
+    const wrapper = mountQueue();
+    await wrapper.get('input').setValue('Reviewed archive contents');
+    await wrapper.get('button').trigger('click');
+    await flushPromises();
+
+    expect({
+      mutation: mockClear.mock.calls.at(-1)?.[0],
+      refetched: mockRefetch.mock.calls.length > 0,
+    }).toEqual({
+      mutation: {
+        downloadableFileId: 'file-1',
+        reason: 'Reviewed archive contents',
+      },
+      refetched: true,
+    });
+  });
+});

--- a/components/admin/DownloadScanReviewQueue.vue
+++ b/components/admin/DownloadScanReviewQueue.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useMutation, useQuery } from '@vue/apollo-composable';
+import { ShieldCheck } from 'lucide-vue-next';
+import { GET_DOWNLOAD_SCAN_REVIEW_QUEUE } from '@/graphQLData/admin/queries';
+import { CLEAR_DOWNLOADABLE_FILE_SCAN } from '@/graphQLData/discussion/mutations';
+
+type ReviewItem = {
+  downloadableFileId: string;
+  fileName: string;
+  scanStatus: 'SUSPICIOUS' | 'INFECTED';
+  scanReason?: string | null;
+  reviewRequestedAt?: string | null;
+  reviewRequestReason?: string | null;
+  uploaderUsername?: string | null;
+  discussionId: string;
+  discussionTitle?: string | null;
+  channelUniqueName?: string | null;
+};
+
+const reviewNotes = ref<Record<string, string>>({});
+const clearingFileId = ref('');
+
+const {
+  result,
+  loading,
+  error,
+  refetch,
+} = useQuery(GET_DOWNLOAD_SCAN_REVIEW_QUEUE, { limit: 50 }, {
+  fetchPolicy: 'cache-and-network',
+  prefetch: false,
+});
+
+const {
+  mutate: clearDownloadableFileScan,
+  loading: clearing,
+  error: clearError,
+} = useMutation(CLEAR_DOWNLOADABLE_FILE_SCAN);
+
+const clearReview = async (item: ReviewItem) => {
+  if (clearing.value) return;
+  clearingFileId.value = item.downloadableFileId;
+  try {
+    await clearDownloadableFileScan({
+      downloadableFileId: item.downloadableFileId,
+      reason: reviewNotes.value[item.downloadableFileId]?.trim() || null,
+    });
+    await refetch();
+  } catch {
+    // Apollo exposes the mutation error through clearError below.
+  } finally {
+    clearingFileId.value = '';
+  }
+};
+
+const discussionPath = (item: ReviewItem) => {
+  if (!item.channelUniqueName) return null;
+  return `/forums/${item.channelUniqueName}/downloads/${item.discussionId}`;
+};
+</script>
+
+<template>
+  <section
+    class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+    data-testid="download-scan-review-queue"
+  >
+    <div class="flex items-start justify-between gap-3">
+      <div>
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Download security review queue
+        </h2>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          Suspicious and infected files remain unavailable until a reviewer clears them.
+        </p>
+      </div>
+      <ShieldCheck class="h-5 w-5 text-orange-600 dark:text-orange-300" />
+    </div>
+
+    <p v-if="loading && !result" class="mt-4 text-sm text-gray-600 dark:text-gray-300">
+      Loading security reviews…
+    </p>
+    <p v-else-if="error" class="mt-4 text-sm text-red-700 dark:text-red-300">
+      {{ error.message }}
+    </p>
+    <p
+      v-else-if="!result?.getDownloadScanReviewQueue?.length"
+      class="mt-4 text-sm text-gray-600 dark:text-gray-300"
+    >
+      No downloads are waiting for security review.
+    </p>
+
+    <div v-else class="mt-4 space-y-3">
+      <article
+        v-for="item in result.getDownloadScanReviewQueue as ReviewItem[]"
+        :key="item.downloadableFileId"
+        class="rounded-md border border-gray-200 p-3 dark:border-gray-700"
+      >
+        <div class="flex flex-wrap items-start justify-between gap-2">
+          <div>
+            <p class="font-medium text-gray-900 dark:text-gray-100">
+              {{ item.fileName }}
+            </p>
+            <p class="text-sm text-gray-600 dark:text-gray-300">
+              {{ item.discussionTitle || item.discussionId }}
+              <span v-if="item.uploaderUsername"> · {{ item.uploaderUsername }}</span>
+            </p>
+          </div>
+          <span
+            class="rounded-full px-2 py-1 text-xs font-medium"
+            :class="item.scanStatus === 'INFECTED'
+              ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200'
+              : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200'"
+          >
+            {{ item.scanStatus }}
+          </span>
+        </div>
+
+        <p v-if="item.scanReason" class="mt-2 text-sm text-gray-700 dark:text-gray-200">
+          Scanner: {{ item.scanReason }}
+        </p>
+        <p
+          v-if="item.reviewRequestedAt"
+          class="mt-2 text-sm font-medium text-orange-700 dark:text-orange-200"
+        >
+          Creator requested human review<span v-if="item.reviewRequestReason">: {{ item.reviewRequestReason }}</span>
+        </p>
+
+        <div class="mt-3 flex flex-col gap-2 md:flex-row md:items-end">
+          <label class="flex-1 text-sm text-gray-700 dark:text-gray-200">
+            Review note
+            <input
+              v-model="reviewNotes[item.downloadableFileId]"
+              :aria-label="`Review note for ${item.fileName}`"
+              class="mt-1 w-full rounded-md border-gray-300 text-sm dark:border-gray-700 dark:bg-gray-800"
+              placeholder="Why this file is safe"
+            >
+          </label>
+          <NuxtLink
+            v-if="discussionPath(item)"
+            :to="discussionPath(item) || ''"
+            class="text-sm font-medium text-orange-700 underline dark:text-orange-200"
+          >
+            Open download
+          </NuxtLink>
+          <button
+            type="button"
+            class="rounded-md bg-green-700 px-3 py-2 text-sm font-medium text-white hover:bg-green-800 disabled:opacity-60"
+            :disabled="clearing"
+            @click="clearReview(item)"
+          >
+            {{ clearing && clearingFileId === item.downloadableFileId ? 'Clearing…' : 'Clear as clean' }}
+          </button>
+        </div>
+      </article>
+    </div>
+
+    <p v-if="clearError" class="mt-3 text-sm text-red-700 dark:text-red-300">
+      {{ clearError.message }}
+    </p>
+  </section>
+</template>

--- a/components/channel/DownloadSidebar.spec.ts
+++ b/components/channel/DownloadSidebar.spec.ts
@@ -28,6 +28,9 @@ vi.mock('@vue/apollo-composable', () => ({
   })),
   useMutation: vi.fn(() => ({
     mutate: trackDownloadMock,
+    loading: ref(false),
+    error: ref(null),
+    onDone: vi.fn(),
   })),
 }));
 
@@ -229,7 +232,9 @@ describe('DownloadSidebar', () => {
 
     expect({
       status: wrapper.get('[data-testid="download-scan-status"]').text(),
-      button: wrapper.get('button').text(),
+      button: wrapper.findAll('button').find((button) =>
+        button.text() === 'Download for review'
+      )?.text(),
     }).toEqual({
       status: expect.stringContaining(
         'This upload was blocked by the security scan: Known malware signature.'
@@ -258,6 +263,56 @@ describe('DownloadSidebar', () => {
     });
 
     expect(wrapper.text()).not.toContain('Private scanner detail');
+  });
+
+  it('sends a targeted human-review request for the creator', async () => {
+    mockUsernameRef.value = 'author';
+    const wrapper = mount(DownloadSidebar, {
+      props: {
+        discussion: makeDiscussion({
+          ...discussionWithFile,
+          DownloadableFiles: [
+            {
+              ...discussionWithFile.DownloadableFiles[0],
+              scanStatus: 'SUSPICIOUS',
+            },
+          ],
+        }),
+        discussionId: 'discussion-1',
+        channelUniqueName: 'test-forum',
+      },
+    });
+
+    await wrapper.get('[data-testid="download-scan-status"] button').trigger('click');
+
+    expect(trackDownloadMock).toHaveBeenCalledWith({
+      downloadableFileId: 'file-1',
+      reason: null,
+    });
+  });
+
+  it('shows when human review was already requested', () => {
+    mockUsernameRef.value = 'author';
+    const wrapper = mount(DownloadSidebar, {
+      props: {
+        discussion: makeDiscussion({
+          ...discussionWithFile,
+          DownloadableFiles: [
+            {
+              ...discussionWithFile.DownloadableFiles[0],
+              scanStatus: 'SUSPICIOUS',
+              reviewRequestedAt: '2026-07-19T00:00:00Z',
+            },
+          ],
+        }),
+        discussionId: 'discussion-1',
+        channelUniqueName: 'test-forum',
+      },
+    });
+
+    expect(wrapper.get('[data-testid="download-scan-status"] button').text()).toBe(
+      'Human review requested'
+    );
   });
 
   it('identifies a failed scan as a server-side problem for the creator', () => {

--- a/components/channel/DownloadSidebar.vue
+++ b/components/channel/DownloadSidebar.vue
@@ -9,7 +9,10 @@ import ScopedPipelineView from '@/components/plugins/ScopedPipelineView.vue';
 import { computed, ref } from 'vue';
 import { useMutation, useQuery } from '@vue/apollo-composable';
 import { GET_DOWNLOAD_LABELS } from '@/graphQLData/discussion/queries';
-import { RETRY_DOWNLOADABLE_FILE_SCAN } from '@/graphQLData/discussion/mutations';
+import {
+  REQUEST_DOWNLOADABLE_FILE_REVIEW,
+  RETRY_DOWNLOADABLE_FILE_SCAN,
+} from '@/graphQLData/discussion/mutations';
 import { useUsername } from '@/composables/useAuthState';
 
 type DownloadScanStatus =
@@ -27,6 +30,8 @@ type ScannedDownloadableFile = Omit<
   scanReason?: string | null;
   scanCheckedAt?: string | null;
   uploadedByUsername?: string | null;
+  reviewRequestedAt?: string | null;
+  reviewRequestReason?: string | null;
 };
 
 const props = defineProps({
@@ -51,6 +56,16 @@ const retryError = ref('');
 const { mutate: retryDownloadableFileScan } = useMutation(
   RETRY_DOWNLOADABLE_FILE_SCAN
 );
+const reviewRequestedLocally = ref(false);
+const {
+  mutate: requestDownloadableFileReview,
+  loading: requestingReview,
+  error: requestReviewError,
+  onDone: onReviewRequested,
+} = useMutation(REQUEST_DOWNLOADABLE_FILE_REVIEW);
+onReviewRequested(() => {
+  reviewRequestedLocally.value = true;
+});
 
 // Popover state
 const showSuccessPopover = ref(false);
@@ -88,6 +103,20 @@ const creatorIsViewing = computed(
   () => Boolean(username.value) && props.discussion?.Author?.username === username.value
 );
 
+const reviewRequested = computed(
+  () => reviewRequestedLocally.value || Boolean(primaryFile.value?.reviewRequestedAt)
+);
+
+const requestHumanReview = () => {
+  if (!primaryFile.value?.id || requestingReview.value || reviewRequested.value) {
+    return;
+  }
+  requestDownloadableFileReview({
+    downloadableFileId: primaryFile.value.id,
+    reason: null,
+  });
+};
+
 const hasReviewAccess = computed(
   () => scanStatus.value !== 'CLEAN' && Boolean(primaryFile.value?.url)
 );
@@ -104,10 +133,6 @@ const downloadLabel = computed(() =>
 
 const replaceFilePath = computed(
   () => `/forums/${props.channelUniqueName}/downloads/edit/${props.discussionId}`
-);
-
-const requestReviewPath = computed(
-  () => `/forums/${props.channelUniqueName}/issues/create`
 );
 
 // Format price display
@@ -274,10 +299,18 @@ const groupedLabels = computed(() => {
               <NuxtLink class="font-medium underline" :to="replaceFilePath">
                 Replace file
               </NuxtLink>
-              <NuxtLink class="font-medium underline" :to="requestReviewPath">
-                Request human review
-              </NuxtLink>
+              <button
+                type="button"
+                class="font-medium underline disabled:no-underline disabled:opacity-70"
+                :disabled="requestingReview || reviewRequested"
+                @click="requestHumanReview"
+              >
+                {{ reviewRequested ? 'Human review requested' : requestingReview ? 'Requesting review…' : 'Request human review' }}
+              </button>
             </div>
+            <p v-if="requestReviewError" class="mt-2 font-medium">
+              The review request could not be sent. Please try again.
+            </p>
           </template>
           <template v-else>
             <p class="font-medium">

--- a/graphQLData/admin/queries.js
+++ b/graphQLData/admin/queries.js
@@ -190,6 +190,24 @@ export const GET_SERVER_HEALTH_DASHBOARD = gql`
   }
 `;
 
+export const GET_DOWNLOAD_SCAN_REVIEW_QUEUE = gql`
+  query getDownloadScanReviewQueue($limit: Int) {
+    getDownloadScanReviewQueue(limit: $limit) {
+      downloadableFileId
+      fileName
+      scanStatus
+      scanReason
+      scanCheckedAt
+      reviewRequestedAt
+      reviewRequestReason
+      uploaderUsername
+      discussionId
+      discussionTitle
+      channelUniqueName
+    }
+  }
+`;
+
 export const GET_SERVER_HEALTH_DASHBOARD_OVERVIEW = gql`
   query getServerHealthDashboardOverview(
     $startDate: String

--- a/graphQLData/discussion/mutations.js
+++ b/graphQLData/discussion/mutations.js
@@ -110,6 +110,40 @@ export const RETRY_DOWNLOADABLE_FILE_SCAN = gql`
   }
 `;
 
+export const REQUEST_DOWNLOADABLE_FILE_REVIEW = gql`
+  mutation requestDownloadableFileReview(
+    $downloadableFileId: ID!
+    $reason: String
+  ) {
+    requestDownloadableFileReview(
+      downloadableFileId: $downloadableFileId
+      reason: $reason
+    ) {
+      id
+      scanStatus
+      reviewRequestedAt
+      reviewRequestReason
+    }
+  }
+`;
+
+export const CLEAR_DOWNLOADABLE_FILE_SCAN = gql`
+  mutation clearDownloadableFileScan(
+    $downloadableFileId: ID!
+    $reason: String
+  ) {
+    clearDownloadableFileScan(
+      downloadableFileId: $downloadableFileId
+      reason: $reason
+    ) {
+      id
+      scanStatus
+      scanReason
+      scanCheckedAt
+    }
+  }
+`;
+
 export const PERMANENTLY_DELETE_IMAGE = gql`
   mutation permanentlyDeleteImage($imageId: ID!) {
     permanentlyDeleteImage(imageId: $imageId) {

--- a/graphQLData/discussion/queries.js
+++ b/graphQLData/discussion/queries.js
@@ -377,6 +377,8 @@ export const GET_DISCUSSION = gql`
         scanStatus
         scanCheckedAt
         scanReason
+        reviewRequestedAt
+        reviewRequestReason
         uploadedByUsername
         license {
           id
@@ -480,6 +482,8 @@ export const GET_DISCUSSION_FEEDBACK = gql`
         scanStatus
         scanCheckedAt
         scanReason
+        reviewRequestedAt
+        reviewRequestReason
         uploadedByUsername
       }
       CrosspostedDiscussion {

--- a/pages/admin/dashboard.spec.ts
+++ b/pages/admin/dashboard.spec.ts
@@ -140,6 +140,9 @@ const mountDashboard = async (
         ClientOnly: {
           template: '<slot /><slot name="fallback" />',
         },
+        DownloadScanReviewQueue: {
+          template: '<div data-testid="scan-review-queue" />',
+        },
       },
     },
   });

--- a/pages/admin/dashboard/index.vue
+++ b/pages/admin/dashboard/index.vue
@@ -7,6 +7,7 @@ import ServerDashboardActivityChart from '@/components/admin/ServerDashboardActi
 import ServerDashboardIssueAging from '@/components/admin/ServerDashboardIssueAging.vue';
 import ServerDashboardMetricCards from '@/components/admin/ServerDashboardMetricCards.vue';
 import ServerDashboardSecondaryStats from '@/components/admin/ServerDashboardSecondaryStats.vue';
+import DownloadScanReviewQueue from '@/components/admin/DownloadScanReviewQueue.vue';
 import { RefreshCw } from 'lucide-vue-next';
 import {
   GET_SERVER_HEALTH_CHANNEL_HEALTH,
@@ -341,6 +342,8 @@ const updateChannelSort = (sortBy: ChannelHealthSortKey) => {
 
       <template v-else-if="dashboard">
         <ServerDashboardMetricCards :summary="dashboard.summary" />
+
+        <DownloadScanReviewQueue />
 
         <section
           class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]"


### PR DESCRIPTION
Frontend half of the second download-scan completion slice.

Depends on:
- [multiforum-backend#170](https://github.com/gennit-project/multiforum-backend/pull/170)
- [multiforum-backend#171](https://github.com/gennit-project/multiforum-backend/pull/171)

## What changed

- replace the generic issue link with a file-specific human review request
- show creators when review has already been requested
- add a download security review queue to the server dashboard
- show scanner status/reason, uploader, discussion, and creator request context
- let authorized reviewers open the held download and clear it to `CLEAN` with a review note

## Validation

- Vue TypeScript check passed
- ESLint passed on changed files
- sidebar, review queue, and dashboard tests passed (21/21)