### PR TITLE
fix(ssr): register v-click-outside universally so SSR pages don't crash

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -375,7 +375,7 @@ export default defineNuxtConfig({
     { src: '@/plugins/pinia', mode: 'all' },
     { src: '@/plugins/google-maps', mode: 'client' },
     { src: '@/plugins/performance.client', mode: 'client' },
-    { src: '@/plugins/click-outside.client', mode: 'client' },
+    { src: '@/plugins/click-outside', mode: 'all' },
     { src: '@/plugins/accented.client', mode: 'client' },
     { src: '@/plugins/test-auth.client', mode: 'client' },
   ],

--- a/plugins/click-outside.ts
+++ b/plugins/click-outside.ts
@@ -1,5 +1,16 @@
+// Registered universally (server + client). During SSR only `getSSRProps` is
+// invoked; the lifecycle hooks below run client-side. Registering this as a
+// `.client`-only plugin left the directive undefined during SSR, so
+// @vue/server-renderer crashed reading `.getSSRProps` off it whenever an
+// SSR-rendered page used `v-click-outside` (e.g. the discussion create form and
+// forum wiki pages, via MultiSelect / EmojiPicker / SiteSidenav).
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.directive('click-outside', {
+    // The directive attaches no attributes/props to the element itself, so
+    // there is nothing to serialize during SSR.
+    getSSRProps() {
+      return {};
+    },
     beforeMount(el, binding) {
       el.clickOutsideEvent = function (event: Event) {
         // Check if the clicked element is outside the bound element

--- a/tests/playwright/mocked/reactions/emojiPickerOpens.spec.ts
+++ b/tests/playwright/mocked/reactions/emojiPickerOpens.spec.ts
@@ -10,7 +10,7 @@ const DISCUSSION_ID = 'discussion-1';
 // Regression: the emoji "React" button opens a FloatingDropdown containing the
 // emoji picker. The picker's own v-click-outside handler used to fire on the
 // very click that opened the dropdown, closing it again immediately, so the
-// picker never appeared. See plugins/click-outside.client.ts.
+// picker never appeared. See plugins/click-outside.ts.
 test('clicking the React button opens the emoji picker', async ({
   page,
   setupMockedPage,


### PR DESCRIPTION
## Problem

The `v-click-outside` directive was registered by a **client-only** plugin (`plugins/click-outside.client.ts`). During SSR the directive therefore resolved to `undefined`, and `@vue/server-renderer` crashed reading `.getSSRProps` off it:

> `Cannot read properties of undefined (reading 'getSSRProps')`

Any server-rendered page whose tree used the directive returned a **500 on a hard load / refresh**, including:
- the discussion **create form** (via `MultiSelect` / `ForumPicker`), and
- forum **wiki pages** (via `components/wiki/OnThisPage.vue`).

Soft, client-side navigation worked because the directive registered on the client — so the bug only showed on direct loads/refreshes.

Also exposed via `FileTypePicker`, `SiteSidenav`, and `EmojiPicker`, which use the same directive.

## Fix

- Make the plugin **universal** (`plugins/click-outside.ts`, `mode: 'all'`) and give the directive a no-op `getSSRProps()`.
- Directive lifecycle hooks (`beforeMount`/`unmounted`) still run only on the client — SSR invokes just `getSSRProps` — so the DOM listener behavior is unchanged.
- Update the explicit plugin entry in `nuxt.config.ts` to the new path/mode, and fix a stale filename in a Playwright test comment.

## Verification

- `vue-tsc` and ESLint pass.
- Manually confirmed a forum wiki page now renders on a **hard SSR load** (was a 500), with no console errors. Client-side click-outside behavior (e.g. the emoji picker not self-closing) is covered by `tests/playwright/mocked/reactions/emojiPickerOpens.spec.ts`.

## Note (out of scope)

A hard load of the authenticated create page now surfaces a **separate, pre-existing 426 "Upgrade Required"** from the `@auth0/auth0-nuxt` server-session setup (unrelated to this directive fix). Worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)