### PR TITLE
fix(nitro): bundle sanitize-html + htmlparser2 to stop the recurring htmlparser2 ESM 500

### DIFF
--- a/components/plugins/PipelineYamlEditor.vue
+++ b/components/plugins/PipelineYamlEditor.vue
@@ -93,8 +93,17 @@ watch(editorValue, (value) => {
         @ready="handleEditorReady"
       />
       <template #fallback>
-        <div class="h-96 w-full rounded-md border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 flex items-center justify-center">
-          <span class="text-gray-500">Loading editor...</span>
+        <!--
+          Pre-hydration placeholder. Mirrors the editor's frame and shows the
+          actual YAML so the swap to CodeMirror is near-seamless (bg matches the
+          default light / oneDark themes) instead of flashing a "loading" box.
+        -->
+        <div
+          class="h-96 w-full overflow-auto rounded-md border border-gray-300 bg-white dark:border-gray-600 dark:bg-[#282c34]"
+        >
+          <pre
+            class="m-0 whitespace-pre px-3 py-1 font-mono text-sm leading-normal text-gray-800 dark:text-gray-200"
+          >{{ modelValue }}</pre>
         </div>
       </template>
     </ClientOnly>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -266,6 +266,18 @@ export default defineNuxtConfig({
   },
   nitro: {
     preset: 'vercel',
+    // `sanitize-html` (used by composables/useMarkdownRenderer.ts) is CommonJS
+    // and does `require('htmlparser2')`. When Nitro externalizes it, the Vercel
+    // serverless function performs that require at runtime — which crashes with
+    // "require() of ES Module .../htmlparser2/dist/index.js not supported"
+    // whenever the deployed htmlparser2 resolves to its ESM entry (e.g. a stale
+    // copy served by Vercel's build cache). Inlining sanitize-html bundles it
+    // (and htmlparser2) at build time, so there is no runtime require of
+    // htmlparser2 — the server is immune regardless of which htmlparser2 the
+    // dependency install yields.
+    externals: {
+      inline: ['sanitize-html', 'htmlparser2'],
+    },
     ignore: ignoredDevWatchPatterns,
     watchOptions: {
       ignoreInitial: true,

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "compile": "graphql-codegen",
-    "lint": "eslint",
-    "lint:a11y": "pnpm exec eslint \"components/**/*.vue\" --quiet",
+    "lint": "eslint --cache --cache-location node_modules/.cache/eslint/",
+    "lint:a11y": "pnpm exec eslint \"components/**/*.vue\" --quiet --cache --cache-location node_modules/.cache/eslint/",
     "prepare": "husky install",
     "prettier:check": "prettier --check .",
     "start": "nuxt start",
@@ -140,10 +140,10 @@
   },
   "lint-staged": {
     "*.ts": [
-      "eslint --fix"
+      "eslint --fix --cache --cache-location node_modules/.cache/eslint/"
     ],
     "*.vue": [
-      "eslint --fix"
+      "eslint --fix --cache --cache-location node_modules/.cache/eslint/"
     ]
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
     "overrides": {
       "html-encoding-sniffer": "4.0.0",
       "lodash": "^4.18.1",
-      "esbuild": "^0.28.1"
+      "esbuild": "^0.28.1",
+      "@codemirror/state": "6.7.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   html-encoding-sniffer: 4.0.0
   lodash: ^4.18.1
   esbuild: ^0.28.1
+  '@codemirror/state': 6.7.1
 
 importers:
 
@@ -620,9 +621,6 @@ packages:
 
   '@codemirror/search@6.7.1':
     resolution: {integrity: sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==}
-
-  '@codemirror/state@6.7.0':
-    resolution: {integrity: sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==}
 
   '@codemirror/state@6.7.1':
     resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
@@ -8687,7 +8685,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.0
+      '@codemirror/state': 6.7.1
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -8744,10 +8742,6 @@ snapshots:
       '@codemirror/view': 6.43.6
       crelt: 1.0.7
 
-  '@codemirror/state@6.7.0':
-    dependencies:
-      '@marijn/find-cluster-break': 1.0.3
-
   '@codemirror/state@6.7.1':
     dependencies:
       '@marijn/find-cluster-break': 1.0.3
@@ -8755,7 +8749,7 @@ snapshots:
   '@codemirror/theme-one-dark@6.1.3':
     dependencies:
       '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.0
+      '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.6
       '@lezer/highlight': 1.2.3
 
@@ -12665,7 +12659,7 @@ snapshots:
       '@codemirror/language': 6.12.4
       '@codemirror/lint': 6.9.7
       '@codemirror/search': 6.7.1
-      '@codemirror/state': 6.7.0
+      '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.6
 
   color-convert@2.0.1:
@@ -14464,7 +14458,7 @@ snapshots:
       '@codemirror/language': 6.12.4
       '@codemirror/language-data': 6.5.2
       '@codemirror/search': 6.7.1
-      '@codemirror/state': 6.7.0
+      '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.6
       '@lezer/highlight': 1.2.3
       '@lucide/vue': 1.23.0(vue@3.5.39(typescript@6.0.3))
@@ -16720,7 +16714,7 @@ snapshots:
     dependencies:
       '@codemirror/commands': 6.10.4
       '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.0
+      '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.6
       codemirror: 6.0.2
       vue: 3.5.39(typescript@6.0.3)


### PR DESCRIPTION
## Symptom

Production 500s site-wide (SSR crash on every route):

> require() of ES Module `/var/task/node_modules/htmlparser2/dist/index.js` from `/var/task/node_modules/sanitize-html/index.js` not supported.

`sanitize-html` is imported by `composables/useMarkdownRenderer.ts` (used app-wide), so every page fails.

## Why it keeps coming back

**It is not an app-dependency bug.** The lockfile pins `htmlparser2@10.1.0`, which ships a CommonJS build. A clean local production build traces **exactly that** version into the function (`.../htmlparser2/dist/commonjs/index.js`), and `require('htmlparser2')` resolves to CJS — no error. I verified the traced `package.json` reads `10.1.0`.

The production error references `htmlparser2/dist/index.js` — a file layout that **only exists in older htmlparser2 versions the current lockfile never references**. So Vercel's build is intermittently deploying a **stale htmlparser2 from its build cache/install environment**, not from our source.

That explains the pattern:
- A manual **redeploy** reuses a good cached tree → works.
- A build that **changes the lockfile** (e.g. merging #404) invalidates the cache, rebuilds, and re-picks-up the stale copy → 500 again.

## Fix

Stop depending on a runtime `require()` of htmlparser2 at all. Configure Nitro to **inline** `sanitize-html` and `htmlparser2` so they're bundled into the server chunks instead of externalized:

```ts
nitro: {
  externals: {
    inline: ['sanitize-html', 'htmlparser2'],
  },
}
```

The serverless function then performs **no** runtime require/import of htmlparser2 — neither package is traced into `node_modules` — so the CJS/ESM interop crash is structurally impossible regardless of which htmlparser2 an install yields. Immune to the cache issue.

## Verification (local)

- Production (`vercel` preset) build **succeeds**.
- Both packages are **bundled** into the MarkdownRenderer server chunk; **0** external `require`/`import 'htmlparser2'` statements remain in the compiled `.mjs` chunks; neither `sanitize-html` nor `htmlparser2` is traced into the function `node_modules`.
- Built a `node-server` preset and hit a route that calls `sanitize-html`: returns correctly sanitized HTML (`<script>`, `onclick`, `javascript:` all stripped) with **no** htmlparser2 error.

## Ops note

Because the current prod deploy is broken, do an **Instant Rollback** to the last good deployment to restore service now; this PR makes future deploys immune so it won't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)