### PR TITLE
Add moderator "Permanently remove image" action on the image issue (#182)

### DIFF
--- a/components/mod/IssueDetail.vue
+++ b/components/mod/IssueDetail.vue
@@ -476,8 +476,14 @@ const handleLockReasonUpdate = (value: string) => {
         :channel-id="channelId"
         :is-author-mod="authorType === 'mod'"
         :suspend-mod-disabled="isSuspendedMod || !issueActionVisibility.modActionsEnabled"
+        :can-permanently-remove-image="
+          modPermissions.canPermanentlyRemoveImage &&
+          !isSuspendedMod &&
+          issueActionVisibility.modActionsEnabled
+        "
         @suspended-mod-successfully="resetActivityFeed"
         @unsuspended-mod-successfully="resetActivityFeed"
+        @image-permanently-removed="resetActivityFeed"
       >
         <template #issue-body>
           <IssueBodyEditor

--- a/components/mod/IssueRelatedContent.vue
+++ b/components/mod/IssueRelatedContent.vue
@@ -6,6 +6,7 @@ import CommentDetails from '@/components/mod/CommentDetails.vue';
 import ImageDetails from '@/components/mod/ImageDetails.vue';
 import FlagIcon from '@/components/icons/FlagIcon.vue';
 import SuspendModButton from '@/components/mod/SuspendModButton.vue';
+import PermanentlyRemoveImageButton from '@/components/mod/PermanentlyRemoveImageButton.vue';
 import type { Issue } from '@/__generated__/graphql';
 
 const props = defineProps<{
@@ -15,6 +16,7 @@ const props = defineProps<{
   channelId?: string;
   isAuthorMod?: boolean;
   suspendModDisabled?: boolean;
+  canPermanentlyRemoveImage?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -22,7 +24,12 @@ const emit = defineEmits<{
     e: 'fetchedOriginalAuthorUsername' | 'fetchedOriginalModProfileName',
     value: string
   ): void;
-  (e: 'suspendedModSuccessfully' | 'unsuspendedModSuccessfully'): void;
+  (
+    e:
+      | 'suspendedModSuccessfully'
+      | 'unsuspendedModSuccessfully'
+      | 'imagePermanentlyRemoved'
+  ): void;
 }>();
 
 const getContentTypeLabel = (issue: Issue) => {
@@ -53,6 +60,12 @@ const showSuspendModButton = computed(() => {
         :disabled="suspendModDisabled"
         @suspended-successfully="emit('suspendedModSuccessfully')"
         @unsuspended-successfully="emit('unsuspendedModSuccessfully')"
+      />
+      <!-- Permanently remove image (admin/mod action) for image issues -->
+      <PermanentlyRemoveImageButton
+        v-if="activeIssue?.relatedImageId && canPermanentlyRemoveImage"
+        :image-id="activeIssue.relatedImageId"
+        @removed-successfully="emit('imagePermanentlyRemoved')"
       />
       <div
         v-if="reportCount !== null"

--- a/components/mod/PermanentlyRemoveImageButton.spec.ts
+++ b/components/mod/PermanentlyRemoveImageButton.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import PermanentlyRemoveImageButton from '@/components/mod/PermanentlyRemoveImageButton.vue';
+
+const h = vi.hoisted(() => ({
+  remove: vi.fn(),
+  removeError: { value: null as unknown },
+  onDone: undefined as undefined | (() => void),
+  refetchQueries: vi.fn(),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useApolloClient: () => ({
+    client: { refetchQueries: h.refetchQueries },
+  }),
+  useMutation: () => ({
+    mutate: h.remove,
+    loading: ref(false),
+    error: h.removeError,
+    onDone: (cb: () => void) => {
+      h.onDone = cb;
+    },
+  }),
+}));
+
+const mountButton = (props: Record<string, unknown> = {}) =>
+  mount(PermanentlyRemoveImageButton, {
+    props: { imageId: 'image-1', ...props },
+    global: {
+      stubs: {
+        GenericModal: {
+          name: 'GenericModal',
+          props: ['title', 'open', 'primaryButtonDisabled', 'error'],
+          emits: ['primary-button-click', 'close'],
+          template: '<div><slot name="content" /></div>',
+        },
+        TextEditor: {
+          name: 'TextEditor',
+          props: ['initialValue'],
+          emits: ['update'],
+          template: '<div />',
+        },
+        NotificationComponent: {
+          name: 'NotificationComponent',
+          props: ['show', 'title'],
+          template: '<div />',
+        },
+        TrashIcon: true,
+      },
+    },
+  });
+
+const modal = (w: ReturnType<typeof mount>) =>
+  w.getComponent({ name: 'GenericModal' });
+const editor = (w: ReturnType<typeof mount>) =>
+  w.getComponent({ name: 'TextEditor' });
+const clickButton = (w: ReturnType<typeof mount>) =>
+  w.get('[data-testid="permanently-remove-image-button"]').trigger('click');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.removeError = { value: null };
+  h.onDone = undefined;
+});
+
+describe('PermanentlyRemoveImageButton', () => {
+  it('keeps the modal closed until the button is clicked', () => {
+    const wrapper = mountButton();
+
+    expect(modal(wrapper).props('open')).toBe(false);
+  });
+
+  it('opens the confirmation modal when the button is clicked', async () => {
+    const wrapper = mountButton();
+
+    await clickButton(wrapper);
+
+    expect(modal(wrapper).props('open')).toBe(true);
+  });
+
+  it('does not open the modal when disabled', async () => {
+    const wrapper = mountButton({ disabled: true });
+
+    await clickButton(wrapper);
+
+    expect(modal(wrapper).props('open')).toBe(false);
+  });
+
+  it('disables the confirm button until an explanation is entered', () => {
+    const wrapper = mountButton();
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(true);
+  });
+
+  it('enables the confirm button once an explanation is entered', async () => {
+    const wrapper = mountButton();
+
+    await editor(wrapper).vm.$emit('update', 'Copyright violation');
+
+    expect(modal(wrapper).props('primaryButtonDisabled')).toBe(false);
+  });
+
+  it('submits with the image id and explanation', async () => {
+    const wrapper = mountButton();
+    await editor(wrapper).vm.$emit('update', 'Copyright violation');
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.remove).toHaveBeenCalledWith({
+      imageId: 'image-1',
+      explanation: 'Copyright violation',
+    });
+  });
+
+  it('does not submit when the explanation is empty', async () => {
+    const wrapper = mountButton();
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.remove).not.toHaveBeenCalled();
+  });
+
+  it('refetches the issue after a successful removal', () => {
+    mountButton();
+
+    h.onDone?.();
+
+    expect(h.refetchQueries).toHaveBeenCalled();
+  });
+
+  it('emits removed-successfully after a successful removal', () => {
+    const wrapper = mountButton();
+
+    h.onDone?.();
+
+    expect(wrapper.emitted('removed-successfully')).toBeTruthy();
+  });
+});

--- a/components/mod/PermanentlyRemoveImageButton.vue
+++ b/components/mod/PermanentlyRemoveImageButton.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useApolloClient, useMutation } from '@vue/apollo-composable';
+import GenericModal from '@/components/GenericModal.vue';
+import Notification from '@/components/NotificationComponent.vue';
+import TrashIcon from '@/components/icons/TrashIcon.vue';
+import TextEditor from '@/components/TextEditor.vue';
+import { PERMANENTLY_REMOVE_IMAGE } from '@/graphQLData/issue/mutations';
+import { GET_ISSUE } from '@/graphQLData/issue/queries';
+
+const props = defineProps({
+  imageId: {
+    type: String,
+    required: true,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['removed-successfully']);
+
+const showModal = ref(false);
+const showSuccess = ref(false);
+const explanation = ref('');
+
+const { client } = useApolloClient();
+
+const {
+  mutate: permanentlyRemoveImage,
+  loading: permanentlyRemoveImageLoading,
+  error: permanentlyRemoveImageError,
+  onDone: permanentlyRemoveImageDone,
+} = useMutation(PERMANENTLY_REMOVE_IMAGE);
+
+permanentlyRemoveImageDone(() => {
+  // Refresh the issue so the newly recorded permanent-removal action and the
+  // closed-issue state appear in the activity feed.
+  client.refetchQueries({ include: [GET_ISSUE] });
+  showModal.value = false;
+  explanation.value = '';
+  showSuccess.value = true;
+  emit('removed-successfully');
+});
+
+const openModal = () => {
+  if (props.disabled) {
+    return;
+  }
+  showModal.value = true;
+};
+
+const closeModal = () => {
+  if (permanentlyRemoveImageLoading.value) {
+    return;
+  }
+  showModal.value = false;
+  explanation.value = '';
+};
+
+const submit = () => {
+  if (!explanation.value.trim()) {
+    return;
+  }
+  permanentlyRemoveImage({
+    imageId: props.imageId,
+    explanation: explanation.value,
+  });
+};
+</script>
+
+<template>
+  <button
+    data-testid="permanently-remove-image-button"
+    class="font-semibold flex items-center justify-center gap-2 rounded px-3 py-1.5 text-sm text-white transition"
+    :class="{
+      'cursor-pointer bg-red-600 hover:bg-red-500': !disabled,
+      'cursor-not-allowed bg-gray-500': disabled,
+    }"
+    :disabled="disabled"
+    @click="openModal"
+  >
+    <TrashIcon class="h-4 w-4" />
+    Permanently remove image
+  </button>
+  <GenericModal
+    data-testid="permanently-remove-image-modal"
+    :highlight-color="'red'"
+    :title="'Permanently remove image'"
+    :body="'This permanently removes the image and cannot be undone. A moderation record of this action will be created on the issue.'"
+    :open="showModal"
+    :primary-button-text="'Permanently remove'"
+    :secondary-button-text="'Cancel'"
+    :loading="permanentlyRemoveImageLoading"
+    :primary-button-disabled="!explanation.trim()"
+    :error="permanentlyRemoveImageError?.message"
+    @primary-button-click="submit"
+    @close="closeModal"
+  >
+    <template #icon>
+      <TrashIcon
+        class="h-6 w-6 text-red-600 opacity-100 dark:text-red-400"
+        aria-hidden="true"
+      />
+    </template>
+    <template #content>
+      <h2 class="mt-4 text-sm text-gray-500 dark:text-gray-400">
+        Explain why this image is being permanently removed:
+      </h2>
+      <TextEditor
+        test-id="permanently-remove-image-input"
+        :initial-value="explanation"
+        :placeholder="'Describe why this image violates the rules and is being permanently removed'"
+        :disable-auto-focus="false"
+        :allow-image-upload="false"
+        @update="explanation = $event"
+      />
+    </template>
+  </GenericModal>
+  <Notification
+    :show="showSuccess"
+    :title="'The image was permanently removed.'"
+    @close-notification="showSuccess = false"
+  />
+</template>

--- a/graphQLData/admin/queries.js
+++ b/graphQLData/admin/queries.js
@@ -49,6 +49,7 @@ export const GET_SERVER_CONFIG = gql`
         canCloseSupportTickets
         canReport
         canSuspendUser
+        canPermanentlyRemoveImage
       }
       DefaultElevatedModRole {
         name
@@ -66,6 +67,7 @@ export const GET_SERVER_CONFIG = gql`
         canCloseSupportTickets
         canReport
         canSuspendUser
+        canPermanentlyRemoveImage
       }
       DefaultSuspendedRole {
         name

--- a/graphQLData/channel/queries.js
+++ b/graphQLData/channel/queries.js
@@ -189,6 +189,7 @@ export const GET_CHANNEL = gql`
         canCloseSupportTickets
         canReport
         canSuspendUser
+        canPermanentlyRemoveImage
       }
       ElevatedModRole {
         canHideComment
@@ -203,6 +204,7 @@ export const GET_CHANNEL = gql`
         canCloseSupportTickets
         canReport
         canSuspendUser
+        canPermanentlyRemoveImage
       }
       SuspendedModRole {
         canHideComment

--- a/graphQLData/issue/mutations.js
+++ b/graphQLData/issue/mutations.js
@@ -520,3 +520,12 @@ export const UNARCHIVE_IMAGE = gql`
     }
   }
 `;
+
+export const PERMANENTLY_REMOVE_IMAGE = gql`
+  mutation permanentlyRemoveImage($imageId: ID!, $explanation: String) {
+    permanentlyRemoveImage(imageId: $imageId, explanation: $explanation) {
+      id
+      issueNumber
+    }
+  }
+`;

--- a/tests/unit/utils/headerPermissionUtils.spec.ts
+++ b/tests/unit/utils/headerPermissionUtils.spec.ts
@@ -28,6 +28,7 @@ const createBasePermissions = (
   canCloseSupportTickets: false,
   canLockChannel: false,
   canDeleteWiki: false,
+  canPermanentlyRemoveImage: false,
   // Additional permission keys
   canEditWiki: false,
   canAddMods: false,

--- a/utils/permissionUtils.spec.ts
+++ b/utils/permissionUtils.spec.ts
@@ -101,6 +101,41 @@ describe('permissionUtils', () => {
     expect(permissions.canReport).toBe(false);
   });
 
+  it('resolves canPermanentlyRemoveImage from the mod role', () => {
+    const permissions = getAllPermissions({
+      permissionData: {
+        Moderators: [],
+      },
+      standardModRole: {
+        canPermanentlyRemoveImage: true,
+      },
+      elevatedModRole: null,
+      username: 'user-one',
+      modProfileName: 'mod-one',
+    });
+
+    expect(permissions.canPermanentlyRemoveImage).toBe(true);
+  });
+
+  it('denies canPermanentlyRemoveImage to a suspended mod', () => {
+    const permissions = getAllPermissions({
+      permissionData: {
+        Moderators: [{ displayName: 'mod-one' }],
+        SuspendedMods: [{ modProfileName: 'mod-one' }],
+      },
+      standardModRole: {
+        canPermanentlyRemoveImage: true,
+      },
+      elevatedModRole: {
+        canPermanentlyRemoveImage: true,
+      },
+      username: 'user-one',
+      modProfileName: 'mod-one',
+    });
+
+    expect(permissions.canPermanentlyRemoveImage).toBe(false);
+  });
+
   it('marks the mod profile as suspended when it appears in SuspendedMods', () => {
     const permissions = getAllPermissions({
       permissionData: {

--- a/utils/permissionUtils.ts
+++ b/utils/permissionUtils.ts
@@ -25,6 +25,7 @@ type ModPermissionKey = keyof Pick<
   | 'canCloseSupportTickets'
   | 'canLockChannel'
   | 'canDeleteWiki'
+  | 'canPermanentlyRemoveImage'
 >;
 
 // User permission keys
@@ -54,6 +55,7 @@ export const CORE_PERMISSION_KEYS = [
   'canCloseSupportTickets',
   'canLockChannel',
   'canDeleteWiki',
+  'canPermanentlyRemoveImage',
 ] as const;
 
 export const ADDITIONAL_PERMISSION_KEYS = [
@@ -258,6 +260,7 @@ export const getAllPermissions = (
       canCloseSupportTickets: false,
       canLockChannel: false,
       canDeleteWiki: false,
+      canPermanentlyRemoveImage: false,
       canEditWiki: false,
       canAddMods: false,
       canRemoveMods: false,


### PR DESCRIPTION
## Summary

Fixes #182. The backend has supported `permanentlyRemoveImage(imageId, explanation)` — an admin/mod action gated by the server-level `canPermanentlyRemoveImage` permission that records a `permanent-removal` moderation action and closes the image issue — but the frontend had **no corresponding mutation or UI**. This wires up the moderator flow end to end.

## Changes

1. **Mutation** — add `PERMANENTLY_REMOVE_IMAGE` to `graphQLData/issue/mutations.js` (`imageId: ID!`, `explanation: String`), returning `{ id issueNumber }`.
2. **Permission plumbing** — add `canPermanentlyRemoveImage` to the permission key lists/types in `utils/permissionUtils.ts`, and select it in the `GET_SERVER_CONFIG` (`DefaultModRole` / `DefaultElevatedModRole`) and `GET_CHANNEL` (`DefaultModRole` / `ElevatedModRole`) selection sets so the flag is resolved client-side by `useResolvedModPermissions`.
3. **New component** `components/mod/PermanentlyRemoveImageButton.vue` — an admin-gated red button that opens a confirmation modal requiring an explanation, runs the mutation (loading/error surfaced via `GenericModal`), refetches `GET_ISSUE` so the recorded action and closed-issue state appear in the activity feed, and shows a success notification. Follows existing patterns (`ArchiveButton.vue`, `ReportChannelImageModal.vue`).
4. **Wiring** — mount it in `IssueRelatedContent.vue` for image issues, gated on the `canPermanentlyRemoveImage` flag threaded from `IssueDetail.vue` (also disabled for suspended mods / when mod actions are hidden), and re-emit success up so the issue's activity feed refreshes.

## Scope note

The separate **owner-facing** `permanentlyDeleteImage` flow (an uploader deleting their own image — which the backend already permits via `uploadedByUsername === username`, already wired in `AlbumEditor.vue`) is a distinct capability and is **not** touched here. This PR adds the missing **moderator** "permanently remove" action.

## Testing

- `pnpm run test:unit` — full suite passes (**6936 tests**), including 9 new `PermanentlyRemoveImageButton` tests (open/confirm/submit/disabled/refetch/emit) and 2 new permission-resolution tests.
- `pnpm run tsc` — no type errors.
- `pnpm exec eslint` — clean.

Live end-to-end exercise of this flow requires the backend and an admin session, so it's covered here by unit tests — consistent with the repo's existing image-moderation unit coverage (see #200 for the tracked e2e gap).

## Files changed

- `graphQLData/issue/mutations.js` — new mutation
- `utils/permissionUtils.ts` — new permission flag (+ spec)
- `graphQLData/admin/queries.js`, `graphQLData/channel/queries.js` — select the flag on mod roles
- `components/mod/PermanentlyRemoveImageButton.vue` (+ spec) — the button + confirm modal
- `components/mod/IssueRelatedContent.vue`, `components/mod/IssueDetail.vue` — mount + gate
- `tests/unit/utils/headerPermissionUtils.spec.ts` — base permission object updated for the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzHtVwJgY3x67KbyWuZmnS)_