### PR TITLE
feat(album): fix stuck reusable-image loading + source-aware paginated picker

### DIFF
--- a/components/discussion/form/AlbumDropZone.spec.ts
+++ b/components/discussion/form/AlbumDropZone.spec.ts
@@ -78,6 +78,14 @@ describe('AlbumDropZone actions', () => {
     expect(wrapper.emitted('show-url-input')).toBeTruthy();
   });
 
+  it('emits show-existing-picker from Reuse an Image', async () => {
+    const wrapper = mountZone();
+
+    await buttonByText(wrapper, 'Reuse an Image')!.trigger('click');
+
+    expect(wrapper.emitted('show-existing-picker')).toBeTruthy();
+  });
+
   it('emits drop when files are dropped', async () => {
     const wrapper = mountZone();
 

--- a/components/discussion/form/AlbumDropZone.vue
+++ b/components/discussion/form/AlbumDropZone.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'files-selected', files: FileList): void;
   (e: 'drop', event: DragEvent): void;
-  (e: 'show-url-input'): void;
+  (e: 'show-url-input' | 'show-existing-picker'): void;
 }>();
 
 const fileInputRef = ref<HTMLInputElement | null>(null);
@@ -56,6 +56,18 @@ const handleShowUrlInput = () => {
   }
   emit('show-url-input');
 };
+
+const handleShowExistingPicker = (event?: Event) => {
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  if (props.isLimitReached) {
+    alert(`You've reached the maximum limit of ${props.maxImages} images.`);
+    return;
+  }
+  emit('show-existing-picker');
+};
 </script>
 
 <template>
