### PR TITLE
fix: keep discussion author identity aligned

### DIFF
--- a/components/discussion/detail/DiscussionHeader.spec.ts
+++ b/components/discussion/detail/DiscussionHeader.spec.ts
@@ -125,4 +125,42 @@ describe('DiscussionHeader', () => {
 
     expect(wrapper.text().includes('Server Admin')).toBe(false);
   });
+
+  it('keeps the avatar and author details in one non-wrapping row', () => {
+    const wrapper = buildWrapper();
+    const classes = wrapper
+      .get('[data-testid="discussion-author-row"]')
+      .classes();
+
+    expect({
+      isFlexRow: classes.includes('flex'),
+      alignsAtTop: classes.includes('items-start'),
+      allowsOuterWrapping: classes.includes('flex-wrap'),
+    }).toEqual({
+      isFlexRow: true,
+      alignsAtTop: true,
+      allowsOuterWrapping: false,
+    });
+  });
+
+  it('allows the author identity and badges to wrap within the details column', () => {
+    const wrapper = buildWrapper();
+
+    expect(
+      wrapper
+        .get('[data-testid="discussion-author-details"] a > span')
+        .classes()
+    ).toContain('flex-wrap');
+  });
+
+  it('keeps timestamps inside the author details column', () => {
+    const wrapper = buildWrapper();
+
+    expect(
+      wrapper
+        .get('[data-testid="discussion-author-details"]')
+        .find('[data-testid="discussion-author-meta"]')
+        .exists()
+    ).toBe(true);
+  });
 });

--- a/components/discussion/detail/DiscussionHeader.vue
+++ b/components/discussion/detail/DiscussionHeader.vue
@@ -206,7 +206,9 @@ const { result: getPermissionResult } = useQuery(
   }
 );
 
-const channelData = computed(() => getChannelResult.value?.channels?.[0] ?? null);
+const channelData = computed(
+  () => getChannelResult.value?.channels?.[0] ?? null
+);
 const serverConfig = computed(
   () => getServerResult.value?.serverConfigs?.[0] ?? null
 );
