### PR TITLE
Upload downloadable files to private storage

### DIFF
--- a/components/discussion/form/DownloadEditForm.spec.ts
+++ b/components/discussion/form/DownloadEditForm.spec.ts
@@ -335,6 +335,18 @@ describe('DownloadEditForm file editing', () => {
 });
 
 describe('DownloadEditForm upload', () => {
+  it('requests private storage for downloadable files', async () => {
+    const wrapper = mountForm();
+
+    await setFiles(wrapper, '#downloadable-file-input', [
+      new File(['x'], 'new.stl'),
+    ]);
+
+    expect(h.createSignedStorageUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ uploadTarget: 'PRIVATE_DOWNLOAD' })
+    );
+  });
+
   it('uploads a file and adds it to the form values', async () => {
     const wrapper = mountForm();
 

--- a/components/discussion/form/DownloadEditForm.vue
+++ b/components/discussion/form/DownloadEditForm.vue
@@ -312,6 +312,7 @@ const uploadFile = async (file: File): Promise<boolean> => {
       filename,
       contentType: fileType,
       channelConnections: currentChannelConnections.value,
+      uploadTarget: 'PRIVATE_DOWNLOAD' as const,
     };
 
     // Ask the server for a signed storage URL

--- a/graphQLData/discussion/mutations.js
+++ b/graphQLData/discussion/mutations.js
@@ -5,11 +5,13 @@ export const CREATE_SIGNED_STORAGE_URL = gql`
     $filename: String!
     $contentType: String!
     $channelConnections: [String!]
+    $uploadTarget: StorageUploadTarget
   ) {
     createSignedStorageURL(
       filename: $filename
       contentType: $contentType
       channelConnections: $channelConnections
+      uploadTarget: $uploadTarget
     ) {
       url
       storageObjectName


### PR DESCRIPTION
## Summary

- extend the signed-upload mutation with an optional storage target
- mark downloadable-file uploads as `PRIVATE_DOWNLOAD`
- leave all image and public-media upload callers unchanged
- add focused component coverage for the private target

## Dependency and deployment

Depends on [multiforum-backend#174](https://github.com/gennit-project/multiforum-backend/pull/174).

Configure `GCS_PRIVATE_DOWNLOAD_BUCKET_NAME` and deploy the backend before deploying this frontend change. The backend intentionally fails closed when a private download upload is requested without that bucket configuration.

## Verification

- `pnpm run tsc`
- focused ESLint
- full Vitest suite: 761 files, 6,926 tests passing