@@ -70,9 +82,10 @@ const handleShowUrlInput = () => {
       class="flex h-full w-full cursor-pointer flex-col items-center justify-center"
     >
       <p class="mb-3 text-sm text-gray-500 dark:text-gray-300">
-        Drag and drop, tap to add files, or paste a link to an image
+        Drag and drop, tap to add files, paste a link, or reuse an image you
+        already have
       </p>
-      <div class="flex items-center gap-4 text-black">
+      <div class="flex flex-wrap items-center justify-center gap-4 text-black">
         <button
           type="button"
           class="rounded bg-orange-500 px-4 py-2 transition-colors hover:bg-orange-600"
@@ -80,13 +93,21 @@ const handleShowUrlInput = () => {
         >
           Choose Files
         </button>
-        <div class="h-6 w-px bg-gray-300 dark:bg-gray-600" />
+        <div class="hidden h-6 w-px bg-gray-300 sm:block dark:bg-gray-600" />
         <button
           type="button"
           class="rounded bg-blue-500 px-4 py-2 transition-colors hover:bg-blue-600"
           @click="handleShowUrlInput"
         >
           Link to Image
+        </button>
+        <div class="hidden h-6 w-px bg-gray-300 sm:block dark:bg-gray-600" />
+        <button
+          type="button"
+          class="rounded border border-gray-300 bg-white px-4 py-2 text-gray-800 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+          @click="handleShowExistingPicker"
+        >
+          Reuse an Image
         </button>
       </div>
     </label>

--- a/components/discussion/form/AlbumEditor.spec.ts
+++ b/components/discussion/form/AlbumEditor.spec.ts
@@ -54,7 +54,7 @@ const AlbumImageItemStub = {
 
 const AlbumDropZoneStub = {
   name: 'AlbumDropZone',
-  emits: ['files-selected', 'drop', 'show-url-input'],
+  emits: ['files-selected', 'drop', 'show-url-input', 'show-existing-picker'],
   template: '<div class="drop-zone-stub" />',
 };
 
@@ -71,8 +71,17 @@ const AlbumUrlInputFormStub = {
 const AlbumExistingImagePickerStub = {
   name: 'AlbumExistingImagePicker',
   props: ['selectedImageIds', 'isLimitReached'],
-  emits: ['add-image'],
+  emits: ['add-image', 'close'],
   template: '<div class="existing-image-picker-stub" />',
+};
+
+// The reusable-image picker is hidden until the user asks to reuse an image, so
+// tests must first reveal it via the drop zone before it exists in the tree.
+const revealExistingPicker = async (
+  wrapper: ReturnType<typeof mountEditor>
+) => {
+  wrapper.getComponent(AlbumDropZoneStub).vm.$emit('show-existing-picker');
+  await wrapper.vm.$nextTick();
 };
 
 const WarningModalStub = {
@@ -207,6 +216,7 @@ describe('AlbumEditor', () => {
 
   it('adds an existing image from the picker', async () => {
     const wrapper = mountEditor();
+    await revealExistingPicker(wrapper);
     wrapper.findComponent(AlbumExistingImagePickerStub).vm.$emit('add-image', makeImage('d'));
     await flushPromises();
     expect(lastEmit(wrapper).imageOrder).toEqual(['a', 'b', 'c', 'd']);
@@ -214,6 +224,7 @@ describe('AlbumEditor', () => {
 
   it('does not add a duplicate existing image from the picker', async () => {
     const wrapper = mountEditor();
+    await revealExistingPicker(wrapper);
     wrapper.findComponent(AlbumExistingImagePickerStub).vm.$emit('add-image', makeImage('a'));
     await flushPromises();
     expect(wrapper.emitted('updateFormValues')).toBeUndefined();
@@ -291,6 +302,33 @@ describe('AlbumEditor', () => {
 
       expect(wrapper.emitted('updateFormValues')).toBeUndefined();
       expect(wrapper.findComponent(AlbumUrlInputFormStub).exists()).toBe(true);
+    });
+  });
+
+  describe('existing-image picker flow', () => {
+    it('hides the reusable-image picker until the user requests it', () => {
+      const wrapper = mountEditor();
+      expect(wrapper.findComponent(AlbumExistingImagePickerStub).exists()).toBe(
+        false
+      );
+    });
+
+    it('reveals the reusable-image picker when the drop zone requests it', async () => {
+      const wrapper = mountEditor();
+      await revealExistingPicker(wrapper);
+      expect(wrapper.findComponent(AlbumExistingImagePickerStub).exists()).toBe(
+        true
+      );
+    });
+
+    it('hides the reusable-image picker again on close', async () => {
+      const wrapper = mountEditor();
+      await revealExistingPicker(wrapper);
+      wrapper.getComponent(AlbumExistingImagePickerStub).vm.$emit('close');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.findComponent(AlbumExistingImagePickerStub).exists()).toBe(
+        false
+      );
     });
   });
 });

--- a/components/discussion/form/AlbumEditor.vue
+++ b/components/discussion/form/AlbumEditor.vue
@@ -161,6 +161,9 @@ const {
 
 // URL input form state
 const showUrlInput = ref(false);
+// Existing-image picker is hidden until the user asks to reuse an image, so we
+// don't fire its query on every form load.
+const showExistingImagePicker = ref(false);
 const isCreatingImageFromUrl = ref(false);
 const urlInputFormRef = ref<InstanceType<typeof AlbumUrlInputForm> | null>(null);
 const pendingDeleteImageIndex = ref<number | null>(null);
@@ -319,6 +322,11 @@ const handleShowUrlInput = () => {
   urlInputFormRef.value?.focusInput();
 };
 
+// Reveal the reusable-image picker (and the query it runs) on demand
+const handleShowExistingPicker = () => {
+  showExistingImagePicker.value = true;
+};
+
 // Handle URL submission
 const handleUrlSubmit = async (url: string) => {
   if (!usernameVar.value) {
@@ -413,9 +421,11 @@ const handleUrlCancel = () => {
     />
 
     <AlbumExistingImagePicker
+      v-if="showExistingImagePicker"
       :selected-image-ids="selectedImageIds"
       :is-limit-reached="isImageLimitReached"
       @add-image="addExistingImage"
+      @close="showExistingImagePicker = false"
     />
 
     <!-- Drop zone -->
@@ -425,6 +435,7 @@ const handleUrlCancel = () => {
       @files-selected="handleFilesSelected"
       @drop="handleDropEvent"
       @show-url-input="handleShowUrlInput"
+      @show-existing-picker="handleShowExistingPicker"
     />
 
     <!-- URL input form -->

--- a/components/discussion/form/AlbumExistingImagePicker.spec.ts
+++ b/components/discussion/form/AlbumExistingImagePicker.spec.ts
@@ -108,7 +108,7 @@ describe('AlbumExistingImagePicker', () => {
 
   it('emits the selected image when adding it to the album', async () => {
     const wrapper = mountPicker();
-    await wrapper.findAll('button')[2].trigger('click');
+    await wrapper.findAll('article button')[2].trigger('click');
     expect(wrapper.emitted('addImage')?.[0]?.[0]).toMatchObject({
       id: 'img-3',
       Uploader: { username: 'carol' },
@@ -117,7 +117,7 @@ describe('AlbumExistingImagePicker', () => {
 
   it('disables images already selected in the album', () => {
     const wrapper = mountPicker(['img-1']);
-    const firstButton = wrapper.find('button');
+    const firstButton = wrapper.find('article button');
     expect({
       disabled: firstButton.attributes('disabled'),
       text: firstButton.text(),
@@ -125,5 +125,17 @@ describe('AlbumExistingImagePicker', () => {
       disabled: '',
       text: 'Already in album',
     });
+  });
+
+  it('emits close when the close button is clicked', async () => {
+    const wrapper = mountPicker();
+    await wrapper.get('button[aria-label="Close reusable image picker"]').trigger('click');
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('prompts to sign in instead of spinning when there is no username', () => {
+    usernameRef.value = '';
+    const wrapper = mountPicker();
+    expect(wrapper.text()).toContain('Sign in to reuse images');
   });
 });

--- a/components/discussion/form/AlbumExistingImagePicker.spec.ts
+++ b/components/discussion/form/AlbumExistingImagePicker.spec.ts
@@ -2,77 +2,28 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import AlbumExistingImagePicker from '@/components/discussion/form/AlbumExistingImagePicker.vue';
 
-const { usernameRef, queryResult, queryLoading, queryError } = vi.hoisted(
-  () => ({
-    usernameRef: { value: 'alice' as string },
-    queryResult: {
-      value: {
-        users: [
-          {
-            Images: [
-              {
-                id: 'img-1',
-                url: 'https://img.test/one.jpg',
-                alt: 'One',
-                caption: 'First image',
-                copyright: '',
-                Uploader: { username: 'alice', displayName: 'Alice' },
-              },
-            ],
-            FavoriteImages: [
-              {
-                id: 'img-1',
-                url: 'https://img.test/one.jpg',
-                alt: 'One',
-                caption: 'First image',
-                copyright: '',
-                Uploader: { username: 'alice', displayName: 'Alice' },
-              },
-              {
-                id: 'img-2',
-                url: 'https://img.test/two.jpg',
-                alt: 'Two',
-                caption: 'Second image',
-                copyright: '',
-                Uploader: { username: 'bob', displayName: 'Bob' },
-              },
-            ],
-            Collections: [
-              {
-                id: 'collection-1',
-                name: 'Inspiration',
-                Images: [
-                  {
-                    id: 'img-3',
-                    url: 'https://img.test/three.jpg',
-                    alt: 'Three',
-                    caption: 'Third image',
-                    copyright: '',
-                    Uploader: { username: 'carol', displayName: 'Carol' },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    },
-    queryLoading: { value: false },
-    queryError: { value: null as Error | null },
-  })
-);
+const { usernameRef } = vi.hoisted(() => ({
+  usernameRef: { value: 'alice' as string },
+}));
 
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => usernameRef,
 }));
 
-vi.mock('@vue/apollo-composable', () => ({
-  useQuery: vi.fn(() => ({
-    result: queryResult,
-    loading: queryLoading,
-    error: queryError,
-  })),
-}));
+const UserImagesTabStub = {
+  name: 'AlbumReusableUserImagesTab',
+  props: ['source', 'searchTerm', 'selectedImageIds', 'isLimitReached'],
+  emits: ['add-image'],
+  template:
+    '<div class="user-images-tab" :data-source="source" :data-search="searchTerm" />',
+};
+
+const CollectionsTabStub = {
+  name: 'AlbumReusableCollectionsTab',
+  props: ['searchTerm', 'selectedImageIds', 'isLimitReached'],
+  emits: ['add-image'],
+  template: '<div class="collections-tab" :data-search="searchTerm" />',
+};
 
 const mountPicker = (selectedImageIds: string[] = []) =>
   mountWithDefaults(AlbumExistingImagePicker, {
@@ -82,60 +33,84 @@ const mountPicker = (selectedImageIds: string[] = []) =>
     },
     global: {
       stubs: {
-        LoadingSpinner: { template: '<div />' },
-        ErrorBanner: { props: ['text'], template: '<div class="error" />' },
+        AlbumReusableUserImagesTab: UserImagesTabStub,
+        AlbumReusableCollectionsTab: CollectionsTabStub,
       },
     },
   });
 
+const tabButton = (
+  wrapper: ReturnType<typeof mountPicker>,
+  label: string
+) => wrapper.findAll('[role="tab"]').find((b) => b.text() === label);
+
 beforeEach(() => {
   usernameRef.value = 'alice';
-  queryLoading.value = false;
-  queryError.value = null;
 });
 
 describe('AlbumExistingImagePicker', () => {
-  it('dedupes images across uploads, favorites, and image collections', () => {
+  it('renders a tab for each reusable image source', () => {
     const wrapper = mountPicker();
-    expect({
-      cardCount: wrapper.findAll('article').length,
-      sourceCopy: wrapper.text(),
-    }).toMatchObject({
-      cardCount: 3,
-      sourceCopy: expect.stringContaining('Your uploads · Favorites'),
-    });
+    expect(wrapper.findAll('[role="tab"]').map((b) => b.text())).toEqual([
+      'Your uploads',
+      'Favorites',
+      'Collections',
+    ]);
   });
 
-  it('emits the selected image when adding it to the album', async () => {
+  it('shows the uploads tab by default', () => {
     const wrapper = mountPicker();
-    await wrapper.findAll('article button')[2].trigger('click');
+    expect(wrapper.findComponent(UserImagesTabStub).props('source')).toBe(
+      'uploads'
+    );
+  });
+
+  it('switches the user-images tab to favorites when Favorites is selected', async () => {
+    const wrapper = mountPicker();
+    await tabButton(wrapper, 'Favorites')!.trigger('click');
+    expect(wrapper.findComponent(UserImagesTabStub).props('source')).toBe(
+      'favorites'
+    );
+  });
+
+  it('shows the collections tab when Collections is selected', async () => {
+    const wrapper = mountPicker();
+    await tabButton(wrapper, 'Collections')!.trigger('click');
+    expect(wrapper.findComponent(CollectionsTabStub).exists()).toBe(true);
+  });
+
+  it('passes the search term down to the active tab', async () => {
+    const wrapper = mountPicker();
+    await wrapper.find('#existing-image-search').setValue('sunset');
+    expect(wrapper.findComponent(UserImagesTabStub).props('searchTerm')).toBe(
+      'sunset'
+    );
+  });
+
+  it('forwards addImage from the active tab', () => {
+    const wrapper = mountPicker();
+    wrapper
+      .findComponent(UserImagesTabStub)
+      .vm.$emit('add-image', { id: 'img-9', url: 'https://img.test/9.jpg' });
     expect(wrapper.emitted('addImage')?.[0]?.[0]).toMatchObject({
-      id: 'img-3',
-      Uploader: { username: 'carol' },
-    });
-  });
-
-  it('disables images already selected in the album', () => {
-    const wrapper = mountPicker(['img-1']);
-    const firstButton = wrapper.find('article button');
-    expect({
-      disabled: firstButton.attributes('disabled'),
-      text: firstButton.text(),
-    }).toEqual({
-      disabled: '',
-      text: 'Already in album',
+      id: 'img-9',
     });
   });
 
   it('emits close when the close button is clicked', async () => {
     const wrapper = mountPicker();
-    await wrapper.get('button[aria-label="Close reusable image picker"]').trigger('click');
+    await wrapper
+      .get('button[aria-label="Close reusable image picker"]')
+      .trigger('click');
     expect(wrapper.emitted('close')).toHaveLength(1);
   });
 
-  it('prompts to sign in instead of spinning when there is no username', () => {
+  it('prompts to sign in instead of showing tabs when there is no username', () => {
     usernameRef.value = '';
     const wrapper = mountPicker();
-    expect(wrapper.text()).toContain('Sign in to reuse images');
+    expect({
+      signInText: wrapper.text().includes('Sign in to reuse images'),
+      tabCount: wrapper.findAll('[role="tab"]').length,
+    }).toEqual({ signInText: true, tabCount: 0 });
   });
 });

--- a/components/discussion/form/AlbumExistingImagePicker.vue
+++ b/components/discussion/form/AlbumExistingImagePicker.vue
@@ -121,6 +121,7 @@ const searchPlaceholder = computed(() =>
       <div class="max-h-96 overflow-y-auto">
         <AlbumReusableUserImagesTab
           v-if="activeTab === 'uploads'"
+          key="uploads"
           source="uploads"
           :search-term="searchTerm"
           :selected-image-ids="props.selectedImageIds"
@@ -129,6 +130,7 @@ const searchPlaceholder = computed(() =>
         />
         <AlbumReusableUserImagesTab
           v-else-if="activeTab === 'favorites'"
+          key="favorites"
           source="favorites"
           :search-term="searchTerm"
           :selected-image-ids="props.selectedImageIds"

--- a/components/discussion/form/AlbumExistingImagePicker.vue
+++ b/components/discussion/form/AlbumExistingImagePicker.vue
@@ -43,11 +43,14 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   addImage: [image: ReusableImage];
+  close: [];
 }>();
 
 const usernameVar = useUsername();
 const searchTerm = ref('');
 const limit = 30;
+
+const hasUsername = computed(() => Boolean(usernameVar.value));
 
 const selectedImageIdsSet = computed(() => new Set(props.selectedImageIds));
 
@@ -151,17 +154,36 @@ const getUploaderLabel = (image: ReusableImage) => {
     class="mt-4 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-3 dark:border-gray-600 dark:bg-gray-900/40"
     aria-labelledby="existing-image-picker-heading"
   >
-    <div class="mb-3">
-      <h4
-        id="existing-image-picker-heading"
-        class="text-sm font-semibold text-gray-900 dark:text-white"
+    <div class="mb-3 flex items-start justify-between gap-3">
+      <div>
+        <h4
+          id="existing-image-picker-heading"
+          class="text-sm font-semibold text-gray-900 dark:text-white"
+        >
+          Add an existing image
+        </h4>
+        <p class="mt-1 text-xs text-gray-600 dark:text-gray-300">
+          Reuse images from your uploads, favorites, or image collections without
+          re-uploading. Original uploader attribution is preserved.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="shrink-0 rounded-md p-1 text-gray-500 hover:bg-gray-200 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-orange-500/40 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+        aria-label="Close reusable image picker"
+        @click="emit('close')"
       >
-        Add an existing image
-      </h4>
-      <p class="mt-1 text-xs text-gray-600 dark:text-gray-300">
-        Reuse images from your uploads, favorites, or image collections without
-        re-uploading. Original uploader attribution is preserved.
-      </p>
+        <svg
+          class="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="2"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+        </svg>
+      </button>
     </div>
 
     <label
@@ -184,8 +206,15 @@ const getUploaderLabel = (image: ReusableImage) => {
       :text="error.message"
     />
 
+    <p
+      v-if="!hasUsername"
+      class="mt-3 text-sm text-gray-600 dark:text-gray-300"
+    >
+      Sign in to reuse images from your uploads, favorites, and collections.
+    </p>
+
     <div
-      v-if="loading && images.length === 0"
+      v-else-if="loading && images.length === 0"
       class="mt-3 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
     >
       <LoadingSpinner class="h-4 w-4" />

--- a/components/discussion/form/AlbumExistingImagePicker.vue
+++ b/components/discussion/form/AlbumExistingImagePicker.vue
@@ -1,40 +1,11 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue';
-import { useQuery } from '@vue/apollo-composable';
 import { useUsername } from '@/composables/useAuthState';
-import { GET_REUSABLE_ALBUM_IMAGES } from '@/graphQLData/image/queries';
-import LoadingSpinner from '@/components/LoadingSpinner.vue';
-import ErrorBanner from '@/components/ErrorBanner.vue';
-import type { ImageWhere } from '@/__generated__/graphql';
+import AlbumReusableUserImagesTab from './AlbumReusableUserImagesTab.vue';
+import AlbumReusableCollectionsTab from './AlbumReusableCollectionsTab.vue';
+import type { ReusableImage } from './reusableImageTypes';
 
-type ReusableImage = {
-  id: string;
-  url: string;
-  alt?: string | null;
-  caption?: string | null;
-  copyright?: string | null;
-  createdAt?: string | null;
-  Uploader?: {
-    username?: string | null;
-    displayName?: string | null;
-  } | null;
-};
-
-type ReusableImageResult = {
-  users?: Array<{
-    Images?: ReusableImage[] | null;
-    FavoriteImages?: ReusableImage[] | null;
-    Collections?: Array<{
-      id: string;
-      name?: string | null;
-      Images?: ReusableImage[] | null;
-    }> | null;
-  }> | null;
-};
-
-type PickerImage = ReusableImage & {
-  sourceLabels: string[];
-};
+type TabKey = 'uploads' | 'favorites' | 'collections';
 
 const props = defineProps<{
   selectedImageIds: string[];
@@ -47,106 +18,22 @@ const emit = defineEmits<{
 }>();
 
 const usernameVar = useUsername();
-const searchTerm = ref('');
-const limit = 30;
-
 const hasUsername = computed(() => Boolean(usernameVar.value));
 
-const selectedImageIdsSet = computed(() => new Set(props.selectedImageIds));
+const searchTerm = ref('');
+const activeTab = ref<TabKey>('uploads');
 
-const imageWhere = computed<ImageWhere>(() => {
-  const base: ImageWhere = {
-    archived: false,
-    permanentlyRemoved: false,
-  };
-  const trimmedSearch = searchTerm.value.trim();
+const tabs: Array<{ key: TabKey; label: string }> = [
+  { key: 'uploads', label: 'Your uploads' },
+  { key: 'favorites', label: 'Favorites' },
+  { key: 'collections', label: 'Collections' },
+];
 
-  if (!trimmedSearch) {
-    return base;
-  }
-
-  return {
-    AND: [
-      base,
-      {
-        OR: [
-          { id_CONTAINS: trimmedSearch },
-          { url_CONTAINS: trimmedSearch },
-          { alt_CONTAINS: trimmedSearch },
-          { caption_CONTAINS: trimmedSearch },
-          { copyright_CONTAINS: trimmedSearch },
-        ],
-      },
-    ],
-  };
-});
-
-const { result, loading, error } = useQuery<ReusableImageResult>(
-  GET_REUSABLE_ALBUM_IMAGES,
-  () => ({
-    username: usernameVar.value,
-    where: imageWhere.value,
-    limit,
-  }),
-  () => ({
-    enabled: Boolean(usernameVar.value),
-    fetchPolicy: 'cache-and-network',
-  })
+const searchPlaceholder = computed(() =>
+  activeTab.value === 'collections'
+    ? 'Search collections and their images'
+    : 'Search by caption, alt text, URL, or image ID'
 );
-
-const pushImage = (
-  map: Map<string, PickerImage>,
-  image: ReusableImage,
-  sourceLabel: string
-) => {
-  if (!image.id) return;
-
-  const existing = map.get(image.id);
-  if (existing) {
-    if (!existing.sourceLabels.includes(sourceLabel)) {
-      existing.sourceLabels.push(sourceLabel);
-    }
-    return;
-  }
-
-  map.set(image.id, {
-    ...image,
-    sourceLabels: [sourceLabel],
-  });
-};
-
-const images = computed<PickerImage[]>(() => {
-  const user = result.value?.users?.[0];
-  const imageMap = new Map<string, PickerImage>();
-
-  for (const image of user?.Images || []) {
-    pushImage(imageMap, image, 'Your uploads');
-  }
-
-  for (const image of user?.FavoriteImages || []) {
-    pushImage(imageMap, image, 'Favorites');
-  }
-
-  for (const collection of user?.Collections || []) {
-    const collectionName = collection.name || 'Image collection';
-    for (const image of collection.Images || []) {
-      pushImage(imageMap, image, collectionName);
-    }
-  }
-
-  return [...imageMap.values()];
-});
-
-const getImageAlt = (image: ReusableImage) =>
-  image.alt || image.caption || 'Reusable album image';
-
-const getUploaderLabel = (image: ReusableImage) => {
-  const uploader = image.Uploader;
-  if (!uploader?.username) return 'Unknown uploader';
-  return uploader.displayName
-    ? `${uploader.displayName} (${uploader.username})`
-    : uploader.username;
-};
 </script>
 
 <template>
@@ -186,26 +73,6 @@ const getUploaderLabel = (image: ReusableImage) => {
       </button>
     </div>
 
-    <label
-      class="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-200"
-      for="existing-image-search"
-    >
-      Search reusable images
-    </label>
-    <input
-      id="existing-image-search"
-      v-model="searchTerm"
-      type="search"
-      class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-      placeholder="Search by caption, alt text, URL, or image ID"
-    >
-
-    <ErrorBanner
-      v-if="error"
-      class="mt-3"
-      :text="error.message"
-    />
-
     <p
       v-if="!hasUsername"
       class="mt-3 text-sm text-gray-600 dark:text-gray-300"
@@ -213,58 +80,69 @@ const getUploaderLabel = (image: ReusableImage) => {
       Sign in to reuse images from your uploads, favorites, and collections.
     </p>
 
-    <div
-      v-else-if="loading && images.length === 0"
-      class="mt-3 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
-    >
-      <LoadingSpinner class="h-4 w-4" />
-      <span>Loading reusable images...</span>
-    </div>
-
-    <p
-      v-else-if="images.length === 0"
-      class="mt-3 text-sm text-gray-600 dark:text-gray-300"
-    >
-      No reusable images found.
-    </p>
-
-    <div
-      v-else
-      class="mt-3 grid max-h-96 grid-cols-1 gap-3 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3"
-    >
-      <article
-        v-for="image in images"
-        :key="image.id"
-        class="overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800"
+    <template v-else>
+      <div
+        class="mb-3 flex flex-wrap gap-1 border-b border-gray-200 dark:border-gray-700"
+        role="tablist"
+        aria-label="Reusable image sources"
       >
-        <img
-          :src="image.url"
-          :alt="getImageAlt(image)"
-          class="h-32 w-full object-cover"
-          loading="lazy"
+        <button
+          v-for="tab in tabs"
+          :key="tab.key"
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === tab.key"
+          :class="[
+            'rounded-t-md px-3 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-orange-500/30',
+            activeTab === tab.key
+              ? 'border-b-2 border-orange-500 text-orange-600 dark:text-orange-400'
+              : 'text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white',
+          ]"
+          @click="activeTab = tab.key"
         >
-        <div class="space-y-2 p-3">
-          <p class="line-clamp-2 text-sm font-medium text-gray-900 dark:text-white">
-            {{ image.caption || image.alt || image.id }}
-          </p>
-          <p class="text-xs text-gray-600 dark:text-gray-300">
-            Uploaded by {{ getUploaderLabel(image) }}
-          </p>
-          <p class="line-clamp-1 text-xs text-gray-500 dark:text-gray-400">
-            {{ image.sourceLabels.join(' · ') }}
-          </p>
-          <button
-            type="button"
-            class="w-full rounded-md bg-orange-600 px-3 py-2 text-sm font-medium text-white hover:bg-orange-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-600 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-            :disabled="selectedImageIdsSet.has(image.id) || isLimitReached"
-            @click="emit('addImage', image)"
-          >
-            <span v-if="selectedImageIdsSet.has(image.id)">Already in album</span>
-            <span v-else-if="isLimitReached">Album limit reached</span>
-            <span v-else>Add to album</span>
-          </button>
-        </div>
-      </article>
-    </div>
+          {{ tab.label }}
+        </button>
+      </div>
+
+      <label
+        class="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-200"
+        for="existing-image-search"
+      >
+        Search reusable images
+      </label>
+      <input
+        id="existing-image-search"
+        v-model="searchTerm"
+        type="search"
+        class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        :placeholder="searchPlaceholder"
+      >
+
+      <div class="max-h-96 overflow-y-auto">
+        <AlbumReusableUserImagesTab
+          v-if="activeTab === 'uploads'"
+          source="uploads"
+          :search-term="searchTerm"
+          :selected-image-ids="props.selectedImageIds"
+          :is-limit-reached="props.isLimitReached"
+          @add-image="emit('addImage', $event)"
+        />
+        <AlbumReusableUserImagesTab
+          v-else-if="activeTab === 'favorites'"
+          source="favorites"
+          :search-term="searchTerm"
+          :selected-image-ids="props.selectedImageIds"
+          :is-limit-reached="props.isLimitReached"
+          @add-image="emit('addImage', $event)"
+        />
+        <AlbumReusableCollectionsTab
+          v-else
+          :search-term="searchTerm"
+          :selected-image-ids="props.selectedImageIds"
+          :is-limit-reached="props.isLimitReached"
+          @add-image="emit('addImage', $event)"
+        />
+      </div>
+    </template>
   </section>
 </template>

--- a/components/discussion/form/AlbumReusableCollectionsTab.spec.ts
+++ b/components/discussion/form/AlbumReusableCollectionsTab.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import AlbumReusableCollectionsTab from '@/components/discussion/form/AlbumReusableCollectionsTab.vue';
+
+const {
+  usernameRef,
+  collectionsResult,
+  collectionImagesResult,
+  falseRef,
+  nullRef,
+} = vi.hoisted(() => ({
+  usernameRef: { value: 'alice' as string },
+  collectionsResult: {
+    value: {
+      users: [
+        {
+          Collections: [
+            { id: 'c1', name: 'Inspiration', itemCount: 3 },
+            { id: 'c2', name: 'Memes', itemCount: 1 },
+          ],
+        },
+      ],
+    } as Record<string, unknown>,
+  },
+  collectionImagesResult: {
+    value: {
+      collections: [
+        {
+          id: 'c1',
+          name: 'Inspiration',
+          Images: [
+            { id: 'ci-1', url: 'https://img.test/ci1.jpg' },
+            { id: 'ci-2', url: 'https://img.test/ci2.jpg' },
+          ],
+          ImagesAggregate: { count: 2 },
+        },
+      ],
+    } as Record<string, unknown>,
+  },
+  falseRef: { value: false },
+  nullRef: { value: null as Error | null },
+}));
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => usernameRef,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn((document: { definitions?: Array<{ name?: { value?: string } }> }) => {
+    const opName = document?.definitions?.[0]?.name?.value;
+    if (opName === 'GetReusableImageCollections') {
+      return { result: collectionsResult, loading: falseRef, error: nullRef };
+    }
+    return { result: collectionImagesResult, loading: falseRef, error: nullRef };
+  }),
+}));
+
+const GridStub = {
+  name: 'AlbumReusableImageGrid',
+  props: ['images', 'selectedImageIds', 'isLimitReached', 'loading', 'error', 'emptyMessage'],
+  emits: ['add-image'],
+  template: '<div class="grid-stub" />',
+};
+
+const mountTab = (searchTerm = '') =>
+  mountWithDefaults(AlbumReusableCollectionsTab, {
+    props: {
+      searchTerm,
+      selectedImageIds: [],
+      isLimitReached: false,
+    },
+    global: {
+      stubs: {
+        AlbumReusableImageGrid: GridStub,
+        LoadingSpinner: { template: '<div />' },
+        ErrorBanner: { props: ['text'], template: '<div />' },
+      },
+    },
+  });
+
+const collectionButtons = (wrapper: ReturnType<typeof mountTab>) =>
+  wrapper.findAll('[data-testid="reuse-image-collection-button"]');
+
+beforeEach(() => {
+  usernameRef.value = 'alice';
+});
+
+describe('AlbumReusableCollectionsTab', () => {
+  it('lists a button for each image collection', () => {
+    const wrapper = mountTab();
+    expect(collectionButtons(wrapper).map((b) => b.text())).toEqual([
+      expect.stringContaining('Inspiration'),
+      expect.stringContaining('Memes'),
+    ]);
+  });
+
+  it('filters the collection list by the search term', () => {
+    const wrapper = mountTab('meme');
+    expect(collectionButtons(wrapper).map((b) => b.text())).toEqual([
+      expect.stringContaining('Memes'),
+    ]);
+  });
+
+  it('shows the selected collection images in the grid after choosing a collection', async () => {
+    const wrapper = mountTab();
+    await collectionButtons(wrapper)[0].trigger('click');
+    expect(
+      wrapper.findComponent(GridStub).props('images').map((i: { id: string }) => i.id)
+    ).toEqual(['ci-1', 'ci-2']);
+  });
+
+  it('returns to the collection list from the back button', async () => {
+    const wrapper = mountTab();
+    await collectionButtons(wrapper)[0].trigger('click');
+    await wrapper.get('button').trigger('click');
+    expect(collectionButtons(wrapper).length).toBe(2);
+  });
+
+  it('forwards addImage from the grid', async () => {
+    const wrapper = mountTab();
+    await collectionButtons(wrapper)[0].trigger('click');
+    wrapper.findComponent(GridStub).vm.$emit('add-image', { id: 'ci-1' });
+    expect(wrapper.emitted('addImage')?.[0]?.[0]).toMatchObject({ id: 'ci-1' });
+  });
+});

--- a/components/discussion/form/AlbumReusableCollectionsTab.spec.ts
+++ b/components/discussion/form/AlbumReusableCollectionsTab.spec.ts
@@ -8,6 +8,7 @@ const {
   collectionImagesResult,
   falseRef,
   nullRef,
+  fetchMore,
 } = vi.hoisted(() => ({
   usernameRef: { value: 'alice' as string },
   collectionsResult: {
@@ -32,13 +33,14 @@ const {
             { id: 'ci-1', url: 'https://img.test/ci1.jpg' },
             { id: 'ci-2', url: 'https://img.test/ci2.jpg' },
           ],
-          ImagesAggregate: { count: 2 },
+          ImagesAggregate: { count: 30 },
         },
       ],
     } as Record<string, unknown>,
   },
   falseRef: { value: false },
   nullRef: { value: null as Error | null },
+  fetchMore: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('@/composables/useAuthState', () => ({
@@ -51,7 +53,12 @@ vi.mock('@vue/apollo-composable', () => ({
     if (opName === 'GetReusableImageCollections') {
       return { result: collectionsResult, loading: falseRef, error: nullRef };
     }
-    return { result: collectionImagesResult, loading: falseRef, error: nullRef };
+    return {
+      result: collectionImagesResult,
+      loading: falseRef,
+      error: nullRef,
+      fetchMore,
+    };
   }),
 }));
 
@@ -81,8 +88,12 @@ const mountTab = (searchTerm = '') =>
 const collectionButtons = (wrapper: ReturnType<typeof mountTab>) =>
   wrapper.findAll('[data-testid="reuse-image-collection-button"]');
 
+const loadMoreButton = (wrapper: ReturnType<typeof mountTab>) =>
+  wrapper.findAll('button').find((b) => b.text() === 'Load more');
+
 beforeEach(() => {
   usernameRef.value = 'alice';
+  fetchMore.mockClear();
 });
 
 describe('AlbumReusableCollectionsTab', () => {
@@ -121,5 +132,16 @@ describe('AlbumReusableCollectionsTab', () => {
     await collectionButtons(wrapper)[0].trigger('click');
     wrapper.findComponent(GridStub).vm.$emit('add-image', { id: 'ci-1' });
     expect(wrapper.emitted('addImage')?.[0]?.[0]).toMatchObject({ id: 'ci-1' });
+  });
+
+  it('requests the next page of collection images when Load more is clicked', async () => {
+    const wrapper = mountTab();
+    await collectionButtons(wrapper)[0].trigger('click');
+    await loadMoreButton(wrapper)!.trigger('click');
+    expect(fetchMore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ offset: 24 }),
+      })
+    );
   });
 });

--- a/components/discussion/form/AlbumReusableCollectionsTab.vue
+++ b/components/discussion/form/AlbumReusableCollectionsTab.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { useUsername } from '@/composables/useAuthState';
 import {
@@ -9,6 +9,7 @@ import {
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
 import AlbumReusableImageGrid from './AlbumReusableImageGrid.vue';
+import LoadMore from '@/components/LoadMore.vue';
 import { buildReusableImageWhere } from './reusableImageTypes';
 import type { ReusableImage } from './reusableImageTypes';
 
@@ -47,6 +48,15 @@ const emit = defineEmits<{
 
 const usernameVar = useUsername();
 const selectedCollectionId = ref<string | null>(null);
+const currentOffset = ref(0);
+const isLoadingMore = ref(false);
+
+const buildImageVariables = (offset: number) => ({
+  collectionId: selectedCollectionId.value,
+  where: buildReusableImageWhere(props.searchTerm),
+  offset,
+  limit: PAGE_SIZE,
+});
 
 const {
   result: collectionsResult,
@@ -74,14 +84,10 @@ const {
   result: collectionImagesResult,
   loading: collectionImagesLoading,
   error: collectionImagesError,
+  fetchMore,
 } = useQuery<CollectionImagesResult>(
   GET_REUSABLE_COLLECTION_IMAGES,
-  () => ({
-    collectionId: selectedCollectionId.value,
-    where: buildReusableImageWhere(props.searchTerm),
-    offset: 0,
-    limit: PAGE_SIZE,
-  }),
+  () => buildImageVariables(0),
   () => ({
     enabled: Boolean(selectedCollectionId.value),
     fetchPolicy: 'cache-and-network',
@@ -102,6 +108,57 @@ const selectedCollection = computed(
 const collectionImages = computed<ReusableImage[]>(
   () => selectedCollection.value?.Images || []
 );
+
+const collectionImagesTotal = computed(
+  () => selectedCollection.value?.ImagesAggregate?.count ?? 0
+);
+
+const hasMoreCollectionImages = computed(
+  () => collectionImages.value.length < collectionImagesTotal.value
+);
+
+// Restart image paging whenever the chosen collection or the search changes;
+// the base query refetches at offset 0, so keep our cursor in sync.
+watch([selectedCollectionId, () => props.searchTerm], () => {
+  currentOffset.value = 0;
+});
+
+const loadMoreCollectionImages = async () => {
+  if (!hasMoreCollectionImages.value || isLoadingMore.value) return;
+
+  const newOffset = currentOffset.value + PAGE_SIZE;
+  isLoadingMore.value = true;
+
+  try {
+    await fetchMore({
+      variables: buildImageVariables(newOffset),
+      updateQuery: (previous: CollectionImagesResult, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return previous;
+        const prevCollection = previous.collections?.[0];
+        const nextCollection = fetchMoreResult.collections?.[0];
+        if (!prevCollection || !nextCollection) return previous;
+
+        return {
+          ...previous,
+          collections: [
+            {
+              ...prevCollection,
+              Images: [
+                ...(prevCollection.Images || []),
+                ...(nextCollection.Images || []),
+              ],
+              ImagesAggregate: nextCollection.ImagesAggregate,
+            },
+          ],
+        };
+      },
+    });
+
+    currentOffset.value = newOffset;
+  } finally {
+    isLoadingMore.value = false;
+  }
+};
 
 const selectedCollectionName = computed(() => {
   if (selectedCollection.value?.name) return selectedCollection.value.name;
@@ -191,6 +248,14 @@ const backToCollections = () => {
         :error="collectionImagesErrorMessage"
         empty-message="This collection has no images."
         @add-image="emit('addImage', $event)"
+      />
+
+      <LoadMore
+        v-if="collectionImages.length > 0"
+        class="mt-2"
+        :loading="isLoadingMore"
+        :reached-end-of-results="!hasMoreCollectionImages"
+        @load-more="loadMoreCollectionImages"
       />
     </div>
   </div>

--- a/components/discussion/form/AlbumReusableCollectionsTab.vue
+++ b/components/discussion/form/AlbumReusableCollectionsTab.vue
@@ -1,0 +1,197 @@
+<script lang="ts" setup>
+import { computed, ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { useUsername } from '@/composables/useAuthState';
+import {
+  GET_REUSABLE_IMAGE_COLLECTIONS,
+  GET_REUSABLE_COLLECTION_IMAGES,
+} from '@/graphQLData/image/queries';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import ErrorBanner from '@/components/ErrorBanner.vue';
+import AlbumReusableImageGrid from './AlbumReusableImageGrid.vue';
+import { buildReusableImageWhere } from './reusableImageTypes';
+import type { ReusableImage } from './reusableImageTypes';
+
+const PAGE_SIZE = 24;
+
+type ImageCollection = {
+  id: string;
+  name?: string | null;
+  itemCount?: number | null;
+};
+
+type CollectionsResult = {
+  users?: Array<{
+    Collections?: ImageCollection[] | null;
+  }> | null;
+};
+
+type CollectionImagesResult = {
+  collections?: Array<{
+    id: string;
+    name?: string | null;
+    Images?: ReusableImage[] | null;
+    ImagesAggregate?: { count?: number | null } | null;
+  }> | null;
+};
+
+const props = defineProps<{
+  searchTerm: string;
+  selectedImageIds: string[];
+  isLimitReached: boolean;
+}>();
+
+const emit = defineEmits<{
+  addImage: [image: ReusableImage];
+}>();
+
+const usernameVar = useUsername();
+const selectedCollectionId = ref<string | null>(null);
+
+const {
+  result: collectionsResult,
+  loading: collectionsLoading,
+  error: collectionsError,
+} = useQuery<CollectionsResult>(
+  GET_REUSABLE_IMAGE_COLLECTIONS,
+  () => ({ username: usernameVar.value }),
+  () => ({
+    enabled: Boolean(usernameVar.value),
+    fetchPolicy: 'cache-and-network',
+  })
+);
+
+const collections = computed<ImageCollection[]>(() => {
+  const all = collectionsResult.value?.users?.[0]?.Collections || [];
+  const trimmed = props.searchTerm.trim().toLowerCase();
+  if (!trimmed) return all;
+  return all.filter((collection) =>
+    (collection.name || '').toLowerCase().includes(trimmed)
+  );
+});
+
+const {
+  result: collectionImagesResult,
+  loading: collectionImagesLoading,
+  error: collectionImagesError,
+} = useQuery<CollectionImagesResult>(
+  GET_REUSABLE_COLLECTION_IMAGES,
+  () => ({
+    collectionId: selectedCollectionId.value,
+    where: buildReusableImageWhere(props.searchTerm),
+    offset: 0,
+    limit: PAGE_SIZE,
+  }),
+  () => ({
+    enabled: Boolean(selectedCollectionId.value),
+    fetchPolicy: 'cache-and-network',
+  })
+);
+
+const collectionsErrorMessage = computed(
+  () => collectionsError.value?.message ?? null
+);
+const collectionImagesErrorMessage = computed(
+  () => collectionImagesError.value?.message ?? null
+);
+
+const selectedCollection = computed(
+  () => collectionImagesResult.value?.collections?.[0] || null
+);
+
+const collectionImages = computed<ReusableImage[]>(
+  () => selectedCollection.value?.Images || []
+);
+
+const selectedCollectionName = computed(() => {
+  if (selectedCollection.value?.name) return selectedCollection.value.name;
+  const fromList = collections.value.find(
+    (collection) => collection.id === selectedCollectionId.value
+  );
+  return fromList?.name || 'Image collection';
+});
+
+const openCollection = (id: string) => {
+  selectedCollectionId.value = id;
+};
+
+const backToCollections = () => {
+  selectedCollectionId.value = null;
+};
+</script>
+
+<template>
+  <div>
+    <!-- Collection list view -->
+    <div v-if="!selectedCollectionId">
+      <ErrorBanner
+        v-if="collectionsErrorMessage"
+        class="mt-3"
+        :text="collectionsErrorMessage"
+      />
+
+      <div
+        v-if="collectionsLoading && collections.length === 0"
+        class="mt-3 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
+      >
+        <LoadingSpinner class="h-4 w-4" />
+        <span>Loading collections...</span>
+      </div>
+
+      <p
+        v-else-if="collections.length === 0"
+        class="mt-3 text-sm text-gray-600 dark:text-gray-300"
+      >
+        You have no image collections yet.
+      </p>
+
+      <ul
+        v-else
+        class="mt-3 space-y-2"
+      >
+        <li
+          v-for="collection in collections"
+          :key="collection.id"
+        >
+          <button
+            type="button"
+            class="flex w-full items-center justify-between rounded-md border border-gray-200 bg-white px-3 py-2 text-left text-sm text-gray-900 shadow-sm hover:border-orange-400 hover:bg-orange-50 focus:outline-none focus:ring-2 focus:ring-orange-500/30 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:border-orange-500 dark:hover:bg-gray-700"
+            data-testid="reuse-image-collection-button"
+            @click="openCollection(collection.id)"
+          >
+            <span class="font-medium">{{ collection.name || 'Untitled collection' }}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">
+              {{ collection.itemCount ?? 0 }}
+              {{ (collection.itemCount ?? 0) === 1 ? 'image' : 'images' }}
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Selected collection view -->
+    <div v-else>
+      <button
+        type="button"
+        class="mt-1 inline-flex items-center gap-1 text-sm font-medium text-orange-600 hover:text-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500/30 dark:text-orange-400 dark:hover:text-orange-300"
+        @click="backToCollections"
+      >
+        <span aria-hidden="true">&larr;</span>
+        All collections
+      </button>
+      <h5 class="mt-2 text-sm font-semibold text-gray-900 dark:text-white">
+        {{ selectedCollectionName }}
+      </h5>
+
+      <AlbumReusableImageGrid
+        :images="collectionImages"
+        :selected-image-ids="selectedImageIds"
+        :is-limit-reached="isLimitReached"
+        :loading="collectionImagesLoading"
+        :error="collectionImagesErrorMessage"
+        empty-message="This collection has no images."
+        @add-image="emit('addImage', $event)"
+      />
+    </div>
+  </div>
+</template>

--- a/components/discussion/form/AlbumReusableImageGrid.spec.ts
+++ b/components/discussion/form/AlbumReusableImageGrid.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import AlbumReusableImageGrid from '@/components/discussion/form/AlbumReusableImageGrid.vue';
+
+const image = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  url: `https://img.test/${id}.jpg`,
+  alt: `alt-${id}`,
+  caption: `caption-${id}`,
+  Uploader: { username: 'alice', displayName: 'Alice' },
+  ...extra,
+});
+
+const stubs = {
+  LoadingSpinner: { template: '<div class="spinner" />' },
+  ErrorBanner: { props: ['text'], template: '<div class="error">{{ text }}</div>' },
+};
+
+const mountGrid = (props: Record<string, unknown>) =>
+  mountWithDefaults(AlbumReusableImageGrid, {
+    props: {
+      images: [],
+      selectedImageIds: [],
+      isLimitReached: false,
+      loading: false,
+      ...props,
+    },
+    global: { stubs },
+  });
+
+const addButtons = (wrapper: ReturnType<typeof mountGrid>) =>
+  wrapper.findAll('[data-testid="reuse-image-add-button"]');
+
+describe('AlbumReusableImageGrid', () => {
+  it('renders one card per image', () => {
+    const wrapper = mountGrid({ images: [image('a'), image('b')] });
+    expect(wrapper.findAll('article')).toHaveLength(2);
+  });
+
+  it('shows the loading spinner while loading with no images yet', () => {
+    const wrapper = mountGrid({ images: [], loading: true });
+    expect(wrapper.find('.spinner').exists()).toBe(true);
+  });
+
+  it('shows the empty message when there are no images and not loading', () => {
+    const wrapper = mountGrid({ images: [], emptyMessage: 'Nothing here.' });
+    expect(wrapper.text()).toContain('Nothing here.');
+  });
+
+  it('renders the error banner when an error is passed', () => {
+    const wrapper = mountGrid({ error: 'Boom' });
+    expect(wrapper.find('.error').text()).toBe('Boom');
+  });
+
+  it('emits addImage with the image when Add to album is clicked', async () => {
+    const wrapper = mountGrid({ images: [image('a')] });
+    await addButtons(wrapper)[0].trigger('click');
+    expect(wrapper.emitted('addImage')?.[0]?.[0]).toMatchObject({ id: 'a' });
+  });
+
+  it('disables and relabels the button for an already-selected image', () => {
+    const wrapper = mountGrid({
+      images: [image('a')],
+      selectedImageIds: ['a'],
+    });
+    expect({
+      disabled: addButtons(wrapper)[0].attributes('disabled'),
+      text: addButtons(wrapper)[0].text(),
+    }).toEqual({ disabled: '', text: 'Already in album' });
+  });
+
+  it('disables and relabels the button when the album limit is reached', () => {
+    const wrapper = mountGrid({
+      images: [image('a')],
+      isLimitReached: true,
+    });
+    expect({
+      disabled: addButtons(wrapper)[0].attributes('disabled'),
+      text: addButtons(wrapper)[0].text(),
+    }).toEqual({ disabled: '', text: 'Album limit reached' });
+  });
+});

--- a/components/discussion/form/AlbumReusableImageGrid.vue
+++ b/components/discussion/form/AlbumReusableImageGrid.vue
@@ -1,0 +1,94 @@
+<script lang="ts" setup>
+import { computed } from 'vue';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import ErrorBanner from '@/components/ErrorBanner.vue';
+import type { ReusableImage } from './reusableImageTypes';
+
+const props = defineProps<{
+  images: ReusableImage[];
+  selectedImageIds: string[];
+  isLimitReached: boolean;
+  loading: boolean;
+  error?: string | null;
+  emptyMessage?: string;
+}>();
+
+const emit = defineEmits<{
+  addImage: [image: ReusableImage];
+}>();
+
+const selectedImageIdsSet = computed(() => new Set(props.selectedImageIds));
+
+const getImageAlt = (image: ReusableImage) =>
+  image.alt || image.caption || 'Reusable album image';
+
+const getUploaderLabel = (image: ReusableImage) => {
+  const uploader = image.Uploader;
+  if (!uploader?.username) return 'Unknown uploader';
+  return uploader.displayName
+    ? `${uploader.displayName} (${uploader.username})`
+    : uploader.username;
+};
+</script>
+
+<template>
+  <div>
+    <ErrorBanner
+      v-if="error"
+      class="mt-3"
+      :text="error"
+    />
+
+    <div
+      v-if="loading && images.length === 0"
+      class="mt-3 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
+    >
+      <LoadingSpinner class="h-4 w-4" />
+      <span>Loading images...</span>
+    </div>
+
+    <p
+      v-else-if="images.length === 0"
+      class="mt-3 text-sm text-gray-600 dark:text-gray-300"
+    >
+      {{ emptyMessage || 'No images found.' }}
+    </p>
+
+    <div
+      v-else
+      class="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+    >
+      <article
+        v-for="image in images"
+        :key="image.id"
+        class="overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800"
+      >
+        <img
+          :src="image.url"
+          :alt="getImageAlt(image)"
+          class="h-32 w-full object-cover"
+          loading="lazy"
+        >
+        <div class="space-y-2 p-3">
+          <p class="line-clamp-2 text-sm font-medium text-gray-900 dark:text-white">
+            {{ image.caption || image.alt || image.id }}
+          </p>
+          <p class="text-xs text-gray-600 dark:text-gray-300">
+            Uploaded by {{ getUploaderLabel(image) }}
+          </p>
+          <button
+            type="button"
+            class="w-full rounded-md bg-orange-600 px-3 py-2 text-sm font-medium text-white hover:bg-orange-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-600 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+            data-testid="reuse-image-add-button"
+            :disabled="selectedImageIdsSet.has(image.id) || isLimitReached"
+            @click="emit('addImage', image)"
+          >
+            <span v-if="selectedImageIdsSet.has(image.id)">Already in album</span>
+            <span v-else-if="isLimitReached">Album limit reached</span>
+            <span v-else>Add to album</span>
+          </button>
+        </div>
+      </article>
+    </div>
+  </div>
+</template>

--- a/components/discussion/form/AlbumReusableUserImagesTab.spec.ts
+++ b/components/discussion/form/AlbumReusableUserImagesTab.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import AlbumReusableUserImagesTab from '@/components/discussion/form/AlbumReusableUserImagesTab.vue';
+
+const { usernameRef, queryResult, queryLoading, queryError } = vi.hoisted(
+  () => ({
+    usernameRef: { value: 'alice' as string },
+    queryResult: {
+      value: {
+        users: [
+          {
+            Images: [{ id: 'upload-1', url: 'https://img.test/u1.jpg' }],
+            ImagesAggregate: { count: 1 },
+            FavoriteImages: [
+              { id: 'fav-1', url: 'https://img.test/f1.jpg' },
+              { id: 'fav-2', url: 'https://img.test/f2.jpg' },
+            ],
+            FavoriteImagesAggregate: { count: 2 },
+          },
+        ],
+      } as Record<string, unknown>,
+    },
+    queryLoading: { value: false },
+    queryError: { value: null as Error | null },
+  })
+);
+
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => usernameRef,
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(() => ({
+    result: queryResult,
+    loading: queryLoading,
+    error: queryError,
+  })),
+}));
+
+const GridStub = {
+  name: 'AlbumReusableImageGrid',
+  props: ['images', 'selectedImageIds', 'isLimitReached', 'loading', 'error', 'emptyMessage'],
+  emits: ['add-image'],
+  template: '<div class="grid-stub" />',
+};
+
+const mountTab = (source: 'uploads' | 'favorites') =>
+  mountWithDefaults(AlbumReusableUserImagesTab, {
+    props: {
+      source,
+      searchTerm: '',
+      selectedImageIds: [],
+      isLimitReached: false,
+    },
+    global: { stubs: { AlbumReusableImageGrid: GridStub } },
+  });
+
+const grid = (wrapper: ReturnType<typeof mountTab>) =>
+  wrapper.findComponent(GridStub);
+
+beforeEach(() => {
+  usernameRef.value = 'alice';
+  queryLoading.value = false;
+  queryError.value = null;
+});
+
+describe('AlbumReusableUserImagesTab', () => {
+  it('passes the user uploads to the grid for the uploads source', () => {
+    const wrapper = mountTab('uploads');
+    expect(grid(wrapper).props('images').map((i: { id: string }) => i.id)).toEqual([
+      'upload-1',
+    ]);
+  });
+
+  it('passes the favorited images to the grid for the favorites source', () => {
+    const wrapper = mountTab('favorites');
+    expect(grid(wrapper).props('images').map((i: { id: string }) => i.id)).toEqual([
+      'fav-1',
+      'fav-2',
+    ]);
+  });
+
+  it('uses an uploads-specific empty message', () => {
+    const wrapper = mountTab('uploads');
+    expect(grid(wrapper).props('emptyMessage')).toContain('uploaded');
+  });
+
+  it('uses a favorites-specific empty message', () => {
+    const wrapper = mountTab('favorites');
+    expect(grid(wrapper).props('emptyMessage')).toContain('favorited');
+  });
+
+  it('forwards the query error message to the grid', () => {
+    queryError.value = new Error('kaboom');
+    const wrapper = mountTab('uploads');
+    expect(grid(wrapper).props('error')).toBe('kaboom');
+  });
+});

--- a/components/discussion/form/AlbumReusableUserImagesTab.spec.ts
+++ b/components/discussion/form/AlbumReusableUserImagesTab.spec.ts
@@ -2,15 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import AlbumReusableUserImagesTab from '@/components/discussion/form/AlbumReusableUserImagesTab.vue';
 
-const { usernameRef, queryResult, queryLoading, queryError } = vi.hoisted(
-  () => ({
+const { usernameRef, queryResult, queryLoading, queryError, fetchMore } =
+  vi.hoisted(() => ({
     usernameRef: { value: 'alice' as string },
     queryResult: {
       value: {
         users: [
           {
             Images: [{ id: 'upload-1', url: 'https://img.test/u1.jpg' }],
-            ImagesAggregate: { count: 1 },
+            ImagesAggregate: { count: 30 },
             FavoriteImages: [
               { id: 'fav-1', url: 'https://img.test/f1.jpg' },
               { id: 'fav-2', url: 'https://img.test/f2.jpg' },
@@ -22,8 +22,8 @@ const { usernameRef, queryResult, queryLoading, queryError } = vi.hoisted(
     },
     queryLoading: { value: false },
     queryError: { value: null as Error | null },
-  })
-);
+    fetchMore: vi.fn(() => Promise.resolve()),
+  }));
 
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => usernameRef,
@@ -34,6 +34,7 @@ vi.mock('@vue/apollo-composable', () => ({
     result: queryResult,
     loading: queryLoading,
     error: queryError,
+    fetchMore,
   })),
 }));
 
@@ -58,10 +59,14 @@ const mountTab = (source: 'uploads' | 'favorites') =>
 const grid = (wrapper: ReturnType<typeof mountTab>) =>
   wrapper.findComponent(GridStub);
 
+const loadMoreButton = (wrapper: ReturnType<typeof mountTab>) =>
+  wrapper.findAll('button').find((b) => b.text() === 'Load more');
+
 beforeEach(() => {
   usernameRef.value = 'alice';
   queryLoading.value = false;
   queryError.value = null;
+  fetchMore.mockClear();
 });
 
 describe('AlbumReusableUserImagesTab', () => {
@@ -94,5 +99,25 @@ describe('AlbumReusableUserImagesTab', () => {
     queryError.value = new Error('kaboom');
     const wrapper = mountTab('uploads');
     expect(grid(wrapper).props('error')).toBe('kaboom');
+  });
+
+  it('offers a Load more control while more images remain than are loaded', () => {
+    const wrapper = mountTab('uploads');
+    expect(loadMoreButton(wrapper)).toBeTruthy();
+  });
+
+  it('does not offer Load more once every image is loaded', () => {
+    const wrapper = mountTab('favorites');
+    expect(loadMoreButton(wrapper)).toBeUndefined();
+  });
+
+  it('requests the next page offset when Load more is clicked', async () => {
+    const wrapper = mountTab('uploads');
+    await loadMoreButton(wrapper)!.trigger('click');
+    expect(fetchMore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ offset: 24 }),
+      })
+    );
   });
 });

--- a/components/discussion/form/AlbumReusableUserImagesTab.vue
+++ b/components/discussion/form/AlbumReusableUserImagesTab.vue
@@ -1,0 +1,86 @@
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { useUsername } from '@/composables/useAuthState';
+import {
+  GET_REUSABLE_USER_IMAGES,
+  GET_REUSABLE_FAVORITE_IMAGES,
+} from '@/graphQLData/image/queries';
+import AlbumReusableImageGrid from './AlbumReusableImageGrid.vue';
+import { buildReusableImageWhere } from './reusableImageTypes';
+import type { ReusableImage } from './reusableImageTypes';
+
+// The page size for the first fetch. Loading more images is added in a later
+// phase; for now each tab shows its most recent page.
+const PAGE_SIZE = 24;
+
+type UserImagesResult = {
+  users?: Array<{
+    Images?: ReusableImage[] | null;
+    ImagesAggregate?: { count?: number | null } | null;
+    FavoriteImages?: ReusableImage[] | null;
+    FavoriteImagesAggregate?: { count?: number | null } | null;
+  }> | null;
+};
+
+const props = defineProps<{
+  source: 'uploads' | 'favorites';
+  searchTerm: string;
+  selectedImageIds: string[];
+  isLimitReached: boolean;
+}>();
+
+const emit = defineEmits<{
+  addImage: [image: ReusableImage];
+}>();
+
+const usernameVar = useUsername();
+
+const query = computed(() =>
+  props.source === 'favorites'
+    ? GET_REUSABLE_FAVORITE_IMAGES
+    : GET_REUSABLE_USER_IMAGES
+);
+
+const { result, loading, error } = useQuery<UserImagesResult>(
+  query,
+  () => ({
+    username: usernameVar.value,
+    where: buildReusableImageWhere(props.searchTerm),
+    offset: 0,
+    limit: PAGE_SIZE,
+  }),
+  () => ({
+    enabled: Boolean(usernameVar.value),
+    fetchPolicy: 'cache-and-network',
+  })
+);
+
+const images = computed<ReusableImage[]>(() => {
+  const user = result.value?.users?.[0];
+  if (!user) return [];
+  return (
+    (props.source === 'favorites' ? user.FavoriteImages : user.Images) || []
+  );
+});
+
+const emptyMessage = computed(() =>
+  props.source === 'favorites'
+    ? 'You have not favorited any images yet.'
+    : 'You have not uploaded any images yet.'
+);
+
+const errorMessage = computed(() => error.value?.message ?? null);
+</script>
+
+<template>
+  <AlbumReusableImageGrid
+    :images="images"
+    :selected-image-ids="selectedImageIds"
+    :is-limit-reached="isLimitReached"
+    :loading="loading"
+    :error="errorMessage"
+    :empty-message="emptyMessage"
+    @add-image="emit('addImage', $event)"
+  />
+</template>

--- a/components/discussion/form/AlbumReusableUserImagesTab.vue
+++ b/components/discussion/form/AlbumReusableUserImagesTab.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { useUsername } from '@/composables/useAuthState';
 import {
@@ -7,19 +7,20 @@ import {
   GET_REUSABLE_FAVORITE_IMAGES,
 } from '@/graphQLData/image/queries';
 import AlbumReusableImageGrid from './AlbumReusableImageGrid.vue';
+import LoadMore from '@/components/LoadMore.vue';
 import { buildReusableImageWhere } from './reusableImageTypes';
 import type { ReusableImage } from './reusableImageTypes';
 
-// The page size for the first fetch. Loading more images is added in a later
-// phase; for now each tab shows its most recent page.
 const PAGE_SIZE = 24;
+
+type Aggregate = { count?: number | null } | null;
 
 type UserImagesResult = {
   users?: Array<{
     Images?: ReusableImage[] | null;
-    ImagesAggregate?: { count?: number | null } | null;
+    ImagesAggregate?: Aggregate;
     FavoriteImages?: ReusableImage[] | null;
-    FavoriteImagesAggregate?: { count?: number | null } | null;
+    FavoriteImagesAggregate?: Aggregate;
   }> | null;
 };
 
@@ -35,52 +36,132 @@ const emit = defineEmits<{
 }>();
 
 const usernameVar = useUsername();
+const currentOffset = ref(0);
+const isLoadingMore = ref(false);
+
+const isFavorites = computed(() => props.source === 'favorites');
 
 const query = computed(() =>
-  props.source === 'favorites'
-    ? GET_REUSABLE_FAVORITE_IMAGES
-    : GET_REUSABLE_USER_IMAGES
+  isFavorites.value ? GET_REUSABLE_FAVORITE_IMAGES : GET_REUSABLE_USER_IMAGES
 );
 
-const { result, loading, error } = useQuery<UserImagesResult>(
+const buildVariables = (offset: number) => ({
+  username: usernameVar.value,
+  where: buildReusableImageWhere(props.searchTerm),
+  offset,
+  limit: PAGE_SIZE,
+});
+
+const { result, loading, error, fetchMore } = useQuery<UserImagesResult>(
   query,
-  () => ({
-    username: usernameVar.value,
-    where: buildReusableImageWhere(props.searchTerm),
-    offset: 0,
-    limit: PAGE_SIZE,
-  }),
+  () => buildVariables(0),
   () => ({
     enabled: Boolean(usernameVar.value),
     fetchPolicy: 'cache-and-network',
   })
 );
 
-const images = computed<ReusableImage[]>(() => {
-  const user = result.value?.users?.[0];
-  if (!user) return [];
-  return (
-    (props.source === 'favorites' ? user.FavoriteImages : user.Images) || []
-  );
-});
+const user = computed(() => result.value?.users?.[0] ?? null);
+
+const images = computed<ReusableImage[]>(
+  () => (isFavorites.value ? user.value?.FavoriteImages : user.value?.Images) || []
+);
+
+const totalCount = computed(
+  () =>
+    (isFavorites.value
+      ? user.value?.FavoriteImagesAggregate?.count
+      : user.value?.ImagesAggregate?.count) ?? 0
+);
+
+const hasMore = computed(() => images.value.length < totalCount.value);
+
+const errorMessage = computed(() => error.value?.message ?? null);
 
 const emptyMessage = computed(() =>
-  props.source === 'favorites'
+  isFavorites.value
     ? 'You have not favorited any images yet.'
     : 'You have not uploaded any images yet.'
 );
 
-const errorMessage = computed(() => error.value?.message ?? null);
+// A new search restarts paging from the first page; the base query refetches at
+// offset 0, so reset our paging cursor to match.
+watch(
+  () => props.searchTerm,
+  () => {
+    currentOffset.value = 0;
+  }
+);
+
+const loadMore = async () => {
+  if (!hasMore.value || isLoadingMore.value) return;
+
+  const newOffset = currentOffset.value + PAGE_SIZE;
+  isLoadingMore.value = true;
+
+  try {
+    await fetchMore({
+      variables: buildVariables(newOffset),
+      updateQuery: (previous: UserImagesResult, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return previous;
+        const prevUser = previous.users?.[0];
+        const nextUser = fetchMoreResult.users?.[0];
+        if (!prevUser || !nextUser) return previous;
+
+        if (isFavorites.value) {
+          return {
+            ...previous,
+            users: [
+              {
+                ...prevUser,
+                FavoriteImages: [
+                  ...(prevUser.FavoriteImages || []),
+                  ...(nextUser.FavoriteImages || []),
+                ],
+                FavoriteImagesAggregate: nextUser.FavoriteImagesAggregate,
+              },
+            ],
+          };
+        }
+
+        return {
+          ...previous,
+          users: [
+            {
+              ...prevUser,
+              Images: [...(prevUser.Images || []), ...(nextUser.Images || [])],
+              ImagesAggregate: nextUser.ImagesAggregate,
+            },
+          ],
+        };
+      },
+    });
+
+    currentOffset.value = newOffset;
+  } finally {
+    isLoadingMore.value = false;
+  }
+};
 </script>
 
 <template>
-  <AlbumReusableImageGrid
-    :images="images"
-    :selected-image-ids="selectedImageIds"
-    :is-limit-reached="isLimitReached"
-    :loading="loading"
-    :error="errorMessage"
-    :empty-message="emptyMessage"
-    @add-image="emit('addImage', $event)"
-  />
+  <div>
+    <AlbumReusableImageGrid
+      :images="images"
+      :selected-image-ids="selectedImageIds"
+      :is-limit-reached="isLimitReached"
+      :loading="loading"
+      :error="errorMessage"
+      :empty-message="emptyMessage"
+      @add-image="emit('addImage', $event)"
+    />
+
+    <LoadMore
+      v-if="images.length > 0"
+      class="mt-2"
+      :loading="isLoadingMore"
+      :reached-end-of-results="!hasMore"
+      @load-more="loadMore"
+    />
+  </div>
 </template>

--- a/components/discussion/form/reusableImageTypes.ts
+++ b/components/discussion/form/reusableImageTypes.ts
@@ -1,0 +1,47 @@
+import type { ImageWhere } from '@/__generated__/graphql';
+
+// Shape the reusable-image picker (and its shared grid) render for each image.
+// Kept minimal on purpose: the picker only needs enough to preview an image and
+// connect it to an album by id, preserving the original uploader attribution.
+export type ReusableImage = {
+  id: string;
+  url: string;
+  alt?: string | null;
+  caption?: string | null;
+  copyright?: string | null;
+  createdAt?: string | null;
+  Uploader?: {
+    username?: string | null;
+    displayName?: string | null;
+  } | null;
+};
+
+// Build the ImageWhere filter shared by every source tab: always exclude
+// archived / permanently-removed images, and, when a search term is present,
+// match it against the image's text fields.
+export const buildReusableImageWhere = (searchTerm: string): ImageWhere => {
+  const base: ImageWhere = {
+    archived: false,
+    permanentlyRemoved: false,
+  };
+  const trimmedSearch = searchTerm.trim();
+
+  if (!trimmedSearch) {
+    return base;
+  }
+
+  return {
+    AND: [
+      base,
+      {
+        OR: [
+          { id_CONTAINS: trimmedSearch },
+          { url_CONTAINS: trimmedSearch },
+          { alt_CONTAINS: trimmedSearch },
+          { caption_CONTAINS: trimmedSearch },
+          { copyright_CONTAINS: trimmedSearch },
+        ],
+      },
+    ],
+  };
+};

--- a/graphQLData/image/queries.js
+++ b/graphQLData/image/queries.js
@@ -215,17 +215,24 @@ export const GET_USER_IMAGES = gql`
   }
 `;
 
-export const GET_REUSABLE_ALBUM_IMAGES = gql`
-  query GetReusableAlbumImages(
+// Reusable-image picker queries. Each source (uploads, favorites, a chosen
+// collection) is fetched separately and paginated with offset/limit so the
+// album editor's "Reuse an image" picker can page through large libraries.
+// isFavorited is intentionally omitted here: the picker never displays favorite
+// status and the field is resolver-backed, so selecting it adds cost for nothing.
+
+export const GET_REUSABLE_USER_IMAGES = gql`
+  query GetReusableUserImages(
     $username: String!
     $where: ImageWhere
+    $offset: Int!
     $limit: Int!
   ) {
     users(where: { username: $username }) {
       username
       Images(
         where: $where
-        options: { limit: $limit, sort: { createdAt: DESC } }
+        options: { limit: $limit, offset: $offset, sort: { createdAt: DESC } }
       ) {
         id
         url
@@ -238,9 +245,25 @@ export const GET_REUSABLE_ALBUM_IMAGES = gql`
           displayName
         }
       }
+      ImagesAggregate(where: $where) {
+        count
+      }
+    }
+  }
+`;
+
+export const GET_REUSABLE_FAVORITE_IMAGES = gql`
+  query GetReusableFavoriteImages(
+    $username: String!
+    $where: ImageWhere
+    $offset: Int!
+    $limit: Int!
+  ) {
+    users(where: { username: $username }) {
+      username
       FavoriteImages(
         where: $where
-        options: { limit: $limit, sort: { createdAt: DESC } }
+        options: { limit: $limit, offset: $offset, sort: { createdAt: DESC } }
       ) {
         id
         url
@@ -248,34 +271,61 @@ export const GET_REUSABLE_ALBUM_IMAGES = gql`
         caption
         copyright
         createdAt
-        isFavorited(username: $username)
         Uploader {
           username
           displayName
         }
       }
+      FavoriteImagesAggregate(where: $where) {
+        count
+      }
+    }
+  }
+`;
+
+export const GET_REUSABLE_IMAGE_COLLECTIONS = gql`
+  query GetReusableImageCollections($username: String!) {
+    users(where: { username: $username }) {
+      username
       Collections(
         where: { collectionType: IMAGES }
         options: { sort: [{ updatedAt: DESC }] }
       ) {
         id
         name
-        Images(
-          where: $where
-          options: { limit: $limit, sort: { createdAt: DESC } }
-        ) {
-          id
-          url
-          alt
-          caption
-          copyright
-          createdAt
-          isFavorited(username: $username)
-          Uploader {
-            username
-            displayName
-          }
+        itemCount
+      }
+    }
+  }
+`;
+
+export const GET_REUSABLE_COLLECTION_IMAGES = gql`
+  query GetReusableCollectionImages(
+    $collectionId: ID!
+    $where: ImageWhere
+    $offset: Int!
+    $limit: Int!
+  ) {
+    collections(where: { id: $collectionId }) {
+      id
+      name
+      Images(
+        where: $where
+        options: { limit: $limit, offset: $offset, sort: { createdAt: DESC } }
+      ) {
+        id
+        url
+        alt
+        caption
+        copyright
+        createdAt
+        Uploader {
+          username
+          displayName
         }
+      }
+      ImagesAggregate(where: $where) {
+        count
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "compile": "graphql-codegen",
-    "lint": "eslint",
-    "lint:a11y": "pnpm exec eslint \"components/**/*.vue\" --quiet",
+    "lint": "eslint --cache --cache-location node_modules/.cache/eslint/",
+    "lint:a11y": "pnpm exec eslint \"components/**/*.vue\" --quiet --cache --cache-location node_modules/.cache/eslint/",
     "prepare": "husky install",
     "prettier:check": "prettier --check .",
     "start": "nuxt start",
@@ -140,10 +140,10 @@
   },
   "lint-staged": {
     "*.ts": [
-      "eslint --fix"
+      "eslint --fix --cache --cache-location node_modules/.cache/eslint/"
     ],
     "*.vue": [
-      "eslint --fix"
+      "eslint --fix --cache --cache-location node_modules/.cache/eslint/"
     ]
   },
   "pnpm": {


### PR DESCRIPTION
Enhances the album "reuse an existing image" experience on the discussion create/edit form. The panel used to sit on **"Loading reusable images…"** indefinitely; this reworks it into an on-demand, source-aware, paginated picker.

## Phase 1 — gate the picker + fix the stuck loading
- The picker was mounted unconditionally, so it fired its query on **every** form load and hung forever whenever the username hadn't resolved (the query is disabled without one).
- Now it's hidden until the user clicks **Reuse an Image** in the drop zone (with a close control), so the query only runs on demand.
- The loading state is guarded on a resolved username, and a no-username state shows a sign-in prompt instead of an infinite spinner.

## Phase 2 — source-aware tabbed picker
- Replaces the single merged grid with **Your uploads · Favorites · Collections** tabs (collections lists your image collections, then drills into one).
- Adds lean, pagination-ready per-source queries (`GET_REUSABLE_USER_IMAGES`, `GET_REUSABLE_FAVORITE_IMAGES`, `GET_REUSABLE_IMAGE_COLLECTIONS`, `GET_REUSABLE_COLLECTION_IMAGES`) and drops the old merged `GET_REUSABLE_ALBUM_IMAGES`. `isFavorited` is intentionally omitted (never displayed, resolver-backed, and a likely contributor to the original hang).
- Extracts a shared presentational `AlbumReusableImageGrid`; each tab owns one query and mounts only when active.

## Phase 3 — per-source pagination
- Every tab pages with **Load more** via Apollo `fetchMore` + an accumulating `updateQuery`, driven by each source's `*Aggregate.count`; the cursor resets on search / collection change.

## Testing
- Unit tests for the new components (grid, both tabs, shell) plus updated `AlbumEditor` / `AlbumDropZone` specs. Full unit suite green (`pnpm run test:unit`), `vue-tsc` and ESLint clean.
- **Verified live** against the real backend (logged in): the picker opens on demand, all three tabs load their distinct real data, the Collections empty-state renders correctly, and **Load more** appends the next page of uploads.

## Note
The hard-load SSR crash on the create page that surfaced during testing is a **separate** pre-existing bug, fixed independently in #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)