@@ -373,66 +375,78 @@ const warningModalBody = computed(() => {
   <div>
     <div class="mt-2 flex flex-col gap-2 sm:flex-row sm:justify-between">
       <div
-        class="flex flex-wrap items-center space-x-2 text-xs dark:text-white"
+        data-testid="discussion-author-row"
+        class="flex min-w-0 items-start gap-2 text-xs dark:text-white"
       >
-        <AvatarComponent
-          :text="discussion?.Author?.username ?? '[Deleted]'"
-          :src="discussion?.Author?.profilePicURL ?? ''"
-          :is-small="true"
-        />
-        <nuxt-link
-          v-if="discussion?.Author"
-          class="cursor-pointer font-bold text-black hover:underline dark:text-white"
-          :to="{
-            name: 'u-username',
-            params: { username: discussion.Author.username },
-          }"
-        >
-          <span class="flex flex-row items-center gap-1">
-            <span v-if="!discussion.Author.displayName" class="font-bold">{{
-              discussion.Author.username
-            }}</span>
-            <span v-else class="font-bold">{{
-              discussion.Author.displayName
-            }}</span>
-            <span
-              v-if="discussion.Author.displayName"
-              class="text-gray-500 dark:text-gray-300"
-              >{{ `(u/${discussion.Author.username})` }}</span
-            >
-
-            <span
-              v-if="authorBadges.isServerAdmin"
-              class="rounded-md border border-gray-500 px-1 py-0 text-xs text-gray-500 dark:border-gray-300 dark:text-gray-300"
-              >Server Admin</span
-            >
-            <span
-              v-if="authorBadges.isServerMod"
-              class="rounded-md border border-orange-500 px-1 py-0 text-xs text-gray-500 dark:border-gray-300 dark:text-gray-300"
-              >Server Mod</span
-            >
-            <span
-              v-if="authorBadges.isForumAdmin"
-              class="rounded-md border border-gray-500 px-1 py-0 text-xs text-gray-500 dark:border-gray-300 dark:text-gray-300"
-              >Forum Admin</span
-            >
-            <span
-              v-if="authorBadges.isForumMod"
-              class="rounded-md border border-orange-500 px-1 py-0 text-xs text-gray-500 dark:border-gray-300 dark:text-gray-300"
-              >Forum Mod</span
-            >
-          </span>
-        </nuxt-link>
-        <span v-else>[Deleted]</span>
-        <div>{{ createdAt }}</div>
-        <span v-if="discussion?.updatedAt" class="mx-2">&#8226;</span>
-        <div class="flex items-center">
-          <span>{{ editedAt }}</span>
-          <EditsDropdown
-            v-if="discussion && (discussion.PastBodyVersions?.length ?? 0) > 0"
-            class="ml-2"
-            :discussion="discussion"
+        <div data-testid="discussion-author-avatar" class="shrink-0">
+          <AvatarComponent
+            :text="discussion?.Author?.username ?? '[Deleted]'"
+            :src="discussion?.Author?.profilePicURL ?? ''"
+            :is-small="true"
           />
+        </div>
+        <div data-testid="discussion-author-details" class="min-w-0">
+          <nuxt-link
+            v-if="discussion?.Author"
+            class="cursor-pointer font-bold text-black hover:underline dark:text-white"
+            :to="{
+              name: 'u-username',
+              params: { username: discussion.Author.username },
+            }"
+          >
+            <span class="flex flex-wrap items-center gap-1">
+              <span v-if="!discussion.Author.displayName" class="font-bold">{{
+                discussion.Author.username
+              }}</span>
+              <span v-else class="font-bold">{{
+                discussion.Author.displayName
+              }}</span>
+              <span
+                v-if="discussion.Author.displayName"
+                class="text-gray-500 dark:text-gray-300"
+                >{{ `(u/${discussion.Author.username})` }}</span
+              >
+
+              <span
+                v-if="authorBadges.isServerAdmin"
+                class="rounded-md border border-gray-500 px-1 py-0 text-xs text-gray-500 dark:border-gray-300 dark:text-gray-300"
+                >Server Admin</span
+              >
+              <span
+                v-if="authorBadges.isServerMod"
+                class="rounded-md border border-orange-500 px-1 py-0 text-xs text-gray-500 dark:border-gray-300 dark:text-gray-300"
+                >Server Mod</span
+              >
+              <span
+                v-if="authorBadges.isForumAdmin"
+                class="rounded-md border border-gray-500 px-1 py-0 text-xs text-gray-500 dark:border-gray-300 dark:text-gray-300"
+                >Forum Admin</span
+              >
+              <span
+                v-if="authorBadges.isForumMod"
+                class="rounded-md border border-orange-500 px-1 py-0 text-xs text-gray-500 dark:border-gray-300 dark:text-gray-300"
+                >Forum Mod</span
+              >
+            </span>
+          </nuxt-link>
+          <span v-else>[Deleted]</span>
+          <div
+            data-testid="discussion-author-meta"
+            class="mt-0.5 flex flex-wrap items-center gap-x-2"
+          >
+            <div>{{ createdAt }}</div>
+            <span v-if="discussion?.updatedAt">&#8226;</span>
+            <div class="flex items-center">
+              <span>{{ editedAt }}</span>
+              <EditsDropdown
+                v-if="
+                  discussion && (discussion.PastBodyVersions?.length ?? 0) > 0
+                "
+                class="ml-2"
+                :discussion="discussion"
+              />
+            </div>
+          </div>
         </div>
       </div>
       <div class="flex items-center gap-2">

