### PR TITLE
Fix downloadable file review queries

### DIFF
--- a/components/channel/DownloadSidebar.spec.ts
+++ b/components/channel/DownloadSidebar.spec.ts
@@ -304,30 +304,6 @@ describe('DownloadSidebar', () => {
     });
   });
 
-  it('shows when human review was already requested', () => {
-    mockUsernameRef.value = 'author';
-    const wrapper = mount(DownloadSidebar, {
-      props: {
-        discussion: makeDiscussion({
-          ...discussionWithFile,
-          DownloadableFiles: [
-            {
-              ...discussionWithFile.DownloadableFiles[0],
-              scanStatus: 'SUSPICIOUS',
-              reviewRequestedAt: '2026-07-19T00:00:00Z',
-            },
-          ],
-        }),
-        discussionId: 'discussion-1',
-        channelUniqueName: 'test-forum',
-      },
-    });
-
-    expect(wrapper.get('[data-testid="download-scan-status"] button').text()).toBe(
-      'Human review requested'
-    );
-  });
-
   it('identifies a failed scan as a server-side problem for the creator', () => {
     mockUsernameRef.value = 'author';
     const wrapper = mount(DownloadSidebar, {

--- a/components/channel/DownloadSidebar.vue
+++ b/components/channel/DownloadSidebar.vue
@@ -30,8 +30,6 @@ type ScannedDownloadableFile = Omit<
   scanReason?: string | null;
   scanCheckedAt?: string | null;
   uploadedByUsername?: string | null;
-  reviewRequestedAt?: string | null;
-  reviewRequestReason?: string | null;
 };
 
 const props = defineProps({
@@ -104,7 +102,7 @@ const creatorIsViewing = computed(
 );
 
 const reviewRequested = computed(
-  () => reviewRequestedLocally.value || Boolean(primaryFile.value?.reviewRequestedAt)
+  () => reviewRequestedLocally.value
 );
 
 const requestHumanReview = () => {

--- a/graphQLData/discussion/mutations.js
+++ b/graphQLData/discussion/mutations.js
@@ -131,8 +131,6 @@ export const REQUEST_DOWNLOADABLE_FILE_REVIEW = gql`
     ) {
       id
       scanStatus
-      reviewRequestedAt
-      reviewRequestReason
     }
   }
 `;

--- a/graphQLData/discussion/queries.js
+++ b/graphQLData/discussion/queries.js
@@ -377,8 +377,6 @@ export const GET_DISCUSSION = gql`
         scanStatus
         scanCheckedAt
         scanReason
-        reviewRequestedAt
-        reviewRequestReason
         uploadedByUsername
         license {
           id
@@ -482,8 +480,6 @@ export const GET_DISCUSSION_FEEDBACK = gql`
         scanStatus
         scanCheckedAt
         scanReason
-        reviewRequestedAt
-        reviewRequestReason
         uploadedByUsername
       }
       CrosspostedDiscussion {

--- a/tests/unit/downloadableFileQueryCompatibility.spec.ts
+++ b/tests/unit/downloadableFileQueryCompatibility.spec.ts
@@ -1,0 +1,28 @@
+import { print } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import { REQUEST_DOWNLOADABLE_FILE_REVIEW } from '@/graphQLData/discussion/mutations';
+import {
+  GET_DISCUSSION,
+  GET_DISCUSSION_FEEDBACK,
+} from '@/graphQLData/discussion/queries';
+
+describe('DownloadableFile GraphQL operations', () => {
+  it('do not select review queue fields from DownloadableFile', () => {
+    const operations = [
+      GET_DISCUSSION,
+      GET_DISCUSSION_FEEDBACK,
+      REQUEST_DOWNLOADABLE_FILE_REVIEW,
+    ].map(print);
+
+    expect(
+      operations.map((operation) => ({
+        reviewRequestedAt: operation.includes('reviewRequestedAt'),
+        reviewRequestReason: operation.includes('reviewRequestReason'),
+      }))
+    ).toEqual([
+      { reviewRequestedAt: false, reviewRequestReason: false },
+      { reviewRequestedAt: false, reviewRequestReason: false },
+      { reviewRequestedAt: false, reviewRequestReason: false },
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

- Removed `reviewRequestedAt` and `reviewRequestReason` from `DownloadableFile` selections in the discussion detail and feedback queries.
- Removed the same unsupported fields from the human-review request mutation response.
- Kept the sidebar's post-request confirmation as local mutation state.
- Added a regression test covering all three affected GraphQL documents.

## Why

Production's GraphQL schema does not define `reviewRequestedAt` or `reviewRequestReason` on `DownloadableFile`. The discussion detail request therefore failed GraphQL validation before any page data could load. Those fields remain valid on the custom admin review-queue payload and are unchanged there.

## Impact

Discussion and download detail pages can load again against the production schema, and creators can still submit human-review requests and see immediate confirmation.

## Validation

- `pnpm exec vitest run tests/unit/downloadableFileQueryCompatibility.spec.ts components/channel/DownloadSidebar.spec.ts` — 11 tests passed
- `pnpm run tsc`
- ESLint on the changed Vue/TypeScript files
- `git diff --check`