### PR TITLE
feat: require flairs in channel discussion form

### DIFF
--- a/components/discussion/form/CreateDiscussion.spec.ts
+++ b/components/discussion/form/CreateDiscussion.spec.ts
@@ -3,15 +3,32 @@ import { mount } from '@vue/test-utils';
 import { ref } from 'vue';
 import CreateDiscussion from '@/components/discussion/form/CreateDiscussion.vue';
 import { useUsername } from '@/composables/useAuthState';
-import type { Mutation } from '@/__generated__/graphql';
+import type { DiscussionCreateInput, Mutation } from '@/__generated__/graphql';
 
 type CreateDiscussionResult = {
   data?: Pick<Mutation, 'createDiscussionWithChannelConnections'>;
 };
 
-const { mockUsername } = await vi.hoisted(async () => {
+type CreateMutationOptions = {
+  variables: {
+    input: Array<{
+      discussionCreateInput: DiscussionCreateInput;
+      channelConnections: string[];
+      channelFlairSelections: Array<{
+        channelUniqueName: string;
+        flairIds: string[];
+      }>;
+    }>;
+  };
+  update: (cache: unknown, result: unknown) => void;
+};
+
+const { mockUsername, mockFlairConfigResult } = await vi.hoisted(async () => {
   const { ref } = await import('vue');
-  return { mockUsername: ref('alice') };
+  return {
+    mockUsername: ref('alice'),
+    mockFlairConfigResult: ref<Record<string, unknown> | null>(null),
+  };
 });
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => mockUsername,
@@ -21,7 +38,7 @@ vi.mock('@/composables/useAuthState', () => ({
 const mockPush = vi.fn();
 const onDoneCallbacks: Array<(result: CreateDiscussionResult) => void> = [];
 const createMutate = vi.fn();
-let capturedCreateOptions: (() => any) | null = null;
+let capturedCreateOptions: (() => CreateMutationOptions) | null = null;
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({
@@ -34,7 +51,7 @@ vi.mock('nuxt/app', () => ({
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
-  useMutation: vi.fn((_doc: unknown, optsFn: () => any) => {
+  useMutation: vi.fn((_doc: unknown, optsFn: () => CreateMutationOptions) => {
     capturedCreateOptions = optsFn;
     return {
       mutate: createMutate,
@@ -45,8 +62,12 @@ vi.mock('@vue/apollo-composable', () => ({
       },
     };
   }),
-  useQuery: vi.fn(() => ({
-    result: ref(null),
+  useQuery: vi.fn((document: { definitions?: Array<{ name?: { value?: string } }> }) => ({
+    result:
+      document.definitions?.[0]?.name?.value ===
+      'getChannelDiscussionFlairConfig'
+        ? mockFlairConfigResult
+        : ref(null),
     loading: ref(false),
     error: ref(null),
   })),
@@ -65,6 +86,7 @@ describe('CreateDiscussion', () => {
   beforeEach(() => {
     onDoneCallbacks.length = 0;
     mockPush.mockReset();
+    mockFlairConfigResult.value = null;
     useUsername().value = 'alice';
   });
 
@@ -144,12 +166,19 @@ describe('CreateDiscussion — builder, cache, handlers', () => {
     mockPush.mockReset();
     createMutate.mockReset();
     capturedCreateOptions = null;
+    mockFlairConfigResult.value = null;
     useUsername().value = 'alice';
   });
 
   const fieldsStub = {
     name: 'CreateEditDiscussionFields',
-    props: ['submitError', 'formValues', 'lockedChannelName'],
+    props: [
+      'submitError',
+      'formValues',
+      'lockedChannelName',
+      'discussionFlairs',
+      'discussionFlairRequired',
+    ],
     template:
       '<button data-testid="submit" @click="$emit(\'submit\')"></button>',
     emits: ['submit', 'update-form-values'],
@@ -169,6 +198,8 @@ describe('CreateDiscussion — builder, cache, handlers', () => {
     wrapper.findComponent({ name: 'CreateEditDiscussionFields' });
   const buildInput = () =>
     capturedCreateOptions!().variables.input[0].discussionCreateInput;
+  const buildChannelFlairSelections = () =>
+    capturedCreateOptions!().variables.input[0].channelFlairSelections;
 
   it('submits the create mutation for an authenticated user', async () => {
     const wrapper = mountCD();
@@ -228,6 +259,44 @@ describe('CreateDiscussion — builder, cache, handlers', () => {
     await fields(wrapper).vm.$emit('update-form-values', { crosspostId: 'src-1' });
 
     expect(buildInput().CrosspostedDiscussion).toBeTruthy();
+  });
+
+  it('submits the selected flair IDs for the routed channel', async () => {
+    mockFlairConfigResult.value = {
+      getChannelDiscussionFlairConfig: {
+        channelUniqueName: 'cats',
+        flairRequired: true,
+        flairs: [{ id: 'question', displayName: 'Question', color: '#2563EB' }],
+      },
+    };
+    const wrapper = mountCD();
+    await fields(wrapper).vm.$emit('update-form-values', {
+      selectedFlairIdsByChannel: { cats: ['question'] },
+    });
+
+    expect(buildChannelFlairSelections()).toEqual([
+      { channelUniqueName: 'cats', flairIds: ['question'] },
+    ]);
+  });
+
+  it('blocks submission when the routed channel requires a flair', async () => {
+    mockFlairConfigResult.value = {
+      getChannelDiscussionFlairConfig: {
+        channelUniqueName: 'cats',
+        flairRequired: true,
+        flairs: [{ id: 'question', displayName: 'Question', color: '#2563EB' }],
+      },
+    };
+    const wrapper = mountCD();
+    await wrapper.find('[data-testid="submit"]').trigger('click');
+
+    expect({
+      mutationCalls: createMutate.mock.calls.length,
+      error: fields(wrapper).props('submitError'),
+    }).toEqual({
+      mutationCalls: 0,
+      error: 'Select at least one flair for cats.',
+    });
   });
 
   it('writes the new discussion into the channel list cache', () => {

--- a/components/discussion/form/CreateDiscussion.vue
+++ b/components/discussion/form/CreateDiscussion.vue
@@ -22,6 +22,8 @@ import { useRouter, useRoute } from 'nuxt/app';
 import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
 import { useForumLock } from '@/composables/useForumLock';
 import { useUsername } from '@/composables/useAuthState';
+import { GET_CHANNEL_DISCUSSION_FLAIR_CONFIG } from '@/graphQLData/channel/queries';
+import type { DiscussionFlairOption } from '@/components/discussion/form/DiscussionFlairPicker.vue';
 
 const usernameVar = useUsername();
 
@@ -48,6 +50,7 @@ const createDiscussionDefaultValues: CreateEditDiscussionFormValues = {
   title: '',
   body: '',
   selectedChannels: channelId.value ? [channelId.value] : [],
+  selectedFlairIdsByChannel: {},
   selectedTags: [],
   author: usernameVar.value,
   album: {
@@ -58,6 +61,37 @@ const createDiscussionDefaultValues: CreateEditDiscussionFormValues = {
 };
 
 const formValues = ref(createDiscussionDefaultValues);
+
+type ChannelDiscussionFlairConfig = {
+  channelUniqueName: string;
+  flairRequired: boolean;
+  flairs: DiscussionFlairOption[];
+};
+
+const {
+  result: flairConfigResult,
+  loading: discussionFlairsLoading,
+  error: discussionFlairsQueryError,
+} = useQuery(
+  GET_CHANNEL_DISCUSSION_FLAIR_CONFIG,
+  () => ({
+    channelUniqueName: channelId.value,
+    includeArchived: false,
+  }),
+  { enabled: computed(() => Boolean(channelId.value)) }
+);
+
+const flairConfig = computed<ChannelDiscussionFlairConfig | null>(
+  () => flairConfigResult.value?.getChannelDiscussionFlairConfig || null
+);
+
+const channelFlairSelections = computed(() => {
+  const flairIds =
+    formValues.value.selectedFlairIdsByChannel?.[channelId.value] || [];
+  return flairIds.length > 0
+    ? [{ channelUniqueName: channelId.value, flairIds }]
+    : [];
+});
 
 watch(
   () => crosspostDiscussionId.value,
@@ -192,6 +226,7 @@ const {
       {
         discussionCreateInput: discussionCreateInput.value,
         channelConnections: channelConnections.value,
+        channelFlairSelections: channelFlairSelections.value,
       },
     ],
   },
@@ -287,6 +322,22 @@ function submit() {
     submitError.value = lockError.value;
     return;
   }
+  if (discussionFlairsLoading.value) {
+    submitError.value = 'Wait for the forum flair options to finish loading.';
+    return;
+  }
+  if (discussionFlairsQueryError.value) {
+    submitError.value =
+      'Unable to load the forum flair options. Please try again.';
+    return;
+  }
+  if (
+    flairConfig.value?.flairRequired &&
+    channelFlairSelections.value.length === 0
+  ) {
+    submitError.value = `Select at least one flair for ${channelId.value}.`;
+    return;
+  }
   createDiscussion();
 }
 
@@ -348,6 +399,10 @@ function updateFormValues(data: Partial<CreateEditDiscussionFormValues>) {
         :crosspost-loading="crosspostPreviewLoading"
         :locked-channel-name="channelId || undefined"
         :locked-channel-label="channelId || undefined"
+        :discussion-flairs="flairConfig?.flairs || []"
+        :discussion-flair-required="flairConfig?.flairRequired || false"
+        :discussion-flairs-loading="discussionFlairsLoading"
+        :discussion-flairs-error="discussionFlairsQueryError?.message"
         @submit="submit"
         @update-form-values="updateFormValues"
       />

--- a/components/discussion/form/CreateEditDiscussionFields.spec.ts
+++ b/components/discussion/form/CreateEditDiscussionFields.spec.ts
@@ -56,6 +56,19 @@ const mockComponents = {
     props: ['selectedChannels', 'testId', 'lockedChannelName', 'lockedChannelLabel'],
     emits: ['setSelectedChannels'],
   },
+  DiscussionFlairPicker: {
+    name: 'DiscussionFlairPicker',
+    template: '<button data-testid="flair-picker" />',
+    props: [
+      'channelUniqueName',
+      'flairs',
+      'modelValue',
+      'required',
+      'loading',
+      'errorMessage',
+    ],
+    emits: ['update:modelValue'],
+  },
   ErrorBanner: {
     template:
       '<div class="error-banner" data-testid="error-banner">{{ text }}</div>',
@@ -191,6 +204,38 @@ describe('CreateEditDiscussionFields Component', () => {
       }).toEqual({
         lockedChannelName: 'cats',
         lockedChannelLabel: 'Cats',
+      });
+    });
+
+    it('maps the routed forum flair selection into form values', async () => {
+      const wrapper = mount(CreateEditDiscussionFields, {
+        props: {
+          editMode: false,
+          downloadMode: false,
+          formValues: {
+            ...defaultFormValues,
+            title: 'Question about cats',
+            selectedChannels: ['cats'],
+            selectedFlairIdsByChannel: { cats: [] },
+          },
+          lockedChannelName: 'cats',
+          discussionFlairs: [
+            { id: 'question', displayName: 'Question', color: '#2563EB' },
+          ],
+          discussionFlairRequired: true,
+        },
+        global: { stubs: mockComponents },
+      });
+      const picker = wrapper.findComponent({ name: 'DiscussionFlairPicker' });
+      picker.vm.$emit('update:modelValue', ['question']);
+      await nextTick();
+
+      expect({
+        pickerRequired: picker.props('required'),
+        update: wrapper.emitted('updateFormValues')?.[0],
+      }).toEqual({
+        pickerRequired: true,
+        update: [{ selectedFlairIdsByChannel: { cats: ['question'] } }],
       });
     });
 

--- a/components/discussion/form/CreateEditDiscussionFields.vue
+++ b/components/discussion/form/CreateEditDiscussionFields.vue
@@ -22,6 +22,8 @@ import AlbumEditForm from '../detail/AlbumEditForm.vue';
 import DownloadEditForm from './DownloadEditForm.vue';
 import type { Channel, Discussion } from '@/__generated__/graphql';
 import CrosspostedDiscussionEmbed from '@/components/discussion/detail/CrosspostedDiscussionEmbed.vue';
+import DiscussionFlairPicker from '@/components/discussion/form/DiscussionFlairPicker.vue';
+import type { DiscussionFlairOption } from '@/components/discussion/form/DiscussionFlairPicker.vue';
 
 const props = defineProps<{
   editMode: boolean;
@@ -45,6 +47,10 @@ const props = defineProps<{
   crosspostLoading?: boolean;
   lockedChannelName?: string;
   lockedChannelLabel?: string;
+  discussionFlairs?: DiscussionFlairOption[];
+  discussionFlairRequired?: boolean;
+  discussionFlairsLoading?: boolean;
+  discussionFlairsError?: string;
 }>();
 
 defineEmits(['submit', 'updateFormValues', 'cancel']);
@@ -70,7 +76,31 @@ const discussionFormValidationInput = computed(() => ({
   selectedChannelsCount: props.formValues?.selectedChannels?.length || 0,
   title: props.formValues?.title || '',
   body: props.formValues?.body || '',
+  flairSelectionPending: props.discussionFlairsLoading,
+  flairSelectionUnavailable: Boolean(props.discussionFlairsError),
+  missingRequiredFlair:
+    props.discussionFlairRequired === true &&
+    (props.formValues?.selectedFlairIdsByChannel?.[
+      props.lockedChannelName || ''
+    ]?.length || 0) === 0,
+  requiredFlairChannelName: props.lockedChannelLabel || props.lockedChannelName,
 }));
+
+const selectedFlairIds = computed(
+  () =>
+    props.formValues?.selectedFlairIdsByChannel?.[
+      props.lockedChannelName || ''
+    ] || []
+);
+
+const showDiscussionFlairs = computed(
+  () =>
+    Boolean(props.lockedChannelName) &&
+    (props.discussionFlairsLoading ||
+      props.discussionFlairsError ||
+      props.discussionFlairRequired ||
+      (props.discussionFlairs?.length || 0) > 0)
+);
 
 const needsChanges = computed(() =>
   discussionFormNeedsChanges(discussionFormValidationInput.value)
@@ -304,6 +334,30 @@ onMounted(() => {
                   "
                   @set-selected-channels="
                     $emit('updateFormValues', { selectedChannels: $event })
+                  "
+                />
+              </template>
+            </FormRow>
+
+            <FormRow
+              v-if="showDiscussionFlairs"
+              :required="discussionFlairRequired"
+            >
+              <template #content>
+                <DiscussionFlairPicker
+                  :channel-unique-name="lockedChannelLabel || lockedChannelName || ''"
+                  :flairs="discussionFlairs || []"
+                  :model-value="selectedFlairIds"
+                  :required="discussionFlairRequired"
+                  :loading="discussionFlairsLoading"
+                  :error-message="discussionFlairsError"
+                  @update:model-value="
+                    $emit('updateFormValues', {
+                      selectedFlairIdsByChannel: {
+                        ...(formValues.selectedFlairIdsByChannel || {}),
+                        [lockedChannelName || '']: $event,
+                      },
+                    })
                   "
                 />
               </template>

--- a/components/discussion/form/DiscussionFlairPicker.spec.ts
+++ b/components/discussion/form/DiscussionFlairPicker.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import DiscussionFlairPicker from './DiscussionFlairPicker.vue';
+
+const flairs = [
+  { id: 'question', displayName: 'Question', color: '#2563EB' },
+  { id: 'guide', displayName: 'Guide', color: '#16A34A' },
+];
+
+const mountPicker = (modelValue: string[] = []) =>
+  mount(DiscussionFlairPicker, {
+    props: {
+      channelUniqueName: 'cats',
+      flairs,
+      modelValue,
+      required: true,
+    },
+    global: {
+      stubs: {
+        ErrorBanner: { template: '<div />' },
+        LoadingSpinner: { template: '<span />' },
+      },
+    },
+  });
+
+describe('DiscussionFlairPicker', () => {
+  it('renders each flair as an accessible multi-select option', () => {
+    const wrapper = mountPicker(['question']);
+
+    expect(
+      wrapper.findAll('button').map((button) => ({
+        label: button.attributes('aria-label'),
+        pressed: button.attributes('aria-pressed'),
+      }))
+    ).toEqual([
+      { label: 'Remove Question flair', pressed: 'true' },
+      { label: 'Select Guide flair', pressed: 'false' },
+    ]);
+  });
+
+  it('adds a flair without discarding an existing selection', async () => {
+    const wrapper = mountPicker(['question']);
+    await wrapper.get('[aria-label="Select Guide flair"]').trigger('click');
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([
+      ['question', 'guide'],
+    ]);
+  });
+
+  it('removes a selected flair', async () => {
+    const wrapper = mountPicker(['question', 'guide']);
+    await wrapper.get('[aria-label="Remove Question flair"]').trigger('click');
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([['guide']]);
+  });
+});

--- a/components/discussion/form/DiscussionFlairPicker.vue
+++ b/components/discussion/form/DiscussionFlairPicker.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import ErrorBanner from '@/components/ErrorBanner.vue';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+
+export type DiscussionFlairOption = {
+  id: string;
+  displayName: string;
+  color?: string | null;
+};
+
+const props = defineProps<{
+  channelUniqueName: string;
+  flairs: DiscussionFlairOption[];
+  modelValue: string[];
+  required?: boolean;
+  loading?: boolean;
+  errorMessage?: string;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [flairIds: string[]];
+}>();
+
+const toggleFlair = (flairId: string) => {
+  const selected = new Set(props.modelValue);
+  if (selected.has(flairId)) {
+    selected.delete(flairId);
+  } else {
+    selected.add(flairId);
+  }
+  emit('update:modelValue', [...selected]);
+};
+</script>
+
+<template>
+  <fieldset class="space-y-2" :aria-required="required">
+    <legend class="text-sm font-medium text-gray-900 dark:text-gray-100">
+      Post flair
+      <span v-if="required" class="text-red-600 dark:text-red-400">
+        (required)
+      </span>
+    </legend>
+    <p class="text-sm text-gray-600 dark:text-gray-400">
+      Select one or more categories for {{ channelUniqueName }}.
+    </p>
+
+    <div
+      v-if="loading"
+      class="flex items-center py-2 text-sm text-gray-600 dark:text-gray-300"
+    >
+      <LoadingSpinner class="mr-2" />
+      Loading flair options...
+    </div>
+    <ErrorBanner v-else-if="errorMessage" :text="errorMessage" />
+    <div v-else class="flex flex-wrap gap-2" data-testid="flair-picker">
+      <button
+        v-for="flair in flairs"
+        :key="flair.id"
+        type="button"
+        class="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+        :class="
+          modelValue.includes(flair.id)
+            ? 'border-orange-600 bg-orange-50 text-orange-800 dark:bg-orange-900/30 dark:text-orange-100'
+            : 'border-gray-300 bg-white text-gray-700 hover:border-orange-400 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200'
+        "
+        :aria-pressed="modelValue.includes(flair.id)"
+        :aria-label="`${modelValue.includes(flair.id) ? 'Remove' : 'Select'} ${flair.displayName} flair`"
+        @click="toggleFlair(flair.id)"
+      >
+        <span
+          v-if="flair.color"
+          class="h-3 w-3 rounded-full border border-black/10"
+          :style="{ backgroundColor: flair.color }"
+          aria-hidden="true"
+        />
+        {{ flair.displayName }}
+      </button>
+    </div>
+  </fieldset>
+</template>

--- a/tests/playwright/helpers/mockedDiscussionHandlers.ts
+++ b/tests/playwright/helpers/mockedDiscussionHandlers.ts
@@ -34,11 +34,16 @@ export type MockDiscussionState = {
 export type DiscussionState = {
   discussions: MockDiscussionState[];
   nextDiscussionId: number;
+  lastChannelFlairSelections: Array<{
+    channelUniqueName: string;
+    flairIds: string[];
+  }>;
 };
 
 export const createDiscussionState = (): DiscussionState => ({
   discussions: [],
   nextDiscussionId: 1,
+  lastChannelFlairSelections: [],
 });
 
 type CreateDiscussionVariables = {
@@ -229,13 +234,24 @@ export const createDiscussionHandlers = (
     },
 
     createDiscussion: ({ body }: { body: { variables?: CreateDiscussionVariables } }) => {
-      const input = body.variables?.input?.[0]?.discussionCreateInput;
+      const requestInput = body.variables?.input?.[0] as
+        | (DiscussionCreateInputWithChannels & {
+            channelFlairSelections?: Array<{
+              channelUniqueName: string;
+              flairIds: string[];
+            }>;
+          })
+        | undefined;
+      const input = requestInput?.discussionCreateInput;
 
       if (!input) {
         throw new Error(
           'Missing discussionCreateInput in mocked createDiscussion request'
         );
       }
+
+      state.lastChannelFlairSelections =
+        requestInput?.channelFlairSelections ?? [];
 
       const id = `discussion-${state.nextDiscussionId++}`;
       const discussionChannelId = `discussion-channel-${id}`;
@@ -367,6 +383,16 @@ export const createDiscussionHandlers = (
     getChannel: () => ({
       data: {
         channels: [buildChannel({ uniqueName: config.channelId })],
+      },
+    }),
+
+    getChannelDiscussionFlairConfig: () => ({
+      data: {
+        getChannelDiscussionFlairConfig: {
+          channelUniqueName: config.channelId,
+          flairRequired: false,
+          flairs: [],
+        },
       },
     }),
   };

--- a/tests/playwright/mocked/channels/channelLocking.spec.ts
+++ b/tests/playwright/mocked/channels/channelLocking.spec.ts
@@ -65,6 +65,15 @@ const getBaseMocks = (username: string) => ({
   getTags: () => ({
     data: { tags: [] },
   }),
+  getChannelDiscussionFlairConfig: () => ({
+    data: {
+      getChannelDiscussionFlairConfig: {
+        channelUniqueName: TEST_CHANNEL,
+        flairRequired: false,
+        flairs: [],
+      },
+    },
+  }),
   userIsModInChannel: () => ({
     data: {
       channels: [

--- a/tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts
+++ b/tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts
@@ -99,3 +99,52 @@ test('creates, edits and deletes a discussion', async ({
 
   expect(diagnostics.pageErrors).toEqual([]);
 });
+
+test('requires and submits a flair in the channel-scoped form', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createDiscussionState();
+  await setupMockedPage({
+    handlers: {
+      ...createDiscussionHandlers(state, {
+        channelId: TEST_CHANNEL,
+        username: 'cluse',
+      }),
+      getChannelDiscussionFlairConfig: () => ({
+        data: {
+          getChannelDiscussionFlairConfig: {
+            channelUniqueName: TEST_CHANNEL,
+            flairRequired: true,
+            flairs: [
+              {
+                id: 'question',
+                channelUniqueName: TEST_CHANNEL,
+                displayName: 'Question',
+                color: '#2563EB',
+                order: 0,
+                archived: false,
+              },
+            ],
+          },
+        },
+      }),
+    },
+  });
+
+  await page.goto(`/forums/${TEST_CHANNEL}/discussions/create`);
+  await page.getByTestId('title-input').fill(TEST_DISCUSSION);
+
+  const saveButton = page.getByRole('button', { name: 'Save' }).first();
+  await expect(saveButton).toBeDisabled();
+  await page.getByRole('button', { name: 'Select Question flair' }).click();
+  await expect(saveButton).toBeEnabled();
+  await saveButton.click();
+
+  await expect(page).toHaveURL(
+    `/forums/${TEST_CHANNEL}/discussions/discussion-1`
+  );
+  expect(state.lastChannelFlairSelections).toEqual([
+    { channelUniqueName: TEST_CHANNEL, flairIds: ['question'] },
+  ]);
+});

--- a/tests/playwright/mocked/suspensions/suspendedUserNotices.spec.ts
+++ b/tests/playwright/mocked/suspensions/suspendedUserNotices.spec.ts
@@ -158,6 +158,15 @@ const getBaseMocks = (username: string) => ({
   getTags: () => ({
     data: { tags: [] },
   }),
+  getChannelDiscussionFlairConfig: () => ({
+    data: {
+      getChannelDiscussionFlairConfig: {
+        channelUniqueName: TEST_CHANNEL,
+        flairRequired: false,
+        flairs: [],
+      },
+    },
+  }),
   userIsModInChannel: () => ({
     data: {
       channels: [

--- a/types/Discussion.ts
+++ b/types/Discussion.ts
@@ -3,6 +3,7 @@ export interface CreateEditDiscussionFormValues {
   body: string;
   selectedTags: Array<string>;
   selectedChannels: Array<string>;
+  selectedFlairIdsByChannel?: Record<string, string[]>;
   author: string;
   album: {
     images: {

--- a/utils/discussionFormValidation.spec.ts
+++ b/utils/discussionFormValidation.spec.ts
@@ -25,6 +25,27 @@ describe('discussionFormNeedsChanges', () => {
       true
     );
   });
+
+  it('is true while flair requirements are loading', () => {
+    expect(
+      discussionFormNeedsChanges({ ...valid, flairSelectionPending: true })
+    ).toBe(true);
+  });
+
+  it('is true when a required flair is missing', () => {
+    expect(
+      discussionFormNeedsChanges({ ...valid, missingRequiredFlair: true })
+    ).toBe(true);
+  });
+
+  it('is true when flair requirements are unavailable', () => {
+    expect(
+      discussionFormNeedsChanges({
+        ...valid,
+        flairSelectionUnavailable: true,
+      })
+    ).toBe(true);
+  });
 });
 
 describe('getDiscussionFormValidationMessage', () => {
@@ -42,5 +63,15 @@ describe('getDiscussionFormValidationMessage', () => {
 
   it('returns an empty string for a valid form', () => {
     expect(getDiscussionFormValidationMessage(valid)).toBe('');
+  });
+
+  it('identifies the forum whose required flair is missing', () => {
+    expect(
+      getDiscussionFormValidationMessage({
+        ...valid,
+        missingRequiredFlair: true,
+        requiredFlairChannelName: 'cats',
+      })
+    ).toBe('Select at least one flair for cats.');
   });
 });

--- a/utils/discussionFormValidation.ts
+++ b/utils/discussionFormValidation.ts
@@ -11,18 +11,32 @@ export type DiscussionFormValidationInput = {
   selectedChannelsCount: number;
   title: string;
   body: string;
+  flairSelectionPending?: boolean;
+  flairSelectionUnavailable?: boolean;
+  missingRequiredFlair?: boolean;
+  requiredFlairChannelName?: string;
 };
 
 /** True when the form is NOT yet submittable. */
 export function discussionFormNeedsChanges(
   input: DiscussionFormValidationInput
 ): boolean {
-  const { selectedChannelsCount, title, body } = input;
+  const {
+    selectedChannelsCount,
+    title,
+    body,
+    flairSelectionPending,
+    flairSelectionUnavailable,
+    missingRequiredFlair,
+  } = input;
   return !(
     selectedChannelsCount > 0 &&
     !!title &&
     body.length <= MAX_CHARS_IN_DISCUSSION_BODY &&
-    title.length <= DISCUSSION_TITLE_CHAR_LIMIT
+    title.length <= DISCUSSION_TITLE_CHAR_LIMIT &&
+    !flairSelectionPending &&
+    !flairSelectionUnavailable &&
+    !missingRequiredFlair
   );
 }
 
@@ -36,6 +50,15 @@ export function getDiscussionFormValidationMessage(
   }
   if (selectedChannelsCount === 0) {
     return 'Must select at least one forum.';
+  }
+  if (input.flairSelectionPending) {
+    return 'Wait for the forum flair options to finish loading.';
+  }
+  if (input.flairSelectionUnavailable) {
+    return 'Unable to load the forum flair options. Please try again.';
+  }
+  if (input.missingRequiredFlair) {
+    return `Select at least one flair for ${input.requiredFlairChannelName || 'this forum'}.`;
   }
   if (body.length > MAX_CHARS_IN_DISCUSSION_BODY) {
     return `Body cannot exceed ${MAX_CHARS_IN_DISCUSSION_BODY} characters.`;


### PR DESCRIPTION
## Summary
- load active flair options for the routed forum in the channel-scoped discussion form
- render an accessible multi-select with flair colors
- block submission while requirements are loading, unavailable, or missing a required selection
- send selected IDs through channelFlairSelections for the routed forum
- preserve sitewide discussion creation behavior for the following phase

## Validation
- pnpm run tsc
- pnpm run test:unit:run (777 files, 7,062 tests)
- focused form and flair selector unit tests (52 tests)
- pnpm exec playwright test tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts (2 tests)
- ESLint on all changed files

## Dependencies
- backend flair assignment and enforcement from PR #185
- channel flair management UI from PR #431

## Scope
This is Phase 4 of the discussion flairs project. Per-forum flair controls in the sitewide multi-forum creation form remain for the next phase.