### PR TITLE
a11y: sweep remaining audit gaps (P1/P3/P4/P5) + lint caching

### DIFF
--- a/components/FileTypePicker.vue
+++ b/components/FileTypePicker.vue
@@ -76,7 +76,7 @@ const removeSelection = (fileType: string) => {
     </div>
     <div class="relative">
       <div
-        class="flex min-h-10 w-full cursor-text flex-wrap items-center rounded-lg border px-4 text-left text-sm focus-within:ring-2 focus-within:ring-orange-500 dark:border-gray-700 dark:bg-gray-700"
+        class="flex min-h-10 w-full cursor-text flex-wrap items-center rounded-lg border px-4 text-left text-sm focus-within:ring-2 focus-within:ring-orange-500 focus-within:ring-offset-2 dark:border-gray-700 dark:bg-gray-700"
         :class="{
           'cursor-not-allowed opacity-50': disabled,
           'cursor-text': !disabled,

--- a/components/FilterChip.spec.ts
+++ b/components/FilterChip.spec.ts
@@ -45,6 +45,26 @@ describe('FilterChip', () => {
     expect(wrapper.emitted('click')).toBeTruthy();
   });
 
+  it('marks the trigger as a popup control', () => {
+    const wrapper = mountChip();
+
+    expect(button(wrapper).attributes('aria-haspopup')).toBe('true');
+  });
+
+  it('starts collapsed', () => {
+    const wrapper = mountChip();
+
+    expect(button(wrapper).attributes('aria-expanded')).toBe('false');
+  });
+
+  it('reflects the expanded state after opening', async () => {
+    const wrapper = mountChip();
+
+    await button(wrapper).trigger('click');
+
+    expect(button(wrapper).attributes('aria-expanded')).toBe('true');
+  });
+
   it('renders the icon slot', () => {
     const wrapper = mountChip({}, { icon: '<span class="icon" />' });
 

--- a/components/FilterChip.vue
+++ b/components/FilterChip.vue
@@ -38,6 +38,9 @@ const handleClick = () => {
         <template #default>
           <button
             :data-testid="dataTestid"
+            type="button"
+            aria-haspopup="true"
+            :aria-expanded="isOpen"
             :class="[
               highlighted
                 ? 'border-gray-500 ring-1 ring-gray-400 dark:border-gray-400 dark:ring-gray-500'
@@ -63,6 +66,9 @@ const handleClick = () => {
       <template #fallback>
         <button
           :data-testid="dataTestid"
+          type="button"
+          aria-haspopup="true"
+          :aria-expanded="false"
           :class="[
             highlighted
               ? 'border-gray-500 ring-1 ring-gray-400 dark:border-gray-400 dark:ring-gray-500'

--- a/components/FormRow.spec.ts
+++ b/components/FormRow.spec.ts
@@ -39,4 +39,10 @@ describe('FormRow', () => {
 
     expect(wrapper.get('[data-testid="slot-input"]').exists()).toBe(true);
   });
+
+  it('associates the label with a valid (whitespace-free) generated id', () => {
+    const wrapper = mountRow({ sectionTitle: 'Display Name' });
+
+    expect(wrapper.get('label').attributes('for')).not.toMatch(/\s/);
+  });
 });

--- a/components/FormRow.vue
+++ b/components/FormRow.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { useId } from 'vue';
+
 defineProps({
   sectionTitle: {
     type: String,
@@ -17,13 +19,19 @@ defineProps({
     default: false,
   },
 });
+
+// The label previously pointed `for` at the section title text (spaces and all),
+// which never matches a real control id. Use a valid generated id instead and
+// expose it to the content slot so callers can bind it to their input for a
+// proper label association.
+const fieldId = useId();
 </script>
 
 <template>
   <div class="mb-2">
     <label
       v-if="sectionTitle"
-      :for="sectionTitle"
+      :for="fieldId"
       :class="dangerous ? 'text-red-400' : 'text-gray-900 dark:text-gray-200'"
       class="block text-sm font-medium leading-6"
     >
@@ -36,7 +44,7 @@ defineProps({
       {{ description }}
     </p>
     <div>
-      <slot name="content" v-bind="$attrs" />
+      <slot name="content" v-bind="$attrs" :field-id="fieldId" />
     </div>
   </div>
 </template>

--- a/components/StatusMessage.spec.ts
+++ b/components/StatusMessage.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import StatusMessage from '@/components/StatusMessage.vue';
+
+const mountStatus = (props: Record<string, unknown> = {}) =>
+  mount(StatusMessage, { props, slots: { default: 'Loading...' } });
+
+describe('StatusMessage', () => {
+  it('is a polite status region by default', () => {
+    const wrapper = mountStatus();
+
+    expect(wrapper.attributes('role')).toBe('status');
+  });
+
+  it('uses aria-live polite by default', () => {
+    const wrapper = mountStatus();
+
+    expect(wrapper.attributes('aria-live')).toBe('polite');
+  });
+
+  it('becomes an assertive alert when assertive is set', () => {
+    const wrapper = mountStatus({ assertive: true });
+
+    expect(wrapper.attributes('role')).toBe('alert');
+  });
+
+  it('exposes aria-busy while busy', () => {
+    const wrapper = mountStatus({ busy: true });
+
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+  });
+
+  it('omits aria-busy when not busy', () => {
+    const wrapper = mountStatus();
+
+    expect(wrapper.attributes('aria-busy')).toBeUndefined();
+  });
+
+  it('renders slotted status text', () => {
+    const wrapper = mountStatus();
+
+    expect(wrapper.text()).toContain('Loading...');
+  });
+});

--- a/components/StatusMessage.vue
+++ b/components/StatusMessage.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+// A persistent live region for async loading / empty / status text. Render it
+// once (do not gate the wrapper itself behind v-if) and swap the inner text so
+// screen readers announce transitions between loading, empty, and loaded states.
+//
+// - role/aria-live default to status/polite; pass `assertive` for errors.
+// - pass `busy` while content is loading so assistive tech knows the region is
+//   updating (maps to aria-busy).
+withDefaults(
+  defineProps<{
+    busy?: boolean;
+    assertive?: boolean;
+  }>(),
+  {
+    busy: false,
+    assertive: false,
+  }
+);
+</script>
+
+<template>
+  <div
+    :role="assertive ? 'alert' : 'status'"
+    :aria-live="assertive ? 'assertive' : 'polite'"
+    :aria-busy="busy || undefined"
+  >
+    <slot />
+  </div>
+</template>

--- a/components/Table.vue
+++ b/components/Table.vue
@@ -2,9 +2,18 @@
 defineOptions({
   name: 'TableComponent',
 });
+
+// Optional accessible name for the table. Rendered as a visually hidden
+// <caption> so screen-reader users get table context without changing layout.
+defineProps<{
+  caption?: string;
+}>();
 </script>
 <template>
   <table class="min-w-full table-auto divide-y divide-gray-200">
+    <caption v-if="caption" class="sr-only">
+      {{ caption }}
+    </caption>
     <thead class="bg-gray-50">
       <slot name="head" />
     </thead>

--- a/components/channel/DownloadList.vue
+++ b/components/channel/DownloadList.vue
@@ -227,8 +227,11 @@ const reachedEndOfResults = computed(() => {
           downloadChannelResult?.getDiscussionsInChannel?.discussionChannels
             ?.length === 0)
       "
+      role="status"
+      aria-busy="true"
       class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
     >
+      <span class="sr-only">Loading downloads…</span>
       <DownloadSkeletonCard v-for="n in 8" :key="n" />
     </div>
     <ErrorBanner

--- a/components/channel/DownloadNowButton.spec.ts
+++ b/components/channel/DownloadNowButton.spec.ts
@@ -18,6 +18,12 @@ describe('DownloadNowButton', () => {
     });
   });
 
+  it('paints a visible focus ring (ring width present, not just offset/color)', () => {
+    const wrapper = mountWithDefaults(DownloadNowButton);
+
+    expect(wrapper.get('button').classes()).toContain('focus:ring-2');
+  });
+
   it('renders a disabled button state when disabled is true', () => {
     const wrapper = mountWithDefaults(DownloadNowButton, {
       props: { disabled: true },

--- a/components/channel/DownloadNowButton.vue
+++ b/components/channel/DownloadNowButton.vue
@@ -11,7 +11,7 @@ defineProps({
 });
 
 const buttonBaseClasses =
-  'max-height-4 inline-flex w-full items-center justify-center whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium focus:outline-none focus:ring-offset-2 focus:ring-offset-gray-100';
+  'max-height-4 inline-flex w-full items-center justify-center whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100';
 
 const activeDownloadButtonClasses = `${buttonBaseClasses} bg-orange-400 hover:bg-orange-400 focus:ring-orange-500 dark:border dark:border-orange-500 dark:bg-orange-400 dark:text-black dark:hover:bg-orange-400`;
 

--- a/components/channel/SearchableForumList.vue
+++ b/components/channel/SearchableForumList.vue
@@ -294,14 +294,17 @@ const areAllFavoritesSelected = computed(() =>
       @keydown.enter.prevent
       @update-search-input="updateSearchResult"
     />
-    <div v-if="channelsLoading && regularChannels?.length === 0">
+    <StatusMessage
+      v-if="channelsLoading && regularChannels?.length === 0"
+      busy
+    >
       Loading...
-    </div>
-    <div v-else-if="channelsError">
+    </StatusMessage>
+    <StatusMessage v-else-if="channelsError" assertive>
       <div v-for="(error, i) of channelsError?.graphQLErrors" :key="i">
         {{ error.message }}
       </div>
-    </div>
+    </StatusMessage>
     <template v-else>
       <!-- Favorite Forums Section -->
       <div

--- a/components/charts/GithubContributionChart.spec.ts
+++ b/components/charts/GithubContributionChart.spec.ts
@@ -155,6 +155,67 @@ describe('GithubContributionChart', () => {
     expect(wrapper.find('.mt-4.p-4.rounded-lg.border').exists()).toBe(true);
   });
 
+  it('gives each day cell a button role', async () => {
+    const wrapper = mount(GithubContributionChart, {
+      props: { contributionData: contributionDataFixture, year: 2023 },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.find('rect').attributes('role')).toBe('button');
+  });
+
+  it('gives each day cell a descriptive accessible name', async () => {
+    const wrapper = mount(GithubContributionChart, {
+      props: { contributionData: contributionDataFixture, year: 2023 },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.find('rect').attributes('aria-label')).toContain(
+      'contributions on'
+    );
+  });
+
+  it('keeps only the focused cell in the tab order (roving tabindex)', async () => {
+    const wrapper = mount(GithubContributionChart, {
+      props: { contributionData: contributionDataFixture, year: 2023 },
+    });
+
+    await flushPromises();
+
+    const tabbable = wrapper
+      .findAll('rect')
+      .filter((r) => r.attributes('tabindex') === '0');
+    expect(tabbable.length).toBe(1);
+  });
+
+  it('selects a day when Enter is pressed on a cell', async () => {
+    const wrapper = mount(GithubContributionChart, {
+      props: { contributionData: contributionDataFixture, year: 2023 },
+    });
+
+    await flushPromises();
+
+    await wrapper.find('rect').trigger('keydown', { key: 'Enter' });
+
+    expect(wrapper.emitted('day-select')).toBeTruthy();
+  });
+
+  it('moves the tab-order cell with ArrowRight', async () => {
+    const wrapper = mount(GithubContributionChart, {
+      props: { contributionData: contributionDataFixture, year: 2023 },
+    });
+
+    await flushPromises();
+
+    await wrapper.find('rect').trigger('keydown', { key: 'ArrowRight' });
+
+    expect(
+      wrapper.find('#contribution-cell-1-0').attributes('tabindex')
+    ).toBe('0');
+  });
+
   // Test color scheme based on contribution count
   it('assigns correct colors based on contribution count', async () => {
     const wrapper = mount(GithubContributionChart, {

--- a/components/charts/GithubContributionChart.vue
+++ b/components/charts/GithubContributionChart.vue
@@ -277,6 +277,64 @@ const selectDay = (weekIndex: number, dayIndex: number) => {
   emit('day-select', dayInfo);
 };
 
+// --- Keyboard navigation (roving tabindex over the day grid) ---
+// Only one cell is in the tab order at a time; arrow keys move focus between
+// cells so the heatmap is fully keyboard-operable without adding hundreds of
+// tab stops.
+const focusedCell = ref<{ week: number; day: number }>({ week: 0, day: 0 });
+
+const cellDomId = (week: number, day: number) =>
+  `contribution-cell-${week}-${day}`;
+
+const isCellFocusable = (week: number, day: number) =>
+  focusedCell.value.week === week && focusedCell.value.day === day;
+
+const focusCell = async (week: number, day: number) => {
+  if (!gridData.value[week] || !gridData.value[week][day]) return;
+  focusedCell.value = { week, day };
+  await nextTick();
+  // Not gated on import.meta.client: keydown only fires client-side, and jsdom
+  // provides document in unit tests.
+  document.getElementById(cellDomId(week, day))?.focus();
+};
+
+const onCellKeydown = (event: KeyboardEvent, week: number, day: number) => {
+  const weekCount = gridData.value.length;
+  switch (event.key) {
+    case 'Enter':
+    case ' ':
+      event.preventDefault();
+      selectDay(week, day);
+      break;
+    case 'ArrowRight':
+      event.preventDefault();
+      focusCell(Math.min(week + 1, weekCount - 1), day);
+      break;
+    case 'ArrowLeft':
+      event.preventDefault();
+      focusCell(Math.max(week - 1, 0), day);
+      break;
+    case 'ArrowDown':
+      event.preventDefault();
+      focusCell(week, Math.min(day + 1, 6));
+      break;
+    case 'ArrowUp':
+      event.preventDefault();
+      focusCell(week, Math.max(day - 1, 0));
+      break;
+    case 'Home':
+      event.preventDefault();
+      focusCell(0, day);
+      break;
+    case 'End':
+      event.preventDefault();
+      focusCell(weekCount - 1, day);
+      break;
+    default:
+      break;
+  }
+};
+
 // Format the date from ISO string or date string
 const formatDate = (dateStr: string) => {
   try {
@@ -447,6 +505,7 @@ const cellCount = computed(() => {
               >
                 <rect
                   v-for="(dayData, dayIndex) in week"
+                  :id="cellDomId(weekIndex, dayIndex)"
                   :key="`day-${weekIndex}-${dayIndex}`"
                   x="0"
                   :y="dayIndex * 14"
@@ -457,7 +516,15 @@ const cellCount = computed(() => {
                   ry="2"
                   :data-date="dayData.date"
                   :data-count="dayData.count"
-                  class="cursor-pointer transition-colors duration-200 hover:stroke-1"
+                  role="button"
+                  :tabindex="isCellFocusable(weekIndex, dayIndex) ? 0 : -1"
+                  :aria-label="`${dayData.count} contributions on ${formatDate(dayData.date)}`"
+                  :aria-pressed="
+                    !!selectedDay &&
+                    selectedDay.week === weekIndex &&
+                    selectedDay.day === dayIndex
+                  "
+                  class="cursor-pointer transition-colors duration-200 focus:outline-none focus-visible:stroke-blue-600 focus-visible:stroke-2 hover:stroke-1"
                   :class="[
                     darkMode
                       ? 'hover:stroke-green-600'
@@ -469,6 +536,8 @@ const cellCount = computed(() => {
                       : '',
                   ]"
                   @click="selectDay(weekIndex, dayIndex)"
+                  @keydown="onCellKeydown($event, weekIndex, dayIndex)"
+                  @focus="focusedCell = { week: weekIndex, day: dayIndex }"
                 >
                   <title>
                     {{ dayData.count }} contributions on

--- a/components/notifications/NotificationTabs.vue
+++ b/components/notifications/NotificationTabs.vue
@@ -135,7 +135,9 @@ markAsReadDone(() => {
 // Per-notification actions for super-upvote ("scratchpad") notifications:
 // "Show on profile" publishes the thank-you note and marks the notification
 // read; "Ignore" just marks it read.
-const { mutate: markNotificationAsRead } = useMutation(MARK_NOTIFICATION_AS_READ);
+const { mutate: markNotificationAsRead } = useMutation(
+  MARK_NOTIFICATION_AS_READ
+);
 const { mutate: showScratchpadEntry } = useMutation(
   UPDATE_SCRATCHPAD_ENTRY_VISIBILITY
 );
@@ -240,11 +242,15 @@ const currentTotalCount = computed(() => {
 });
 
 const isLoading = computed(() => {
-  return activeTab.value === 'general' ? generalLoading.value : feedbackLoading.value;
+  return activeTab.value === 'general'
+    ? generalLoading.value
+    : feedbackLoading.value;
 });
 
 const currentError = computed(() => {
-  return activeTab.value === 'general' ? generalError.value : feedbackError.value;
+  return activeTab.value === 'general'
+    ? generalError.value
+    : feedbackError.value;
 });
 
 const loadMore = () => {
@@ -368,103 +374,105 @@ const reachedEnd = computed(() => {
         :aria-labelledby="activeTabId"
         tabindex="0"
       >
-      <p v-if="isLoading" class="px-4">Loading...</p>
+        <StatusMessage :busy="isLoading">
+          <p v-if="isLoading" class="px-4">Loading...</p>
 
-      <ErrorBanner v-else-if="currentError" :text="currentError.message" />
-
-      <p
-        v-else-if="currentNotifications.length === 0"
-        class="my-6 flex gap-2 px-4"
-      >
-        <span class="dark:text-white">
-          {{
-            activeTab === 'general'
-              ? 'No general notifications to show.'
-              : 'No feedback notifications to show.'
-          }}
-        </span>
-      </p>
-
-      <div v-if="currentNotifications.length > 0" class="flex flex-col gap-2">
-        <p class="mx-4 text-sm text-gray-500 dark:text-gray-300">
-          You have {{ currentUnreadCount }} unread
-          {{ activeTab === 'feedback' ? 'feedback ' : '' }}notifications
-        </p>
-        <div>
-          <GenericButton
-            class="mx-4"
-            text="Mark all as read"
-            :loading="markAsReadLoading"
-            @click="markAllAsRead"
-          />
-        </div>
-        <ErrorBanner v-if="markAsReadError" :text="markAsReadError.message" />
-        <ErrorBanner v-if="actionError" :text="actionError" />
-
-        <ul
-          role="list"
-          class="flex-1 flex-col divide-y divide-gray-200 bg-white shadow dark:divide-gray-700 dark:bg-gray-800 dark:text-white sm:rounded-lg"
-          data-testid="notification-list"
-        >
-          <li
-            v-for="notification in currentNotifications"
-            :key="notification.id"
-            class="p-4"
+          <p
+            v-else-if="currentNotifications.length === 0"
+            class="my-6 flex gap-2 px-4"
           >
-            <p class="mb-2 text-sm text-gray-500 dark:text-gray-300">
-              {{ timeAgo(new Date(notification.createdAt)) }} -
-              {{ notification.read ? 'Read' : 'Unread' }}
-            </p>
-            <MarkdownRenderer
-              v-if="notification.text"
-              :text="notification.text"
-              class="w-full"
-            />
-            <div
-              v-if="canActOnScratchpadEntry(notification)"
-              class="mt-3 flex flex-wrap items-center gap-2"
-              :data-testid="`scratchpad-notification-actions-${notification.id}`"
-            >
-              <button
-                type="button"
-                data-testid="notification-show-on-profile"
-                :disabled="pendingNotificationId === notification.id"
-                class="inline-flex items-center gap-1 rounded-full bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
-                @click="handleShowOnProfile(notification)"
-              >
-                <i class="fa-solid fa-star" />
-                Show on profile
-              </button>
-              <button
-                type="button"
-                data-testid="notification-ignore"
-                :disabled="pendingNotificationId === notification.id"
-                class="inline-flex items-center gap-1 rounded-full border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                @click="handleIgnore(notification)"
-              >
-                Ignore
-              </button>
-            </div>
-            <p
-              v-else-if="isPublishedScratchpadEntry(notification)"
-              class="mt-2 text-sm text-green-600 dark:text-green-400"
-              data-testid="notification-showing-on-profile"
-            >
-              <i class="fa-solid fa-circle-check mr-1" />
-              Showing on your Kudos page
-            </p>
-          </li>
-        </ul>
+            <span class="dark:text-white">
+              {{
+                activeTab === 'general'
+                  ? 'No general notifications to show.'
+                  : 'No feedback notifications to show.'
+              }}
+            </span>
+          </p>
+        </StatusMessage>
 
-        <div v-if="!reachedEnd">
-          <LoadMore
-            class="ml-4 justify-self-center"
-            :loading="isLoading"
-            :reached-end-of-results="reachedEnd"
-            @load-more="loadMore"
-          />
+        <ErrorBanner v-if="currentError" :text="currentError.message" />
+
+        <div v-if="currentNotifications.length > 0" class="flex flex-col gap-2">
+          <p class="mx-4 text-sm text-gray-500 dark:text-gray-300">
+            You have {{ currentUnreadCount }} unread
+            {{ activeTab === 'feedback' ? 'feedback ' : '' }}notifications
+          </p>
+          <div>
+            <GenericButton
+              class="mx-4"
+              text="Mark all as read"
+              :loading="markAsReadLoading"
+              @click="markAllAsRead"
+            />
+          </div>
+          <ErrorBanner v-if="markAsReadError" :text="markAsReadError.message" />
+          <ErrorBanner v-if="actionError" :text="actionError" />
+
+          <ul
+            role="list"
+            class="flex-1 flex-col divide-y divide-gray-200 bg-white shadow dark:divide-gray-700 dark:bg-gray-800 dark:text-white sm:rounded-lg"
+            data-testid="notification-list"
+          >
+            <li
+              v-for="notification in currentNotifications"
+              :key="notification.id"
+              class="p-4"
+            >
+              <p class="mb-2 text-sm text-gray-500 dark:text-gray-300">
+                {{ timeAgo(new Date(notification.createdAt)) }} -
+                {{ notification.read ? 'Read' : 'Unread' }}
+              </p>
+              <MarkdownRenderer
+                v-if="notification.text"
+                :text="notification.text"
+                class="w-full"
+              />
+              <div
+                v-if="canActOnScratchpadEntry(notification)"
+                class="mt-3 flex flex-wrap items-center gap-2"
+                :data-testid="`scratchpad-notification-actions-${notification.id}`"
+              >
+                <button
+                  type="button"
+                  data-testid="notification-show-on-profile"
+                  :disabled="pendingNotificationId === notification.id"
+                  class="inline-flex items-center gap-1 rounded-full bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+                  @click="handleShowOnProfile(notification)"
+                >
+                  <i class="fa-solid fa-star" />
+                  Show on profile
+                </button>
+                <button
+                  type="button"
+                  data-testid="notification-ignore"
+                  :disabled="pendingNotificationId === notification.id"
+                  class="hover:bg-gray-50 inline-flex items-center gap-1 rounded-full border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                  @click="handleIgnore(notification)"
+                >
+                  Ignore
+                </button>
+              </div>
+              <p
+                v-else-if="isPublishedScratchpadEntry(notification)"
+                class="mt-2 text-sm text-green-600 dark:text-green-400"
+                data-testid="notification-showing-on-profile"
+              >
+                <i class="fa-solid fa-circle-check mr-1" />
+                Showing on your Kudos page
+              </p>
+            </li>
+          </ul>
+
+          <div v-if="!reachedEnd">
+            <LoadMore
+              class="ml-4 justify-self-center"
+              :loading="isLoading"
+              :reached-end-of-results="reachedEnd"
+              @load-more="loadMore"
+            />
+          </div>
         </div>
-      </div>
       </div>
     </div>
   </div>

--- a/components/plugins/PluginPipeline.spec.ts
+++ b/components/plugins/PluginPipeline.spec.ts
@@ -292,6 +292,45 @@ describe('PluginPipeline Component', () => {
     expect(wrapper.find('.fa-chevron-down').exists()).toBe(true);
   });
 
+  it('renders the collapsible header as a real button', async () => {
+    const PluginPipeline = await import('./PluginPipeline.vue').then(
+      (m) => m.default
+    );
+
+    mockLatestPipeline.value = createMockPipelineGroup();
+
+    const wrapper = mount(PluginPipeline, {
+      props: {
+        targetId: 'file-1',
+        targetType: 'DownloadableFile',
+        collapsible: true,
+      },
+    });
+
+    expect(wrapper.find('button.cursor-pointer').exists()).toBe(true);
+  });
+
+  it('reflects the expanded state on the header via aria-expanded', async () => {
+    const PluginPipeline = await import('./PluginPipeline.vue').then(
+      (m) => m.default
+    );
+
+    mockLatestPipeline.value = createMockPipelineGroup();
+
+    const wrapper = mount(PluginPipeline, {
+      props: {
+        targetId: 'file-1',
+        targetType: 'DownloadableFile',
+        collapsible: true,
+      },
+    });
+
+    const header = wrapper.find('button.cursor-pointer');
+    await header.trigger('click');
+
+    expect(header.attributes('aria-expanded')).toBe('false');
+  });
+
   it('should render pipeline stages', async () => {
     const PluginPipeline = await import('./PluginPipeline.vue').then(
       (m) => m.default

--- a/components/plugins/PluginPipeline.vue
+++ b/components/plugins/PluginPipeline.vue
@@ -99,6 +99,8 @@ const handleCloseModal = () => {
     <!-- Loading State -->
     <div
       v-if="loading && !latestPipeline"
+      role="status"
+      aria-busy="true"
       class="p-4 text-center"
     >
       <i class="fa-solid fa-spinner fa-spin mr-2 text-gray-400" />
@@ -110,6 +112,7 @@ const handleCloseModal = () => {
     <!-- Error State -->
     <div
       v-else-if="error"
+      role="alert"
       class="p-4 text-center"
     >
       <i class="fa-solid fa-exclamation-triangle mr-2 text-red-400" />

--- a/components/plugins/PluginPipeline.vue
+++ b/components/plugins/PluginPipeline.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, toRef } from 'vue';
+import { ref, toRef, useId } from 'vue';
 import { usePluginPipeline, type PipelineRun } from '@/composables/usePluginPipeline';
 import PluginPipelineStage from './PluginPipelineStage.vue';
 import PluginLogsModal from './PluginLogsModal.vue';
@@ -12,6 +12,7 @@ const props = defineProps<{
 }>();
 
 const isExpanded = ref(true);
+const pipelineContentId = useId();
 const selectedRun = ref<PipelineRun | null>(null);
 const showLogsModal = ref(false);
 
@@ -44,9 +45,13 @@ const handleCloseModal = () => {
     class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
   >
     <!-- Header -->
-    <div
+    <component
+      :is="collapsible ? 'button' : 'div'"
+      :type="collapsible ? 'button' : undefined"
+      :aria-expanded="collapsible ? isExpanded : undefined"
+      :aria-controls="collapsible ? pipelineContentId : undefined"
       class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700"
-      :class="{ 'cursor-pointer': collapsible }"
+      :class="{ 'w-full cursor-pointer text-left': collapsible }"
       @click="collapsible && (isExpanded = !isExpanded)"
     >
       <div class="flex items-center space-x-2">
@@ -78,20 +83,18 @@ const handleCloseModal = () => {
         >
           <i class="fa-solid fa-sync fa-spin" />
         </span>
-        <button
+        <span
           v-if="collapsible"
-          type="button"
-          :aria-expanded="isExpanded"
-          :aria-label="isExpanded ? 'Collapse pipeline details' : 'Expand pipeline details'"
+          aria-hidden="true"
           class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
         >
           <i
             :class="isExpanded ? 'fa-solid fa-chevron-up' : 'fa-solid fa-chevron-down'"
             aria-hidden="true"
           />
-        </button>
+        </span>
       </div>
-    </div>
+    </component>
 
     <!-- Loading State -->
     <div
@@ -118,6 +121,7 @@ const handleCloseModal = () => {
     <!-- Pipeline Content -->
     <div
       v-else-if="latestPipeline && isExpanded"
+      :id="pipelineContentId"
       class="p-4"
     >
       <!-- Pipeline stages -->

--- a/components/revision/RevisionDiffContent.vue
+++ b/components/revision/RevisionDiffContent.vue
@@ -172,7 +172,7 @@ const getLineNumberClass = (kind: SideKind) => {
           >
             <table class="w-full border-collapse text-xs">
               <caption class="sr-only">
-                Previous version, line by line
+                Previous revision, line by line
               </caption>
               <tbody>
                 <tr
@@ -233,7 +233,7 @@ const getLineNumberClass = (kind: SideKind) => {
           >
             <table class="w-full border-collapse text-xs">
               <caption class="sr-only">
-                Current version, line by line
+                Current revision, line by line
               </caption>
               <tbody>
                 <tr

--- a/components/revision/RevisionDiffContent.vue
+++ b/components/revision/RevisionDiffContent.vue
@@ -171,6 +171,9 @@ const getLineNumberClass = (kind: SideKind) => {
             class="h-full min-h-[200px] overflow-auto rounded border border-red-300 bg-white dark:border-red-700 dark:bg-gray-800"
           >
             <table class="w-full border-collapse text-xs">
+              <caption class="sr-only">
+                Previous version, line by line
+              </caption>
               <tbody>
                 <tr
                   v-for="row in renderRows"
@@ -229,6 +232,9 @@ const getLineNumberClass = (kind: SideKind) => {
             class="h-full min-h-[200px] overflow-auto rounded border border-green-300 bg-white dark:border-green-700 dark:bg-gray-800"
           >
             <table class="w-full border-collapse text-xs">
+              <caption class="sr-only">
+                Current version, line by line
+              </caption>
               <tbody>
                 <tr
                   v-for="row in renderRows"

--- a/components/settings/SaveStatus.vue
+++ b/components/settings/SaveStatus.vue
@@ -26,12 +26,13 @@ defineProps({
   <div
     class="flex min-h-[1.25rem] items-center text-xs"
     data-testid="save-status"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
   >
     <span
       v-if="status === 'saving'"
       class="flex items-center text-gray-500 dark:text-gray-400"
-      role="status"
-      aria-live="polite"
     >
       <LoadingSpinner class="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
       Saving…
@@ -39,8 +40,6 @@ defineProps({
     <span
       v-else-if="status === 'saved'"
       class="flex items-center text-green-600 dark:text-green-400"
-      role="status"
-      aria-live="polite"
     >
       <CheckIcon class="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
       Saved

--- a/components/text-editor/TextEditorToolbar.spec.ts
+++ b/components/text-editor/TextEditorToolbar.spec.ts
@@ -13,19 +13,31 @@ describe('TextEditorToolbar rendering', () => {
   it('renders the format buttons', () => {
     const wrapper = mountToolbar();
 
-    expect(button(wrapper, 'B').exists()).toBe(true);
+    expect(button(wrapper, 'Bold').exists()).toBe(true);
+  });
+
+  it('gives icon/glyph buttons a full-word accessible name', () => {
+    const wrapper = mountToolbar({ showFullscreenButton: true });
+
+    expect(button(wrapper, 'Toggle fullscreen').exists()).toBe(true);
+  });
+
+  it('keeps the visible glyph on the bold button', () => {
+    const wrapper = mountToolbar();
+
+    expect(button(wrapper, 'Bold').text()).toBe('B');
   });
 
   it('hides the fullscreen button by default', () => {
     const wrapper = mountToolbar();
 
-    expect(button(wrapper, '⛶').exists()).toBe(false);
+    expect(button(wrapper, 'Toggle fullscreen').exists()).toBe(false);
   });
 
   it('shows the fullscreen button when enabled', () => {
     const wrapper = mountToolbar({ showFullscreenButton: true });
 
-    expect(button(wrapper, '⛶').exists()).toBe(true);
+    expect(button(wrapper, 'Toggle fullscreen').exists()).toBe(true);
   });
 });
 
@@ -33,7 +45,7 @@ describe('TextEditorToolbar actions', () => {
   it('emits format for a formatting button', async () => {
     const wrapper = mountToolbar();
 
-    await button(wrapper, 'B').trigger('click');
+    await button(wrapper, 'Bold').trigger('click');
 
     expect(wrapper.emitted('format')?.[0]).toEqual(['bold']);
   });
@@ -41,7 +53,7 @@ describe('TextEditorToolbar actions', () => {
   it('emits toggle-emoji from the emoji button', async () => {
     const wrapper = mountToolbar();
 
-    await button(wrapper, 'Emoji').trigger('click');
+    await button(wrapper, 'Insert emoji').trigger('click');
 
     expect(wrapper.emitted('toggle-emoji')).toBeTruthy();
   });
@@ -49,7 +61,7 @@ describe('TextEditorToolbar actions', () => {
   it('emits toggle-fullscreen from the fullscreen button', async () => {
     const wrapper = mountToolbar({ showFullscreenButton: true });
 
-    await button(wrapper, '⛶').trigger('click');
+    await button(wrapper, 'Toggle fullscreen').trigger('click');
 
     expect(wrapper.emitted('toggle-fullscreen')).toBeTruthy();
   });
@@ -57,7 +69,7 @@ describe('TextEditorToolbar actions', () => {
   it('does not emit format for the emoji button', async () => {
     const wrapper = mountToolbar();
 
-    await button(wrapper, 'Emoji').trigger('click');
+    await button(wrapper, 'Insert emoji').trigger('click');
 
     expect(wrapper.emitted('format')).toBeUndefined();
   });

--- a/components/text-editor/TextEditorToolbar.vue
+++ b/components/text-editor/TextEditorToolbar.vue
@@ -5,6 +5,8 @@ export type FormatButton = {
   label: string;
   format: string;
   class?: string;
+  // Full-word accessible name; falls back to `label` when omitted.
+  ariaLabel?: string;
 };
 
 const props = defineProps<{
@@ -18,16 +20,21 @@ const emit = defineEmits<{
 }>();
 
 const formatButtons: FormatButton[] = [
-  { label: 'B', format: 'bold' },
-  { label: 'I', format: 'italic' },
-  { label: 'U', format: 'underline' },
-  { label: 'H1', format: 'header1' },
-  { label: 'H2', format: 'header2' },
-  { label: 'H3', format: 'header3' },
-  { label: 'Quote', format: 'quote' },
-  { label: 'spoiler', format: 'spoiler', class: 'line-through' },
-  { label: 'Emoji', format: 'emoji' },
-  { label: '⛶', format: 'fullscreen' },
+  { label: 'B', format: 'bold', ariaLabel: 'Bold' },
+  { label: 'I', format: 'italic', ariaLabel: 'Italic' },
+  { label: 'U', format: 'underline', ariaLabel: 'Underline' },
+  { label: 'H1', format: 'header1', ariaLabel: 'Heading 1' },
+  { label: 'H2', format: 'header2', ariaLabel: 'Heading 2' },
+  { label: 'H3', format: 'header3', ariaLabel: 'Heading 3' },
+  { label: 'Quote', format: 'quote', ariaLabel: 'Quote' },
+  {
+    label: 'spoiler',
+    format: 'spoiler',
+    class: 'line-through',
+    ariaLabel: 'Spoiler',
+  },
+  { label: 'Emoji', format: 'emoji', ariaLabel: 'Insert emoji' },
+  { label: '⛶', format: 'fullscreen', ariaLabel: 'Toggle fullscreen' },
 ];
 
 const visibleButtons = props.showFullscreenButton
@@ -51,7 +58,7 @@ const handleButtonClick = (button: FormatButton, event: MouseEvent) => {
       v-for="button in visibleButtons"
       :key="button.label"
       type="button"
-      :aria-label="button.label"
+      :aria-label="button.ariaLabel ?? button.label"
       :class="[
         'border-transparent text-md rounded-md px-2 py-1 font-medium hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700',
         button.class,

--- a/components/user/NotificationList.vue
+++ b/components/user/NotificationList.vue
@@ -113,17 +113,21 @@ const markAllAsRead = () => {
 <template>
   <div class="dark:text-white flex justify-center">
     <div class="w-full max-w-5xl">
-      <p v-if="notificationLoading">Loading...</p>
+      <StatusMessage :busy="notificationLoading">
+        <p v-if="notificationLoading">Loading...</p>
+        <p
+          v-else-if="notifications && notifications.length === 0"
+          class="my-6 flex gap-2 px-4"
+        >
+          <span class="dark:text-white"
+            >There are no notifications to show.</span
+          >
+        </p>
+      </StatusMessage>
       <ErrorBanner
-        v-else-if="notificationError"
+        v-if="notificationError"
         :text="notificationError.message"
       />
-      <p
-        v-else-if="notifications && notifications.length === 0"
-        class="my-6 flex gap-2 px-4"
-      >
-        <span class="dark:text-white">There are no notifications to show.</span>
-      </p>
       <div
         v-if="notifications && notifications.length > 0"
         class="flex flex-col gap-2"

--- a/components/user/UserProfileSidebar.vue
+++ b/components/user/UserProfileSidebar.vue
@@ -115,12 +115,12 @@ const handleReportSuccess = () => {
         {{ username }}
         <span
           v-if="serverRoleBadge === 'serverAdmin'"
-          class="rounded-md border border-orange-500 px-2 py-1 text-xs text-orange-700 dark:text-orange-500"
+          class="rounded-md border border-orange-700 px-2 py-1 text-xs text-orange-700 dark:border-orange-500 dark:text-orange-500"
           >Server Admin</span
         >
         <span
           v-else-if="serverRoleBadge === 'serverMod'"
-          class="rounded-md border border-orange-500 px-2 py-1 text-xs text-orange-700 dark:text-orange-500"
+          class="rounded-md border border-orange-700 px-2 py-1 text-xs text-orange-700 dark:border-orange-500 dark:text-orange-500"
           >Server Mod</span
         >
       </h1>
@@ -131,12 +131,12 @@ const handleReportSuccess = () => {
         {{ user.displayName }}
         <span
           v-if="serverRoleBadge === 'serverAdmin'"
-          class="rounded-md border border-orange-600 px-2 py-1 text-sm text-orange-600 dark:border-orange-500 dark:text-orange-500"
+          class="rounded-md border border-orange-700 px-2 py-1 text-sm text-orange-700 dark:border-orange-500 dark:text-orange-500"
           >Server Admin</span
         >
         <span
           v-else-if="serverRoleBadge === 'serverMod'"
-          class="rounded-md border border-orange-600 px-2 py-1 text-sm text-orange-600 dark:border-orange-500 dark:text-orange-500"
+          class="rounded-md border border-orange-700 px-2 py-1 text-sm text-orange-700 dark:border-orange-500 dark:text-orange-500"
           >Server Mod</span
         >
       </h1>

--- a/docs/accessibility-audit-2026-07.md
+++ b/docs/accessibility-audit-2026-07.md
@@ -108,9 +108,18 @@ Specific controls that are completely unusable without a mouse, plus global shel
 - **`FileTypePicker.vue:65`** — `<div @click>` trigger, mouse-only open; chip-remove `<div>`/`<span>` unfocusable (`:81,88`).
 - **`TagComponent.vue:84,100`** — interactive tag is a `<span @click>`; delete icon has no name/keyboard.
 - **`collection/AddToListPopover.vue:494,529,686,722`** — list rows are `<div @click.stop>` with `readonly` checkbox; toggle is mouse-only.
-- **`plugins/PluginPipeline.vue:47` & `plugins/ScopedPipelineView.vue:89`** — collapse header is a `<div @click>` while the visible chevron `<button>` is inert.
-- **`charts/GithubContributionChart.vue:448-477`** — day `<rect>`s carry `@click` with no `tabindex`/`role`/keydown; whole heatmap is mouse-only.
-- **`user/DiscussionItemInProfile.vue:53`, `user/EventItemInProfile.vue:48`, `event/list/EventListItem.vue:215`** — whole-card `<li @click>` navigation, no keyboard path. Make the title a real `<NuxtLink>`.
+- **`plugins/PluginPipeline.vue` & `plugins/ScopedPipelineView.vue`** — ✅ **DONE.** Both collapse
+  headers render as a real `<button>` when collapsible (aria-expanded + aria-controls) and the
+  chevron is an aria-hidden `<span>`.
+- **`charts/GithubContributionChart.vue`** — ✅ **DONE (2026-07).** Day cells are now
+  `role="button"` with a roving tabindex (one tabbable cell), arrow-key + Home/End
+  navigation, Enter/Space to toggle day details, descriptive per-cell `aria-label`,
+  `aria-pressed` for the selected day, and a visible focus-visible outline. Tests added.
+- **`user/DiscussionItemInProfile.vue`, `user/EventItemInProfile.vue`** — ✅ **DONE.** Titles are
+  real `<nuxt-link>`s and the `<li>` no longer carries `@click`.
+  **`event/list/EventListItem.vue:215`** — title is already a real `<router-link>` (keyboard path
+  exists); the residual whole-card `@click` is a multi-mode mouse convenience (select/preview/
+  navigate) left in place.
 
 ### App shell (global, one edit each)
 - **Skip-to-content link** — none exists. Add a visually-hidden-until-focused link as the first focusable element in `layouts/default.vue`, targeting the main content id. Serious.
@@ -162,28 +171,37 @@ Pervasive: async loading/error/validation states swap silently (near-zero `aria-
 
 - **Toasts** — `ToastNotification.vue:9` container is not a live region. Add `aria-live="polite"`/`role="status"` (assertive for errors). Moderate.
 - **Form errors** — `ErrorBanner.vue:11`, `ErrorMessage.vue:8` lack `role="alert"`; inputs aren't tied to errors via `aria-describedby` + `aria-invalid`. Moderate.
-- **Loading / empty / error text** without `role="status"`/`aria-live`/`aria-busy` across:
-  `user/NotificationList.vue:116`, `notifications/NotificationTabs.vue:309`,
-  `auth/CreateUsernameForm.vue:262`, `user/UserProfileSidebar.vue:171`,
-  `settings/EditAccountSettingsFields.vue:182`, `dashboard/ChannelHealthDetailView.vue:336`,
-  `channel/SearchableForumList.vue:297`, `channel/DownloadList.vue:214`,
-  `plugins/PluginPipeline.vue:93`, `plugins/ScopedPipelineView.vue:136`,
-  `plugins/PipelineVisualEditor.vue:279`, `plugins/PipelineYamlEditor.vue:102`, plus ~45
-  mod/admin components (`admin/ChannelHealthTable.vue:170` skeletons, `admin/ImageReportsList.vue`,
-  `admin/ServerSuspendedModList.vue:37`, `mod/IssueRelatedChannel.vue:112`, etc.). Consider a
-  shared `<StatusRegion>` helper. Moderate. **(Confirmed zero `aria-live`/`role="status"`/`aria-busy` in the mod & admin folders.)**
+- **Loading / empty / error text** without `role="status"`/`aria-live`/`aria-busy`. ✅ **Shared
+  helper + first rollout DONE (2026-07):** added `components/StatusMessage.vue` (a persistent
+  live-region wrapper: role status/alert, aria-live, aria-busy) and rolled it out to
+  `user/NotificationList.vue`, `notifications/NotificationTabs.vue`,
+  `channel/SearchableForumList.vue`, `channel/DownloadList.vue` (skeleton grid), and
+  `plugins/PluginPipeline.vue` (loading/error). **Remaining:** `auth/CreateUsernameForm.vue:262`,
+  `user/UserProfileSidebar.vue:171`, `settings/EditAccountSettingsFields.vue:182`,
+  `dashboard/ChannelHealthDetailView.vue:336`, `plugins/ScopedPipelineView.vue`,
+  `plugins/PipelineVisualEditor.vue`, `plugins/PipelineYamlEditor.vue`, plus ~45 mod/admin
+  components (`admin/ImageReportsList.vue`, `admin/ServerSuspendedModList.vue:37`,
+  `mod/IssueRelatedChannel.vue:112`, etc.) — wrap each with `<StatusMessage>`. Moderate.
 - **`CharCounter.vue:34`** count and **`LoadingSpinner.vue`** state are silent. Add `aria-live` / `role="status"` + sr-only label. Minor.
-- **`settings/SaveStatus.vue:27`** — live region is `v-if`-mounted with text already present (SRs miss it). Render a persistent wrapper, swap inner text. Minor.
+- **`settings/SaveStatus.vue`** — ✅ **DONE.** The polite live region now lives on the persistent
+  outer wrapper (with `aria-atomic`); saving/saved text swaps inside it. Error keeps `role="alert"`
+  (alert-on-insert is correct). Minor.
 
 ---
 
 ## P4 — Remaining widgets, media, forms & polish
 
 ### Custom-widget ARIA
-- `SortDropdown.vue:14` — `aria-expanded` hardcoded `false`; items are placeholder `<a href="#">`; no Escape/click-outside. Serious-ish; consider replacing with Headless `Menu`.
-- `FilterChip.vue:39` — add `aria-haspopup`/`:aria-expanded`.
+- `SortDropdown.vue` — ⚠️ **Dead component** (not imported anywhere; placeholder `<a href="#">`
+  items). Flagged for deletion rather than ARIA-fixing; rebuild with `MenuButton.vue` if sort UI is
+  needed later.
+- `FilterChip.vue` — ✅ **DONE.** Trigger (and SSR fallback) now have `aria-haspopup` +
+  `:aria-expanded` bound to `isOpen`.
 - `nav/SiteSidenav.vue:237` search-type dropdown & `nav/CreateAnythingButton.vue:187` menu — add listbox/menu ARIA + arrow-key nav / focus-into-menu.
-- `notifications/NotificationTabs.vue:272` & `channel/ChannelTabs.vue:299` — add `role="tablist"/"tab"/"tabpanel"` + `aria-selected` (or `aria-current`).
+- `notifications/NotificationTabs.vue` & `channel/ChannelTabs.vue` — ✅ **DONE.** NotificationTabs
+  (in-page) got the full `role="tablist"/"tab"/"tabpanel"` pattern with `aria-selected`, roving
+  tabindex, and arrow-key switching; ChannelTabs (route nav via `TabButton`) got
+  `aria-current="page"` on the active link.
 - `TextEditor.vue` autocomplete — expose combobox/listbox ARIA (`aria-expanded`/`aria-controls`/`aria-activedescendant`) for `BotSuggestionsPopover`/`ModSuggestionsPopover`.
 - `GenericButton.vue:33` (+ `GenericSmallButton:18`, `SaveButton:27`, `CancelButton:13`) — `@keydown.enter.prevent` cancels native Enter activation. Remove `.prevent`.
 
@@ -191,19 +209,23 @@ Pervasive: async loading/error/validation states swap silently (near-zero `aria-
 - `filter/FilterOptionManager.vue` (~6×) & `filter/FilterGroupManager.vue` — `<label>` with no `for`, inputs no `id`. Associate them.
 - `plugins/PipelineVisualEditor.vue:173,201` — unassociated `<select>` labels; remove-step (`:242`) title-only. Also provide keyboard reorder (drag-only today, `:147`).
 - `auth/CreateUsernameForm.vue:177,235` — username/birthday label/id mismatch.
-- `FormRow.vue:24` — `:for` points at a label id no slotted control has.
+- `FormRow.vue` — ✅ **Partially DONE.** The label now uses a valid generated id (was the
+  section-title text, spaces and all) and exposes it to the content slot as `field-id`. Full
+  association still requires each consumer to bind `field-id` to its input.
 - `RadioButtons.vue:25,34` — `<fieldset>` has no `<legend>`; hardcoded `name` breaks two instances per page.
 - `TextInput.vue:63` — name falls back to placeholder; no `required`/`aria-required`.
-- `text-editor/TextEditorToolbar.vue:54` — single-glyph aria-labels ("B","I"); use "Bold","Italic".
-- `RulesEditor.vue:83` — button missing `type="button"` (defaults to submit).
+- `text-editor/TextEditorToolbar.vue` — ✅ **DONE.** Buttons now carry full-word aria-labels
+  (Bold/Italic/Heading 1/…/Toggle fullscreen) while keeping the visible glyph.
+- `RulesEditor.vue` — ✅ **DONE** (both buttons have `type="button"`).
 - **Placeholder-only inputs (no label/aria-label):** `admin/ServerMembershipEditor.vue:181,274` (admin/mod invite), `admin/plugins/PluginSecretsSection.vue:123` (secret value). Serious.
 - `mod/BrokenRulesModal.vue:704` — "Suspend user for" `<label>` not associated with its `<select>` (`:708` has no `id`). Moderate.
 
 ### Media / charts text alternatives
 - `charts/ContributionLineChart.vue:131` (+ `ChannelContributionChart.vue`) — `<canvas>` chart with no `role="img"`/`aria-label`/data-table alternative. Serious.
 - `ModelViewer.vue:29` — hardcoded `alt="3D Model Preview"`; accept + forward a real `alt` from `image/ImageListItem.vue:52`. Fullscreen/close buttons rely on `title` only (`:14,60`).
-- `LinkPreview.vue:54` — `:alt="title"` becomes `alt=""` while loading (link then has no text). Add a stable fallback.
-- `revision/RevisionDiffContent.vue:173` & `Table.vue:7` — tables have no `<caption>`/`aria-label`.
+- `LinkPreview.vue` — ✅ **DONE.** Image alt falls back to "Link preview image" when title is empty.
+- `revision/RevisionDiffContent.vue` & `Table.vue` — ✅ **DONE.** Both diff tables have an sr-only
+  `<caption>`; the generic `Table.vue` gained an optional `caption` prop rendering an sr-only caption.
 
 ### Icon-only buttons relying on `title` (add `aria-label`)
 - `plugins/PluginLogsModal.vue:123` (close), `plugins/PipelineVisualEditor.vue:242` (remove),
@@ -214,12 +236,12 @@ Pervasive: async loading/error/validation states swap silently (near-zero `aria-
 
 ### Contrast (light-mode small text below 4.5:1)
 - `text-gray-400` hints: `plugins/fields/PluginNumberField.vue:114`, `PluginSecretField.vue:210`, `nav/SiteSidenav.vue:317`.
-- `text-orange-500` badge: `user/UserProfileSidebar.vue:116` → use `text-orange-700`.
-- `text-gray-400 dark:text-gray-500` fails both modes: `admin/ImageReportsList.vue:161` → `text-gray-500 dark:text-gray-400`.
-- Typo `dak:text-white` → `dark:text-white` in `user/NotificationList.vue:114`.
+- `text-orange-500` badge: `user/UserProfileSidebar.vue` — ✅ **DONE** (role badges bumped to `text-orange-700` in light mode, `dark:text-orange-500`).
+- `text-gray-400 dark:text-gray-500` fails both modes: `admin/ImageReportsList.vue` — ✅ **DONE** (flipped to `text-gray-500 dark:text-gray-400`).
+- Typo `dak:text-white` → `dark:text-white` in `user/NotificationList.vue` — ✅ **DONE**.
 
 ### Tables / lists (mod & admin)
-- `admin/ChannelHealthTable.vue:142` — column `<th>`s lack `scope="col"`.
+- `admin/ChannelHealthTable.vue` — ✅ **DONE** (`scope="col"` added to header cells).
 - `admin/ServerSuspendedModList.vue:53` & `admin/ServerSuspendedUserList.vue` — `<div v-for>` lists losing semantics → `<ul role="list">`/`<li>`.
 - `admin/ServerTabs.vue:166` — decorative chevron `<i>` needs `aria-hidden="true"`.
 
@@ -256,10 +278,17 @@ _Per CLAUDE.md: implement incrementally, one file at a time, with unit/Playwrigh
 
 Not called out by the original audit's high-leverage list; pick up after P0–P4.
 
-- **Broad `focus:outline-none`-without-replacement sweep.** Beyond the P0 button primitives and
-  the P1 nav components (both done), grep still finds **~18** components that set
-  `outline-none` / `focus:outline-none` without a `focus:ring-*` or `focus-visible:ring-*`
-  replacement, so keyboard focus is invisible on those controls too. Sweep them the same way:
+- **Broad `focus:outline-none`-without-replacement sweep.** ✅ **Interactive controls DONE
+  (2026-07):** added the focus-visible ring convention to the real focus targets —
+  `IconButtonDropdown.vue` (both triggers), `TextButtonDropdown.vue` (both triggers),
+  `nav/RecentForumsDrawer.vue` (Cancel button), `FileTypePicker.vue` (focus-within ring on the
+  combobox pill), and `channel/DownloadNowButton.vue` (was missing the ring *width* so no ring
+  painted — the P0 bug pattern). **Remaining (intentionally left):** non-focusable dropdown
+  *panels* (`SelectComponent`, `IconButtonDropdown`/`TextButtonDropdown` menu containers,
+  `event/detail/EventNotificationsMenu`, `nav/CreateAnythingButton` menu) and programmatically-
+  focused page containers (`pages/admin.vue`, `pages/forums/[forumId].vue`, `pages/server/issues.vue`,
+  the discussion/download detail panels, `pages/settings.vue`, `pages/create-username.vue`) — these
+  are not keyboard focus targets. If any later gains a real `tabindex`, sweep it the same way:
   add `focus-visible:ring-2` + a ring color/offset (use `focus-visible:` for icon/toggle/input
   controls, `focus:ring-2` where the file already uses `focus:ring-*`). Find the current list with:
   ```


### PR DESCRIPTION
Works through the still-open items in [docs/accessibility-audit-2026-07.md](docs/accessibility-audit-2026-07.md), committed in themed slices. Each functional change ships with unit tests; the audit doc is updated to reflect what's done.

## Lint speedup (bonus)
- Enable ESLint `--cache` on `lint`, `lint:a11y`, and both lint-staged entries. Full warm run drops **~64s → ~6s**. Cache lives in `node_modules/.cache/` (already gitignored).

## P1 — keyboard blockers
- **GithubContributionChart**: day cells were `<rect @click>` (mouse-only). Now a roving-tabindex grid — one tabbable cell, arrow keys + Home/End, Enter/Space toggles day details, per-cell `aria-label`, `aria-pressed`, visible focus ring.
- **PluginPipeline**: collapse header was a `<div @click>` with an inert chevron button. Now a real `<button>` (aria-expanded + aria-controls); chevron demoted to `aria-hidden`.
- **EventListItem**: left as-is — its title is already a real `<router-link>` (keyboard path exists); the residual card `@click` is a multi-mode mouse convenience.

## P3 — live regions for async state
- New reusable **`StatusMessage`** wrapper (role status/alert, aria-live, aria-busy).
- Rolled out to NotificationList, NotificationTabs, SearchableForumList, DownloadList (skeleton grid), PluginPipeline loading/error.
- **SaveStatus**: moved the polite live region onto the persistent wrapper (was v-if-mounted with text, which SRs miss).

## P4 — widget ARIA / forms / media / tables / contrast
- **FilterChip**: `aria-haspopup` + `:aria-expanded`.
- **Tab semantics**: NotificationTabs (in-page) → full tablist/tab/tabpanel + roving tabindex + arrow keys; ChannelTabs (route nav) → `aria-current="page"`.
- **TextEditorToolbar**: full-word aria-labels (Bold/Italic/…), visible glyph kept.
- **FormRow**: valid generated label id (was the section-title text) + exposes `field-id` to the content slot.
- **LinkPreview**: image alt fallback when title is empty.
- **Tables**: `scope="col"` on ChannelHealthTable; sr-only `<caption>` on both diff tables; optional `caption` prop on the generic Table.
- **Contrast**: fixed `dak:text-white` typo; role badges → `orange-700` (AA); ImageReportsList gray flip.

## P5 — visible focus rings
- Added the app's focus-visible ring to interactive controls (IconButtonDropdown, TextButtonDropdown triggers, RecentForumsDrawer cancel, FileTypePicker pill via focus-within, DownloadNowButton which was missing the ring *width*). Non-focusable panels/page containers intentionally left.

## Also
- Flagged the dead `SortDropdown.vue` (unused template leftover) for deletion rather than ARIA-polishing it.

## Verification
- `pnpm run tsc` clean; `pnpm run lint` 0 errors; all 19 touched spec files (192 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)