### PR TITLE
Show the security scan before downloads

### DIFF
--- a/components/channel/DownloadSidebar.spec.ts
+++ b/components/channel/DownloadSidebar.spec.ts
@@ -1,12 +1,29 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mount } from '@vue/test-utils';
-import { defineComponent, nextTick, ref } from 'vue';
+import { flushPromises, mount } from '@vue/test-utils';
+import { defineComponent, ref } from 'vue';
 import DownloadSidebar from '@/components/channel/DownloadSidebar.vue';
 import { makeDiscussion } from '@/tests/utils/factories';
 
 const authState = ref(false);
 const mockUsernameRef = ref('');
-const trackDownloadMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const trackDownloadMock = vi.hoisted(() => vi.fn(() => Promise.resolve({
+  data: {
+    prepareDownload: {
+      ready: true,
+      url: 'https://signed.example.com/asset.zip',
+      scanStatus: 'CLEAN',
+      reviewAccess: false,
+      message: 'No threats found. Your download is ready.',
+    },
+  },
+})));
+
+vi.mock('@/stores/toastStore', () => ({
+  useToastStore: () => ({
+    showToast: vi.fn(() => 'toast-1'),
+    updateToast: vi.fn(),
+  }),
+}));
 
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => mockUsernameRef,
@@ -99,11 +116,9 @@ describe('DownloadSidebar', () => {
     authState.value = false;
     mockUsernameRef.value = '';
     trackDownloadMock.mockClear();
-    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -123,7 +138,6 @@ describe('DownloadSidebar', () => {
     expect(button.attributes('disabled')).toBeUndefined();
 
     await button.trigger('click');
-    vi.runAllTimers();
 
     expect(appendSpy).not.toHaveBeenCalled();
     expect(trackDownloadMock).not.toHaveBeenCalled();
@@ -142,8 +156,7 @@ describe('DownloadSidebar', () => {
     });
 
     await wrapper.get('button').trigger('click');
-    vi.advanceTimersByTime(500);
-    await nextTick();
+    await flushPromises();
 
     expect(trackDownloadMock).toHaveBeenCalledWith({
       downloadableFileId: 'file-1',

--- a/components/channel/DownloadSidebar.vue
+++ b/components/channel/DownloadSidebar.vue
@@ -375,7 +375,6 @@ const groupedLabels = computed(() => {
         <template #has-auth>
           <FunctionalDownloadNow
             :disabled="downloadDisabled"
-            :url="primaryFile?.url || ''"
             :file-name="primaryFile?.fileName || 'download'"
             :downloadable-file-id="primaryFile?.id || ''"
             :discussion-id="discussionId"

--- a/components/channel/FunctionalDownloadNow.spec.ts
+++ b/components/channel/FunctionalDownloadNow.spec.ts
@@ -1,25 +1,37 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { ref } from 'vue';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import FunctionalDownloadNow from '@/components/channel/FunctionalDownloadNow.vue';
 
-const h = vi.hoisted(() => ({
-  trackDownload: vi.fn(() => Promise.resolve()),
-}));
+const mockPrepareDownload = vi.fn();
+const mockLoading = ref(false);
+const mockError = ref<Error | null>(null);
+const mockShowToast = vi.fn(() => 'toast-1');
+const mockUpdateToast = vi.fn();
 
 vi.mock('@vue/apollo-composable', () => ({
   useMutation: () => ({
-    mutate: h.trackDownload,
+    mutate: mockPrepareDownload,
+    loading: mockLoading,
+    error: mockError,
+  }),
+}));
+
+vi.mock('@/stores/toastStore', () => ({
+  useToastStore: () => ({
+    showToast: mockShowToast,
+    updateToast: mockUpdateToast,
   }),
 }));
 
 vi.mock('@/graphQLData/discussion/mutations', () => ({
-  TRACK_DOWNLOAD: 'TRACK_DOWNLOAD',
+  PREPARE_DOWNLOAD: 'PREPARE_DOWNLOAD',
 }));
 
 const mountButton = (props: Record<string, unknown> = {}) =>
   mountWithDefaults(FunctionalDownloadNow, {
     props: {
-      url: 'https://example.com/file.zip',
       fileName: 'file.zip',
       downloadableFileId: 'file-1',
       discussionId: 'discussion-1',
@@ -29,10 +41,10 @@ const mountButton = (props: Record<string, unknown> = {}) =>
       stubs: {
         DownloadNowButton: {
           name: 'DownloadNowButton',
-          props: ['disabled'],
+          props: ['disabled', 'label'],
           emits: ['click'],
           template:
-            '<button class="download-now-button" :disabled="disabled" @click="$emit(\'click\')" />',
+            '<button class="download-now-button" :disabled="disabled" @click="$emit(\'click\')">{{ label }}</button>',
         },
       },
     },
@@ -40,54 +52,103 @@ const mountButton = (props: Record<string, unknown> = {}) =>
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.useFakeTimers();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
+  mockLoading.value = false;
+  mockError.value = null;
+  mockPrepareDownload.mockResolvedValue({
+    data: {
+      prepareDownload: {
+        ready: true,
+        url: 'https://signed.example.com/file.zip',
+        scanStatus: 'CLEAN',
+        scanReason: null,
+        reviewAccess: false,
+        message: 'No threats found. Your download is ready.',
+      },
+    },
+  });
 });
 
 describe('FunctionalDownloadNow', () => {
-  it('tracks the download and emits downloaded after a successful click', async () => {
+  it('prepares the download before opening the returned URL', async () => {
     const anchor = document.createElement('a');
     const originalCreateElement = document.createElement.bind(document);
     const createElementSpy = vi
       .spyOn(document, 'createElement')
       .mockImplementation((tagName: string) =>
-        tagName === 'a'
-          ? anchor
-          : originalCreateElement(tagName)
+        tagName === 'a' ? anchor : originalCreateElement(tagName)
       );
     const wrapper = mountButton();
 
     await wrapper.get('.download-now-button').trigger('click');
-    await vi.runAllTimersAsync();
+    await flushPromises();
 
     expect({
-      tracked: h.trackDownload.mock.calls,
+      preparedWith: mockPrepareDownload.mock.calls,
       emitted: wrapper.emitted('downloaded'),
+      toast: mockUpdateToast.mock.calls.at(-1),
     }).toEqual({
-      tracked: [[{ downloadableFileId: 'file-1', discussionId: 'discussion-1' }]],
+      preparedWith: [[{
+        downloadableFileId: 'file-1',
+        discussionId: 'discussion-1',
+      }]],
       emitted: [[]],
+      toast: ['toast-1', {
+        message: 'No threats found in file.zip — download started.',
+        type: 'success',
+      }],
     });
 
     createElementSpy.mockRestore();
   });
 
-  it('logs an error and skips tracking when there is no download url', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const wrapper = mountButton({ url: '' });
+  it('shows the checking toast while requesting the gated URL', async () => {
+    const wrapper = mountButton();
 
     await wrapper.get('.download-now-button').trigger('click');
 
-    expect({
-      error: errorSpy.mock.calls[0]?.[0],
-      tracked: h.trackDownload.mock.calls.length,
-      emitted: wrapper.emitted('downloaded'),
-    }).toEqual({
-      error: 'No download URL available',
-      tracked: 0,
-      emitted: undefined,
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'Checking file.zip for threats…',
+      'info'
+    );
+  });
+
+  it('does not open a URL when the security scan blocks the download', async () => {
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    mockPrepareDownload.mockResolvedValue({
+      data: {
+        prepareDownload: {
+          ready: false,
+          url: null,
+          scanStatus: 'INFECTED',
+          reviewAccess: false,
+          message: 'This download was blocked by the security check.',
+        },
+      },
     });
+    const wrapper = mountButton();
+
+    await wrapper.get('.download-now-button').trigger('click');
+    await flushPromises();
+
+    expect({
+      opened: appendSpy.mock.calls.length,
+      emitted: wrapper.emitted('downloaded'),
+      toast: mockUpdateToast.mock.calls.at(-1),
+    }).toEqual({
+      opened: 0,
+      emitted: undefined,
+      toast: ['toast-1', {
+        message: 'This download was blocked by the security check.',
+        type: 'error',
+      }],
+    });
+  });
+
+  it('does nothing when required download identifiers are missing', async () => {
+    const wrapper = mountButton({ downloadableFileId: '' });
+
+    await wrapper.get('.download-now-button').trigger('click');
+
+    expect(mockPrepareDownload).not.toHaveBeenCalled();
   });
 });

--- a/components/channel/FunctionalDownloadNow.vue
+++ b/components/channel/FunctionalDownloadNow.vue
@@ -1,16 +1,22 @@
 <script setup lang="ts">
 import DownloadNowButton from '@/components/channel/DownloadNowButton.vue';
-import { TRACK_DOWNLOAD } from '@/graphQLData/discussion/mutations';
+import { PREPARE_DOWNLOAD } from '@/graphQLData/discussion/mutations';
+import { useToastStore } from '@/stores/toastStore';
 import { useMutation } from '@vue/apollo-composable';
+
+type PrepareDownloadResult = {
+  ready: boolean;
+  url?: string | null;
+  scanStatus: 'PENDING' | 'CLEAN' | 'INFECTED' | 'SUSPICIOUS' | 'FAILED';
+  scanReason?: string | null;
+  reviewAccess: boolean;
+  message: string;
+};
 
 const props = defineProps({
   disabled: {
     type: Boolean,
     default: false,
-  },
-  url: {
-    type: String,
-    default: '',
   },
   fileName: {
     type: String,
@@ -32,42 +38,82 @@ const props = defineProps({
 
 const emit = defineEmits(['downloaded']);
 
-const { mutate: trackDownload } = useMutation(TRACK_DOWNLOAD);
+const toastStore = useToastStore();
+const {
+  mutate: prepareDownload,
+  loading: preparingDownload,
+  error: prepareDownloadError,
+} = useMutation(PREPARE_DOWNLOAD);
 
-const handleDownload = () => {
-  if (props.disabled || !props.url) {
-    console.error('No download URL available');
+const startBrowserDownload = (url: string) => {
+  if (!import.meta.client) return;
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = props.fileName || 'download';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+const handleDownload = async () => {
+  if (
+    props.disabled ||
+    preparingDownload.value ||
+    !props.downloadableFileId ||
+    !props.discussionId
+  ) {
     return;
   }
 
-  if (import.meta.client) {
-    const link = document.createElement('a');
-    link.href = props.url;
-    link.download = props.fileName || 'download';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }
+  const toastId = toastStore.showToast(
+    `Checking ${props.fileName || 'download'} for threats…`,
+    'info'
+  );
 
-  if (props.downloadableFileId && props.discussionId) {
-    trackDownload({
+  try {
+    const response = await prepareDownload({
       downloadableFileId: props.downloadableFileId,
       discussionId: props.discussionId,
-    }).catch((error) => {
-      console.error('Failed to track download', error);
+    });
+    const result = response?.data?.prepareDownload as
+      | PrepareDownloadResult
+      | undefined;
+
+    if (!result?.ready || !result.url) {
+      toastStore.updateToast(toastId, {
+        message:
+          result?.message ||
+          'The security check could not be completed. Please try again.',
+        type: 'error',
+      });
+      return;
+    }
+
+    startBrowserDownload(result.url);
+    toastStore.updateToast(toastId, {
+      message: result.reviewAccess
+        ? result.message
+        : `No threats found in ${props.fileName || 'the file'} — download started.`,
+      type: 'success',
+    });
+    emit('downloaded');
+  } catch {
+    toastStore.updateToast(toastId, {
+      message:
+        prepareDownloadError.value?.message ||
+        'The security check could not be completed. Please try again.',
+      type: 'error',
     });
   }
-
-  setTimeout(() => {
-    emit('downloaded');
-  }, 500);
 };
+
 </script>
 
 <template>
   <DownloadNowButton
-    :disabled="disabled"
-    :label="label"
+    :disabled="disabled || preparingDownload"
+    :label="preparingDownload ? 'Checking…' : label"
     @click="handleDownload"
   />
 </template>

--- a/graphQLData/discussion/mutations.js
+++ b/graphQLData/discussion/mutations.js
@@ -92,12 +92,20 @@ export const CREATE_DOWNLOADABLE_FILE = gql`
   }
 `;
 
-export const TRACK_DOWNLOAD = gql`
-  mutation trackDownload($downloadableFileId: ID!, $discussionId: ID!) {
-    trackDownload(
+export const PREPARE_DOWNLOAD = gql`
+  mutation prepareDownload($downloadableFileId: ID!, $discussionId: ID!) {
+    prepareDownload(
       downloadableFileId: $downloadableFileId
       discussionId: $discussionId
-    )
+    ) {
+      ready
+      url
+      scanStatus
+      scanReason
+      scanCheckedAt
+      reviewAccess
+      message
+    }
   }
 `;
 

--- a/stores/toastStore.ts
+++ b/stores/toastStore.ts
@@ -13,6 +13,9 @@ interface ToastAction {
   onClick: () => void;
 }
 
+type ToastUpdate = Pick<Toast, 'message'> &
+  Partial<Pick<Toast, 'type' | 'action'>>;
+
 export const useToastStore = defineStore('toast', () => {
   const toasts = ref<Toast[]>([]);
 
@@ -38,6 +41,13 @@ export const useToastStore = defineStore('toast', () => {
     }
   }
 
+  function updateToast(id: string, update: ToastUpdate) {
+    const toast = toasts.value.find((item) => item.id === id);
+    if (!toast) return;
+
+    Object.assign(toast, update);
+  }
+
   function clearAllToasts() {
     toasts.value = [];
   }
@@ -45,6 +55,7 @@ export const useToastStore = defineStore('toast', () => {
   return {
     toasts,
     showToast,
+    updateToast,
     dismissToast,
     clearAllToasts,
   };

--- a/tests/unit/stores/toastStore.spec.ts
+++ b/tests/unit/stores/toastStore.spec.ts
@@ -34,6 +34,25 @@ describe('toastStore', () => {
     expect(store.toasts.length).toBe(1);
   });
 
+  it('updates an existing toast in place', () => {
+    const store = useToastStore();
+    const id = store.showToast('Checking…', 'info');
+
+    store.updateToast(id, {
+      message: 'No threats found',
+      type: 'success',
+    });
+
+    expect(store.toasts).toEqual([
+      {
+        id,
+        message: 'No threats found',
+        type: 'success',
+        action: undefined,
+      },
+    ]);
+  });
+
   it('clears all toasts', () => {
     const store = useToastStore();
     store.showToast('First', 'success');


### PR DESCRIPTION
## Summary

- replace the click-then-track browser flow with the gated `prepareDownload` mutation
- show one toast that transitions from checking to success, blocked, or unavailable
- open only the short-lived URL returned after the backend scan approves the request
- disable the button and show `Checking…` while the VirusTotal-backed scan is running
- keep the existing post-download attribution and support popover

Depends on backend PR #172.

## Validation

- `pnpm exec vitest run components/channel/FunctionalDownloadNow.spec.ts components/channel/DownloadSidebar.spec.ts tests/unit/stores/toastStore.spec.ts` (19 passing)
- `pnpm run tsc`
- focused ESLint over all changed frontend files

The existing `security-attachment-scan` plugin already handles `downloadableFile.downloaded`, so no plugin release is required for this slice.