--- a/tests/playwright/mocked/discussions/discussionHeaderLayout.spec.ts
+++ b/tests/playwright/mocked/discussions/discussionHeaderLayout.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '../../helpers/testFixture';
+import {
+  buildDiscussion,
+  buildDiscussionChannel,
+  buildUser,
+} from '../../helpers/graphqlFixtures';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+
+const TEST_CHANNEL = 'sourceit';
+const DISCUSSION_ID = 'discussion-1';
+const DISCUSSION_CHANNEL_ID = 'discussion-channel-1';
+const DISCUSSION_TITLE = 'A discussion with a narrow header';
+const AUTHOR_USERNAME = 'cluse';
+
+test('keeps the discussion author avatar aligned with the identity on narrow screens', async ({
+  page,
+  setupMockedPage,
+}) => {
+  await page.setViewportSize({ width: 600, height: 800 });
+
+  const { diagnostics } = await setupMockedPage({
+    username: 'viewer',
+    email: 'viewer@example.com',
+    handlers: {
+      ...createBaseHandlers({
+        username: 'viewer',
+        channelId: TEST_CHANNEL,
+        discussionsCount: 1,
+        serverConfigOverrides: {
+          Admins: [{ username: AUTHOR_USERNAME }],
+        },
+      }),
+      getModsByChannel: () => ({
+        data: {
+          channels: [
+            {
+              uniqueName: TEST_CHANNEL,
+              Admins: [{ username: AUTHOR_USERNAME }],
+              Moderators: [],
+            },
+          ],
+        },
+      }),
+      getDiscussion: () => ({
+        data: {
+          discussions: [
+            buildDiscussion({
+              id: DISCUSSION_ID,
+              discussionChannelId: DISCUSSION_CHANNEL_ID,
+              channelUniqueName: TEST_CHANNEL,
+              title: DISCUSSION_TITLE,
+              overrides: {
+                Author: buildUser({
+                  username: AUTHOR_USERNAME,
+                  displayName: 'Catherine',
+                }),
+              },
+            }),
+          ],
+        },
+      }),
+      getCommentSection: () => ({
+        data: {
+          getCommentSection: {
+            DiscussionChannel: buildDiscussionChannel({
+              id: DISCUSSION_CHANNEL_ID,
+              discussionId: DISCUSSION_ID,
+              channelUniqueName: TEST_CHANNEL,
+              title: DISCUSSION_TITLE,
+            }),
+            Comments: [],
+          },
+        },
+      }),
+      getDiscussionChannelRootCommentAggregate: () => ({
+        data: {
+          discussionChannels: [
+            {
+              id: DISCUSSION_CHANNEL_ID,
+              discussionId: DISCUSSION_ID,
+              channelUniqueName: TEST_CHANNEL,
+              archived: false,
+              answered: false,
+              locked: false,
+              CommentsAggregate: { count: 0 },
+            },
+          ],
+        },
+      }),
+      isDiscussionAnswered: () => ({
+        data: {
+          discussionChannels: [
+            {
+              id: DISCUSSION_CHANNEL_ID,
+              discussionId: DISCUSSION_ID,
+              channelUniqueName: TEST_CHANNEL,
+              weightedVotesCount: 1,
+              archived: false,
+              answered: false,
+              locked: false,
+              Channel: { uniqueName: TEST_CHANNEL },
+            },
+          ],
+        },
+      }),
+      getDiscussionCommentIssue: () => ({
+        data: {
+          discussionChannels: [{ id: DISCUSSION_CHANNEL_ID, Comments: [] }],
+        },
+      }),
+      getDiscussionChannels: () => ({
+        data: {
+          discussionChannels: [
+            { id: DISCUSSION_CHANNEL_ID, RelatedIssues: [] },
+          ],
+        },
+      }),
+    },
+  });
+
+  await page.goto(`/forums/${TEST_CHANNEL}/discussions/${DISCUSSION_ID}`);
+
+  const authorRow = page.getByTestId('discussion-author-row');
+  await expect(authorRow).toBeVisible({ timeout: 30000 });
+
+  const avatarBox = await page
+    .getByTestId('discussion-author-avatar')
+    .boundingBox();
+  const identityBox = await page
+    .getByTestId('discussion-author-details')
+    .locator('a')
+    .boundingBox();
+
+  expect({
+    avatarTop: Math.round(avatarBox?.y ?? -1),
+    identityTop: Math.round(identityBox?.y ?? -2),
+    pageErrors: diagnostics.pageErrors,
+  }).toEqual({
+    avatarTop: Math.round(identityBox?.y ?? -2),
+    identityTop: Math.round(identityBox?.y ?? -2),
+    pageErrors: [],
+  });
+});


### PR DESCRIPTION
## Summary

- keep the discussion author avatar and identity in one stable flex row
- allow the username and role badges to wrap inside the details column without pushing the entire identity below the avatar
- keep posted/edited metadata grouped below the author identity
- add unit coverage for the wrapping structure and a mocked browser regression test that measures alignment at a 600px viewport

## Why

The avatar, author link, badges, and timestamps were all separate items in one wrapping flex container. In the constrained discussion side panel, the author link was wider than the remaining row space, so the browser moved the whole username-and-badges block beneath the avatar.

## Impact

Discussion headers now keep the original poster’s avatar level with their username and role badges while still allowing long identities and metadata to wrap cleanly at narrow widths.

## Validation

- `pnpm run test:unit:run` — 765 files, 6,967 tests passed
- `pnpm run tsc`
- focused DiscussionHeader tests — 18 passed
- mocked Playwright regression at 600×800 — passed
- ESLint and Prettier on changed files
- `git diff --check`