### PR TITLE
fix: remove server-only permission from channel query

### DIFF
--- a/graphQLData/channel/queries.js
+++ b/graphQLData/channel/queries.js
@@ -189,7 +189,6 @@ export const GET_CHANNEL = gql`
         canCloseSupportTickets
         canReport
         canSuspendUser
-        canPermanentlyRemoveImage
       }
       ElevatedModRole {
         canHideComment
@@ -204,7 +203,6 @@ export const GET_CHANNEL = gql`
         canCloseSupportTickets
         canReport
         canSuspendUser
-        canPermanentlyRemoveImage
       }
       SuspendedModRole {
         canHideComment

--- a/tests/unit/channelQueries.spec.ts
+++ b/tests/unit/channelQueries.spec.ts
@@ -1,0 +1,15 @@
+import { print } from 'graphql';
+import { describe, expect, it } from 'vitest';
+
+import { GET_SERVER_CONFIG } from '../../graphQLData/admin/queries';
+import { GET_CHANNEL } from '../../graphQLData/channel/queries';
+
+describe('channel role queries', () => {
+  it('does not request server-only permissions from channel moderator roles', () => {
+    expect(print(GET_CHANNEL)).not.toContain('canPermanentlyRemoveImage');
+  });
+
+  it('requests permanent image removal through the server configuration', () => {
+    expect(print(GET_SERVER_CONFIG)).toContain('canPermanentlyRemoveImage');
+  });
+});


### PR DESCRIPTION
## Summary
- stop requesting the server-only permanent image removal permission from channel moderator roles
- keep the permission in the server configuration query
- add regression coverage for the schema boundary

## Production impact
This fixes channel and download SSR failures caused by GraphQL rejecting GET_CHANNEL with a 400 response.

## Verification
- pnpm exec vitest run tests/unit/channelQueries.spec.ts
- pnpm exec eslint tests/unit/channelQueries.spec.ts graphQLData/channel/queries.js
- pnpm run tsc