### PR TITLE
fix: improve wiki mobile usability

### DIFF
--- a/assets/css/markdown-body.scss
+++ b/assets/css/markdown-body.scss
@@ -23,8 +23,11 @@
 }
 
 .markdown-body {
+  min-width: 0;
+  width: 100%;
   word-wrap: break-word;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   max-width: 70ch; /* Optimal line length for readability */
   box-sizing: border-box;
   color: #24292f !important;
@@ -123,6 +126,8 @@
     margin-top: 1.75rem !important;
     margin-bottom: 0.75rem !important;
     line-height: 1.3 !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
 
     &:first-child {
       margin-top: 0 !important;
@@ -133,6 +138,8 @@
     margin-bottom: 1.25rem !important;
     margin-top: 0 !important;
     line-height: 1.65 !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
   }
 
   ul,
@@ -154,6 +161,8 @@
     margin: 0 !important;
     padding: 0 !important;
     line-height: 1.65 !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
 
     /* Remove paragraph margins inside list items */
     p {

--- a/components/channel/ChannelSidebar.spec.ts
+++ b/components/channel/ChannelSidebar.spec.ts
@@ -103,7 +103,13 @@ describe('ChannelSidebar content', () => {
   it('renders pinned wiki page links', () => {
     const wrapper = mountSidebar({
       channel: channel({
-        PinnedWikiPages: [{ id: 'wiki-1', title: 'Install Guide', slug: 'install' }],
+        PinnedWikiPages: [
+          {
+            id: 'wiki-1',
+            title: '**Install** [Guide](https://example.com)',
+            slug: 'install',
+          },
+        ],
       }),
     });
 

--- a/components/channel/ChannelSidebar.vue
+++ b/components/channel/ChannelSidebar.vue
@@ -16,6 +16,7 @@ import RobotIcon from '@/components/icons/RobotIcon.vue';
 import TagIcon from '@/components/icons/TagIcon.vue';
 import ThumbtackIcon from '@/components/icons/ThumbtackIcon.vue';
 import { useIsAuthenticated } from '@/composables/useAuthState';
+import { getPlainWikiTitle } from '@/utils/wikiTitle';
 
 const isAuthenticatedVar = useIsAuthenticated();
 
@@ -193,7 +194,7 @@ const handleBecomeAdminSuccess = () => {
                 }"
                 class="rounded-md px-2 py-1 text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white"
               >
-                {{ page.title }}
+                {{ getPlainWikiTitle(page.title) }}
               </nuxt-link>
             </div>
           </div>

--- a/components/channel/ChannelTabs.spec.ts
+++ b/components/channel/ChannelTabs.spec.ts
@@ -12,6 +12,7 @@ const h = vi.hoisted(() => ({
   serverConfig: null as unknown,
   mdAndUp: null as unknown,
   route: null as unknown,
+  closePopper: vi.fn(),
 }));
 
 vi.mock('@/composables/useAuthState', () => ({
@@ -44,7 +45,11 @@ const mountTabs = (props: Record<string, unknown> = {}) =>
     global: {
       stubs: {
         ClientOnly: { template: '<div><slot /></div>' },
-        Popper: { template: '<div><slot /><slot name="content" /></div>' },
+        Popper: {
+          setup: () => ({ close: h.closePopper }),
+          template:
+            '<div><slot /><slot name="content" :close="close" /></div>',
+        },
         TabButton: {
           name: 'TabButton',
           props: ['label', 'isActive', 'count', 'to', 'showCount', 'vertical'],
@@ -74,6 +79,7 @@ beforeEach(() => {
     params: { forumId: 'cats' },
     path: '/forums/cats/discussions',
   });
+  h.closePopper.mockReset();
 });
 
 describe('ChannelTabs base tabs', () => {
@@ -196,5 +202,14 @@ describe('ChannelTabs mobile layout', () => {
     const wrapper = mountTabs();
 
     expect(wrapper.text()).toContain('Discussions');
+  });
+
+  it('closes the mobile dropdown when a channel tab is clicked', async () => {
+    (h.mdAndUp as { value: boolean }).value = false;
+    const wrapper = mountTabs();
+
+    await wrapper.get('[data-testid="mobile-dropdown-about"]').trigger('click');
+
+    expect(h.closePopper).toHaveBeenCalledOnce();
   });
 });

--- a/components/channel/ChannelTabs.vue
+++ b/components/channel/ChannelTabs.vue
@@ -324,7 +324,7 @@ const tabs = computed((): Tab[] => {
             </button>
           </template>
 
-          <template #content>
+          <template #content="{ close }">
             <div
               class="mt-1 w-56 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-gray-800 dark:ring-gray-600"
             >
@@ -341,6 +341,7 @@ const tabs = computed((): Tab[] => {
                       ? 'bg-orange-50 text-orange-700 dark:bg-orange-900/20 dark:text-orange-300'
                       : 'text-gray-700 dark:text-gray-200',
                   ]"
+                  @click="close"
                 >
                   <div class="flex items-center space-x-2">
                     <component :is="tab.icon" class="h-5 w-5 shrink-0" />

--- a/components/nav/SiteSidenav.spec.ts
+++ b/components/nav/SiteSidenav.spec.ts
@@ -146,6 +146,31 @@ describe('SiteSidenav search', () => {
       expect.objectContaining({ path: '/comments/search' })
     );
   });
+
+  it('keeps the site drawer open while selecting the Forums search type', async () => {
+    const wrapper = mountNav();
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Discussions')!
+      .trigger('click');
+
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Forums')!
+      .trigger('click');
+
+    expect({
+      selectedType: wrapper
+        .findAll('button')
+        .some((button) => button.text() === 'Forums'),
+      closed: wrapper.emitted('close'),
+      drawerVisible: wrapper.find('[role="dialog"]').exists(),
+    }).toEqual({
+      selectedType: true,
+      closed: undefined,
+      drawerVisible: true,
+    });
+  });
 });
 
 describe('SiteSidenav auth links', () => {

--- a/components/nav/SiteSidenav.vue
+++ b/components/nav/SiteSidenav.vue
@@ -212,7 +212,6 @@ const selectSearchType = (type: SearchType) => {
     />
     <div
       ref="panelRef"
-      v-click-outside="outside"
       role="dialog"
       aria-modal="true"
       aria-label="Site navigation"
@@ -254,8 +253,12 @@ const selectSearchType = (type: SearchType) => {
             <div class="relative flex-1">
               <button
                 type="button"
+                aria-haspopup="listbox"
+                :aria-expanded="showSearchTypeDropdown"
                 class="hover:bg-gray-50 flex h-8 w-full items-center justify-between rounded-md border border-gray-200 bg-white px-3 text-xs text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-                @click="showSearchTypeDropdown = !showSearchTypeDropdown"
+                @click.stop="
+                  showSearchTypeDropdown = !showSearchTypeDropdown
+                "
               >
                 <span>{{ selectedSearchTypeLabel }}</span>
                 <ChevronDownIcon
@@ -265,12 +268,17 @@ const selectSearchType = (type: SearchType) => {
               </button>
               <div
                 v-if="showSearchTypeDropdown"
+                role="listbox"
+                aria-label="Search type"
                 class="absolute left-0 right-0 top-full z-50 mt-1 rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-800"
+                @click.stop
               >
                 <button
                   v-for="option in searchTypeOptions"
                   :key="option.value"
                   type="button"
+                  role="option"
+                  :aria-selected="selectedSearchType === option.value"
                   class="flex w-full items-center justify-between px-3 py-2 text-left text-xs hover:bg-gray-100 dark:hover:bg-gray-700"
                   :class="[
                     selectedSearchType === option.value

--- a/components/wiki/OnThisPage.spec.ts
+++ b/components/wiki/OnThisPage.spec.ts
@@ -19,7 +19,33 @@ vi.mock('@/composables/useMarkdownHeadings', () => ({
 const mountToc = (props: Record<string, unknown> = {}) =>
   mount(OnThisPage, {
     props: { markdownContent: '# hi', ...props },
-    global: { stubs: { ChevronDownIcon: true } },
+    global: {
+      directives: {
+        'click-outside': {
+          beforeMount(
+            el: HTMLElement & {
+              clickOutsideEvent?: (event: Event) => void;
+            },
+            binding: { value: (event: Event) => void }
+          ) {
+            el.clickOutsideEvent = (event: Event) => {
+              if (!el.contains(event.target as Node)) binding.value(event);
+            };
+            document.addEventListener('click', el.clickOutsideEvent);
+          },
+          unmounted(
+            el: HTMLElement & {
+              clickOutsideEvent?: (event: Event) => void;
+            }
+          ) {
+            if (el.clickOutsideEvent) {
+              document.removeEventListener('click', el.clickOutsideEvent);
+            }
+          },
+        },
+      },
+      stubs: { ChevronDownIcon: true },
+    },
   });
 
 beforeEach(() => {
@@ -127,6 +153,16 @@ describe('OnThisPage mobile', () => {
     await wrapper.get('button').trigger('click');
 
     await wrapper.findAll('nav button')[0].trigger('click');
+
+    expect(wrapper.find('nav').exists()).toBe(false);
+  });
+
+  it('closes the dropdown after clicking outside', async () => {
+    const wrapper = mountToc({ isMobile: true });
+    await wrapper.get('button').trigger('click');
+
+    document.body.click();
+    await wrapper.vm.$nextTick();
 
     expect(wrapper.find('nav').exists()).toBe(false);
   });

--- a/components/wiki/OnThisPage.vue
+++ b/components/wiki/OnThisPage.vue
@@ -87,13 +87,20 @@ onUnmounted(() => {
 const toggleDropdown = () => {
   isDropdownOpen.value = !isDropdownOpen.value;
 };
+
+const closeDropdown = () => {
+  isDropdownOpen.value = false;
+};
 </script>
 
 <template>
   <div v-if="filteredHeadings.length > 0">
     <!-- Mobile Dropdown -->
-    <div v-if="isMobile" class="relative">
+    <div v-if="isMobile" v-click-outside="closeDropdown" class="relative">
       <button
+        type="button"
+        aria-haspopup="menu"
+        :aria-expanded="isDropdownOpen"
         :class="[
           'hover:bg-gray-50 flex w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
         ]"
@@ -105,6 +112,7 @@ const toggleDropdown = () => {
             'h-4 w-4 transition-transform duration-200',
             { 'rotate-180': isDropdownOpen },
           ]"
+          aria-hidden="true"
         />
       </button>
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "md-editor-v3": "^6.5.3",
     "nuxt": "^4.4.8",
     "pinia": "^3.0.2",
+    "remove-markdown": "^0.6.4",
     "sanitize-html": "^2.17.6",
     "three": "^0.183.2",
     "tslib": "^2.8.1",

--- a/pages/admin/settings/wiki.vue
+++ b/pages/admin/settings/wiki.vue
@@ -9,6 +9,7 @@ import {
   GET_SITE_WIDE_WIKI_LIST,
   GET_WIKI_PAGES_BY_IDS,
 } from '@/graphQLData/wiki/queries';
+import { getPlainWikiTitle } from '@/utils/wikiTitle';
 
 type WikiPageOption = {
   id: string;
@@ -137,7 +138,7 @@ const movePage = (pageId: string, direction: -1 | 1) => {
               type="search"
               class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
               placeholder="Search by title or body"
-            />
+            >
           </div>
 
           <div v-if="selectedPages.length" class="space-y-2">
@@ -152,7 +153,8 @@ const movePage = (pageId: string, direction: -1 | 1) => {
               >
                 <div>
                   <div class="font-medium text-gray-900 dark:text-gray-100">
-                    {{ index + 1 }}. {{ page.title || page.id }}
+                    {{ index + 1 }}.
+                    {{ getPlainWikiTitle(page.title, page.id) }}
                   </div>
                   <div class="text-xs text-gray-500 dark:text-gray-400">
                     {{ page.channelUniqueName }}/{{ page.slug }}
@@ -209,7 +211,7 @@ const movePage = (pageId: string, direction: -1 | 1) => {
               >
                 <div>
                   <div class="font-medium text-gray-900 dark:text-gray-100">
-                    {{ page.title || page.id }}
+                    {{ getPlainWikiTitle(page.title, page.id) }}
                   </div>
                   <div class="text-xs text-gray-500 dark:text-gray-400">
                     {{ page.channelUniqueName }}/{{ page.slug }}

--- a/pages/forums/[forumId]/wiki/[slug].spec.ts
+++ b/pages/forums/[forumId]/wiki/[slug].spec.ts
@@ -77,4 +77,41 @@ describe('wiki page', () => {
         .some((button) => button.props('label') === 'Edit Page')
     ).toBe(false);
   });
+
+  it('gives the mobile wiki title its own wrapping row', async () => {
+    const wrapper = await mountWith({
+      title: 'A very long wiki page title',
+      body: 'Body',
+    });
+
+    expect(
+      wrapper.get('[data-testid="wiki-page-title"]').classes()
+    ).toEqual(expect.arrayContaining(['min-w-0', 'break-words']));
+  });
+
+  it('keeps the wiki body in a shrinkable full-width container', async () => {
+    const wrapper = await mountWith({ title: 'Intro', body: 'Body' });
+    const container =
+      wrapper.findComponent(MarkdownRenderer).element.parentElement;
+
+    expect(
+      {
+        minWidth: container?.classList.contains('min-w-0'),
+        fullWidth: container?.classList.contains('w-full'),
+      }
+    ).toEqual({ minWidth: true, fullWidth: true });
+  });
+
+  it('places the mobile font-size picker after the wiki body', async () => {
+    const wrapper = await mountWith({ title: 'Intro', body: 'Body' });
+    const markdown = wrapper.findComponent(MarkdownRenderer).element;
+    const fontSize = wrapper.get(
+      '[data-testid="mobile-wiki-font-size"]'
+    ).element;
+
+    expect(
+      markdown.compareDocumentPosition(fontSize) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
 });

--- a/pages/forums/[forumId]/wiki/[slug].vue
+++ b/pages/forums/[forumId]/wiki/[slug].vue
@@ -149,11 +149,16 @@ onGetWikiPageResult((result) => {
           }}</span>
         </nav>
 
-        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <h1 class="text-2xl font-bold dark:text-white">
+        <div class="sm:flex sm:items-start sm:justify-between sm:gap-4">
+          <h1
+            data-testid="wiki-page-title"
+            class="min-w-0 break-words text-2xl font-bold [overflow-wrap:anywhere] dark:text-white"
+          >
             {{ wikiPage.title }}
           </h1>
-          <div class="flex flex-wrap items-center gap-2">
+          <div
+            class="mt-3 flex w-full flex-wrap items-center gap-2 sm:mt-0 sm:w-auto sm:shrink-0"
+          >
             <WikiPagePinButton
               v-if="channel"
               :channel="channel"
@@ -180,7 +185,7 @@ onGetWikiPageResult((result) => {
           </div>
         </div>
         <div
-          class="mt-1 flex items-center text-sm text-gray-500 dark:text-gray-400"
+          class="mt-1 flex flex-wrap items-center text-sm text-gray-500 dark:text-gray-400"
         >
           <span>
             Last updated by {{ wikiPage.VersionAuthor?.username || 'Unknown' }}
@@ -228,16 +233,11 @@ onGetWikiPageResult((result) => {
         <OnThisPage :markdown-content="wikiPage.body" :is-mobile="true" />
       </div>
 
-      <!-- Mobile font size control -->
-      <div class="mb-4 block xl:hidden">
-        <FontSizeControl />
-      </div>
-
       <div class="flex flex-col gap-6 xl:flex-row">
         <!-- Main content - first on mobile/tablet, middle on desktop -->
         <div class="min-w-0 flex-1 xl:order-2">
           <div class="flex w-full justify-center">
-            <div>
+            <div class="min-w-0 w-full max-w-[70ch]">
               <MarkdownRenderer :text="wikiPage.body" :font-size="fontSize" />
             </div>
           </div>
@@ -254,6 +254,13 @@ onGetWikiPageResult((result) => {
               <PencilIcon class="mr-2 h-4 w-4" />
               Edit this page
             </button>
+          </div>
+
+          <div
+            data-testid="mobile-wiki-font-size"
+            class="mt-8 border-t border-gray-200 pt-6 dark:border-gray-700 xl:hidden"
+          >
+            <FontSizeControl />
           </div>
         </div>
 

--- a/pages/forums/[forumId]/wiki/index.spec.ts
+++ b/pages/forums/[forumId]/wiki/index.spec.ts
@@ -85,4 +85,50 @@ describe('wiki home page', () => {
     expect(buttons.length).toBeGreaterThan(0);
     expect(buttons.every((b) => b.props('disabled') === true)).toBe(true);
   });
+
+  it('gives the mobile wiki title its own wrapping row', async () => {
+    const wrapper = await mountWith({
+      wikiEnabled: true,
+      WikiHomePage: { title: 'A very long wiki title', body: 'Welcome' },
+    });
+
+    expect(
+      wrapper.get('[data-testid="wiki-page-title"]').classes()
+    ).toEqual(expect.arrayContaining(['min-w-0', 'break-words']));
+  });
+
+  it('places the mobile font-size picker after the wiki body', async () => {
+    const wrapper = await mountWith({
+      wikiEnabled: true,
+      WikiHomePage: { title: 'Home', body: 'Welcome' },
+    });
+    const markdown = wrapper.findComponent(MarkdownRenderer).element;
+    const fontSize = wrapper.get(
+      '[data-testid="mobile-wiki-font-size"]'
+    ).element;
+
+    expect(
+      markdown.compareDocumentPosition(fontSize) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('removes markdown formatting from child-page list titles', async () => {
+    const wrapper = await mountWith({
+      wikiEnabled: true,
+      WikiHomePage: {
+        title: 'Home',
+        body: 'Welcome',
+        ChildPages: [
+          {
+            id: 'child',
+            title: '**Child** [Guide](https://example.com)',
+            slug: 'child',
+          },
+        ],
+      },
+    });
+
+    expect(wrapper.text()).toContain('Child Guide');
+  });
 });

--- a/pages/forums/[forumId]/wiki/index.vue
+++ b/pages/forums/[forumId]/wiki/index.vue
@@ -19,6 +19,7 @@ import { storeToRefs } from 'pinia';
 import { timeAgo } from '@/utils';
 import { useUsername } from '@/composables/useAuthState';
 import { buildWikiHomeHead } from '@/utils/wikiSeo';
+import { getPlainWikiTitle } from '@/utils/wikiTitle';
 
 const usernameVar = useUsername();
 
@@ -175,11 +176,16 @@ onGetChannelResult((result) => {
     <div v-else class="mx-auto max-w-full p-4">
       <!-- Wiki Home Page Content -->
       <div class="mb-4">
-        <div class="flex items-center justify-between">
-          <h1 class="text-2xl font-bold dark:text-white">
+        <div class="sm:flex sm:items-start sm:justify-between sm:gap-4">
+          <h1
+            data-testid="wiki-page-title"
+            class="min-w-0 break-words text-2xl font-bold [overflow-wrap:anywhere] dark:text-white"
+          >
             {{ wikiHomePage.title }}
           </h1>
-          <div class="flex space-x-3">
+          <div
+            class="mt-3 flex w-full flex-wrap gap-3 sm:mt-0 sm:w-auto sm:shrink-0"
+          >
             <RequireAuth>
               <template #has-auth>
                 <GenericButton
@@ -224,7 +230,7 @@ onGetChannelResult((result) => {
           :suspended-indefinitely="suspendedIndefinitely"
         />
         <div
-          class="mt-1 flex items-center text-sm text-gray-500 dark:text-gray-400"
+          class="mt-1 flex flex-wrap items-center text-sm text-gray-500 dark:text-gray-400"
         >
           <span>
             Last updated by
@@ -258,11 +264,6 @@ onGetChannelResult((result) => {
         <OnThisPage :markdown-content="wikiHomePage.body" :is-mobile="true" />
       </div>
 
-      <!-- Mobile font size control -->
-      <div class="mb-4 block xl:hidden">
-        <FontSizeControl />
-      </div>
-
       <div class="flex flex-col gap-6 xl:flex-row">
         <!-- Main content - first on mobile/tablet, middle on desktop -->
         <div class="min-w-0 flex-1 xl:order-2">
@@ -282,6 +283,13 @@ onGetChannelResult((result) => {
               <PencilIcon class="mr-2 h-4 w-4" />
               Edit this page
             </button>
+          </div>
+
+          <div
+            data-testid="mobile-wiki-font-size"
+            class="mt-8 border-t border-gray-200 pt-6 dark:border-gray-700 xl:hidden"
+          >
+            <FontSizeControl />
           </div>
         </div>
 
@@ -328,7 +336,7 @@ onGetChannelResult((result) => {
                       router.push(`/forums/${forumId}/wiki/${childPage.slug}`)
                     "
                   >
-                    {{ childPage.title }}
+                    {{ getPlainWikiTitle(childPage.title) }}
                   </a>
                   <p class="ml-1 text-xs text-gray-500 dark:text-gray-400">
                     Updated
@@ -369,7 +377,7 @@ onGetChannelResult((result) => {
                   router.push(`/forums/${forumId}/wiki/${childPage.slug}`)
                 "
               >
-                {{ childPage.title }}
+                {{ getPlainWikiTitle(childPage.title) }}
               </a>
               <p class="ml-3 text-xs text-gray-500 dark:text-gray-400">
                 Updated

--- a/pages/wiki/search.spec.ts
+++ b/pages/wiki/search.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
+import HighlightedSearchTerms from '@/components/HighlightedSearchTerms.vue';
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ query: {}, params: {} }),
@@ -65,5 +66,21 @@ describe('wiki search page', () => {
     const page = { id: 'w1', title: 'Cats', slug: 'cats', channelUniqueName: 'cats', body: 'hi' };
     const wrapper = await mountWith([page], [page]);
     expect(wrapper.findAll('[data-testid="wiki-search-results"] > li')).toHaveLength(0);
+  });
+
+  it('passes plain-text wiki titles to search result highlighting', async () => {
+    const wrapper = await mountWith([
+      {
+        id: 'w1',
+        title: '**Cat** [Care](https://example.com)',
+        slug: 'cats',
+        channelUniqueName: 'cats',
+        body: 'hi',
+      },
+    ]);
+
+    expect(
+      wrapper.findComponent(HighlightedSearchTerms).props('text')
+    ).toBe('Cat Care');
   });
 });

--- a/pages/wiki/search.vue
+++ b/pages/wiki/search.vue
@@ -14,6 +14,7 @@ import { getChannelLabel, relativeTime } from '@/utils';
 import { getDiscussionFilterValuesFromParams } from '@/utils/getDiscussionFilterValuesFromParams';
 import { GET_SITE_WIDE_WIKI_LIST } from '@/graphQLData/wiki/queries';
 import { formatWordCount } from '@/utils/wikiSearchDisplay';
+import { getPlainWikiTitle } from '@/utils/wikiTitle';
 
 const WIKI_PAGE_LIMIT = 25;
 
@@ -222,7 +223,7 @@ watch(
                   :to="`/forums/${wikiPage.channelUniqueName}/wiki/${wikiPage.slug}`"
                 >
                   <HighlightedSearchTerms
-                    :text="wikiPage.title || undefined"
+                    :text="getPlainWikiTitle(wikiPage.title) || undefined"
                     :search-input="searchInputComputed"
                   />
                 </nuxt-link>
@@ -256,7 +257,7 @@ watch(
                 :to="`/forums/${wikiPage.channelUniqueName}/wiki/${wikiPage.slug}`"
               >
                 <HighlightedSearchTerms
-                  :text="wikiPage.title || undefined"
+                  :text="getPlainWikiTitle(wikiPage.title) || undefined"
                   :search-input="searchInputComputed"
                 />
               </nuxt-link>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       pinia:
         specifier: ^3.0.2
         version: 3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3))
+      remove-markdown:
+        specifier: ^0.6.4
+        version: 0.6.4
       sanitize-html:
         specifier: ^2.17.6
         version: 2.17.6
@@ -6943,6 +6946,9 @@ packages:
 
   remedial@1.0.8:
     resolution: {integrity: sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==}
+
+  remove-markdown@0.6.4:
+    resolution: {integrity: sha512-BompiLClzjfh46irZmzv+1Q61jZYlKN3iq/hzae9EOUwf7ctr/5wpD4qwgn/FWDAYE18RORO7z/yr+HXZJCY8Q==}
 
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
@@ -15633,6 +15639,8 @@ snapshots:
   rehackt@0.1.0: {}
 
   remedial@1.0.8: {}
+
+  remove-markdown@0.6.4: {}
 
   remove-trailing-separator@1.1.0: {}
 

--- a/utils/wikiTitle.spec.ts
+++ b/utils/wikiTitle.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { getPlainWikiTitle } from './wikiTitle';
+
+describe('getPlainWikiTitle', () => {
+  it('removes markdown formatting from wiki titles', () => {
+    expect(getPlainWikiTitle('**Install** the [CLI](https://example.com)')).toBe(
+      'Install the CLI'
+    );
+  });
+
+  it('uses the fallback for an empty title', () => {
+    expect(getPlainWikiTitle('', 'Untitled')).toBe('Untitled');
+  });
+});

--- a/utils/wikiTitle.ts
+++ b/utils/wikiTitle.ts
@@ -1,0 +1,9 @@
+import removeMarkdown from 'remove-markdown';
+
+export function getPlainWikiTitle(
+  title: string | null | undefined,
+  fallback = ''
+): string {
+  if (!title) return fallback;
+  return removeMarkdown(title).trim() || fallback;
+}


### PR DESCRIPTION
## Summary

- keep the mobile site navigation open while switching its search type, including forum search
- give wiki titles and action controls separate mobile rows and make long titles/content wrap safely
- move the mobile wiki font-size control below the article
- close the mobile channel-tab menu after navigation and close the mobile “On this page” menu on outside clicks
- strip Markdown syntax from wiki titles shown in page lists, pinned pages, search results, and admin settings using `remove-markdown`

## Why

Several wiki and navigation controls were awkward or unusable at mobile widths. The site drawer’s panel-level outside-click handler treated interactions with its nested search-type menu as outside clicks, wiki layout elements competed for limited horizontal space, and transient dropdowns did not consistently dismiss after selection or outside interaction.

## Impact

Mobile users can select forum search without losing the navigation drawer, wiki headers and article text fit narrow screens, secondary controls take less attention above the content, and wiki lists display readable plain-text titles.

## Validation

- `pnpm run test:unit:run` — 765 files, 6,964 tests passed
- `pnpm run tsc`
- ESLint on all changed TypeScript and Vue files
- `git diff --check`
- responsive browser verification at 390×844 confirming the site drawer remains open and switches to “Forums”