### PR TITLE
refactor: extract plugin configuration status into a composable

### DIFF
--- a/components/admin/plugins/PluginStatusCards.vue
+++ b/components/admin/plugins/PluginStatusCards.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import type { PluginConfigFieldStatus } from '@/composables/usePluginConfigStatus';
 
 defineProps<{
   isEnabled: boolean;
   installedVersion?: string | null;
   canEnable: boolean;
   enabling: boolean;
-  blockingConfigFields?: Array<{
-    key: string;
-    label: string;
-    kind: 'SETTING' | 'SECRET';
-    message?: string | null;
-  }>;
+  blockingConfigFields?: PluginConfigFieldStatus[];
 }>();
 
 const emit = defineEmits<{

--- a/composables/usePluginConfigStatus.spec.ts
+++ b/composables/usePluginConfigStatus.spec.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, ref, type Ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { usePluginConfigStatus } from './usePluginConfigStatus';
+
+const h = vi.hoisted(() => ({
+  query: null as unknown as {
+    result: Ref<unknown>;
+    loading: Ref<boolean>;
+    error: Ref<Error | null>;
+    refetch: ReturnType<typeof vi.fn>;
+  },
+}));
+
+vi.mock('@vue/apollo-composable', async () => {
+  const { ref } = await import('vue');
+  h.query = {
+    result: ref(null),
+    loading: ref(false),
+    error: ref(null),
+    refetch: vi.fn(),
+  };
+  return {
+    useQuery: vi.fn(() => h.query),
+  };
+});
+
+vi.mock('@/graphQLData/admin/queries', () => ({
+  GET_PLUGIN_CONFIG_STATUS: 'CONFIG_STATUS',
+}));
+
+describe('usePluginConfigStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.query.result.value = null;
+    h.query.loading.value = false;
+    h.query.error.value = null;
+  });
+
+  it('passes reactive plugin, version, and scope variables to the query', async () => {
+    const pluginId = ref('example-plugin');
+    const version = ref('1.0.0');
+    const scope = ref<'server' | 'channel'>('server');
+
+    usePluginConfigStatus({ pluginId, version, scope });
+    const queryVariables = vi.mocked(useQuery).mock.calls[0]![1] as {
+      value: Record<string, string>;
+    };
+
+    pluginId.value = 'other-plugin';
+    version.value = '2.0.0';
+    scope.value = 'channel';
+    await nextTick();
+
+    expect(queryVariables.value).toEqual({
+      pluginId: 'other-plugin',
+      version: '2.0.0',
+      scope: 'channel',
+    });
+  });
+
+  it.each([
+    {
+      name: 'missing plugin ID',
+      pluginId: '',
+      version: '1.0.0',
+    },
+    {
+      name: 'missing version',
+      pluginId: 'example-plugin',
+      version: '',
+    },
+  ])('disables the query for $name', ({ pluginId, version }) => {
+    usePluginConfigStatus({
+      pluginId: ref(pluginId),
+      version: ref(version),
+      scope: 'server',
+    });
+    const queryOptions = vi.mocked(useQuery).mock.calls[0]![2] as {
+      enabled: { value: boolean };
+    };
+
+    expect(queryOptions.enabled.value).toBe(false);
+  });
+
+  it('clears exposed status when a required query input disappears', async () => {
+    const version = ref('1.0.0');
+    h.query.result.value = {
+      getPluginConfigStatus: {
+        isFullyConfigured: true,
+        fields: [],
+      },
+    };
+    const { status, isFullyConfigured } = usePluginConfigStatus({
+      pluginId: 'example-plugin',
+      version,
+      scope: 'server',
+    });
+
+    version.value = '';
+    await nextTick();
+
+    expect({
+      status: status.value,
+      isFullyConfigured: isFullyConfigured.value,
+    }).toEqual({
+      status: null,
+      isFullyConfigured: false,
+    });
+  });
+
+  it('derives every required missing or invalid blocking field', () => {
+    h.query.result.value = {
+      getPluginConfigStatus: {
+        isFullyConfigured: false,
+        fields: [
+          {
+            key: 'missing',
+            label: 'Missing',
+            scope: 'server',
+            kind: 'SETTING',
+            required: true,
+            isSet: false,
+            isValid: false,
+          },
+          {
+            key: 'invalid',
+            label: 'Invalid',
+            scope: 'server',
+            kind: 'SECRET',
+            required: true,
+            isSet: true,
+            isValid: false,
+          },
+          {
+            key: 'optional',
+            label: 'Optional',
+            scope: 'server',
+            kind: 'SETTING',
+            required: false,
+            isSet: false,
+            isValid: false,
+          },
+          {
+            key: 'valid',
+            label: 'Valid',
+            scope: 'server',
+            kind: 'SETTING',
+            required: true,
+            isSet: true,
+            isValid: true,
+          },
+        ],
+      },
+    };
+    const { blockingFields } = usePluginConfigStatus({
+      pluginId: 'example-plugin',
+      version: '1.0.0',
+      scope: 'server',
+    });
+
+    expect(blockingFields.value.map(({ key }) => key)).toEqual([
+      'missing',
+      'invalid',
+    ]);
+  });
+
+  it('exposes the query refetch operation', async () => {
+    const { refetch } = usePluginConfigStatus({
+      pluginId: 'example-plugin',
+      version: '1.0.0',
+      scope: 'server',
+    });
+
+    await refetch();
+
+    expect(h.query.refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/composables/usePluginConfigStatus.ts
+++ b/composables/usePluginConfigStatus.ts
@@ -1,0 +1,86 @@
+import {
+  computed,
+  toValue,
+  type MaybeRefOrGetter,
+} from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { GET_PLUGIN_CONFIG_STATUS } from '@/graphQLData/admin/queries';
+
+export type PluginConfigScope = 'server' | 'channel';
+
+export interface PluginConfigFieldStatus {
+  key: string;
+  label: string;
+  scope: PluginConfigScope;
+  kind: 'SETTING' | 'SECRET';
+  required: boolean;
+  isSet: boolean;
+  isValid: boolean;
+  message?: string | null;
+}
+
+export interface PluginConfigStatus {
+  isFullyConfigured: boolean;
+  fields: PluginConfigFieldStatus[];
+}
+
+interface UsePluginConfigStatusOptions {
+  pluginId: MaybeRefOrGetter<string | null | undefined>;
+  version: MaybeRefOrGetter<string | null | undefined>;
+  scope: MaybeRefOrGetter<PluginConfigScope>;
+}
+
+export function usePluginConfigStatus({
+  pluginId,
+  version,
+  scope,
+}: UsePluginConfigStatusOptions) {
+  const queryVariables = computed(() => ({
+    pluginId: toValue(pluginId) || '',
+    version: toValue(version) || '',
+    scope: toValue(scope),
+  }));
+
+  const queryEnabled = computed(
+    () => !!queryVariables.value.pluginId && !!queryVariables.value.version
+  );
+
+  const {
+    result,
+    loading: queryLoading,
+    error: queryError,
+    refetch,
+  } = useQuery(GET_PLUGIN_CONFIG_STATUS, queryVariables, {
+    enabled: queryEnabled,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const status = computed<PluginConfigStatus | null>(() => {
+    if (!queryEnabled.value) return null;
+    return result.value?.getPluginConfigStatus || null;
+  });
+
+  const blockingFields = computed<PluginConfigFieldStatus[]>(() =>
+    (status.value?.fields || []).filter(
+      (field) => field.required && (!field.isSet || !field.isValid)
+    )
+  );
+
+  const isFullyConfigured = computed(
+    () => status.value?.isFullyConfigured === true
+  );
+
+  const loading = computed(() => queryEnabled.value && queryLoading.value);
+  const error = computed(() =>
+    queryEnabled.value ? queryError.value : null
+  );
+
+  return {
+    status,
+    isFullyConfigured,
+    blockingFields,
+    loading,
+    error,
+    refetch,
+  };
+}

--- a/pages/admin/settings/plugins/[pluginId].vue
+++ b/pages/admin/settings/plugins/[pluginId].vue
@@ -14,6 +14,7 @@ import PluginSecretsSection from '@/components/admin/plugins/PluginSecretsSectio
 import PluginSettingsSection from '@/components/admin/plugins/PluginSettingsSection.vue';
 import PluginManifestSection from '@/components/admin/plugins/PluginManifestSection.vue';
 import PluginReadmeSection from '@/components/admin/plugins/PluginReadmeSection.vue';
+import { usePluginConfigStatus } from '@/composables/usePluginConfigStatus';
 import { useToast } from '@/composables/useToast';
 import { resolveDefaultVersion } from '@/utils/versionUtils';
 import {
@@ -50,7 +51,6 @@ import {
   GET_AVAILABLE_PLUGINS,
   GET_INSTALLED_PLUGINS,
   GET_SERVER_PLUGIN_SECRETS,
-  GET_PLUGIN_CONFIG_STATUS,
   GET_PLUGIN_DETAIL,
 } from '@/graphQLData/admin/queries';
 import {
@@ -91,17 +91,6 @@ interface PluginSecretStatus {
   required?: boolean;
   lastValidatedAt?: string;
   validationError?: string;
-}
-
-interface PluginConfigFieldStatus {
-  key: string;
-  label: string;
-  scope: string;
-  kind: 'SETTING' | 'SECRET';
-  required: boolean;
-  isSet: boolean;
-  isValid: boolean;
-  message?: string | null;
 }
 
 interface PluginMetadata {
@@ -271,33 +260,15 @@ const isInstalled = computed(() => !!installedPlugin.value);
 const isEnabled = computed(() => installedPlugin.value?.enabled ?? false);
 const installedVersion = computed(() => installedPlugin.value?.version);
 
-const configStatusQueryVars = computed(() => ({
-  pluginId: pluginSlug.value,
-  version: installedVersion.value || '',
+const {
+  isFullyConfigured: hasCompleteConfig,
+  blockingFields: blockingConfigFields,
+  refetch: refetchConfigStatus,
+} = usePluginConfigStatus({
+  pluginId: pluginSlug,
+  version: installedVersion,
   scope: 'server',
-}));
-
-const { result: configStatusResult, refetch: refetchConfigStatus } = useQuery(
-  GET_PLUGIN_CONFIG_STATUS,
-  configStatusQueryVars,
-  {
-    enabled: computed(
-      () => !!pluginSlug.value && !!installedVersion.value
-    ),
-    fetchPolicy: 'cache-and-network',
-  }
-);
-
-const configStatus = computed(() =>
-  configStatusResult.value?.getPluginConfigStatus || null
-);
-
-const blockingConfigFields = computed((): PluginConfigFieldStatus[] =>
-  (configStatus.value?.fields || []).filter(
-    (field: PluginConfigFieldStatus) =>
-      field.required && (!field.isSet || !field.isValid)
-  )
-);
+});
 
 // Only show full-page loading on initial load, not during refetches
 // Check if we're loading AND don't have any data yet
@@ -402,7 +373,7 @@ const pluginApiVersion = computed(
 );
 
 const canEnable = computed(() => {
-  return isInstalled.value && configStatus.value?.isFullyConfigured === true;
+  return isInstalled.value && hasCompleteConfig.value;
 });
 
 const availableVersions = computed(() =>


### PR DESCRIPTION
## Summary

- extract plugin configuration status querying into a typed `usePluginConfigStatus` composable
- expose the configuration rollup, blocking fields, loading/error state, and refetch operation
- clear exposed query state when the reactive plugin ID or version becomes unavailable
- share configuration field types with the plugin status card
- migrate the server plugin detail page without changing its existing refetch behavior

## Why

The plugin detail page owned the Apollo query, reactive variables, enablement rules, field types, and blocking-field derivation locally. Keeping that behavior together in a composable makes configuration status reusable and prevents other plugin-management surfaces from duplicating or drifting from the same rules.

## Impact

Plugin enablement behavior remains unchanged. Consumers can now reuse one typed source for configuration completeness, and missing query inputs cannot leave stale status visible.

## Validation

- `pnpm run tsc`
- ESLint on the changed files
- focused unit tests: 36 passed
- full unit suite: 6,952 passed across 764 files

Closes #396