### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,48 @@
+name: PR Title
+
+# Enforce Conventional Commits on the PR *title*, because the repo squash-merges
+# and the PR title becomes the squash commit subject on `main`. Validating the
+# title here keeps `main`'s history conventional even though there is no local
+# commit-msg hook.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed conventional-commit types (matches the types already used in
+          # this repo's history). Keep in sync with any release tooling.
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Scope is optional; when present it must be lower-case / kebab-case.
+          requireScope: false
+          # Disallow a title that is just a bare type, e.g. "chore:".
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" is invalid: it must not be empty and must not
+            start with an upper-case letter (e.g. use "fix(markdown): keep table
+            cell words whole", not "Fix Table").


### PR DESCRIPTION
## What

Adds a CI check that validates every PR **title** against Conventional Commits, using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request).

## Why the title (not commits)

This repo squash-merges, so the **PR title becomes the squash commit subject on `main`**. There's no local `commit-msg` hook (only a `pre-commit` lint-staged hook), so individual commit messages aren't gated — the title is the thing that actually lands on `main`. Validating it here keeps `main`'s history conventional.

## Behavior

- Runs on PR `opened` / `edited` / `reopened` / `synchronize` — so fixing the title re-runs the check without a new push.
- Allowed types match the repo's existing history: `feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert`.
- Scope optional; subject must be non-empty and not start with an upper-case letter.
- Read-only token (`pull-requests: read`); sets a status check, posts no comments.

## ⚠️ One required repo setting (maintainer action, not in this PR)

For the check to actually protect `main`, the squash commit must use the PR title. In **Settings → General → Pull Requests**, set **"Default to pull request title"** for squash merge commit messages. (Optionally add the PR-title check to branch-protection required checks.)

I can set that via `gh api` if you'd like — it's a repo-settings change, so I'll only do it with your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)