### PR TITLE
ux: link plugin enablement blockers to configuration fields

### DIFF
--- a/components/admin/plugins/PluginSecretsSection.spec.ts
+++ b/components/admin/plugins/PluginSecretsSection.spec.ts
@@ -131,6 +131,35 @@ describe('PluginSecretsSection input toggle', () => {
     ).toBe('Value for API_KEY');
   });
 
+  it('gives a closed secret control its canonical configuration ID', () => {
+    const wrapper = mountSection();
+
+    expect(buttonByText(wrapper, 'Set Secret')!.attributes('id')).toBe(
+      'plugin-config-secret-41-50-49-5f-4b-45-59'
+    );
+  });
+
+  it('keeps the canonical configuration ID when the secret input opens', () => {
+    const wrapper = mountSection({ showSecretInputs: { API_KEY: true } });
+
+    expect(wrapper.find('input[type="password"]').attributes('id')).toBe(
+      'plugin-config-secret-41-50-49-5f-4b-45-59'
+    );
+  });
+
+  it('gives duplicate secret keys unique control IDs', () => {
+    const wrapper = mountSection({
+      secrets: [secret(), secret()],
+    });
+
+    expect(
+      wrapper.findAll('button').map((button) => button.attributes('id'))
+    ).toEqual([
+      'plugin-config-secret-41-50-49-5f-4b-45-59',
+      'plugin-config-secret-41-50-49-5f-4b-45-59--2',
+    ]);
+  });
+
   it('emits the updated secret value on input', async () => {
     const wrapper = mountSection({ showSecretInputs: { API_KEY: true } });
 

--- a/components/admin/plugins/PluginSecretsSection.vue
+++ b/components/admin/plugins/PluginSecretsSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import FormRow from '@/components/FormRow.vue';
+import { getPluginConfigFieldId } from '@/utils/pluginConfigFieldIds';
 
 interface PluginSecretStatus {
   key: string;
@@ -76,6 +77,20 @@ const getSecretStatusText = (secret: PluginSecretStatus) => {
       return secret.required ? 'Required — not set' : 'Not set';
   }
 };
+
+const getSecretControlId = (
+  secret: PluginSecretStatus,
+  index: number
+): string => {
+  const occurrence = props.secrets
+    .slice(0, index)
+    .filter((candidate) => candidate.key === secret.key).length;
+  return getPluginConfigFieldId({
+    kind: 'SECRET',
+    key: secret.key,
+    occurrence,
+  });
+};
 </script>
 
 <template>
@@ -98,8 +113,8 @@ const getSecretStatusText = (secret: PluginSecretStatus) => {
         </p>
 
         <div
-          v-for="secret in secrets"
-          :key="secret.key"
+          v-for="(secret, index) in secrets"
+          :key="getSecretControlId(secret, index)"
           class="rounded-lg border border-gray-200 p-4 dark:border-gray-700"
         >
           <div class="mb-3 flex items-center justify-between">
@@ -113,6 +128,7 @@ const getSecretStatusText = (secret: PluginSecretStatus) => {
                 Server
               </span>
               <span
+                :id="`${getSecretControlId(secret, index)}-status`"
                 class="font-semibold rounded-full px-2 py-1 text-xs"
                 :class="getSecretStatusColor(secret.status)"
               >
@@ -123,10 +139,13 @@ const getSecretStatusText = (secret: PluginSecretStatus) => {
 
           <div v-if="showSecretInputs[secret.key]" class="space-y-3">
             <input
+              :id="getSecretControlId(secret, index)"
               :value="secretValues[secret.key] || ''"
               type="password"
               placeholder="Enter secret value"
               :aria-label="`Value for ${secret.key}`"
+              :aria-describedby="`${getSecretControlId(secret, index)}-status`"
+              :aria-invalid="secret.status === 'INVALID'"
               class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
               @input="updateSecretValue(secret.key, ($event.target as HTMLInputElement).value)"
             >
@@ -185,8 +204,10 @@ const getSecretStatusText = (secret: PluginSecretStatus) => {
 
           <div v-else class="flex space-x-2">
             <button
+              :id="getSecretControlId(secret, index)"
               type="button"
-              class="rounded bg-gray-100 px-3 py-1 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+              :aria-describedby="`${getSecretControlId(secret, index)}-status`"
+              class="rounded bg-gray-100 px-3 py-1 text-sm text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
               @click="updateShowSecretInput(secret.key, true)"
             >
               {{

--- a/components/admin/plugins/PluginStatusCards.spec.ts
+++ b/components/admin/plugins/PluginStatusCards.spec.ts
@@ -77,6 +77,39 @@ describe('PluginStatusCards disabled state', () => {
     ]);
   });
 
+  it.each([
+    {
+      kind: 'SETTING',
+      key: 'url',
+      label: 'Service URL',
+    },
+    {
+      kind: 'SECRET',
+      key: 'key',
+      label: 'API key',
+    },
+  ])('emits $kind blockers for focus when activated', async (field) => {
+    const wrapper = mountCards({
+      canEnable: false,
+      blockingConfigFields: [field],
+    });
+
+    await wrapper.get('li button').trigger('click');
+
+    expect(wrapper.emitted('focus-config-field')?.[0]).toEqual([field]);
+  });
+
+  it('uses native buttons for keyboard-accessible blocker activation', () => {
+    const wrapper = mountCards({
+      canEnable: false,
+      blockingConfigFields: [
+        { key: 'url', label: 'Service URL', kind: 'SETTING' },
+      ],
+    });
+
+    expect(wrapper.get('li button').attributes('type')).toBe('button');
+  });
+
   it('hides the Enable button when it cannot be enabled', () => {
     const wrapper = mountCards({ isEnabled: false, canEnable: false });
 

--- a/components/admin/plugins/PluginStatusCards.vue
+++ b/components/admin/plugins/PluginStatusCards.vue
@@ -12,6 +12,7 @@ defineProps<{
 
 const emit = defineEmits<{
   (e: 'toggle-enabled', enabled: boolean): void;
+  (e: 'focus-config-field', field: PluginConfigFieldStatus): void;
 }>();
 </script>
 
@@ -106,9 +107,18 @@ const emit = defineEmits<{
             Required before enabling
           </p>
           <ul v-if="blockingConfigFields?.length" class="mt-2 list-disc space-y-1 pl-5">
-            <li v-for="field in blockingConfigFields" :key="`${field.kind}:${field.key}`">
-              {{ field.label }}
-              <span class="text-xs opacity-80">({{ field.kind.toLowerCase() }})</span>
+            <li
+              v-for="(field, index) in blockingConfigFields"
+              :key="`${field.kind}:${field.key}:${index}`"
+            >
+              <button
+                type="button"
+                class="rounded-sm text-left underline decoration-amber-600/60 underline-offset-2 hover:decoration-current focus:outline-none focus:ring-2 focus:ring-amber-700 focus:ring-offset-2 focus:ring-offset-amber-50 dark:focus:ring-amber-300 dark:focus:ring-offset-amber-950"
+                @click="emit('focus-config-field', field)"
+              >
+                {{ field.label }}
+                <span class="text-xs opacity-80">({{ field.kind.toLowerCase() }})</span>
+              </button>
             </li>
           </ul>
           <p v-else class="mt-1 text-xs">Configure the required fields below.</p>

--- a/components/plugins/PluginSettingsForm.spec.ts
+++ b/components/plugins/PluginSettingsForm.spec.ts
@@ -5,7 +5,7 @@ import PluginSettingsForm from '@/components/plugins/PluginSettingsForm.vue';
 
 const fieldStub = (name: string) => ({
   name,
-  props: ['field', 'modelValue', 'error', 'secretStatus'],
+  props: ['field', 'modelValue', 'error', 'secretStatus', 'inputId'],
   emits: ['update:model-value'],
   template: `<div class="${name}" />`,
 });
@@ -105,5 +105,35 @@ describe('PluginSettingsForm values', () => {
     expect(
       wrapper.getComponent({ name: 'PluginSecretField' }).props('secretStatus')
     ).toEqual({ key: 'apiKey', status: 'SET' });
+  });
+
+  it('passes a DOM-safe canonical ID for an unusual setting key', () => {
+    const wrapper = mountForm({
+      sections: [section([{ key: 'api/key 🔑', type: 'text' }])],
+    });
+
+    expect(
+      wrapper.getComponent({ name: 'PluginTextField' }).props('inputId')
+    ).toBe('plugin-config-setting-61-70-69-2f-6b-65-79-20-1f511');
+  });
+
+  it('gives duplicate setting keys unique IDs', () => {
+    const wrapper = mountForm({
+      sections: [
+        section([
+          { key: 'endpoint', type: 'text' },
+          { key: 'endpoint', type: 'text' },
+        ]),
+      ],
+    });
+
+    expect(
+      wrapper
+        .findAllComponents({ name: 'PluginTextField' })
+        .map((component) => component.props('inputId'))
+    ).toEqual([
+      'plugin-config-setting-65-6e-64-70-6f-69-6e-74',
+      'plugin-config-setting-65-6e-64-70-6f-69-6e-74--2',
+    ]);
   });
 });

--- a/components/plugins/PluginSettingsForm.vue
+++ b/components/plugins/PluginSettingsForm.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import type {
   PluginFormSection,
   PluginField,
@@ -6,6 +7,7 @@ import type {
   PluginConfigValue,
   PluginSettings,
 } from '@/types/pluginForms';
+import { getPluginConfigFieldId } from '@/utils/pluginConfigFieldIds';
 import PluginTextField from './fields/PluginTextField.vue';
 import PluginNumberField from './fields/PluginNumberField.vue';
 import PluginBooleanField from './fields/PluginBooleanField.vue';
@@ -68,12 +70,35 @@ function getFieldComponent(field: PluginField) {
       return PluginTextField;
   }
 }
+
+const renderedSections = computed(() => {
+  const occurrences = new Map<string, number>();
+
+  return props.sections.map((section) => ({
+    ...section,
+    fields: section.fields.map((field) => {
+      const kind = field.type === 'secret' ? 'SECRET' : 'SETTING';
+      const occurrenceKey = `${kind}:${field.key}`;
+      const occurrence = occurrences.get(occurrenceKey) || 0;
+      occurrences.set(occurrenceKey, occurrence + 1);
+
+      return {
+        field,
+        inputId: getPluginConfigFieldId({
+          kind,
+          key: field.key,
+          occurrence,
+        }),
+      };
+    }),
+  }));
+});
 </script>
 
 <template>
   <div class="space-y-6">
     <div
-      v-for="section in sections"
+      v-for="section in renderedSections"
       :key="section.title"
       class="space-y-4"
     >
@@ -91,12 +116,13 @@ function getFieldComponent(field: PluginField) {
 
       <div class="space-y-4">
         <template
-          v-for="field in section.fields"
-          :key="field.key"
+          v-for="{ field, inputId } in section.fields"
+          :key="inputId"
         >
           <component
             :is="getFieldComponent(field)"
             :field="field"
+            :input-id="inputId"
             :model-value="getFieldValue(field.key)"
             :error="getFieldError(field.key)"
             :secret-status="field.type === 'secret' ? getSecretStatus(field.key) : undefined"

--- a/components/plugins/fields/PluginBooleanField.vue
+++ b/components/plugins/fields/PluginBooleanField.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   field: PluginField;
   modelValue: boolean | undefined;
   error?: string;
+  inputId?: string;
 }>();
 
 const emit = defineEmits<{
@@ -13,6 +14,7 @@ const emit = defineEmits<{
 }>();
 
 const touched = ref(false);
+const controlId = computed(() => props.inputId || props.field.key);
 
 const inputValue = computed({
   get: () => props.modelValue ?? (props.field.default as boolean) ?? false,
@@ -28,6 +30,15 @@ const validationError = computed(() => {
   return '';
 });
 
+const descriptionId = computed(() => `${controlId.value}-description`);
+const errorId = computed(() => `${controlId.value}-error`);
+const describedBy = computed(() => {
+  const ids = [];
+  if (props.field.description) ids.push(descriptionId.value);
+  if (props.error || validationError.value) ids.push(errorId.value);
+  return ids.join(' ') || undefined;
+});
+
 const toggleValue = () => {
   if (!touched.value) {
     touched.value = true;
@@ -40,11 +51,13 @@ const toggleValue = () => {
   <div class="space-y-1">
     <div class="flex items-center gap-3">
       <button
-        :id="field.key"
+        :id="controlId"
         type="button"
         role="switch"
         :aria-checked="inputValue"
         :aria-label="field.label"
+        :aria-describedby="describedBy"
+        :aria-invalid="!!(error || validationError)"
         class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
         :class="inputValue ? 'bg-orange-500' : 'bg-gray-200 dark:bg-gray-600'"
         @click="toggleValue"
@@ -55,7 +68,7 @@ const toggleValue = () => {
         />
       </button>
       <label
-        :for="field.key"
+        :for="controlId"
         class="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer"
         @click="toggleValue"
       >
@@ -68,12 +81,14 @@ const toggleValue = () => {
     </div>
     <p
       v-if="field.description"
+      :id="descriptionId"
       class="text-xs text-gray-500 dark:text-gray-400 ml-14"
     >
       {{ field.description }}
     </p>
     <p
       v-if="error || validationError"
+      :id="errorId"
       class="text-xs text-red-600 dark:text-red-400 ml-14"
     >
       {{ error || validationError }}

--- a/components/plugins/fields/PluginNumberField.vue
+++ b/components/plugins/fields/PluginNumberField.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   field: PluginField;
   modelValue: number | undefined;
   error?: string;
+  inputId?: string;
 }>();
 
 const emit = defineEmits<{
@@ -13,6 +14,7 @@ const emit = defineEmits<{
 }>();
 
 const touched = ref(false);
+const controlId = computed(() => props.inputId || props.field.key);
 
 const inputValue = computed({
   get: () => props.modelValue ?? (props.field.default as number),
@@ -80,12 +82,25 @@ const validationError = computed(() => {
   }
   return '';
 });
+
+const descriptionId = computed(() => `${controlId.value}-description`);
+const hintId = computed(() => `${controlId.value}-hint`);
+const errorId = computed(() => `${controlId.value}-error`);
+const describedBy = computed(() => {
+  const ids = [];
+  if (props.field.description) ids.push(descriptionId.value);
+  if (rangeHint.value && !props.error && !validationError.value) {
+    ids.push(hintId.value);
+  }
+  if (props.error || validationError.value) ids.push(errorId.value);
+  return ids.join(' ') || undefined;
+});
 </script>
 
 <template>
   <div class="space-y-1">
     <label
-      :for="field.key"
+      :for="controlId"
       class="block text-sm font-medium text-gray-700 dark:text-gray-300"
     >
       {{ field.label }}
@@ -96,27 +111,32 @@ const validationError = computed(() => {
     </label>
     <p
       v-if="field.description"
+      :id="descriptionId"
       class="text-xs text-gray-500 dark:text-gray-400"
     >
       {{ field.description }}
     </p>
     <input
-      :id="field.key"
+      :id="controlId"
       v-model.number="inputValue"
       type="number"
       :placeholder="field.placeholder"
       v-bind="validationAttrs"
+      :aria-describedby="describedBy"
+      :aria-invalid="!!(error || validationError)"
       class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
       :class="{ 'border-red-500': error || validationError }"
     >
     <p
       v-if="rangeHint && !error && !validationError"
+      :id="hintId"
       class="text-xs text-gray-500 dark:text-gray-400"
     >
       {{ rangeHint }}
     </p>
     <p
       v-if="error || validationError"
+      :id="errorId"
       class="text-xs text-red-600 dark:text-red-400"
     >
       {{ error || validationError }}

--- a/components/plugins/fields/PluginSecretField.vue
+++ b/components/plugins/fields/PluginSecretField.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   modelValue: string | undefined;
   error?: string;
   secretStatus?: PluginSecretStatus;
+  inputId?: string;
 }>();
 
 const emit = defineEmits<{
@@ -15,6 +16,7 @@ const emit = defineEmits<{
 
 const showValue = ref(false);
 const touched = ref(false);
+const controlId = computed(() => props.inputId || props.field.key);
 
 const inputValue = computed({
   get: () => props.modelValue ?? '',
@@ -102,13 +104,30 @@ const validationError = computed(() => {
   // Skip pattern validation for secrets - they are validated by the backend when used
   return '';
 });
+
+const descriptionId = computed(() => `${controlId.value}-description`);
+const statusId = computed(() => `${controlId.value}-status`);
+const errorId = computed(() => `${controlId.value}-error`);
+const describedBy = computed(() => {
+  const ids = [];
+  if (props.field.description) ids.push(descriptionId.value);
+  if (props.secretStatus) ids.push(statusId.value);
+  if (
+    props.secretStatus?.validationError ||
+    props.error ||
+    validationError.value
+  ) {
+    ids.push(errorId.value);
+  }
+  return ids.join(' ') || undefined;
+});
 </script>
 
 <template>
   <div class="space-y-1">
     <div class="flex items-center justify-between">
       <label
-        :for="field.key"
+        :for="controlId"
         class="block text-sm font-medium text-gray-700 dark:text-gray-300"
       >
         {{ field.label }}
@@ -119,6 +138,7 @@ const validationError = computed(() => {
       </label>
       <span
         v-if="secretStatus"
+        :id="statusId"
         class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
         :class="statusColor"
       >
@@ -127,6 +147,7 @@ const validationError = computed(() => {
     </div>
     <p
       v-if="field.description"
+      :id="descriptionId"
       class="text-xs text-gray-500 dark:text-gray-400"
     >
       {{ field.description }}
@@ -141,11 +162,15 @@ const validationError = computed(() => {
     </p>
     <div class="relative">
       <input
-        :id="field.key"
+        :id="controlId"
         v-model="inputValue"
         :type="showValue ? 'text' : 'password'"
         :placeholder="hasValue ? '[encrypted - cannot be viewed]' : field.placeholder"
         v-bind="validationAttrs"
+        :aria-describedby="describedBy"
+        :aria-invalid="
+          !!(secretStatus?.validationError || error || validationError)
+        "
         class="w-full rounded-md border border-gray-300 px-3 py-2 pr-20 text-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
         :class="{ 'border-red-500': error }"
       >
@@ -199,12 +224,14 @@ const validationError = computed(() => {
     </div>
     <p
       v-if="secretStatus?.validationError"
+      :id="errorId"
       class="text-xs text-red-600 dark:text-red-400"
     >
       {{ secretStatus.validationError }}
     </p>
     <p
       v-else-if="error || validationError"
+      :id="errorId"
       class="text-xs text-red-600 dark:text-red-400"
     >
       {{ error || validationError }}

--- a/components/plugins/fields/PluginSelectField.vue
+++ b/components/plugins/fields/PluginSelectField.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   field: PluginField;
   modelValue: string | number | boolean | undefined;
   error?: string;
+  inputId?: string;
 }>();
 
 const emit = defineEmits<{
@@ -13,6 +14,7 @@ const emit = defineEmits<{
 }>();
 
 const touched = ref(false);
+const controlId = computed(() => props.inputId || props.field.key);
 
 const inputValue = computed({
   get: () => props.modelValue ?? props.field.default ?? '',
@@ -41,12 +43,21 @@ const validationError = computed(() => {
   }
   return '';
 });
+
+const descriptionId = computed(() => `${controlId.value}-description`);
+const errorId = computed(() => `${controlId.value}-error`);
+const describedBy = computed(() => {
+  const ids = [];
+  if (props.field.description) ids.push(descriptionId.value);
+  if (props.error || validationError.value) ids.push(errorId.value);
+  return ids.join(' ') || undefined;
+});
 </script>
 
 <template>
   <div class="space-y-1">
     <label
-      :for="field.key"
+      :for="controlId"
       class="block text-sm font-medium text-gray-700 dark:text-gray-300"
     >
       {{ field.label }}
@@ -57,14 +68,17 @@ const validationError = computed(() => {
     </label>
     <p
       v-if="field.description"
+      :id="descriptionId"
       class="text-xs text-gray-500 dark:text-gray-400"
     >
       {{ field.description }}
     </p>
     <select
-      :id="field.key"
+      :id="controlId"
       v-model="inputValue"
       v-bind="validationAttrs"
+      :aria-describedby="describedBy"
+      :aria-invalid="!!(error || validationError)"
       class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
       :class="{ 'border-red-500': error || validationError }"
     >
@@ -85,6 +99,7 @@ const validationError = computed(() => {
     </select>
     <p
       v-if="error || validationError"
+      :id="errorId"
       class="text-xs text-red-600 dark:text-red-400"
     >
       {{ error || validationError }}

--- a/components/plugins/fields/PluginTextField.vue
+++ b/components/plugins/fields/PluginTextField.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   field: PluginField;
   modelValue: string | undefined;
   error?: string;
+  inputId?: string;
 }>();
 
 const emit = defineEmits<{
@@ -25,6 +26,7 @@ const inputValue = computed({
 });
 
 const isTextarea = computed(() => props.field.type === 'textarea');
+const controlId = computed(() => props.inputId || props.field.key);
 
 const validationAttrs = computed(() => {
   const attrs: Record<string, string | number | boolean> = {};
@@ -76,12 +78,21 @@ const validationError = computed(() => {
   }
   return '';
 });
+
+const descriptionId = computed(() => `${controlId.value}-description`);
+const errorId = computed(() => `${controlId.value}-error`);
+const describedBy = computed(() => {
+  const ids = [];
+  if (props.field.description) ids.push(descriptionId.value);
+  if (props.error || validationError.value) ids.push(errorId.value);
+  return ids.join(' ') || undefined;
+});
 </script>
 
 <template>
   <div class="space-y-1">
     <label
-      :for="field.key"
+      :for="controlId"
       class="block text-sm font-medium text-gray-700 dark:text-gray-300"
     >
       {{ field.label }}
@@ -92,32 +103,38 @@ const validationError = computed(() => {
     </label>
     <p
       v-if="field.description"
+      :id="descriptionId"
       class="text-xs text-gray-500 dark:text-gray-400"
     >
       {{ field.description }}
     </p>
     <textarea
       v-if="isTextarea"
-      :id="field.key"
+      :id="controlId"
       v-model="inputValue"
       :placeholder="field.placeholder"
       v-bind="validationAttrs"
+      :aria-describedby="describedBy"
+      :aria-invalid="!!(error || validationError)"
       rows="3"
       class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
       :class="{ 'border-red-500': error || validationError }"
     />
     <input
       v-else
-      :id="field.key"
+      :id="controlId"
       v-model="inputValue"
       type="text"
       :placeholder="field.placeholder"
       v-bind="validationAttrs"
+      :aria-describedby="describedBy"
+      :aria-invalid="!!(error || validationError)"
       class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
       :class="{ 'border-red-500': error || validationError }"
     >
     <p
       v-if="error || validationError"
+      :id="errorId"
       class="text-xs text-red-600 dark:text-red-400"
     >
       {{ error || validationError }}

--- a/composables/usePluginConfigStatus.ts
+++ b/composables/usePluginConfigStatus.ts
@@ -5,6 +5,7 @@ import {
 } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_PLUGIN_CONFIG_STATUS } from '@/graphQLData/admin/queries';
+import type { PluginConfigFieldKind } from '@/types/pluginForms';
 
 export type PluginConfigScope = 'server' | 'channel';
 
@@ -12,7 +13,7 @@ export interface PluginConfigFieldStatus {
   key: string;
   label: string;
   scope: PluginConfigScope;
-  kind: 'SETTING' | 'SECRET';
+  kind: PluginConfigFieldKind;
   required: boolean;
   isSet: boolean;
   isValid: boolean;

--- a/pages/admin/settings/plugins/[pluginId].spec.ts
+++ b/pages/admin/settings/plugins/[pluginId].spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushPromises } from '@vue/test-utils';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 
@@ -68,7 +68,7 @@ vi.mock('@/composables/useToast', () => ({ useToast: () => toast }));
 const sectionStub = (name: string) => ({ name, template: `<div data-stub="${name}" />` });
 const stubs = {
   PluginDetailHeader: { name: 'PluginDetailHeader', props: ['pluginDisplayName'], template: '<div class="header">{{ pluginDisplayName }}</div>' },
-  PluginStatusCards: { name: 'PluginStatusCards', props: ['isEnabled', 'canEnable', 'enabling', 'blockingConfigFields'], emits: ['toggle-enabled'], template: '<button type="button" data-test="toggle-enabled" @click="$emit(\'toggle-enabled\', false)" />' },
+  PluginStatusCards: { name: 'PluginStatusCards', props: ['isEnabled', 'canEnable', 'enabling', 'blockingConfigFields'], emits: ['toggle-enabled', 'focus-config-field'], template: '<button type="button" data-test="toggle-enabled" @click="$emit(\'toggle-enabled\', false)" />' },
   PluginUpdateBanner: sectionStub('PluginUpdateBanner'),
   PluginUpgradePreviewModal: {
     name: 'PluginUpgradePreviewModal',
@@ -157,6 +157,10 @@ beforeEach(() => {
   h.mutations = {};
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('Plugin detail page', () => {
   it('shows the initial loading state', () => {
     h.q.AVAILABLE.loading.value = true;
@@ -183,6 +187,45 @@ describe('Plugin detail page', () => {
 
     expect(wrapper.findComponent({ name: 'PluginStatusCards' }).exists()).toBe(true);
   });
+
+  it.each([
+    {
+      field: { key: 'service/url', kind: 'SETTING' },
+      expectedId: 'plugin-config-setting-73-65-72-76-69-63-65-2f-75-72-6c',
+    },
+    {
+      field: { key: 'API_KEY', kind: 'SECRET' },
+      expectedId: 'plugin-config-secret-41-50-49-5f-4b-45-59',
+    },
+  ])(
+    'scrolls to and focuses a $field.kind blocker control',
+    async ({ field, expectedId }) => {
+      setInstalledPlugin();
+      const control = {
+        scrollIntoView: vi.fn(),
+        focus: vi.fn(),
+      };
+      const getElementById = vi
+        .spyOn(document, 'getElementById')
+        .mockReturnValue(control as unknown as HTMLElement);
+      const wrapper = mountPage();
+
+      wrapper
+        .findComponent({ name: 'PluginStatusCards' })
+        .vm.$emit('focus-config-field', field);
+      await flushPromises();
+
+      expect({
+        target: getElementById.mock.calls[0],
+        scroll: control.scrollIntoView.mock.calls[0],
+        focus: control.focus.mock.calls[0],
+      }).toEqual({
+        target: [expectedId],
+        scroll: [{ behavior: 'smooth', block: 'center' }],
+        focus: [{ preventScroll: true }],
+      });
+    }
+  );
 
   it('renders a declared missing secret once and removes its duplicate form field', () => {
     setInstalledPlugin({

--- a/pages/admin/settings/plugins/[pluginId].vue
+++ b/pages/admin/settings/plugins/[pluginId].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed, nextTick, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
@@ -14,9 +14,13 @@ import PluginSecretsSection from '@/components/admin/plugins/PluginSecretsSectio
 import PluginSettingsSection from '@/components/admin/plugins/PluginSettingsSection.vue';
 import PluginManifestSection from '@/components/admin/plugins/PluginManifestSection.vue';
 import PluginReadmeSection from '@/components/admin/plugins/PluginReadmeSection.vue';
-import { usePluginConfigStatus } from '@/composables/usePluginConfigStatus';
+import {
+  usePluginConfigStatus,
+  type PluginConfigFieldStatus,
+} from '@/composables/usePluginConfigStatus';
 import { useToast } from '@/composables/useToast';
 import { resolveDefaultVersion } from '@/utils/versionUtils';
+import { getPluginConfigFieldId } from '@/utils/pluginConfigFieldIds';
 import {
   extractSecretKeys,
   filterOutSecrets,
@@ -625,6 +629,17 @@ const handleSetSecret = async (key: string, value: string) => {
   }
 };
 
+const handleFocusConfigField = async (field: PluginConfigFieldStatus) => {
+  await nextTick();
+  const control = document.getElementById(
+    getPluginConfigFieldId({ kind: field.kind, key: field.key })
+  );
+  if (!control) return;
+
+  control.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  control.focus({ preventScroll: true });
+};
+
 const handleSaveSettings = async () => {
   if (!installedPlugin.value) return;
   if (!pluginSlug.value) return;
@@ -747,6 +762,7 @@ const handleSaveSettings = async () => {
             :blocking-config-fields="blockingConfigFields"
             :enabling="enabling"
             @toggle-enabled="handleToggleEnabled"
+            @focus-config-field="handleFocusConfigField"
           />
 
           <!-- Update Available Banner -->

--- a/types/pluginForms.ts
+++ b/types/pluginForms.ts
@@ -34,6 +34,7 @@ export interface PluginFormSection {
 
 // A single plugin configuration field value.
 export type PluginConfigValue = string | number | boolean;
+export type PluginConfigFieldKind = 'SETTING' | 'SECRET';
 
 /**
  * A plugin's configuration settings map. Values are typed as `unknown` because

--- a/utils/pluginConfigFieldIds.spec.ts
+++ b/utils/pluginConfigFieldIds.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getPluginConfigFieldId } from './pluginConfigFieldIds';
+
+describe('getPluginConfigFieldId', () => {
+  it('creates distinct IDs for setting and secret keys', () => {
+    expect([
+      getPluginConfigFieldId({ kind: 'SETTING', key: 'apiKey' }),
+      getPluginConfigFieldId({ kind: 'SECRET', key: 'apiKey' }),
+    ]).toEqual([
+      'plugin-config-setting-61-70-69-4b-65-79',
+      'plugin-config-secret-61-70-69-4b-65-79',
+    ]);
+  });
+
+  it('encodes unusual keys into DOM-safe IDs without collisions', () => {
+    expect([
+      getPluginConfigFieldId({ kind: 'SETTING', key: 'api/key' }),
+      getPluginConfigFieldId({ kind: 'SETTING', key: 'api key' }),
+      getPluginConfigFieldId({ kind: 'SETTING', key: '🔑' }),
+    ]).toEqual([
+      'plugin-config-setting-61-70-69-2f-6b-65-79',
+      'plugin-config-setting-61-70-69-20-6b-65-79',
+      'plugin-config-setting-1f511',
+    ]);
+  });
+
+  it('suffixes duplicate occurrences while preserving the canonical first ID', () => {
+    expect([
+      getPluginConfigFieldId({ kind: 'SECRET', key: 'token' }),
+      getPluginConfigFieldId({
+        kind: 'SECRET',
+        key: 'token',
+        occurrence: 1,
+      }),
+    ]).toEqual([
+      'plugin-config-secret-74-6f-6b-65-6e',
+      'plugin-config-secret-74-6f-6b-65-6e--2',
+    ]);
+  });
+});

--- a/utils/pluginConfigFieldIds.ts
+++ b/utils/pluginConfigFieldIds.ts
@@ -1,0 +1,24 @@
+import type { PluginConfigFieldKind } from '@/types/pluginForms';
+
+interface PluginConfigFieldIdOptions {
+  kind: PluginConfigFieldKind;
+  key: string;
+  occurrence?: number;
+}
+
+function encodePluginConfigKey(key: string): string {
+  return (
+    Array.from(key)
+      .map((character) => character.codePointAt(0)!.toString(16))
+      .join('-') || 'empty'
+  );
+}
+
+export function getPluginConfigFieldId({
+  kind,
+  key,
+  occurrence = 0,
+}: PluginConfigFieldIdOptions): string {
+  const baseId = `plugin-config-${kind.toLowerCase()}-${encodePluginConfigKey(key)}`;
+  return occurrence > 0 ? `${baseId}--${occurrence + 1}` : baseId;
+}


### PR DESCRIPTION
## Summary

- turn plugin enablement blocker entries into keyboard-accessible controls
- scroll to and focus the matching setting or secret control when a blocker is activated
- add deterministic, DOM-safe IDs for configuration keys, including unusual Unicode and punctuation
- suffix duplicate key occurrences so controls never share a DOM ID while blockers still target the canonical first control
- preserve labels and connect field descriptions, validation errors, and secret status to focused controls with ARIA attributes
- cover both setting and secret navigation at the component and page levels

## Why

The enablement card identified missing or invalid configuration, but admins still had to manually locate each field farther down the page. Raw plugin keys were also being used directly as input IDs, which could create duplicate or awkward DOM identifiers.

## Impact

Admins can now activate any blocker with a mouse or keyboard and land directly on the relevant control with a visible focus indicator. Screen-reader users retain the control label and available validation or secret-status context after focus moves.

## Validation

- `pnpm run tsc`
- ESLint on changed files
- focused tests: 103 passed
- full unit suite: 6,965 passed across 765 files

Closes #395