### PR TITLE
fix(markdown): keep table cell words whole instead of breaking mid-word

### DIFF
--- a/assets/css/markdown-body.scss
+++ b/assets/css/markdown-body.scss
@@ -392,6 +392,11 @@
     text-align: left !important;
     font-weight: 600 !important;
     font-size: 0.8rem !important;
+    /* Don't break inside normal words — let the table grow and scroll
+       instead of shattering short headers like "Compare" into "Compar e". */
+    word-break: normal !important;
+    overflow-wrap: break-word !important;
+    hyphens: none !important;
     border-bottom: 1px solid #d0d7de !important;
     border-right: 1px solid #d0d7de !important;
     background-color: #f6f8fa !important;
@@ -410,6 +415,11 @@
   td {
     padding: 0.75rem 1rem !important;
     font-size: 0.8rem !important;
+    /* Same as th: only wrap at spaces; break a word solely as a last
+       resort (e.g. a long unbreakable URL), never mid-word by default. */
+    word-break: normal !important;
+    overflow-wrap: break-word !important;
+    hyphens: none !important;
     border-bottom: 1px solid #d0d7de !important;
     border-right: 1px solid #d0d7de !important;
 


### PR DESCRIPTION
## Problem

Markdown tables with several columns and one long-prose column render badly: short headers get shattered mid-word ("Compare" → "Compar / e", "Step" → "St / ep").

The tables already scroll horizontally (`.table-wrapper { overflow-x: auto }`), but `th`/`td` cells were **inheriting** `word-break: break-word` + `overflow-wrap: anywhere` from the global `.markdown-body` rule. `overflow-wrap: anywhere` lets the layout engine shrink a column below the width of its longest word, so the narrow columns get starved and the browser breaks *inside* words instead of letting the table grow and scroll.

## Fix

Override the inherited wrapping on `th`/`td` in `assets/css/markdown-body.scss`:

```scss
word-break: normal !important;
overflow-wrap: break-word !important;  /* not "anywhere" — keeps words whole for intrinsic sizing */
hyphens: none !important;
```

`overflow-wrap: break-word` (rather than `anywhere`) keeps whole words when column widths are computed, so the table grows and scrolls in its existing wrapper — but a genuinely unbreakable string (long URL/filename) still breaks as a last resort.

## Verification

Rendered the problem table through the app's real markdown structure at a realistic article width and compared old rule vs. shipped fix:

- **Before:** "Compar / e / Filenam / es", "Confirm / Metadat / a" — words split mid-word.
- **After:** "Compare / Filenames" breaks only at the space; "TinEye.com", "Google Images" stay whole; `john_smith_brooklyn_bridge.jpg` still wraps as a last resort.

Confirmed the running dev page computes `word-break: normal`, `overflow-wrap: break-word`, `hyphens: none` on table cells.

## Scope note

This is a **global** markdown-table rule, so it improves every markdown table in the app (the desired outcome). CSS-only change; no TS/lint impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)