### PR TITLE
test: raise application coverage above 90 percent

### DIFF
--- a/components/MenuButton.spec.ts
+++ b/components/MenuButton.spec.ts
@@ -26,8 +26,7 @@ const stubs = {
   },
   NuxtLink: {
     props: ['to'],
-    template:
-      '<a :href="typeof to === \'string\' ? to : to.path"><slot /></a>',
+    template: '<a :href="typeof to === \'string\' ? to : to.path"><slot /></a>',
   },
   ChevronDownIcon: true,
 };
@@ -142,8 +141,12 @@ describe('MenuButton', () => {
     });
 
     expect({
-      hasPopup: wrapper.get('[data-testid="custom"]').attributes('aria-haspopup'),
-      expanded: wrapper.get('[data-testid="custom"]').attributes('aria-expanded'),
+      hasPopup: wrapper
+        .get('[data-testid="custom"]')
+        .attributes('aria-haspopup'),
+      expanded: wrapper
+        .get('[data-testid="custom"]')
+        .attributes('aria-expanded'),
     }).toEqual({
       hasPopup: 'menu',
       expanded: 'false',
@@ -172,10 +175,8 @@ describe('MenuButton keyboard navigation', () => {
       global: { stubs },
     });
 
-  const item = (
-    wrapper: ReturnType<typeof mountAttached>,
-    label: string
-  ) => wrapper.get(`[data-testid="actions-item-${label}"]`);
+  const item = (wrapper: ReturnType<typeof mountAttached>, label: string) =>
+    wrapper.get(`[data-testid="actions-item-${label}"]`);
 
   it('keeps menu items out of the tab sequence (roving focus)', async () => {
     const wrapper = await openMenu(mountMenu({ items }));
@@ -191,7 +192,30 @@ describe('MenuButton keyboard navigation', () => {
     });
     await flushPromises();
 
-    expect(wrapper.find('[data-testid="actions-item-One"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="actions-item-One"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('opens the menu at the last item with ArrowUp', async () => {
+    const wrapper = mountAttached();
+    await wrapper.get('[data-testid="actions"]').trigger('keydown', {
+      key: 'ArrowUp',
+    });
+    await flushPromises();
+    const focused = document.activeElement === item(wrapper, 'Three').element;
+    wrapper.unmount();
+    expect(focused).toBe(true);
+  });
+
+  it('ignores trigger arrow keys when disabled', async () => {
+    const wrapper = mountMenu({ items, disabled: true });
+    await wrapper.get('[data-testid="actions"]').trigger('keydown', {
+      key: 'ArrowDown',
+    });
+    expect(wrapper.find('[data-testid="actions-item-One"]').exists()).toBe(
+      false
+    );
   });
 
   it('moves focus to the first item when the menu opens', async () => {
@@ -244,5 +268,31 @@ describe('MenuButton keyboard navigation', () => {
     wrapper.unmount();
 
     expect(result).toEqual({ stillOpen: false, triggerFocused: true });
+  });
+
+  it('supports Home, End, and Tab inside the menu', async () => {
+    const wrapper = mountAttached();
+    await wrapper.get('[data-testid="actions"]').trigger('click');
+    await flushPromises();
+    await item(wrapper, 'One').trigger('keydown', { key: 'End' });
+    await item(wrapper, 'Three').trigger('keydown', { key: 'Home' });
+    const homeFocused = document.activeElement === item(wrapper, 'One').element;
+    await item(wrapper, 'One').trigger('keydown', { key: 'Tab' });
+    const closed = !wrapper.find('[data-testid="actions-item-One"]').exists();
+    wrapper.unmount();
+    expect({ homeFocused, closed }).toEqual({
+      homeFocused: true,
+      closed: true,
+    });
+  });
+
+  it('closes when focus leaves the trigger and menu', async () => {
+    const wrapper = await openMenu(mountMenu({ items }));
+    await wrapper.get('.inline-block').trigger('focusout', {
+      relatedTarget: document.body,
+    });
+    expect(wrapper.find('[data-testid="actions-item-One"]').exists()).toBe(
+      false
+    );
   });
 });

--- a/components/MultiSelect.spec.ts
+++ b/components/MultiSelect.spec.ts
@@ -27,8 +27,9 @@ const clickOutsideDirective = {
       }
     };
     el.dataset.testClickOutsideBound = 'true';
-    (el as HTMLElement & { clickOutsideEvent?: (event: Event) => void }).clickOutsideEvent =
-      handler;
+    (
+      el as HTMLElement & { clickOutsideEvent?: (event: Event) => void }
+    ).clickOutsideEvent = handler;
     document.addEventListener('click', handler);
   },
   unmounted(el: HTMLElement) {
@@ -122,7 +123,10 @@ describe('MultiSelect', () => {
     expect(wrapper.emitted('update:modelValue')).toBeUndefined();
   });
 
-  const clickRow = async (wrapper: ReturnType<typeof mountSelect>, label: string) => {
+  const clickRow = async (
+    wrapper: ReturnType<typeof mountSelect>,
+    label: string
+  ) => {
     const row = wrapper
       .findAll('button[data-selection-control]')
       .find((r) => r.text().includes(label));
@@ -167,9 +171,9 @@ describe('MultiSelect', () => {
         .get('[data-selection-control][aria-label="Apple (a)"]')
         .trigger('keydown', { key: 'ArrowDown' });
 
-      expect((document.activeElement as HTMLElement).getAttribute('aria-label')).toBe(
-        'Banana (b)'
-      );
+      expect(
+        (document.activeElement as HTMLElement).getAttribute('aria-label')
+      ).toBe('Banana (b)');
       wrapper.unmount();
     });
 
@@ -180,9 +184,9 @@ describe('MultiSelect', () => {
         .get('[data-selection-control][aria-label="Apple (a)"]')
         .trigger('keydown', { key: 'End' });
 
-      expect((document.activeElement as HTMLElement).getAttribute('aria-label')).toBe(
-        'Cherry (c)'
-      );
+      expect(
+        (document.activeElement as HTMLElement).getAttribute('aria-label')
+      ).toBe('Cherry (c)');
       wrapper.unmount();
     });
 
@@ -190,7 +194,9 @@ describe('MultiSelect', () => {
       const wrapper = mountAttachedSelect({ modelValue: [] });
       await toggleButton(wrapper).trigger('click');
 
-      await wrapper.get('button[data-selection-control][aria-label="Apple (a)"]').trigger('click');
+      await wrapper
+        .get('button[data-selection-control][aria-label="Apple (a)"]')
+        .trigger('click');
 
       expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['a']]);
     });
@@ -198,9 +204,9 @@ describe('MultiSelect', () => {
     it('gives each selected chip a labelled remove button', () => {
       const wrapper = mountSelect({ modelValue: ['a'] });
 
-      expect(
-        wrapper.get('button[aria-label="Remove a"]').element.tagName
-      ).toBe('BUTTON');
+      expect(wrapper.get('button[aria-label="Remove a"]').element.tagName).toBe(
+        'BUTTON'
+      );
     });
 
     it('closes the popup on Escape', async () => {
@@ -210,9 +216,7 @@ describe('MultiSelect', () => {
 
       await wrapper
         .get(
-          `#${wrapper
-            .get('button[aria-controls]')
-            .attributes('aria-controls')}`
+          `#${wrapper.get('button[aria-controls]').attributes('aria-controls')}`
         )
         .trigger('keydown', { key: 'Escape' });
 
@@ -229,6 +233,75 @@ describe('MultiSelect', () => {
       expect(document.activeElement).toBe(toggleButton(wrapper).element);
       wrapper.unmount();
     });
+
+    it('closes an open popup when the toggle is clicked again', async () => {
+      const wrapper = mountSelect({ modelValue: [] });
+      await toggleButton(wrapper).trigger('click');
+      await toggleButton(wrapper).trigger('click');
+
+      expect(toggleButton(wrapper).attributes('aria-expanded')).toBe('false');
+    });
+
+    it.each([
+      ['ArrowDown', 'Apple (a)'],
+      ['ArrowUp', 'Cherry (c)'],
+    ])('opens at the expected option with %s', async (key, ariaLabel) => {
+      const wrapper = mountAttachedSelect({ modelValue: [] });
+
+      await toggleButton(wrapper).trigger('keydown', { key });
+
+      expect(
+        (document.activeElement as HTMLElement).getAttribute('aria-label')
+      ).toBe(ariaLabel);
+      wrapper.unmount();
+    });
+
+    it.each([
+      ['ArrowUp', 'Cherry (c)'],
+      ['Home', 'Apple (a)'],
+    ])('moves focus with %s inside the popup', async (key, ariaLabel) => {
+      const wrapper = mountAttachedSelect({ modelValue: [] });
+      await toggleButton(wrapper).trigger('click');
+
+      await wrapper
+        .get('[data-selection-control][aria-label="Apple (a)"]')
+        .trigger('keydown', { key });
+
+      expect(
+        (document.activeElement as HTMLElement).getAttribute('aria-label')
+      ).toBe(ariaLabel);
+      wrapper.unmount();
+    });
+
+    it.each([
+      [
+        'Escape',
+        false,
+        'Select items... Current selection: No selection. Show options',
+      ],
+      ['ArrowDown', true, 'Apple (a)'],
+      ['ArrowUp', true, 'Cherry (c)'],
+    ])(
+      'handles %s from the search input',
+      async (key, remainsOpen, ariaLabel) => {
+        const wrapper = mountAttachedSelect({
+          modelValue: [],
+          searchable: true,
+        });
+        await toggleButton(wrapper).trigger('click');
+        const input = wrapper.get('input');
+
+        await input.trigger('keydown', { key });
+
+        expect({
+          open: toggleButton(wrapper).attributes('aria-expanded') === 'true',
+          focusedOption: (document.activeElement as HTMLElement).getAttribute(
+            'aria-label'
+          ),
+        }).toEqual({ open: remainsOpen, focusedOption: ariaLabel });
+        wrapper.unmount();
+      }
+    );
   });
 
   describe('single-select mode', () => {
@@ -261,7 +334,13 @@ describe('MultiSelect', () => {
     ];
     const mountSections = (props: Record<string, unknown> = {}) =>
       mountWithDefaults(MultiSelect, {
-        props: { options: [], sections, multiple: true, testId: 'ms', ...props },
+        props: {
+          options: [],
+          sections,
+          multiple: true,
+          testId: 'ms',
+          ...props,
+        },
       });
 
     it('renders the section title and a select-all row', async () => {
@@ -274,14 +353,20 @@ describe('MultiSelect', () => {
     it('select-all selects every option in the section', async () => {
       const wrapper = mountSections({ modelValue: [] });
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      await wrapper.get('button[data-selection-control][aria-pressed="false"]').trigger('click');
-      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['a', 'b']]);
+      await wrapper
+        .get('button[data-selection-control][aria-pressed="false"]')
+        .trigger('click');
+      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([
+        ['a', 'b'],
+      ]);
     });
 
     it('select-all deselects when the section is already fully selected', async () => {
       const wrapper = mountSections({ modelValue: ['a', 'b'] });
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      const selectAll = wrapper.get('button[data-selection-control][aria-pressed="true"]');
+      const selectAll = wrapper.get(
+        'button[data-selection-control][aria-pressed="true"]'
+      );
       await selectAll.trigger('click');
       expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([[]]);
     });
@@ -397,7 +482,13 @@ describe('MultiSelect', () => {
 
     it('toggles a plain section option on row click', async () => {
       const wrapper = mountWithDefaults(MultiSelect, {
-        props: { options: [], sections: plainSection, multiple: true, testId: 'ms', modelValue: [] },
+        props: {
+          options: [],
+          sections: plainSection,
+          multiple: true,
+          testId: 'ms',
+          modelValue: [],
+        },
       });
       await wrapper.get('[data-testid="ms"]').trigger('click');
       await clickRow(wrapper, 'Apple');
@@ -408,7 +499,9 @@ describe('MultiSelect', () => {
       const wrapper = mountWithDefaults(MultiSelect, {
         props: {
           options: [],
-          sections: [{ title: 'Empty', options: [], emptyMessage: 'Nothing here' }],
+          sections: [
+            { title: 'Empty', options: [], emptyMessage: 'Nothing here' },
+          ],
           testId: 'ms',
           modelValue: [],
         },
@@ -433,31 +526,51 @@ describe('MultiSelect', () => {
     ];
     const mountBig = () =>
       mountWithDefaults(MultiSelect, {
-        props: { options: [], sections: bigSection, multiple: true, testId: 'ms', modelValue: [] },
+        props: {
+          options: [],
+          sections: bigSection,
+          multiple: true,
+          testId: 'ms',
+          modelValue: [],
+        },
       });
 
     it('collapses the preview to the first three values with a "show all" toggle', async () => {
       const wrapper = mountBig();
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      const showAll = wrapper.findAll('button').find((b) => b.text().includes('show all'));
+      const showAll = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('show all'));
       expect(showAll).toBeTruthy();
     });
 
     it('reveals all values and offers "show less" after expanding', async () => {
       const wrapper = mountBig();
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      const showAll = wrapper.findAll('button').find((b) => b.text().includes('show all'))!;
+      const showAll = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('show all'))!;
       await showAll.trigger('click');
-      const showLess = wrapper.findAll('button').find((b) => b.text().includes('show less'));
+      const showLess = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('show less'));
       expect(showLess).toBeTruthy();
     });
 
     it('collapses again when "show less" is clicked', async () => {
       const wrapper = mountBig();
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      await wrapper.findAll('button').find((b) => b.text().includes('show all'))!.trigger('click');
-      await wrapper.findAll('button').find((b) => b.text().includes('show less'))!.trigger('click');
-      const showAllAgain = wrapper.findAll('button').find((b) => b.text().includes('show all'));
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('show all'))!
+        .trigger('click');
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('show less'))!
+        .trigger('click');
+      const showAllAgain = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('show all'));
       expect(showAllAgain).toBeTruthy();
     });
   });
@@ -485,7 +598,9 @@ describe('MultiSelect', () => {
       const wrapper = mountCollection(['x', 'y']);
       await wrapper.get('[data-testid="ms"]').trigger('click');
       await clickRow(wrapper, 'My Collection');
-      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['x', 'y']]);
+      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([
+        ['x', 'y'],
+      ]);
     });
 
     it('deselects every channel when the collection is already fully selected', async () => {
@@ -502,11 +617,17 @@ describe('MultiSelect', () => {
     it('expands a collection with more than three channels and collapses again', async () => {
       const wrapper = mountCollection(['a', 'b', 'c', 'd']);
       await wrapper.get('[data-testid="ms"]').trigger('click');
-      const showMore = wrapper.findAll('button').find((b) => b.text().includes('show more'))!;
+      const showMore = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('show more'))!;
       await showMore.trigger('click');
-      const showLess = wrapper.findAll('button').find((b) => b.text().includes('show less'))!;
+      const showLess = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('show less'))!;
       await showLess.trigger('click');
-      const showMoreAgain = wrapper.findAll('button').find((b) => b.text().includes('show more'));
+      const showMoreAgain = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('show more'));
       expect(showMoreAgain).toBeTruthy();
     });
   });

--- a/components/TextEditor.mount.spec.ts
+++ b/components/TextEditor.mount.spec.ts
@@ -27,11 +27,73 @@ vi.mock('@/composables/useImageUpload', () => ({
       placeholderText: `uploading ${file.name}`,
     }),
     createImageMarkdown: (name: string, link: string) => `![${name}](${link})`,
-    createErrorMarkdown: (name: string, err: string) => `[upload error: ${name} ${err}]`,
+    createErrorMarkdown: (name: string, err: string) =>
+      `[upload error: ${name} ${err}]`,
     createPlaceholderRegex: (placeholderText: string, id: string) =>
       new RegExp(`!\\[${placeholderText} \\(id:${id}\\)\\]\\(\\)`),
     createSignedStorageUrlError: ref(null),
   }),
+}));
+
+const autocomplete = vi.hoisted(() => ({
+  botVisible: { value: false, __v_isRef: true },
+  botSuggestions: { value: [{ name: 'helper' }], __v_isRef: true },
+  botActiveIndex: { value: 0, __v_isRef: true },
+  botCaret: vi.fn(),
+  applyBot: vi.fn(),
+  moveBot: vi.fn(),
+  modVisible: { value: false, __v_isRef: true },
+  modSuggestions: { value: [{ username: 'moderator' }], __v_isRef: true },
+  modActiveIndex: { value: 0, __v_isRef: true },
+  modCaret: vi.fn(),
+  applyMod: vi.fn(),
+  moveMod: vi.fn(),
+  emojiVisible: { value: false, __v_isRef: true },
+  insertEmoji: vi.fn(),
+}));
+
+vi.mock('@/composables/useBotAutocomplete', () => ({
+  useBotAutocomplete: () => ({
+    showBotSuggestions: autocomplete.botVisible,
+    showBotHelperText: { value: false, __v_isRef: true },
+    filteredBotSuggestions: autocomplete.botSuggestions,
+    suggestionPopoverStyle: { value: {}, __v_isRef: true },
+    updateCaretCoordinates: autocomplete.botCaret,
+    applyBotSuggestion: autocomplete.applyBot,
+    activeSuggestionIndex: autocomplete.botActiveIndex,
+    moveActiveSuggestion: autocomplete.moveBot,
+  }),
+}));
+
+vi.mock('@/composables/useModAutocomplete', () => ({
+  useModAutocomplete: () => ({
+    showModSuggestions: autocomplete.modVisible,
+    showModHelperText: { value: false, __v_isRef: true },
+    filteredModSuggestions: autocomplete.modSuggestions,
+    suggestionPopoverStyle: { value: {}, __v_isRef: true },
+    updateCaretCoordinates: autocomplete.modCaret,
+    applyModSuggestion: autocomplete.applyMod,
+    activeSuggestionIndex: autocomplete.modActiveIndex,
+    moveActiveSuggestion: autocomplete.moveMod,
+  }),
+}));
+
+vi.mock('@/composables/useEmojiPicker', () => ({
+  useEmojiPicker: () => ({
+    showEmojiPicker: autocomplete.emojiVisible,
+    emojiPickerPosition: { value: {}, __v_isRef: true },
+    toggleEmojiPicker: vi.fn(),
+    closeEmojiPicker: vi.fn(),
+    insertEmoji: autocomplete.insertEmoji,
+  }),
+}));
+
+vi.mock('@/components/text-editor/EmojiPickerWrapper.vue', () => ({
+  default: {
+    name: 'EmojiPickerWrapper',
+    emits: ['emoji-click', 'close'],
+    template: '<div class="emoji-picker" />',
+  },
 }));
 
 // Mount the REAL component (not a mock). Child components are stubbed so we
@@ -56,12 +118,27 @@ const mountEditor = (props: Record<string, unknown> = {}) =>
   });
 
 describe('TextEditor (real mount)', () => {
+  beforeEach(() => {
+    autocomplete.botVisible.value = false;
+    autocomplete.modVisible.value = false;
+    autocomplete.emojiVisible.value = false;
+    autocomplete.botCaret.mockClear();
+    autocomplete.modCaret.mockClear();
+    autocomplete.applyBot.mockClear();
+    autocomplete.applyMod.mockClear();
+    autocomplete.moveBot.mockClear();
+    autocomplete.moveMod.mockClear();
+    autocomplete.insertEmoji.mockClear();
+  });
+
   it('renders the textarea seeded with initialValue', () => {
     const wrapper = mountEditor({ initialValue: 'hello world' });
 
     expect(
-      (wrapper.get('[data-testid="texteditor-textarea"]').element as HTMLTextAreaElement)
-        .value
+      (
+        wrapper.get('[data-testid="texteditor-textarea"]')
+          .element as HTMLTextAreaElement
+      ).value
     ).toBe('hello world');
   });
 
@@ -159,6 +236,77 @@ describe('TextEditor (real mount)', () => {
       expect(wrapper.emitted('update')).toBeTruthy();
     });
   });
+
+  it('updates both autocomplete caret positions when the cursor moves', async () => {
+    const wrapper = mountEditor({
+      enableBotAutocomplete: true,
+      botSuggestions: [{ name: 'helper' }],
+      enableModAutocomplete: true,
+      modSuggestions: [{ username: 'moderator' }],
+    });
+    autocomplete.botCaret.mockClear();
+    autocomplete.modCaret.mockClear();
+    await wrapper.get('textarea').trigger('keyup');
+    await flushPromises();
+    expect({
+      bot: autocomplete.botCaret.mock.calls.length,
+      mod: autocomplete.modCaret.mock.calls.length,
+    }).toEqual({ bot: 1, mod: 1 });
+  });
+
+  it.each([
+    ['Enter', autocomplete.applyBot, undefined],
+    ['ArrowDown', autocomplete.moveBot, 1],
+    ['ArrowUp', autocomplete.moveBot, -1],
+  ])('handles %s for bot autocomplete', async (key, callback, argument) => {
+    autocomplete.botVisible.value = true;
+    const wrapper = mountEditor();
+    await wrapper.get('textarea').trigger('keydown', { key });
+    expect(callback).toHaveBeenCalledWith(
+      argument === undefined ? autocomplete.botSuggestions.value[0] : argument
+    );
+  });
+
+  it.each([
+    ['Tab', autocomplete.applyMod, undefined],
+    ['ArrowDown', autocomplete.moveMod, 1],
+    ['ArrowUp', autocomplete.moveMod, -1],
+  ])(
+    'handles %s for moderator autocomplete',
+    async (key, callback, argument) => {
+      autocomplete.modVisible.value = true;
+      const wrapper = mountEditor();
+      await wrapper.get('textarea').trigger('keydown', { key });
+      expect(callback).toHaveBeenCalledWith(
+        argument === undefined ? autocomplete.modSuggestions.value[0] : argument
+      );
+    }
+  );
+
+  it('passes emoji selections to the picker composable', async () => {
+    autocomplete.emojiVisible.value = true;
+    const wrapper = mountEditor();
+    const emoji = { unicode: '🎉' };
+    await wrapper
+      .findComponent({ name: 'EmojiPickerWrapper' })
+      .vm.$emit('emoji-click', emoji);
+    expect(autocomplete.insertEmoji).toHaveBeenCalledWith(
+      expect.objectContaining({ event: emoji })
+    );
+  });
+
+  it('returns focus to the textarea when switching back to Write', async () => {
+    const focus = vi.spyOn(HTMLTextAreaElement.prototype, 'focus');
+    const wrapper = mountEditor();
+    focus.mockClear();
+    const buttons = wrapper.findAll('button');
+    await buttons
+      .find((button) => button.text() === 'Preview')
+      ?.trigger('click');
+    await buttons.find((button) => button.text() === 'Write')?.trigger('click');
+    await flushPromises();
+    expect(focus).toHaveBeenCalledOnce();
+  });
 });
 
 describe('TextEditor image upload', () => {
@@ -234,5 +382,41 @@ describe('TextEditor image upload', () => {
     await emitFileChange(wrapper, bigFile);
 
     expect(uploadFileMock).not.toHaveBeenCalled();
+  });
+
+  it('appends the image when the upload placeholder was removed while uploading', async () => {
+    let finishUpload:
+      ((value: { success: boolean; embeddedLink: string }) => void) | undefined;
+    uploadFileMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishUpload = resolve;
+      })
+    );
+    const wrapper = mountEditor();
+    const upload = emitFileChange(wrapper, new File(['x'], 'pic.png'));
+    await Promise.resolve();
+    await wrapper.get('textarea').setValue('placeholder removed');
+    finishUpload?.({
+      success: true,
+      embeddedLink: 'https://cdn.example.com/late.png',
+    });
+    await upload;
+    expect(wrapper.emitted('update')?.at(-1)?.[0]).toContain('late.png');
+  });
+
+  it('inserts an error at the original range when the placeholder was removed', async () => {
+    let failUpload: ((reason: Error) => void) | undefined;
+    uploadFileMock.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        failUpload = reject;
+      })
+    );
+    const wrapper = mountEditor();
+    const upload = emitFileChange(wrapper, new File(['x'], 'pic.png'));
+    await Promise.resolve();
+    await wrapper.get('textarea').setValue('placeholder removed');
+    failUpload?.(new Error('late failure'));
+    await upload;
+    expect(wrapper.emitted('update')?.at(-1)?.[0]).toContain('late failure');
   });
 });

--- a/components/charts/GithubContributionChart.spec.ts
+++ b/components/charts/GithubContributionChart.spec.ts
@@ -211,9 +211,51 @@ describe('GithubContributionChart', () => {
 
     await wrapper.find('rect').trigger('keydown', { key: 'ArrowRight' });
 
-    expect(
-      wrapper.find('#contribution-cell-1-0').attributes('tabindex')
-    ).toBe('0');
+    expect(wrapper.find('#contribution-cell-1-0').attributes('tabindex')).toBe(
+      '0'
+    );
+  });
+
+  it('supports the remaining keyboard navigation commands', async () => {
+    const wrapper = mount(GithubContributionChart, {
+      props: { contributionData: contributionDataFixture, year: 2023 },
+    });
+    await flushPromises();
+    const cell = wrapper.find('rect');
+    for (const key of [
+      'ArrowLeft',
+      'ArrowDown',
+      'ArrowUp',
+      'Home',
+      'End',
+      ' ',
+    ]) {
+      await cell.trigger('keydown', { key });
+    }
+    expect(wrapper.emitted('day-select')).toBeTruthy();
+  });
+
+  it('emits the year selected in the dropdown', async () => {
+    const wrapper = mount(GithubContributionChart, {
+      props: {
+        contributionData: contributionDataFixture,
+        year: 2023,
+        minYear: 2022,
+        maxYear: 2024,
+      },
+    });
+    await wrapper.get('#year-select').setValue('2024');
+    expect(wrapper.emitted('year-select')).toEqual([[2024]]);
+  });
+
+  it('updates the roving tab stop when a cell receives focus', async () => {
+    const wrapper = mount(GithubContributionChart, {
+      props: { contributionData: contributionDataFixture, year: 2023 },
+    });
+    await flushPromises();
+    const cell = wrapper.find('#contribution-cell-1-0');
+    await cell.trigger('focus');
+    expect(cell.attributes('tabindex')).toBe('0');
   });
 
   // Test color scheme based on contribution count
@@ -360,6 +402,23 @@ describe('GithubContributionChart', () => {
     expect(targets).toContain(
       '/forums/cats/wiki/revisions/diff/cat-care/selected-we1'
     );
+  });
+
+  it('omits links for wiki edits without page routing data', async () => {
+    const invalidWikiData = structuredClone(wikiEditsContributionData);
+    invalidWikiData[0].activities[0].WikiEdits![0].WikiPage = undefined;
+    const wrapper = mount(GithubContributionChart, {
+      props: { contributionData: invalidWikiData, year: 2023 },
+      global: { stubs: { NuxtLink: NuxtLinkStub } },
+    });
+    await flushPromises();
+    await wrapper.find('rect[data-count="2"]').trigger('click');
+    expect(
+      wrapper.findAllComponents(NuxtLinkStub).map((link) => link.props('to'))
+    ).toEqual([
+      '/forums/dogs/wiki/dog-care',
+      '/forums/dogs/wiki/revisions/diff/dog-care/selected-we2',
+    ]);
   });
 
   // Test deselecting a day

--- a/components/comments/Comment.handlers.spec.ts
+++ b/components/comments/Comment.handlers.spec.ts
@@ -9,6 +9,11 @@ let routeParams: Record<string, unknown> = {};
 const copyLinkSpy = vi.fn((cb?: (v: boolean) => void) => cb?.(true));
 const handleMarkAsBestAnswer = vi.fn();
 const handleUnmarkAsBestAnswer = vi.fn();
+let bestAnswerOptions: {
+  discussionId: { value: unknown };
+  onMarked: () => void;
+  onUnmarked: () => void;
+};
 // useMutation is called for SUBSCRIBE_TO_COMMENT then UNSUBSCRIBE_FROM_COMMENT.
 const mutateSpies: ReturnType<typeof vi.fn>[] = [];
 let useMutationCall = 0;
@@ -32,19 +37,18 @@ vi.mock('@vue/apollo-composable', () => ({
   },
 }));
 vi.mock('@/composables/useCommentPermissions', () => ({
-  useCommentPermissions: () =>
-    ({
-      userPermissions: ref({
-        canReport: true,
-        canGiveFeedback: true,
-        canHideComment: true,
-        canSuspendUser: true,
-        isChannelOwner: true,
-        isElevatedMod: true,
-        isSuspendedMod: false,
-        isSuspendedUser: false,
-      }),
+  useCommentPermissions: () => ({
+    userPermissions: ref({
+      canReport: true,
+      canGiveFeedback: true,
+      canHideComment: true,
+      canSuspendUser: true,
+      isChannelOwner: true,
+      isElevatedMod: true,
+      isSuspendedMod: false,
+      isSuspendedUser: false,
     }),
+  }),
 }));
 vi.mock('@/composables/useForumRoleMembership', () => ({
   useForumRoleMembership: () => ({
@@ -61,12 +65,16 @@ vi.mock('@/composables/useServerRoleMembership', () => ({
   }),
 }));
 vi.mock('@/composables/useBestAnswerMutations', () => ({
-  useBestAnswerMutations: () => ({
-    isDiscussionAuthor: ref(true),
-    isMarkedAsAnswer: ref(false),
-    handleMarkAsBestAnswer,
-    handleUnmarkAsBestAnswer,
-  }),
+  useBestAnswerMutations: (options: typeof bestAnswerOptions) => {
+    bestAnswerOptions = options;
+    void options.discussionId.value;
+    return {
+      isDiscussionAuthor: ref(true),
+      isMarkedAsAnswer: ref(false),
+      handleMarkAsBestAnswer,
+      handleUnmarkAsBestAnswer,
+    };
+  },
 }));
 vi.mock('@/composables/useCommentPermalink', () => ({
   useCommentPermalink: () => ({
@@ -82,8 +90,18 @@ vi.mock('@/composables/useAutoUnsubscribe', () => ({
 const stubs = {
   CommentHeader: { template: '<div />' },
   CommentButtons: {
-    template:
-      '<div class="comment-buttons-stub"><slot /></div>',
+    name: 'CommentButtons',
+    emits: [
+      'start-comment-save',
+      'open-reply-editor',
+      'hide-reply-editor',
+      'open-edit-comment-editor',
+      'hide-edit-comment-editor',
+      'open-mod-profile',
+      'save-edit',
+      'handle-view-feedback',
+    ],
+    template: '<div class="comment-buttons-stub"><slot /></div>',
   },
   MarkdownPreview: { props: ['text'], template: '<div>{{ text }}</div>' },
   ArchivedCommentText: { template: '<div />' },
@@ -94,6 +112,12 @@ const stubs = {
   RightArrowIcon: { template: '<i />' },
   MenuButton: {
     props: ['items'],
+    emits: [
+      'handle-edit',
+      'click-feedback',
+      'click-undo-feedback',
+      'click-edit-feedback',
+    ],
     template: '<button data-testid="commentMenu"><slot /></button>',
   },
 };
@@ -109,7 +133,12 @@ const baseComment = (overrides: Partial<Comment> = {}): Comment =>
 
 const mountComment = (commentData: Comment = baseComment()) =>
   mountWithDefaults(CommentComponent, {
-    props: { commentData, depth: 1, parentCommentId: 'parent-1', enableFeedback: true },
+    props: {
+      commentData,
+      depth: 1,
+      parentCommentId: 'parent-1',
+      enableFeedback: true,
+    },
     global: { stubs },
   });
 
@@ -183,6 +212,38 @@ describe('Comment — CommentButtons handlers', () => {
     await buttons(wrapper).vm.$emit('click-edit-feedback');
 
     expect(wrapper.emitted('clickEditFeedback')).toBeTruthy();
+  });
+
+  it('re-emits editor and save lifecycle events', async () => {
+    const wrapper = mountComment();
+    const commentButtons = buttons(wrapper);
+    await commentButtons.vm.$emit('start-comment-save', 'saving');
+    await commentButtons.vm.$emit('open-reply-editor', 'c1');
+    await commentButtons.vm.$emit('hide-reply-editor');
+    await commentButtons.vm.$emit('open-edit-comment-editor');
+    await commentButtons.vm.$emit('hide-edit-comment-editor');
+    await commentButtons.vm.$emit('open-mod-profile');
+    await commentButtons.vm.$emit('save-edit');
+    await commentButtons.vm.$emit('handle-view-feedback');
+    expect({
+      saving: wrapper.emitted('startCommentSave'),
+      openReply: wrapper.emitted('openReplyEditor'),
+      hideReply: wrapper.emitted('hideReplyEditor'),
+      openEdit: wrapper.emitted('openEditCommentEditor'),
+      hideEdit: wrapper.emitted('hideEditCommentEditor'),
+      mod: wrapper.emitted('openModProfile'),
+      save: wrapper.emitted('saveEdit'),
+      feedback: wrapper.emitted('handleViewFeedback'),
+    }).toEqual({
+      saving: [['saving']],
+      openReply: [['c1']],
+      hideReply: [[]],
+      openEdit: [['c1']],
+      hideEdit: [[]],
+      mod: [[]],
+      save: [[]],
+      feedback: [['c1']],
+    });
   });
 });
 
@@ -263,6 +324,46 @@ describe('Comment — MenuButton handlers', () => {
 
     expect(wrapper.emitted('handleViewFeedback')).toEqual([['c1']]);
   });
+
+  it('routes edit and feedback actions from the menu', async () => {
+    const wrapper = mountComment();
+    const commentMenu = menu(wrapper);
+    await commentMenu.vm.$emit('handle-edit');
+    await commentMenu.vm.$emit('click-feedback');
+    await commentMenu.vm.$emit('click-undo-feedback');
+    await commentMenu.vm.$emit('click-edit-feedback');
+    expect({
+      edit: wrapper.emitted('click-edit-comment'),
+      feedback: wrapper.emitted('clickFeedback'),
+      undo: wrapper.emitted('clickUndoFeedback'),
+      editFeedback: wrapper.emitted('clickEditFeedback'),
+    }).toEqual({
+      edit: [[expect.objectContaining({ id: 'c1' })]],
+      feedback: [[expect.objectContaining({ parentCommentId: 'parent-1' })]],
+      undo: [[expect.objectContaining({ parentCommentId: 'parent-1' })]],
+      editFeedback: [
+        [
+          expect.objectContaining({
+            commentData: expect.objectContaining({ id: 'c1' }),
+          }),
+        ],
+      ],
+    });
+  });
+});
+
+describe('Comment — best answer notifications', () => {
+  it.each([
+    ['onMarked', 'showMarkedAsBestAnswerNotification'],
+    ['onUnmarked', 'showUnmarkedAsBestAnswerNotification'],
+  ] as const)('shows and clears the %s notification', (callback, eventName) => {
+    vi.useFakeTimers();
+    const wrapper = mountComment();
+    bestAnswerOptions[callback]();
+    vi.advanceTimersByTime(3000);
+    expect(wrapper.emitted(eventName)).toEqual([[true], [false]]);
+    vi.useRealTimers();
+  });
 });
 
 describe('Comment — forum id resolution', () => {
@@ -289,5 +390,16 @@ describe('Comment — forum id resolution', () => {
     );
 
     expect(wrapper.find('.comment-buttons-stub').exists()).toBe(true);
+  });
+
+  it.each([
+    ['discussion-1', 'discussion-1'],
+    [['discussion-2'], 'discussion-2'],
+  ])('normalizes the route discussion id %j', (discussionId) => {
+    routeParams = { discussionId };
+    mountComment();
+    expect(bestAnswerOptions.discussionId.value).toBe(
+      Array.isArray(discussionId) ? discussionId[0] : discussionId
+    );
   });
 });

--- a/components/comments/Comment.realmount.spec.ts
+++ b/components/comments/Comment.realmount.spec.ts
@@ -51,12 +51,17 @@ vi.mock('@/composables/useCommentPermalink', () => ({
     copyLink: vi.fn(),
   }),
 }));
-vi.mock('@/composables/useAutoUnsubscribe', () => ({ useAutoUnsubscribe: vi.fn() }));
+vi.mock('@/composables/useAutoUnsubscribe', () => ({
+  useAutoUnsubscribe: vi.fn(),
+}));
 
 const stubs = {
   CommentHeader: { template: '<div class="comment-header-stub" />' },
   CommentButtons: { template: '<div class="comment-buttons-stub" />' },
-  MarkdownPreview: { props: ['text'], template: '<div class="md-stub">{{ text }}</div>' },
+  MarkdownPreview: {
+    props: ['text'],
+    template: '<div class="md-stub">{{ text }}</div>',
+  },
   ArchivedCommentText: { template: '<div class="archived-stub" />' },
   TextEditor: {
     name: 'TextEditor',
@@ -67,7 +72,7 @@ const stubs = {
   ChildComments: {
     name: 'ChildComments',
     template:
-      '<div class="child-comments-stub"><slot :comments="[{ id: \'child-1\', text: \'Child body\', CommentAuthor: { __typename: \'User\', username: \'child\' }, Channel: { uniqueName: \'cats\' } }]" /></div>',
+      "<div class=\"child-comments-stub\"><slot :comments=\"[{ id: 'child-1', text: 'Child body', CommentAuthor: { __typename: 'User', username: 'child' }, Channel: { uniqueName: 'cats' } }]\" /></div>",
   },
   ErrorBanner: {
     name: 'ErrorBanner',
@@ -105,12 +110,16 @@ describe('Comment (real mount)', () => {
   });
 
   it('renders the comment text via the markdown preview', () => {
-    const wrapper = mountComment(baseComment({ text: 'A unique body' } as Partial<Comment>));
+    const wrapper = mountComment(
+      baseComment({ text: 'A unique body' } as Partial<Comment>)
+    );
     expect(wrapper.text()).toContain('A unique body');
   });
 
   it('shows the archived text for an archived comment', () => {
-    const wrapper = mountComment(baseComment({ archived: true } as Partial<Comment>));
+    const wrapper = mountComment(
+      baseComment({ archived: true } as Partial<Comment>)
+    );
     expect(wrapper.find('.archived-stub').exists()).toBe(true);
   });
 
@@ -144,7 +153,9 @@ describe('Comment (real mount)', () => {
       global: { stubs },
     });
 
-    await wrapper.findComponent({ name: 'TextEditor' }).vm.$emit('update', 'edited');
+    await wrapper
+      .findComponent({ name: 'TextEditor' })
+      .vm.$emit('update', 'edited');
 
     expect(wrapper.emitted('update-edit-comment-input')).toEqual([
       ['edited', true],
@@ -198,6 +209,81 @@ describe('Comment (real mount)', () => {
     );
 
     expect(wrapper.text()).toContain('Child body');
+  });
+
+  it('forwards events emitted by an inline child comment', async () => {
+    const wrapper = mountComment(
+      baseComment({
+        ChildCommentsAggregate: { count: 1 },
+      } as unknown as Partial<Comment>)
+    );
+    const child = wrapper.findAllComponents(Comment)[0];
+    await child.vm.$emit('start-comment-save');
+    await child.vm.$emit('click-report', { id: 'child-1' });
+    await child.vm.$emit('delete-comment', { commentId: 'child-1' });
+    await child.vm.$emit('create-comment');
+    await child.vm.$emit('save-edit');
+    await child.vm.$emit('update-edit-comment-input', 'edited', 1);
+    await child.vm.$emit('show-copied-link-notification', true);
+    await child.vm.$emit('open-mod-profile');
+    await child.vm.$emit('scroll-to-top');
+    await child.vm.$emit('open-reply-editor', 'child-1');
+    await child.vm.$emit('hide-reply-editor');
+    await child.vm.$emit('open-edit-comment-editor');
+    await child.vm.$emit('hide-edit-comment-editor');
+    await child.vm.$emit('handle-view-feedback', 'child-1');
+    await child.vm.$emit('handle-click-archive', 'child-1');
+    await child.vm.$emit('handle-click-archive-and-suspend', 'child-1');
+    await child.vm.$emit('handle-click-unarchive', 'child-1');
+    expect({
+      saveStart: wrapper.emitted('startCommentSave'),
+      report: wrapper.emitted('clickReport'),
+      remove: wrapper.emitted('delete-comment'),
+      create: wrapper.emitted('createComment'),
+      save: wrapper.emitted('saveEdit'),
+      edit: wrapper.emitted('update-edit-comment-input'),
+      copied: wrapper.emitted('showCopiedLinkNotification'),
+      mod: wrapper.emitted('openModProfile'),
+      scroll: wrapper.emitted('scrollToTop'),
+      openReply: wrapper.emitted('openReplyEditor'),
+      hideReply: wrapper.emitted('hideReplyEditor'),
+      openEdit: wrapper.emitted('openEditCommentEditor'),
+      hideEdit: wrapper.emitted('hideEditCommentEditor'),
+      viewFeedback: wrapper.emitted('handleViewFeedback'),
+      archive: wrapper.emitted('handleClickArchive'),
+      archiveSuspend: wrapper.emitted('handleClickArchiveAndSuspend'),
+      unarchive: wrapper.emitted('handleClickUnarchive'),
+    }).toEqual({
+      saveStart: [[]],
+      report: [[{ id: 'child-1' }]],
+      remove: [[{ commentId: 'child-1' }]],
+      create: [[]],
+      save: [[]],
+      edit: [['edited', true]],
+      copied: [[true]],
+      mod: [[]],
+      scroll: [[]],
+      openReply: [['child-1']],
+      hideReply: [[]],
+      openEdit: [['child-1']],
+      hideEdit: [[]],
+      viewFeedback: [['child-1']],
+      archive: [['child-1']],
+      archiveSuspend: [['child-1']],
+      unarchive: [['child-1']],
+    });
+  });
+
+  it('handles hover state on the child comment list', async () => {
+    const wrapper = mountComment(
+      baseComment({
+        ChildCommentsAggregate: { count: 1 },
+      } as unknown as Partial<Comment>)
+    );
+    const children = wrapper.findComponent({ name: 'ChildComments' });
+    await children.trigger('mouseenter');
+    await children.trigger('mouseleave');
+    expect(children.exists()).toBe(true);
   });
 
   it('renders a continue-thread link when reply depth exceeds the inline limit', async () => {

--- a/components/comments/CommentRevisionDiffModal.spec.ts
+++ b/components/comments/CommentRevisionDiffModal.spec.ts
@@ -1,6 +1,22 @@
-import { describe, it, expect } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
 import CommentRevisionDiffModal from './CommentRevisionDiffModal.vue';
+
+const mutation = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  done: undefined as undefined | (() => void),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({
+    mutate: mutation.mutate,
+    loading: false,
+    error: null,
+    onDone: (callback: () => void) => {
+      mutation.done = callback;
+    },
+  }),
+}));
 
 vi.mock('@headlessui/vue', () => ({
   TransitionRoot: { name: 'TransitionRoot', template: '<div><slot /></div>' },
@@ -42,6 +58,12 @@ const newVersion = {
   createdAt: new Date().toISOString(),
   Author: { username: 'new' },
 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mutation.done = undefined;
+  mutation.mutate.mockResolvedValue({});
+});
 
 describe('CommentRevisionDiffModal', () => {
   it('uses a neutral primary action and a danger redaction action', () => {
@@ -127,5 +149,60 @@ describe('CommentRevisionDiffModal', () => {
       hasOldLine: true,
       hasNewLine: true,
     });
+  });
+
+  it('redacts the older revision after confirmation', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    const wrapper = mount(CommentRevisionDiffModal, {
+      props: { open: true, oldVersion, newVersion },
+    });
+
+    wrapper
+      .findComponent({ name: 'GenericModal' })
+      .vm.$emit('danger-button-click');
+    await flushPromises();
+
+    expect(mutation.mutate).toHaveBeenCalledWith({ textVersionId: 'c1' });
+  });
+
+  it('emits deletion and closure after the mutation completes', () => {
+    const wrapper = mount(CommentRevisionDiffModal, {
+      props: { open: true, oldVersion, newVersion },
+    });
+
+    mutation.done?.();
+
+    expect(wrapper.emitted()).toMatchObject({ deleted: [['c1']], close: [[]] });
+  });
+
+  it('restores the redaction action after a failed mutation', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    mutation.mutate.mockRejectedValue(new Error('denied'));
+    const wrapper = mount(CommentRevisionDiffModal, {
+      props: { open: true, oldVersion, newVersion },
+    });
+
+    wrapper
+      .findComponent({ name: 'GenericModal' })
+      .vm.$emit('danger-button-click');
+    await flushPromises();
+
+    expect(
+      wrapper
+        .findComponent({ name: 'GenericModal' })
+        .props('dangerButtonLoading')
+    ).toBe(false);
+  });
+
+  it('closes from the primary action', () => {
+    const wrapper = mount(CommentRevisionDiffModal, {
+      props: { open: true, oldVersion, newVersion },
+    });
+
+    wrapper
+      .findComponent({ name: 'GenericModal' })
+      .vm.$emit('primary-button-click');
+
+    expect(wrapper.emitted('close')).toEqual([[]]);
   });
 });

--- a/components/comments/CommentSection.callbacks.spec.ts
+++ b/components/comments/CommentSection.callbacks.spec.ts
@@ -26,7 +26,10 @@ vi.mock('@vue/apollo-composable', () => ({
   useMutation: vi.fn(),
 }));
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({ params: { discussionId: 'd1', forumId: 'cats' }, query: {} }),
+  useRoute: () => ({
+    params: { discussionId: 'd1', forumId: 'cats' },
+    query: {},
+  }),
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
 }));
 vi.mock('@/composables/useAuthState', () => ({
@@ -37,17 +40,30 @@ vi.mock('@/composables/useAuthState', () => ({
 const NotificationStub = {
   name: 'Notification',
   props: ['show', 'title'],
-  template: '<div class="notification-stub" :data-show="String(show)" :data-title="title" />',
+  template:
+    '<div class="notification-stub" :data-show="String(show)" :data-title="title" />',
 };
 
 const stubs = {
-  Comment: { name: 'Comment', props: ['commentData'], template: '<div class="comment-stub" />' },
+  Comment: {
+    name: 'Comment',
+    props: ['commentData', 'commentInProcess'],
+    template: '<div class="comment-stub" />',
+  },
   LoadMore: { template: '<div />' },
   SortButtons: { template: '<div />' },
-  PinnedAnswers: { name: 'PinnedAnswers', props: ['answers'], template: '<div />' },
-  WarningModal: { template: '<div />' },
+  PinnedAnswers: {
+    name: 'PinnedAnswers',
+    props: ['answers'],
+    template: '<div />',
+  },
+  WarningModal: { name: 'WarningModal', props: ['open'], template: '<div />' },
   BrokenRulesModal: { template: '<div />' },
-  GenericFeedbackFormModal: { name: 'GenericFeedbackFormModal', props: ['open'], template: '<div class="feedback-modal-stub" />' },
+  GenericFeedbackFormModal: {
+    name: 'GenericFeedbackFormModal',
+    props: ['open'],
+    template: '<div class="feedback-modal-stub" />',
+  },
   Notification: NotificationStub,
   ConfirmUndoCommentFeedbackModal: { template: '<div />' },
   EditCommentFeedbackModal: { template: '<div />' },
@@ -108,7 +124,9 @@ describe('CommentSection — mutation callbacks', () => {
     router.get('createComment').update!(fakeCache(), {
       data: {
         createComments: {
-          comments: [{ __typename: 'Comment', id: 'new-1', ParentComment: null }],
+          comments: [
+            { __typename: 'Comment', id: 'new-1', ParentComment: null },
+          ],
         },
       },
     });
@@ -127,6 +145,37 @@ describe('CommentSection — mutation callbacks', () => {
     await wrapper.vm.$nextTick();
     expect(feedbackToast(wrapper).attributes('data-show')).toBe('true');
   });
+
+  it('clears the delete modal state after deletion completes', () => {
+    const wrapper = mountSection();
+    router.get('deleteComment').fireDone();
+    expect(wrapper.findComponent({ name: 'WarningModal' }).props('open')).toBe(
+      false
+    );
+  });
+
+  it('emits the feedback cache update to the parent', () => {
+    const wrapper = mountSection();
+    router.get('addFeedbackCommentToComment').update?.(fakeCache(), {
+      data: {
+        createComments: {
+          comments: [makeComment({ id: 'feedback-1', text: 'Feedback' })],
+        },
+      },
+    });
+    expect(wrapper.emitted('updateCommentSectionQueryResult')).toBeTruthy();
+  });
+
+  it('clears the in-process state when comment creation errors', () => {
+    const wrapper = mountSection();
+    const create = router.get('createComment');
+    const onError = create.onError.mock.calls[0]?.[0] as
+      (() => void) | undefined;
+    onError?.();
+    expect(
+      wrapper.findComponent({ name: 'Comment' }).props('commentInProcess')
+    ).toBe(false);
+  });
 });
 
 describe('CommentSection — loaded-state watchers', () => {
@@ -134,7 +183,10 @@ describe('CommentSection — loaded-state watchers', () => {
     const wrapper = mountSection({ comments: [], loading: true });
     const before = wrapper.find('[aria-busy="true"]').exists();
     await wrapper.setProps({ comments: [makeComment({ id: 'x1' })] });
-    expect([before, wrapper.find('[aria-busy="true"]').exists()]).toEqual([true, false]);
+    expect([before, wrapper.find('[aria-busy="true"]').exists()]).toEqual([
+      true,
+      false,
+    ]);
   });
 
   it('hides the loading spinner once loading finishes', async () => {

--- a/components/comments/CommentSection.spec.ts
+++ b/components/comments/CommentSection.spec.ts
@@ -61,6 +61,7 @@ const CommentStub = {
   name: 'Comment',
   props: ['commentData'],
   emits: [
+    'start-comment-save',
     'create-comment',
     'update-create-reply-comment-input',
     'click-edit-comment',
@@ -72,6 +73,19 @@ const CommentStub = {
     'hide-edit-comment-editor',
     'scroll-to-top',
     'handle-view-feedback',
+    'show-copied-link-notification',
+    'show-marked-as-best-answer-notification',
+    'show-unmarked-as-best-answer-notification',
+    'open-mod-profile-modal',
+    'click-report',
+    'click-feedback',
+    'click-undo-feedback',
+    'click-edit-feedback',
+    'update-feedback',
+    'delete-comment',
+    'handle-click-archive',
+    'handle-click-archive-and-suspend',
+    'handle-click-unarchive',
   ],
   template: '<div class="comment-stub" />',
 };
@@ -80,6 +94,7 @@ const PinnedAnswersStub = {
   name: 'PinnedAnswers',
   props: ['answers'],
   emits: [
+    'start-comment-save',
     'create-comment',
     'click-edit-comment',
     'click-report',
@@ -87,6 +102,11 @@ const PinnedAnswersStub = {
     'handle-click-archive-and-suspend',
     'handle-click-unarchive',
     'update-create-reply-comment-input',
+    'show-copied-link-notification',
+    'show-marked-as-best-answer-notification',
+    'show-unmarked-as-best-answer-notification',
+    'open-mod-profile',
+    'scroll-to-top',
   ],
   template: '<div class="pinned-answers-stub" />',
 };
@@ -113,12 +133,34 @@ const stubs = {
     emits: ['load-more'],
     template: '<button class="load-more-stub" @click="$emit(\'load-more\')" />',
   },
-  Notification: inert('Notification'),
-  WarningModal: inert('WarningModal'),
+  Notification: {
+    name: 'Notification',
+    props: ['show', 'title'],
+    emits: ['close-notification'],
+    template: '<div class="notification-stub" />',
+  },
+  WarningModal: {
+    name: 'WarningModal',
+    props: ['open'],
+    emits: ['close', 'primary-button-click'],
+    template: '<div class="warning-modal-stub" />',
+  },
   BrokenRulesModal: inert('BrokenRulesModal'),
-  GenericFeedbackFormModal: inert('GenericFeedbackFormModal'),
-  ConfirmUndoCommentFeedbackModal: inert('ConfirmUndoCommentFeedbackModal'),
-  EditCommentFeedbackModal: inert('EditCommentFeedbackModal'),
+  GenericFeedbackFormModal: {
+    name: 'GenericFeedbackFormModal',
+    emits: ['close', 'update-feedback', 'primary-button-click'],
+    template: '<div class="feedback-modal-stub" />',
+  },
+  ConfirmUndoCommentFeedbackModal: {
+    name: 'ConfirmUndoCommentFeedbackModal',
+    emits: ['close'],
+    template: '<div class="undo-feedback-modal-stub" />',
+  },
+  EditCommentFeedbackModal: {
+    name: 'EditCommentFeedbackModal',
+    emits: ['close'],
+    template: '<div class="edit-feedback-modal-stub" />',
+  },
   UnarchiveModal: inert('UnarchiveModal'),
   NuxtPage: {
     name: 'NuxtPage',
@@ -130,6 +172,10 @@ const stubs = {
       'save-edit',
       'scroll-to-top',
       'handle-view-feedback',
+      'start-comment-save',
+      'show-copied-link-notification',
+      'show-marked-as-best-answer-notification',
+      'show-unmarked-as-best-answer-notification',
     ],
     template: '<div class="nuxt-page-stub" />',
   },
@@ -288,7 +334,10 @@ describe('CommentSection', () => {
   });
 
   it('navigates to the comment-feedback route when viewing feedback', async () => {
-    routeRef.value = { params: { forumId: 'cats', discussionId: 'd1' }, query: {} };
+    routeRef.value = {
+      params: { forumId: 'cats', discussionId: 'd1' },
+      query: {},
+    };
     const wrapper = mountSection();
     await wrapper
       .findAllComponents(CommentStub)[0]
@@ -323,7 +372,10 @@ describe('CommentSection', () => {
   });
 
   it('forwards NuxtPage editor and navigation events when nested routes are shown', async () => {
-    routeRef.value = { params: { forumId: 'cats', discussionId: 'd1' }, query: {} };
+    routeRef.value = {
+      params: { forumId: 'cats', discussionId: 'd1' },
+      query: {},
+    };
     const wrapper = mountSection({ showNuxtPage: true });
     const page = wrapper.findComponent({ name: 'NuxtPage' });
 
@@ -344,5 +396,81 @@ describe('CommentSection', () => {
       scrolled: expect.any(Function),
       routed: 1,
     });
+  });
+
+  it.each([0, 2])('deletes a comment with %i replies', async (replyCount) => {
+    const wrapper = mountSection();
+    await wrapper.findAllComponents(CommentStub)[0].vm.$emit('delete-comment', {
+      commentId: 'c1',
+      parentCommentId: '',
+      replyCount,
+    });
+    await wrapper
+      .findComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+    expect(wrapper.findComponent({ name: 'WarningModal' }).props('open')).toBe(
+      false
+    );
+  });
+
+  it('submits feedback selected from a comment', async () => {
+    const wrapper = mountSection({ enableFeedback: true });
+    const comment = wrapper.findAllComponents(CommentStub)[0];
+    await comment.vm.$emit('click-feedback', {
+      commentData: makeComment('c1'),
+      parentCommentId: '',
+    });
+    const modal = wrapper.findComponent({ name: 'GenericFeedbackFormModal' });
+    await modal.vm.$emit('update-feedback', 'Helpful note');
+    await modal.vm.$emit('primary-button-click');
+    expect(modal.exists()).toBe(true);
+  });
+
+  it('updates notification and profile state from pinned answers', async () => {
+    const wrapper = mountSection({ answers: [makeComment('a1')] });
+    const pinned = wrapper.findComponent(PinnedAnswersStub);
+    await pinned.vm.$emit('start-comment-save');
+    await pinned.vm.$emit('show-copied-link-notification', true);
+    await pinned.vm.$emit('show-marked-as-best-answer-notification', true);
+    await pinned.vm.$emit('show-unmarked-as-best-answer-notification', true);
+    await pinned.vm.$emit('open-mod-profile');
+    await pinned.vm.$emit('scroll-to-top');
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('updates notification and profile state from an inline comment', async () => {
+    const wrapper = mountSection();
+    const comment = wrapper.findAllComponents(CommentStub)[0];
+    await comment.vm.$emit('start-comment-save');
+    await comment.vm.$emit('show-copied-link-notification', true);
+    await comment.vm.$emit('show-marked-as-best-answer-notification', true);
+    await comment.vm.$emit('show-unmarked-as-best-answer-notification', true);
+    await comment.vm.$emit('open-mod-profile-modal');
+    expect(wrapper.findAllComponents({ name: 'Notification' })).toHaveLength(8);
+  });
+
+  it('updates notification state from a nested Nuxt page', async () => {
+    const wrapper = mountSection({ showNuxtPage: true });
+    const page = wrapper.findComponent({ name: 'NuxtPage' });
+    await page.vm.$emit('start-comment-save');
+    await page.vm.$emit('show-copied-link-notification', true);
+    await page.vm.$emit('show-marked-as-best-answer-notification', true);
+    await page.vm.$emit('show-unmarked-as-best-answer-notification', true);
+    expect(page.exists()).toBe(true);
+  });
+
+  it('closes comment-section notifications and feedback modals', async () => {
+    const wrapper = mountSection();
+    for (const notification of wrapper.findAllComponents({
+      name: 'Notification',
+    })) {
+      await notification.vm.$emit('close-notification');
+    }
+    await wrapper
+      .findComponent({ name: 'GenericFeedbackFormModal' })
+      .vm.$emit('close');
+    expect(
+      wrapper.findComponent({ name: 'GenericFeedbackFormModal' }).exists()
+    ).toBe(true);
   });
 });

--- a/components/discussion/detail/DiscussionAlbum.spec.ts
+++ b/components/discussion/detail/DiscussionAlbum.spec.ts
@@ -18,7 +18,7 @@ vi.mock('@/composables/useAuthState', () => ({
 const stubs = {
   ModelViewer: { template: '<div class="model-viewer-stub" />' },
   StlViewer: { template: '<div class="stl-viewer-stub" />' },
-  CarouselThumbnail: { template: '<div />' },
+  CarouselThumbnail: { name: 'CarouselThumbnail', template: '<div />' },
   ClientOnly: { template: '<div><slot /></div>' },
   ImageLightbox: {
     template: '<button class="lightbox-stub" @click="$emit(\'close\')" />',
@@ -79,7 +79,9 @@ describe('DiscussionAlbum', () => {
 
   it('falls back to the Images array (in order) when imageOrder is empty', () => {
     const wrapper = mountAlbum({ album: makeAlbum(['a', 'b'], []) });
-    const srcs = cells(wrapper).map((cell) => cell.find('img').attributes('src'));
+    const srcs = cells(wrapper).map((cell) =>
+      cell.find('img').attributes('src')
+    );
     expect(srcs).toEqual([
       'https://example.com/a.jpg',
       'https://example.com/b.jpg',
@@ -87,7 +89,9 @@ describe('DiscussionAlbum', () => {
   });
 
   it('orders the cells according to imageOrder', () => {
-    const wrapper = mountAlbum({ album: makeAlbum(['a', 'b', 'c'], ['c', 'a', 'b']) });
+    const wrapper = mountAlbum({
+      album: makeAlbum(['a', 'b', 'c'], ['c', 'a', 'b']),
+    });
     const firstImg = cells(wrapper)[0].find('img');
     expect(firstImg.attributes('src')).toContain('/c.jpg');
   });
@@ -95,7 +99,9 @@ describe('DiscussionAlbum', () => {
   it('appends a synthetic cell for STL files', () => {
     const wrapper = mountAlbum({
       album: makeAlbum(['a']),
-      stlFiles: [{ id: 's1', url: 'https://example.com/m.stl', fileName: 'm.stl' }],
+      stlFiles: [
+        { id: 's1', url: 'https://example.com/m.stl', fileName: 'm.stl' },
+      ],
     });
     expect(cells(wrapper)).toHaveLength(2);
   });
@@ -122,7 +128,9 @@ describe('DiscussionAlbum', () => {
   it('renders an STL viewer for STL images', () => {
     const wrapper = mountAlbum({
       album: makeAlbum([]),
-      stlFiles: [{ id: 's1', url: 'https://example.com/m.stl', fileName: 'm.stl' }],
+      stlFiles: [
+        { id: 's1', url: 'https://example.com/m.stl', fileName: 'm.stl' },
+      ],
     });
 
     expect(wrapper.find('.stl-viewer-stub').exists()).toBe(true);
@@ -135,7 +143,9 @@ describe('DiscussionAlbum', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.findComponent({ name: 'TextEditor' }).exists()).toBe(true);
 
-    await wrapper.findComponent({ name: 'TextEditor' }).vm.$emit('update', 'new caption');
+    await wrapper
+      .findComponent({ name: 'TextEditor' })
+      .vm.$emit('update', 'new caption');
     await wrapper.findComponent({ name: 'SaveButton' }).trigger('click');
 
     expect(wrapper.emitted('album-updated')).toBeTruthy();
@@ -153,13 +163,29 @@ describe('DiscussionAlbum', () => {
 
     expect(wrapper.findComponent({ name: 'TextEditor' }).exists()).toBe(false);
   });
+
+  it.each(['enter', 'space'])(
+    'enters caption editing with the %s key',
+    async (key) => {
+      const wrapper = mountAlbum({
+        album: {
+          ...makeAlbum(['a']),
+          Images: [{ ...makeImage('a'), caption: 'Existing caption' }],
+        } as Album,
+      });
+      await wrapper.get('span[role="button"]').trigger(`keydown.${key}`);
+      expect(wrapper.findComponent({ name: 'TextEditor' }).exists()).toBe(true);
+    }
+  );
 });
 
 describe('DiscussionAlbum — lightbox', () => {
   // The lightbox is teleported to <body>, so query the document, not the wrapper.
   beforeEach(() => {
     vi.clearAllMocks();
-    document.body.querySelectorAll('.lightbox-stub').forEach((el) => el.remove());
+    document.body
+      .querySelectorAll('.lightbox-stub')
+      .forEach((el) => el.remove());
   });
 
   it('opens the lightbox when a grid cell is clicked', async () => {
@@ -203,6 +229,22 @@ describe('DiscussionAlbum — carousel navigation', () => {
     expect(wrapper.text()).toContain('3 of 3');
   });
 
+  it('moves left without wrapping from a later image', async () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+    await wrapper.get('[aria-label="Next image"]').trigger('click');
+    await wrapper.get('[aria-label="Previous image"]').trigger('click');
+    expect(wrapper.text()).toContain('1 of 3');
+  });
+
+  it('wraps to the first image after advancing past the end', async () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+    const next = wrapper.get('[aria-label="Next image"]');
+    await next.trigger('click');
+    await next.trigger('click');
+    await next.trigger('click');
+    expect(wrapper.text()).toContain('1 of 3');
+  });
+
   it('navigates by swiping the image container', async () => {
     const wrapper = mountAlbum({ carouselFormat: true });
     const container = wrapper.find('.touch-pan-x');
@@ -210,6 +252,35 @@ describe('DiscussionAlbum — carousel navigation', () => {
     await container.trigger('touchend', { changedTouches: [{ clientX: 100 }] });
 
     expect(wrapper.text()).toContain('2 of 3');
+  });
+
+  it('navigates backward on a right swipe', async () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+    const container = wrapper.find('.touch-pan-x');
+    await container.trigger('touchstart', { touches: [{ clientX: 100 }] });
+    await container.trigger('touchend', { changedTouches: [{ clientX: 200 }] });
+    expect(wrapper.text()).toContain('3 of 3');
+  });
+
+  it('selects carousel images from both thumbnail layouts', async () => {
+    const compact = mountAlbum({ carouselFormat: true, showThumbnails: true });
+    await compact
+      .findAllComponents({ name: 'CarouselThumbnail' })[1]
+      .vm.$emit('click');
+    const expanded = mountAlbum({ carouselFormat: true, expandedView: true });
+    await expanded
+      .findAllComponents({ name: 'CarouselThumbnail' })[2]
+      .vm.$emit('click');
+    expect([compact.text(), expanded.text()]).toEqual([
+      expect.stringContaining('2 of 3'),
+      expect.stringContaining('3 of 3'),
+    ]);
+  });
+
+  it('opens the lightbox from the active carousel image', async () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+    await wrapper.get('.touch-pan-x > div.h-full').trigger('click');
+    expect(document.body.querySelector('.lightbox-stub')).not.toBeNull();
   });
 
   it('renders the taller main image in download expanded view', () => {

--- a/components/discussion/detail/DiscussionDetailContent.spec.ts
+++ b/components/discussion/detail/DiscussionDetailContent.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ref } from 'vue';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import {
   asMock,
@@ -12,12 +13,25 @@ import { useQuery } from '@vue/apollo-composable';
 import DiscussionDetailContent from '@/components/discussion/detail/DiscussionDetailContent.vue';
 
 vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
-vi.mock('nuxt/app', () => ({ useRoute: vi.fn(() => ({ params: {}, query: {} })) }));
-vi.mock('@/composables/useAuthState', () => ({
-  useIsAuthenticated: () => ({ value: false }),
-  useModProfileName: () => ({ value: '' }),
-  useUsername: () => ({ value: '' }),
+vi.mock('nuxt/app', () => ({
+  useRoute: vi.fn(() => ({ params: {}, query: {} })),
 }));
+const auth = vi.hoisted(() => ({
+  isAuthenticated: null as unknown as ReturnType<typeof ref<boolean>>,
+  modProfileName: null as unknown as ReturnType<typeof ref<string>>,
+  username: null as unknown as ReturnType<typeof ref<string>>,
+}));
+vi.mock('@/composables/useAuthState', async () => {
+  const { ref: vref } = await import('vue');
+  auth.isAuthenticated = vref(false);
+  auth.modProfileName = vref('');
+  auth.username = vref('');
+  return {
+    useIsAuthenticated: () => auth.isAuthenticated,
+    useModProfileName: () => auth.modProfileName,
+    useUsername: () => auth.username,
+  };
+});
 vi.mock('@/composables/useForumRoleMembership', () => ({
   provideForumRoleMembership: vi.fn(),
 }));
@@ -52,8 +66,14 @@ const stubs = {
   DiscussionCommentsWrapper: DiscussionCommentsWrapperStub,
   DiscussionChannelLinks: { template: '<div />' },
   PageNotFound: { template: '<div class="page-not-found-stub" />' },
-  InfoBanner: { props: ['text'], template: '<div class="info-banner-stub">{{ text }}</div>' },
-  ErrorBanner: { props: ['text'], template: '<div class="error-banner-stub">{{ text }}</div>' },
+  InfoBanner: {
+    props: ['text'],
+    template: '<div class="info-banner-stub">{{ text }}</div>',
+  },
+  ErrorBanner: {
+    props: ['text'],
+    template: '<div class="error-banner-stub">{{ text }}</div>',
+  },
   DiscussionBodyEditForm: {
     name: 'DiscussionBodyEditForm',
     emits: ['close-editor'],
@@ -64,7 +84,9 @@ const stubs = {
     emits: ['close-editor'],
     template: '<div class="album-edit-stub" />',
   },
-  ArchivedDiscussionInfoBanner: { template: '<div class="archived-banner-stub" />' },
+  ArchivedDiscussionInfoBanner: {
+    template: '<div class="archived-banner-stub" />',
+  },
   DiscussionLayoutManager: {
     name: 'DiscussionLayoutManager',
     emits: [
@@ -126,14 +148,16 @@ const commentSection = (comments: Comment[]) => ({
   },
 });
 
-const setup = (params: {
-  discussions?: Discussion[];
-  comments?: Comment[];
-  hasCommentSection?: boolean;
-  discussionChannelOverrides?: Record<string, unknown>;
-  issueResult?: Record<string, unknown>;
-  commentIssueResult?: Record<string, unknown>;
-} = {}) => {
+const setup = (
+  params: {
+    discussions?: Discussion[];
+    comments?: Comment[];
+    hasCommentSection?: boolean;
+    discussionChannelOverrides?: Record<string, unknown>;
+    issueResult?: Record<string, unknown>;
+    commentIssueResult?: Record<string, unknown>;
+  } = {}
+) => {
   const {
     discussions = [makeDiscussion()],
     comments = [],
@@ -159,7 +183,9 @@ const setup = (params: {
       onResult: (cb: (r: unknown) => void) => cb({ data: csData }),
     }),
     fetchMore: vi.fn(),
-  } as ReturnType<typeof createQueryMock> & { fetchMore: ReturnType<typeof vi.fn> };
+  } as ReturnType<typeof createQueryMock> & {
+    fetchMore: ReturnType<typeof vi.fn>;
+  };
   const commentAggregateQuery = createQueryMock({
     discussionChannels: [{ CommentsAggregate: { count: comments.length } }],
   });
@@ -199,6 +225,9 @@ describe('DiscussionDetailContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     asMock(useQuery).mockReset();
+    auth.isAuthenticated.value = false;
+    auth.modProfileName.value = '';
+    auth.username.value = '';
   });
 
   it('renders the discussion header for a loaded discussion', () => {
@@ -217,7 +246,9 @@ describe('DiscussionDetailContent', () => {
   });
 
   it('passes the comment-section comments through in order', () => {
-    const { wrapper } = setup({ comments: [makeComment('a'), makeComment('b')] });
+    const { wrapper } = setup({
+      comments: [makeComment('a'), makeComment('b')],
+    });
     const passed = wrapper
       .findComponent(DiscussionCommentsWrapperStub)
       .props('comments') as Comment[];
@@ -227,20 +258,28 @@ describe('DiscussionDetailContent', () => {
   it('enters and exits discussion body edit mode from child events', async () => {
     const { wrapper } = setup();
 
-    await wrapper.findComponent({ name: 'DiscussionHeader' }).vm.$emit('handle-click-edit-body');
+    await wrapper
+      .findComponent({ name: 'DiscussionHeader' })
+      .vm.$emit('handle-click-edit-body');
     expect(wrapper.find('.body-edit-stub').exists()).toBe(true);
 
-    await wrapper.findComponent({ name: 'DiscussionBodyEditForm' }).vm.$emit('close-editor');
+    await wrapper
+      .findComponent({ name: 'DiscussionBodyEditForm' })
+      .vm.$emit('close-editor');
     expect(wrapper.find('.body-edit-stub').exists()).toBe(false);
   });
 
   it('enters and exits album edit mode when image uploads are enabled', async () => {
     const { wrapper } = setup();
 
-    await wrapper.findComponent({ name: 'DiscussionHeader' }).vm.$emit('handle-click-add-album');
+    await wrapper
+      .findComponent({ name: 'DiscussionHeader' })
+      .vm.$emit('handle-click-add-album');
     expect(wrapper.find('.album-edit-stub').exists()).toBe(true);
 
-    await wrapper.findComponent({ name: 'AlbumEditForm' }).vm.$emit('close-editor');
+    await wrapper
+      .findComponent({ name: 'AlbumEditForm' })
+      .vm.$emit('close-editor');
     expect(wrapper.find('.album-edit-stub').exists()).toBe(false);
   });
 
@@ -251,7 +290,9 @@ describe('DiscussionDetailContent', () => {
       },
     });
 
-    await wrapper.findComponent({ name: 'DiscussionHeader' }).vm.$emit('handle-click-add-album');
+    await wrapper
+      .findComponent({ name: 'DiscussionHeader' })
+      .vm.$emit('handle-click-add-album');
 
     expect(wrapper.find('.album-edit-stub').exists()).toBe(false);
   });
@@ -288,7 +329,9 @@ describe('DiscussionDetailContent', () => {
       comments: [makeComment('a'), makeComment('b')],
     });
 
-    await wrapper.findComponent(DiscussionCommentsWrapperStub).vm.$emit('load-more');
+    await wrapper
+      .findComponent(DiscussionCommentsWrapperStub)
+      .vm.$emit('load-more');
 
     expect(commentSectionQuery.fetchMore).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -316,7 +359,9 @@ describe('DiscussionDetailContent', () => {
 
     await layout.vm.$emit('discussion-refetch');
     await layout.vm.$emit('discussion-channel-refetch');
-    await wrapper.findComponent({ name: 'FeedbackModalManager' }).vm.$emit('feedback-submitted');
+    await wrapper
+      .findComponent({ name: 'FeedbackModalManager' })
+      .vm.$emit('feedback-submitted');
 
     expect({
       discussionRefetches: discussionQuery.refetch.mock.calls.length,
@@ -332,19 +377,24 @@ describe('DiscussionDetailContent', () => {
       ['handle-click-give-feedback', 'handleClickGiveFeedback'],
       ['handle-click-undo-feedback', 'handleClickUndoFeedback'],
       ['handle-click-edit-feedback', 'handleClickEditFeedback'],
-    ] as const)('forwards %s to the feedback modal manager', async (event, method) => {
-      const { wrapper } = setup();
-      await wrapper
-        .findComponent({ name: 'DiscussionLayoutManager' })
-        .vm.$emit(event);
+    ] as const)(
+      'forwards %s to the feedback modal manager',
+      async (event, method) => {
+        const { wrapper } = setup();
+        await wrapper
+          .findComponent({ name: 'DiscussionLayoutManager' })
+          .vm.$emit(event);
 
-      expect(feedbackManagerSpies[method]).toHaveBeenCalled();
-    });
+        expect(feedbackManagerSpies[method]).toHaveBeenCalled();
+      }
+    );
   });
 
   it('enters album edit mode from the layout edit-album event', async () => {
     const { wrapper } = setup();
-    await wrapper.findComponent({ name: 'DiscussionLayoutManager' }).vm.$emit('edit-album');
+    await wrapper
+      .findComponent({ name: 'DiscussionLayoutManager' })
+      .vm.$emit('edit-album');
 
     expect(wrapper.find('.album-edit-stub').exists()).toBe(true);
   });
@@ -353,7 +403,9 @@ describe('DiscussionDetailContent', () => {
     const { wrapper } = setup({
       discussionChannelOverrides: { Channel: { imageUploadsEnabled: false } },
     });
-    await wrapper.findComponent({ name: 'DiscussionLayoutManager' }).vm.$emit('edit-album');
+    await wrapper
+      .findComponent({ name: 'DiscussionLayoutManager' })
+      .vm.$emit('edit-album');
 
     expect(wrapper.find('.album-edit-stub').exists()).toBe(false);
   });
@@ -362,23 +414,32 @@ describe('DiscussionDetailContent', () => {
     const { wrapper, commentSectionQuery } = setup({
       comments: [makeComment('a')],
     });
-    await wrapper.findComponent(DiscussionCommentsWrapperStub).vm.$emit('load-more');
+    await wrapper
+      .findComponent(DiscussionCommentsWrapperStub)
+      .vm.$emit('load-more');
 
     const { updateQuery } = commentSectionQuery.fetchMore.mock.calls[0]![0];
     const merged = updateQuery(
       { getCommentSection: { Comments: [makeComment('a')] } },
-      { fetchMoreResult: { getCommentSection: { Comments: [makeComment('b')] } } }
+      {
+        fetchMoreResult: {
+          getCommentSection: { Comments: [makeComment('b')] },
+        },
+      }
     );
 
-    expect(merged.getCommentSection.Comments.map((c: Comment) => c.id)).toEqual([
-      'a',
-      'b',
-    ]);
+    expect(merged.getCommentSection.Comments.map((c: Comment) => c.id)).toEqual(
+      ['a', 'b']
+    );
   });
 
   it('returns the previous result when loadMore has no more comments', async () => {
-    const { wrapper, commentSectionQuery } = setup({ comments: [makeComment('a')] });
-    await wrapper.findComponent(DiscussionCommentsWrapperStub).vm.$emit('load-more');
+    const { wrapper, commentSectionQuery } = setup({
+      comments: [makeComment('a')],
+    });
+    await wrapper
+      .findComponent(DiscussionCommentsWrapperStub)
+      .vm.$emit('load-more');
 
     const { updateQuery } = commentSectionQuery.fetchMore.mock.calls[0]![0];
     const previous = { getCommentSection: { Comments: [makeComment('a')] } };
@@ -397,7 +458,9 @@ describe('DiscussionDetailContent', () => {
     });
 
     expect(
-      wrapper.findComponent({ name: 'DiscussionHeader' }).props('relatedIssueLink')
+      wrapper
+        .findComponent({ name: 'DiscussionHeader' })
+        .props('relatedIssueLink')
     ).toEqual({
       name: 'forums-forumId-issues-issueNumber',
       params: { forumId: 'cats', issueNumber: 7 },
@@ -408,7 +471,41 @@ describe('DiscussionDetailContent', () => {
     const { wrapper } = setup();
 
     expect(
-      wrapper.findComponent({ name: 'DiscussionHeader' }).props('relatedIssueLink')
+      wrapper
+        .findComponent({ name: 'DiscussionHeader' })
+        .props('relatedIssueLink')
     ).toBeNull();
+  });
+
+  it('refetches both discussion queries when a username becomes available', async () => {
+    const { wrapper, discussionQuery, commentSectionQuery } = setup();
+    auth.username.value = 'alice';
+    await wrapper.vm.$nextTick();
+    expect([
+      discussionQuery.refetch.mock.calls.length,
+      commentSectionQuery.refetch.mock.calls.length,
+    ]).toEqual([1, 1]);
+  });
+
+  it('refetches the discussion when authentication becomes active', async () => {
+    const { wrapper, discussionQuery } = setup();
+    auth.isAuthenticated.value = true;
+    await wrapper.vm.$nextTick();
+    expect(discussionQuery.refetch).toHaveBeenCalledOnce();
+  });
+
+  it('refetches on mount for an already authenticated user', () => {
+    auth.isAuthenticated.value = true;
+    const { discussionQuery, commentSectionQuery } = setup();
+    expect([
+      discussionQuery.refetch.mock.calls.length,
+      commentSectionQuery.refetch.mock.calls.length,
+    ]).toEqual([1, 1]);
+  });
+
+  it('clears cached comment-section state when the discussion ID changes', async () => {
+    const { wrapper } = setup({ comments: [makeComment('a')] });
+    await wrapper.setProps({ discussionId: 'd2' });
+    expect(wrapper.props('discussionId')).toBe('d2');
   });
 });

--- a/components/discussion/detail/DiscussionHeader.handlers.spec.ts
+++ b/components/discussion/detail/DiscussionHeader.handlers.spec.ts
@@ -4,17 +4,27 @@ import { mount } from '@vue/test-utils';
 import DiscussionHeader from './DiscussionHeader.vue';
 
 let routeName = 'forums-forumId-discussions-discussionId';
-let routeParams: Record<string, unknown> = { forumId: 'cats', discussionId: 'd1' };
+let routeParams: Record<string, unknown> = {
+  forumId: 'cats',
+  discussionId: 'd1',
+};
 const routerPush = vi.fn();
 const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
 // useMutation order: 0 DELETE_DISCUSSION, 1 UPDATE_DISCUSSION_SENSITIVE_CONTENT.
 let mutateSpies: ReturnType<typeof vi.fn>[] = [];
-let mutationOptions: ({ update?: (cache: unknown, payload: { data?: unknown }) => void } | undefined)[] = [];
+let mutationOptions: (
+  { update?: (cache: unknown, payload: { data?: unknown }) => void } | undefined
+)[] = [];
 let onDoneCallbacks: (() => void)[] = [];
 let useMutationCall = 0;
 
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({ name: routeName, params: routeParams, query: {}, path: '' }),
+  useRoute: () => ({
+    name: routeName,
+    params: routeParams,
+    query: {},
+    path: '',
+  }),
   useRouter: () => ({ push: routerPush, resolve: () => ({ href: '/x' }) }),
 }));
 
@@ -31,7 +41,9 @@ vi.mock('@vue/apollo-composable', () => ({
     const index = useMutationCall++;
     const mutate = vi.fn().mockResolvedValue({});
     mutateSpies[index] = mutate;
-    mutationOptions[index] = options as { update?: (cache: unknown, payload: { data?: unknown }) => void };
+    mutationOptions[index] = options as {
+      update?: (cache: unknown, payload: { data?: unknown }) => void;
+    };
     return {
       mutate,
       loading: ref(false),
@@ -69,7 +81,18 @@ vi.mock('@/composables/useForumRoleMembership', () => ({
 const stubs = {
   AvatarComponent: { template: '<div />' },
   ErrorBanner: { template: '<div />' },
-  NotificationComponent: { template: '<div />' },
+  NotificationComponent: {
+    name: 'Notification',
+    props: ['show', 'title'],
+    emits: ['close-notification'],
+    template: '<div />',
+  },
+  Notification: {
+    name: 'Notification',
+    props: ['show', 'title'],
+    emits: ['close-notification'],
+    template: '<div />',
+  },
   BrokenRulesModal: { template: '<div />' },
   EllipsisHorizontal: { template: '<i />' },
   AddToDiscussionFavorites: { template: '<div />' },
@@ -79,7 +102,8 @@ const stubs = {
   NuxtLink: { template: '<a><slot /></a>' },
   WarningModal: {
     props: ['open', 'title', 'body'],
-    template: '<div data-testid="warning-modal" :data-open="open" :data-title="title" />',
+    template:
+      '<div data-testid="warning-modal" :data-open="open" :data-title="title" />',
   },
   MenuButton: {
     props: ['items'],
@@ -95,7 +119,12 @@ const baseDiscussion = (overrides: Record<string, unknown> = {}) => ({
   updatedAt: '2024-01-01T00:00:00Z',
   hasSensitiveContent: false,
   hasDownload: false,
-  Author: { username: 'viewer', displayName: 'Viewer', profilePicURL: '', ChannelRoles: [] },
+  Author: {
+    username: 'viewer',
+    displayName: 'Viewer',
+    profilePicURL: '',
+    ChannelRoles: [],
+  },
   DiscussionChannels: [{ channelUniqueName: 'cats' }],
   ...overrides,
 });
@@ -163,6 +192,24 @@ describe('DiscussionHeader — share menu', () => {
       expect.objectContaining({ name: 'discussions-create' })
     );
   });
+
+  it('clears the copied notification after two seconds', async () => {
+    vi.useFakeTimers();
+    const wrapper = buildWrapper();
+    await shareMenu(wrapper).vm.$emit('copy-link');
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(
+      wrapper.findAllComponents({ name: 'Notification' }).at(-1)?.props('show')
+    ).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('handles a clipboard rejection', async () => {
+    clipboardWriteText.mockRejectedValueOnce(new Error('denied'));
+    const wrapper = buildWrapper();
+    await shareMenu(wrapper).vm.$emit('copy-link');
+    expect(clipboardWriteText).toHaveBeenCalledOnce();
+  });
 });
 
 describe('DiscussionHeader — action menu', () => {
@@ -183,6 +230,46 @@ describe('DiscussionHeader — action menu', () => {
       discussionId: 'd1',
       hasSensitiveContent: true,
     });
+  });
+
+  it('handles a failed sensitive-content update', async () => {
+    const wrapper = buildWrapper();
+    mutateSpies[1].mockRejectedValueOnce(new Error('offline'));
+    await actionMenu(wrapper).vm.$emit('handle-toggle-sensitive-content');
+    expect(mutateSpies[1]).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [false, '/forums/cats/discussions/edit/d1'],
+    [true, '/forums/cats/downloads/edit/d1'],
+  ])(
+    'opens the matching edit route when download is %s',
+    async (hasDownload, path) => {
+      const wrapper = buildWrapper({
+        discussion: baseDiscussion({ hasDownload }),
+      });
+      await actionMenu(wrapper).vm.$emit('handle-edit');
+      expect(routerPush).toHaveBeenCalledWith(path);
+    }
+  );
+
+  it('forwards feedback and album actions and opens the feedback page', async () => {
+    const wrapper = buildWrapper();
+    const menu = actionMenu(wrapper);
+    await menu.vm.$emit('handle-feedback');
+    await menu.vm.$emit('handle-add-album');
+    await menu.vm.$emit('handle-view-feedback');
+    expect([wrapper.emitted(), routerPush.mock.calls]).toMatchObject([
+      { handleClickGiveFeedback: [[]], handleClickAddAlbum: [[]] },
+      [
+        [
+          {
+            name: 'forums-forumId-discussions-feedback-discussionId',
+            params: { forumId: 'cats', discussionId: 'd1' },
+          },
+        ],
+      ],
+    ]);
   });
 });
 
@@ -236,7 +323,9 @@ describe('DiscussionHeader — delete flow', () => {
   it('evicts the deleted discussion from the cache', () => {
     buildWrapper();
     const cache = { evict: vi.fn(), identify: vi.fn(() => 'id') };
-    mutationOptions[0]!.update!(cache, { data: { deleteDiscussions: { nodesDeleted: 1 } } });
+    mutationOptions[0]!.update!(cache, {
+      data: { deleteDiscussions: { nodesDeleted: 1 } },
+    });
 
     expect(cache.evict).toHaveBeenCalledTimes(1);
   });
@@ -244,9 +333,22 @@ describe('DiscussionHeader — delete flow', () => {
   it('does not evict when nothing was deleted', () => {
     buildWrapper();
     const cache = { evict: vi.fn(), identify: vi.fn(() => 'id') };
-    mutationOptions[0]!.update!(cache, { data: { deleteDiscussions: { nodesDeleted: 0 } } });
+    mutationOptions[0]!.update!(cache, {
+      data: { deleteDiscussions: { nodesDeleted: 0 } },
+    });
 
     expect(cache.evict).not.toHaveBeenCalled();
+  });
+
+  it('closes the delete modal from its close event', async () => {
+    const wrapper = buildWrapper();
+    await actionMenu(wrapper).vm.$emit('handle-delete');
+    await wrapper
+      .findComponent('[data-testid="warning-modal"]')
+      .vm.$emit('close');
+    expect(
+      wrapper.find('[data-testid="warning-modal"]').attributes('data-open')
+    ).toBe('false');
   });
 });
 

--- a/components/discussion/detail/ImageLightbox.spec.ts
+++ b/components/discussion/detail/ImageLightbox.spec.ts
@@ -48,19 +48,36 @@ const mountLightbox = (props: Record<string, unknown> = {}) =>
         LightboxImagePanel: childStub(
           'LightboxImagePanel',
           ['currentImage', 'zoomLevel', 'isZoomed', 'isDragging'],
-          ['prev-image', 'next-image', 'mousedown', 'touchstart', 'touchend', 'touchmove']
+          [
+            'prev-image',
+            'next-image',
+            'mousedown',
+            'touchstart',
+            'touchend',
+            'touchmove',
+          ]
         ),
         LightboxInfoPanel: childStub(
           'LightboxInfoPanel',
           ['currentImage', 'isEditing', 'editingCaption'],
-          ['start-editing', 'update-caption', 'save-caption', 'cancel-editing', 'close-panel']
+          [
+            'start-editing',
+            'update-caption',
+            'save-caption',
+            'cancel-editing',
+            'close-panel',
+          ]
         ),
         BrokenRulesModal: childStub(
           'BrokenRulesModal',
           ['open', 'imageId'],
           ['close', 'report-submitted-successfully']
         ),
-        Notification: childStub('Notification', ['show', 'title'], ['close-notification']),
+        Notification: childStub(
+          'Notification',
+          ['show', 'title'],
+          ['close-notification']
+        ),
       },
     },
   });
@@ -106,7 +123,9 @@ describe('ImageLightbox current image', () => {
   it('navigates via the image panel next-image event', async () => {
     const wrapper = mountLightbox();
 
-    await wrapper.getComponent({ name: 'LightboxImagePanel' }).vm.$emit('next-image');
+    await wrapper
+      .getComponent({ name: 'LightboxImagePanel' })
+      .vm.$emit('next-image');
 
     expect(controls(wrapper).props('currentImageId')).toBe('img2');
   });
@@ -294,6 +313,18 @@ describe('ImageLightbox info panel', () => {
 
     expect(infoPanel(wrapper).props('isEditing')).toBe(false);
   });
+
+  it('alerts and stays in edit mode when the caption update fails', async () => {
+    h.updateImage = vi.fn().mockRejectedValueOnce(new Error('offline'));
+    vi.stubGlobal('alert', vi.fn());
+    const wrapper = mountLightbox();
+    await infoPanel(wrapper).vm.$emit('start-editing');
+    await infoPanel(wrapper).vm.$emit('save-caption');
+    expect([
+      vi.mocked(globalThis.alert).mock.calls,
+      infoPanel(wrapper).props('isEditing'),
+    ]).toEqual([[['Error saving caption. Please try again.']], true]);
+  });
 });
 
 describe('ImageLightbox reporting', () => {
@@ -315,15 +346,22 @@ describe('ImageLightbox reporting', () => {
     expect(wrapper.emitted('close')).toBeUndefined();
   });
 
+  it('closes the report modal when the nested modal requests it', async () => {
+    const wrapper = mountLightbox();
+    await controls(wrapper).vm.$emit('report-image');
+    await reportModal(wrapper).vm.$emit('close');
+    expect(reportModal(wrapper).props('open')).toBe(false);
+  });
+
   it('shows the success notification after a report is submitted', async () => {
     const wrapper = mountLightbox();
     await controls(wrapper).vm.$emit('report-image');
 
     await reportModal(wrapper).vm.$emit('report-submitted-successfully');
 
-    expect(
-      wrapper.getComponent({ name: 'Notification' }).props('show')
-    ).toBe(true);
+    expect(wrapper.getComponent({ name: 'Notification' }).props('show')).toBe(
+      true
+    );
   });
 
   it('dismisses the success notification', async () => {
@@ -335,8 +373,54 @@ describe('ImageLightbox reporting', () => {
       .getComponent({ name: 'Notification' })
       .vm.$emit('close-notification');
 
-    expect(
-      wrapper.getComponent({ name: 'Notification' }).props('show')
-    ).toBe(false);
+    expect(wrapper.getComponent({ name: 'Notification' }).props('show')).toBe(
+      false
+    );
+  });
+});
+
+describe('ImageLightbox pointer handling', () => {
+  it('ignores mouseup from an editing control', async () => {
+    const wrapper = mountLightbox();
+    await infoPanel(wrapper).vm.$emit('start-editing');
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const event = new MouseEvent('mouseup', { bubbles: true });
+    const stopPropagation = vi.spyOn(event, 'stopPropagation');
+    button.dispatchEvent(event);
+    button.remove();
+    expect(stopPropagation).toHaveBeenCalled();
+  });
+
+  it('routes zoomed touch gestures through dragging', async () => {
+    const wrapper = mountLightbox();
+    await controls(wrapper).vm.$emit('zoom-in');
+    await imagePanel(wrapper).vm.$emit('touchstart', {
+      touches: [{ clientX: 10, clientY: 10 }],
+      preventDefault: vi.fn(),
+    });
+    await imagePanel(wrapper).vm.$emit('touchmove', {
+      touches: [{ clientX: 20, clientY: 25 }],
+      preventDefault: vi.fn(),
+    });
+    await imagePanel(wrapper).vm.$emit('touchend', {
+      changedTouches: [{ clientX: 30 }],
+    });
+    expect(imagePanel(wrapper).props('isDragging')).toBe(true);
+  });
+
+  it('ignores touch swipes that start on an editing button', async () => {
+    const wrapper = mountLightbox();
+    await infoPanel(wrapper).vm.$emit('start-editing');
+    const button = document.createElement('button');
+    await imagePanel(wrapper).vm.$emit('touchstart', {
+      target: button,
+      touches: [{ clientX: 300 }],
+    });
+    await imagePanel(wrapper).vm.$emit('touchend', {
+      target: button,
+      changedTouches: [{ clientX: 0 }],
+    });
+    expect(controls(wrapper).props('currentImageId')).toBe('img1');
   });
 });

--- a/components/discussion/detail/LightboxControls.spec.ts
+++ b/components/discussion/detail/LightboxControls.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 
 import LightboxControls from '@/components/discussion/detail/LightboxControls.vue';
@@ -20,6 +21,11 @@ const mountControls = (props: Record<string, unknown> = {}) =>
     global: { stubs: { AddImageToFavorites: true } },
   });
 
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe('LightboxControls', () => {
   it.each([
@@ -61,5 +67,62 @@ describe('LightboxControls', () => {
   it('hides the report button when there is no image id', () => {
     const wrapper = mountControls({ currentImageId: '' });
     expect(wrapper.find('[aria-label="Report image"]').exists()).toBe(false);
+  });
+
+  it('downloads the current image and releases its blob URL', async () => {
+    vi.useFakeTimers();
+    const blob = new Blob(['image']);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ blob: () => Promise.resolve(blob) });
+    const createObjectURL = vi.fn().mockReturnValue('blob:test-image');
+    const revokeObjectURL = vi.fn();
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+    vi.stubGlobal('fetch', fetchMock);
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+    const wrapper = mountControls({
+      currentImageUrl: 'https://example.com/files/cat.png',
+    });
+
+    await wrapper.get('[aria-label="Download image"]').trigger('click');
+    await flushPromises();
+    vi.advanceTimersByTime(100);
+
+    expect({
+      requestedUrl: fetchMock.mock.calls[0],
+      createdFrom: createObjectURL.mock.calls[0],
+      releasedUrl: revokeObjectURL.mock.calls[0],
+      clickCount: click.mock.calls.length,
+      remainingLinks: document.body.querySelectorAll('a[download]').length,
+    }).toEqual({
+      requestedUrl: ['https://example.com/files/cat.png'],
+      createdFrom: [blob],
+      releasedUrl: ['blob:test-image'],
+      clickCount: 1,
+      remainingLinks: 0,
+    });
+  });
+
+  it('reports download failures without leaving a link behind', async () => {
+    const failure = new Error('network unavailable');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(failure));
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const wrapper = mountControls();
+
+    await wrapper.get('[aria-label="Download image"]').trigger('click');
+    await flushPromises();
+
+    expect(consoleError).toHaveBeenCalledWith('Download failed:', failure);
   });
 });

--- a/components/discussion/form/DownloadEditForm.spec.ts
+++ b/components/discussion/form/DownloadEditForm.spec.ts
@@ -189,9 +189,9 @@ describe('DownloadEditForm rendering', () => {
       channelData: { FilterGroups: [{ id: 'g1' }] },
     });
 
-    expect(wrapper.findComponent({ name: 'DownloadLabelPicker' }).exists()).toBe(
-      true
-    );
+    expect(
+      wrapper.findComponent({ name: 'DownloadLabelPicker' }).exists()
+    ).toBe(true);
   });
 
   it('hides support fields by default for files without custom values', async () => {
@@ -226,9 +226,9 @@ describe('DownloadEditForm file editing', () => {
 
     await wrapper.get('button[title="Delete this file"]').trigger('click');
 
-    expect(
-      wrapper.getComponent({ name: 'WarningModal' }).props('open')
-    ).toBe(true);
+    expect(wrapper.getComponent({ name: 'WarningModal' }).props('open')).toBe(
+      true
+    );
   });
 
   it('does not remove an existing file before confirmation', async () => {
@@ -255,9 +255,11 @@ describe('DownloadEditForm file editing', () => {
     await flushPromises();
 
     expect(
-      (wrapper.emitted('updateFormValues')?.at(-1)?.[0] as {
-        downloadableFiles: unknown[];
-      }).downloadableFiles
+      (
+        wrapper.emitted('updateFormValues')?.at(-1)?.[0] as {
+          downloadableFiles: unknown[];
+        }
+      ).downloadableFiles
     ).toHaveLength(0);
   });
 
@@ -278,8 +280,9 @@ describe('DownloadEditForm file editing', () => {
   });
 
   it('keeps the file in the form when permanent delete fails', async () => {
-    (h.permanentlyDeleteDownloadableFile as ReturnType<typeof vi.fn>)
-      .mockRejectedValueOnce(new Error('Not authorized'));
+    (
+      h.permanentlyDeleteDownloadableFile as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error('Not authorized'));
     const wrapper = mountForm({
       discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),
     });
@@ -295,8 +298,9 @@ describe('DownloadEditForm file editing', () => {
   });
 
   it('shows the backend delete error when permanent delete fails', async () => {
-    (h.permanentlyDeleteDownloadableFile as ReturnType<typeof vi.fn>)
-      .mockRejectedValueOnce(new Error('Not authorized'));
+    (
+      h.permanentlyDeleteDownloadableFile as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error('Not authorized'));
     const wrapper = mountForm({
       discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),
     });
@@ -319,9 +323,7 @@ describe('DownloadEditForm file editing', () => {
     });
     await flushPromises();
 
-    await wrapper
-      .get('input[type="checkbox"]')
-      .setValue(true);
+    await wrapper.get('input[type="checkbox"]').setValue(true);
     await wrapper.get('textarea').setValue('Thanks for downloading');
 
     expect(
@@ -410,6 +412,99 @@ describe('DownloadEditForm upload', () => {
 
     expect(wrapper.find('.error-banner').exists()).toBe(true);
   });
+
+  it('rejects a file type not allowed by the forum', async () => {
+    const wrapper = mountForm({
+      channelData: { allowedFileTypes: ['application/zip'] },
+    });
+    await setFiles(wrapper, '#downloadable-file-input', [
+      new File(['x'], 'installer.exe', {
+        type: 'application/x-msdownload',
+      }),
+    ]);
+    expect(wrapper.find('.error-banner').exists()).toBe(true);
+  });
+
+  it('does not upload when no username is available', async () => {
+    h.username.value = null;
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = mountForm();
+    await setFiles(wrapper, '#downloadable-file-input', [
+      new File(['x'], 'new.stl'),
+    ]);
+    error.mockRestore();
+    expect(h.createSignedStorageUrl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'signed URL',
+      () => {
+        h.createSignedStorageUrl = vi.fn().mockResolvedValue({ data: {} });
+      },
+    ],
+    [
+      'embedded file URL',
+      () => {
+        h.uploadLink = vi.fn().mockResolvedValue(null);
+      },
+    ],
+    [
+      'database file record',
+      () => {
+        h.createDownloadableFile = vi.fn().mockResolvedValue({
+          data: { createDownloadableFiles: { downloadableFiles: [] } },
+        });
+      },
+    ],
+  ])('surfaces a missing %s response', async (_label, arrange) => {
+    arrange();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = mountForm();
+    await setFiles(wrapper, '#downloadable-file-input', [
+      new File(['x'], 'new.stl'),
+    ]);
+    error.mockRestore();
+    expect(wrapper.find('.error-banner').exists()).toBe(true);
+  });
+});
+
+describe('DownloadEditForm removal controls', () => {
+  it('removes a temporary file without opening confirmation', async () => {
+    const wrapper = mountForm({
+      discussion: makeDiscussion({
+        DownloadableFiles: [{ ...fileRecord(), id: '', url: '' }],
+      }),
+    });
+    await flushPromises();
+    await wrapper.get('button').trigger('click');
+    expect(
+      (
+        wrapper.emitted('updateFormValues')?.at(-1)?.[0] as {
+          downloadableFiles: unknown[];
+        }
+      ).downloadableFiles
+    ).toHaveLength(0);
+  });
+
+  it('closes an open permanent-delete confirmation', async () => {
+    const wrapper = mountForm({
+      discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),
+    });
+    await flushPromises();
+    await wrapper.get('button[title="Delete this file"]').trigger('click');
+    const modal = wrapper.getComponent({ name: 'WarningModal' });
+    await modal.vm.$emit('close');
+    expect(modal.props('open')).toBe(false);
+  });
+
+  it('ignores permanent delete confirmation when no file is pending', async () => {
+    const wrapper = mountForm();
+    await wrapper
+      .getComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+    expect(h.permanentlyDeleteDownloadableFile).not.toHaveBeenCalled();
+  });
 });
 
 describe('DownloadEditForm save side effects', () => {
@@ -428,9 +523,9 @@ describe('DownloadEditForm save side effects', () => {
       .vm.$emit('primary-button-click');
     await flushPromises();
 
-    expect(
-      wrapper.getComponent({ name: 'Notification' }).props('show')
-    ).toBe(true);
+    expect(wrapper.getComponent({ name: 'Notification' }).props('show')).toBe(
+      true
+    );
   });
 
   it('closes the editor when the update mutation completes', () => {
@@ -457,5 +552,26 @@ describe('DownloadEditForm save side effects', () => {
         }
       ).downloadLabels
     ).toEqual({ g1: ['a'] });
+  });
+
+  it('dismisses the temporary saved notification after three seconds', async () => {
+    vi.useFakeTimers();
+    const wrapper = mountForm({
+      discussion: makeDiscussion({
+        id: 'temp-id',
+        DownloadableFiles: [fileRecord()],
+      }),
+    });
+    await flushPromises();
+    await wrapper.get('button[title="Delete this file"]').trigger('click');
+    await wrapper
+      .getComponent({ name: 'WarningModal' })
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(wrapper.getComponent({ name: 'Notification' }).props('show')).toBe(
+      false
+    );
+    vi.useRealTimers();
   });
 });

--- a/components/discussion/list/SitewideDownloadList.spec.ts
+++ b/components/discussion/list/SitewideDownloadList.spec.ts
@@ -21,7 +21,9 @@ vi.mock('nuxt/app', () => ({
   useState: (_k, init) => ref(init ? init() : undefined),
 }));
 
-const SERVER_CONFIG = { serverConfigs: [{ serverName: 'Test', __typename: 'ServerConfig' }] };
+const SERVER_CONFIG = {
+  serverConfigs: [{ serverName: 'Test', __typename: 'ServerConfig' }],
+};
 
 const makeDownload = (id: string) => ({
   id,
@@ -30,7 +32,10 @@ const makeDownload = (id: string) => ({
   __typename: 'Discussion',
 });
 
-const listResult = (discussions: ReturnType<typeof makeDownload>[], aggregate?: number) => ({
+const listResult = (
+  discussions: ReturnType<typeof makeDownload>[],
+  aggregate?: number
+) => ({
   getSiteWideDiscussionList: {
     discussions,
     aggregateDiscussionCount: aggregate ?? discussions.length,
@@ -54,7 +59,10 @@ const stubs = {
     emits: ['loadMore'],
     template: '<button class="load-more-stub" @click="$emit(\'loadMore\')" />',
   },
-  ErrorBanner: { props: ['text'], template: '<div class="error-stub">{{ text }}</div>' },
+  ErrorBanner: {
+    props: ['text'],
+    template: '<div class="error-stub">{{ text }}</div>',
+  },
   NuxtLink: { template: '<a><slot /></a>' },
 };
 
@@ -84,7 +92,9 @@ describe('SitewideDownloadList', () => {
   });
 
   it('renders a card per download', () => {
-    setupQueries(createQueryMock(listResult([makeDownload('1'), makeDownload('2')])));
+    setupQueries(
+      createQueryMock(listResult([makeDownload('1'), makeDownload('2')]))
+    );
     const wrapper = mountList();
     expect(wrapper.findAll('.item-stub')).toHaveLength(2);
   });
@@ -96,7 +106,9 @@ describe('SitewideDownloadList', () => {
   });
 
   it('renders the error banner when the query errors', () => {
-    setupQueries(createQueryMock(listResult([]), { error: ref(new Error('kaboom')) }));
+    setupQueries(
+      createQueryMock(listResult([]), { error: ref(new Error('kaboom')) })
+    );
     const wrapper = mountList();
     expect(wrapper.find('.error-stub').text()).toContain('kaboom');
   });
@@ -109,35 +121,109 @@ describe('SitewideDownloadList', () => {
 
   it('calls fetchMore when LoadMore emits', async () => {
     const fetchMore = vi.fn();
-    setupQueries(createQueryMock(listResult([makeDownload('1')], 5), { ...({ fetchMore } as object) }));
+    setupQueries(
+      createQueryMock(listResult([makeDownload('1')], 5), {
+        ...({ fetchMore } as object),
+      })
+    );
     const wrapper = mountList();
     await wrapper.find('.load-more-stub').trigger('click');
     expect(fetchMore).toHaveBeenCalledTimes(1);
   });
 
+  it('merges the next download page into the existing query result', async () => {
+    const fetchMore = vi.fn();
+    setupQueries(
+      createQueryMock(listResult([makeDownload('1')], 3), {
+        ...({ fetchMore } as object),
+      })
+    );
+    const wrapper = mountList({ query: { sort: 'new' } });
+    await wrapper.find('.load-more-stub').trigger('click');
+    const options = fetchMore.mock.calls[0][0];
+    const merged = options.updateQuery(listResult([makeDownload('1')], 3), {
+      fetchMoreResult: listResult([makeDownload('2'), makeDownload('3')], 3),
+    });
+    expect(merged.getSiteWideDiscussionList.discussions).toHaveLength(3);
+  });
+
+  it('keeps the current result when fetchMore returns nothing', async () => {
+    const fetchMore = vi.fn();
+    const previous = listResult([makeDownload('1')], 3);
+    setupQueries(createQueryMock(previous, { ...({ fetchMore } as object) }));
+    const wrapper = mountList();
+    await wrapper.find('.load-more-stub').trigger('click');
+    const options = fetchMore.mock.calls[0][0];
+    expect(options.updateQuery(previous, { fetchMoreResult: null })).toBe(
+      previous
+    );
+  });
+
   it('adds the tag to the query when filtering by a new tag', () => {
     setupQueries(createQueryMock(listResult([makeDownload('1')])));
     const wrapper = mountList({ query: {} });
-    wrapper.findComponent(stubs.SitewideDownloadListItem).vm.$emit('filterByTag', 'vue');
+    wrapper
+      .findComponent(stubs.SitewideDownloadListItem)
+      .vm.$emit('filterByTag', 'vue');
     expect(replace).toHaveBeenCalledWith({ query: { tags: ['vue'] } });
   });
 
   it('clears the tag when already filtering by only that tag', () => {
     setupQueries(createQueryMock(listResult([makeDownload('1')])));
     const wrapper = mountList({ query: { tags: 'vue' } });
-    wrapper.findComponent(stubs.SitewideDownloadListItem).vm.$emit('filterByTag', 'vue');
+    wrapper
+      .findComponent(stubs.SitewideDownloadListItem)
+      .vm.$emit('filterByTag', 'vue');
     const lastCall = replace.mock.calls.at(-1)?.[0];
     expect(lastCall.query.tags).toBeUndefined();
+  });
+
+  it('removes a selected tag from a multi-tag query', () => {
+    setupQueries(createQueryMock(listResult([makeDownload('1')])));
+    const wrapper = mountList({ query: { tags: ['vue', 'nuxt'] } });
+    wrapper
+      .findComponent(stubs.SitewideDownloadListItem)
+      .vm.$emit('filterByTag', 'vue');
+    expect(replace).toHaveBeenCalledWith({ query: { tags: ['nuxt'] } });
+  });
+
+  it('adds a different tag while preserving the rest of the route query', () => {
+    setupQueries(createQueryMock(listResult([makeDownload('1')])));
+    const wrapper = mountList({ query: { sort: 'top', tags: 'vue' } });
+    wrapper
+      .findComponent(stubs.SitewideDownloadListItem)
+      .vm.$emit('filterByTag', 'nuxt');
+    expect(replace).toHaveBeenCalledWith({
+      query: { sort: 'top', tags: ['nuxt'] },
+    });
   });
 
   it('opens the album lightbox when a child requests it', async () => {
     setupQueries(createQueryMock(listResult([makeDownload('1')])));
     const wrapper = mountList();
-    wrapper.findComponent(stubs.SitewideDownloadListItem).vm.$emit('openAlbum', {
-      discussion: makeDownload('1'),
-      album: { id: 'a1', __typename: 'Album' },
-    });
+    wrapper
+      .findComponent(stubs.SitewideDownloadListItem)
+      .vm.$emit('openAlbum', {
+        discussion: makeDownload('1'),
+        album: { id: 'a1', __typename: 'Album' },
+      });
     await wrapper.vm.$nextTick();
     expect(wrapper.find('.album-stub').exists()).toBe(true);
+  });
+
+  it('closes the album lightbox from the album component', async () => {
+    setupQueries(createQueryMock(listResult([makeDownload('1')])));
+    const wrapper = mountList();
+    wrapper
+      .findComponent(stubs.SitewideDownloadListItem)
+      .vm.$emit('openAlbum', {
+        discussion: makeDownload('1'),
+        album: { id: 'a1', __typename: 'Album' },
+      });
+    await wrapper.vm.$nextTick();
+    await wrapper
+      .findComponent(stubs.DiscussionAlbum)
+      .vm.$emit('close-lightbox');
+    expect(wrapper.find('.album-stub').exists()).toBe(false);
   });
 });

--- a/components/download/StlViewer.spec.ts
+++ b/components/download/StlViewer.spec.ts
@@ -3,7 +3,13 @@ import { mount, flushPromises } from '@vue/test-utils';
 import StlViewer from '@/components/download/StlViewer.vue';
 
 // Control the STL loader's outcome per test.
-const stl = vi.hoisted(() => ({ mode: 'success' as 'success' | 'error' }));
+const stl = vi.hoisted(() => ({
+  mode: 'success' as 'success' | 'error',
+  controls: null as null | Record<string, unknown>,
+  renderer: null as null | Record<string, unknown>,
+  scene: null as null | { children: unknown[]; add: ReturnType<typeof vi.fn> },
+  controlEvents: {} as Record<string, () => void>,
+}));
 
 vi.mock('three/examples/jsm/loaders/STLLoader', () => ({
   STLLoader: vi.fn(function () {
@@ -20,7 +26,10 @@ vi.mock('three/examples/jsm/loaders/STLLoader', () => ({
             return;
           }
           onProgress?.({ loaded: 50, total: 100 });
-          onLoad({ computeBoundingBox: vi.fn(), boundingBox: { getCenter: vi.fn() } });
+          onLoad({
+            computeBoundingBox: vi.fn(),
+            boundingBox: { getCenter: vi.fn() },
+          });
         }
       ),
     };
@@ -29,15 +38,18 @@ vi.mock('three/examples/jsm/loaders/STLLoader', () => ({
 
 vi.mock('three/examples/jsm/controls/OrbitControls', () => ({
   OrbitControls: vi.fn(function () {
-    return {
+    stl.controls = {
       enableDamping: true,
       dampingFactor: 0,
       autoRotate: false,
       autoRotateSpeed: 0,
-      addEventListener: vi.fn(),
+      addEventListener: vi.fn((name: string, callback: () => void) => {
+        stl.controlEvents[name] = callback;
+      }),
       update: vi.fn(),
       dispose: vi.fn(),
     };
+    return stl.controls;
   }),
 }));
 
@@ -45,7 +57,12 @@ vi.mock('three', () => {
   const v3 = () => ({ x: 1, y: 1, z: 1, set: vi.fn(), sub: vi.fn() });
   return {
     Scene: vi.fn(function () {
-      return { add: vi.fn(), background: null, children: [] };
+      const children: unknown[] = [];
+      stl.scene = {
+        children,
+        add: vi.fn((child: unknown) => children.push(child)),
+      };
+      return { ...stl.scene, background: null };
     }),
     Color: vi.fn(function () {
       return {};
@@ -60,12 +77,13 @@ vi.mock('three', () => {
       };
     }),
     WebGLRenderer: vi.fn(function () {
-      return {
+      stl.renderer = {
         setSize: vi.fn(),
         render: vi.fn(),
         dispose: vi.fn(),
         domElement: document.createElement('canvas'),
       };
+      return stl.renderer;
     }),
     AmbientLight: vi.fn(function () {
       return {};
@@ -101,6 +119,10 @@ const mountViewer = (props: Record<string, unknown> = {}) =>
 beforeEach(() => {
   vi.clearAllMocks();
   stl.mode = 'success';
+  stl.controls = null;
+  stl.renderer = null;
+  stl.scene = null;
+  stl.controlEvents = {};
   vi.stubGlobal('requestAnimationFrame', vi.fn().mockReturnValue(1));
   vi.stubGlobal('cancelAnimationFrame', vi.fn());
 });
@@ -132,5 +154,73 @@ describe('StlViewer', () => {
     await wrapper.trigger('mouseenter');
     await wrapper.trigger('mouseleave');
     expect(wrapper.html()).toBeTruthy();
+  });
+
+  it('updates interaction cursor while orbit controls are active', async () => {
+    mountViewer({ src: 'http://x/model.stl' });
+    await flushPromises();
+    stl.controlEvents.start?.();
+    const grabbing = (stl.renderer?.domElement as HTMLCanvasElement).style
+      .cursor;
+    stl.controlEvents.end?.();
+    expect({
+      grabbing,
+      idle: (stl.renderer?.domElement as HTMLCanvasElement).style.cursor,
+    }).toEqual({ grabbing: 'grabbing', idle: 'grab' });
+  });
+
+  it('resizes the renderer and camera when the window changes size', async () => {
+    mountViewer({ src: 'http://x/model.stl' });
+    await flushPromises();
+    (stl.renderer?.setSize as ReturnType<typeof vi.fn>).mockClear();
+    window.dispatchEvent(new Event('resize'));
+    expect(stl.renderer?.setSize).toHaveBeenCalledOnce();
+  });
+
+  it('resets the camera and toggles auto rotation through exposed methods', async () => {
+    const wrapper = mountViewer({ src: 'http://x/model.stl' });
+    await flushPromises();
+    wrapper.vm.resetCamera();
+    wrapper.vm.setAutoRotate(true);
+    expect({
+      autoRotate: stl.controls?.autoRotate,
+      updates: (stl.controls?.update as ReturnType<typeof vi.fn>).mock.calls
+        .length,
+    }).toEqual({ autoRotate: true, updates: 3 });
+  });
+
+  it('cleans up the previous renderer and loads a changed source', async () => {
+    const wrapper = mountViewer({ src: 'http://x/first.stl' });
+    await flushPromises();
+    const firstRenderer = stl.renderer;
+    const firstControls = stl.controls;
+    await wrapper.setProps({ src: 'http://x/second.stl' });
+    await flushPromises();
+    expect({
+      rendererDisposed: (firstRenderer?.dispose as ReturnType<typeof vi.fn>)
+        .mock.calls.length,
+      controlsDisposed: (firstControls?.dispose as ReturnType<typeof vi.fn>)
+        .mock.calls.length,
+      canvases: wrapper.findAll('canvas').length,
+    }).toEqual({
+      rendererDisposed: 1,
+      controlsDisposed: 1,
+      canvases: 1,
+    });
+  });
+
+  it('disposes viewer resources when unmounted', async () => {
+    const wrapper = mountViewer({ src: 'http://x/model.stl' });
+    await flushPromises();
+    const renderer = stl.renderer;
+    const controls = stl.controls;
+    wrapper.unmount();
+    expect({
+      renderer: (renderer?.dispose as ReturnType<typeof vi.fn>).mock.calls
+        .length,
+      controls: (controls?.dispose as ReturnType<typeof vi.fn>).mock.calls
+        .length,
+      animation: vi.mocked(cancelAnimationFrame).mock.calls.length,
+    }).toEqual({ renderer: 1, controls: 1, animation: 1 });
   });
 });

--- a/components/download/StlViewer.vue
+++ b/components/download/StlViewer.vue
@@ -79,7 +79,11 @@ const actualHeight = ref(400);
 
 // THREE.js objects - using any due to missing type declarations
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-let scene: any, camera: any, renderer: any, controls: any, animationId: number | undefined;
+let scene: any,
+  camera: any,
+  renderer: any,
+  controls: any,
+  animationId: number | undefined;
 
 function updateDimensions() {
   if (!container.value) return;
@@ -234,6 +238,7 @@ function resetCamera() {
 }
 
 function cleanup() {
+  const containerElement = container.value;
   if (animationId) {
     cancelAnimationFrame(animationId);
   }
@@ -243,8 +248,12 @@ function cleanup() {
   if (controls) {
     controls.dispose();
   }
-  while (container.value?.firstChild) {
-    container.value.removeChild(container.value.firstChild);
+  if (
+    renderer?.domElement &&
+    renderer.domElement.parentNode === containerElement &&
+    containerElement
+  ) {
+    containerElement.removeChild(renderer.domElement);
   }
 }
 

--- a/components/event/detail/EventDetail.spec.ts
+++ b/components/event/detail/EventDetail.spec.ts
@@ -58,9 +58,16 @@ const stubs = {
     template: '<div class="info-stub">{{ text }}</div>',
   },
   EventHeader: {
-    template: '<button class="event-header-stub" @click="$emit(\'archived-successfully\')" />',
+    template:
+      '<button class="event-header-stub" @click="$emit(\'archived-successfully\')" />',
   },
   EventBody: {
+    name: 'EventBody',
+    props: ['eventDescriptionEditMode'],
+    emits: [
+      'handle-click-edit-event-description',
+      'close-edit-event-description',
+    ],
     template:
       '<button class="event-body-stub" @click="$emit(\'handle-click-edit-event-description\')" />',
   },
@@ -85,25 +92,27 @@ const stubs = {
   Tag: { template: '<span class="tag-stub" />' },
 };
 
-const setup = (params: {
-  event?: Event | null;
-  eventLoading?: boolean;
-  eventError?: Error | null;
-  comments?: Array<Record<string, unknown>>;
-  routeName?: string;
-  routeQuery?: Record<string, unknown>;
-  username?: string;
-  modProfileName?: string;
-  eventChannels?: EventChannel[] | null;
-  rootCommentCount?: number;
-  rootAggregateLoading?: boolean;
-  rootAggregateError?: Error | null;
-  showComments?: boolean;
-  showTitle?: boolean;
-  linkTitle?: boolean;
-  usernameOnTop?: boolean;
-  issueEventId?: string;
-} = {}) => {
+const setup = (
+  params: {
+    event?: Event | null;
+    eventLoading?: boolean;
+    eventError?: Error | null;
+    comments?: Array<Record<string, unknown>>;
+    routeName?: string;
+    routeQuery?: Record<string, unknown>;
+    username?: string;
+    modProfileName?: string;
+    eventChannels?: EventChannel[] | null;
+    rootCommentCount?: number;
+    rootAggregateLoading?: boolean;
+    rootAggregateError?: Error | null;
+    showComments?: boolean;
+    showTitle?: boolean;
+    linkTitle?: boolean;
+    usernameOnTop?: boolean;
+    issueEventId?: string;
+  } = {}
+) => {
   const {
     event = makeEvent(),
     eventLoading = false,
@@ -219,7 +228,9 @@ describe('EventDetail', () => {
   it('shows the not-found message when the event is missing', () => {
     const { wrapper } = setup({ event: null, eventLoading: false });
 
-    expect(wrapper.text()).toContain("Can't find the content that was reported");
+    expect(wrapper.text()).toContain(
+      "Can't find the content that was reported"
+    );
   });
 
   it('emits the original poster username from the event query result', () => {
@@ -368,5 +379,70 @@ describe('EventDetail', () => {
     });
 
     expect(wrapper.find('.expandable-image-stub').exists()).toBe(true);
+  });
+
+  it('reloads comments when a username becomes available', async () => {
+    const { wrapper, commentsQuery } = setup();
+    h.username.value = 'alice';
+    await wrapper.vm.$nextTick();
+    expect(commentsQuery.refetch).toHaveBeenCalledOnce();
+  });
+
+  it('reloads comments on mount for an already signed-in user', () => {
+    const { commentsQuery } = setup({ username: 'alice' });
+    expect(commentsQuery.refetch).toHaveBeenCalledOnce();
+  });
+
+  it('reloads event data after its ID changes', async () => {
+    const { wrapper, eventQuery, commentsQuery, aggregateQuery } = setup();
+    await wrapper.setProps({ eventId: 'e2' });
+    expect([
+      eventQuery.refetch.mock.calls.length,
+      commentsQuery.refetch.mock.calls.length,
+      aggregateQuery.refetch.mock.calls.length,
+    ]).toEqual([1, 1, 1]);
+  });
+
+  it('merges a fetched page of event comments', async () => {
+    const { wrapper, commentsQuery } = setup({ comments: [{ id: 'one' }] });
+    await wrapper.find('.load-more-stub').trigger('click');
+    const options = commentsQuery.fetchMore.mock.calls[0][0];
+    const merged = options.updateQuery(
+      { getEventComments: { Comments: [{ id: 'one' }] } },
+      { fetchMoreResult: { getEventComments: { Comments: [{ id: 'two' }] } } }
+    );
+    expect([options.variables, merged.getEventComments.Comments]).toEqual([
+      { offset: 1 },
+      [{ id: 'one' }, { id: 'two' }],
+    ]);
+  });
+
+  it('keeps the prior event comments when fetchMore returns nothing', async () => {
+    const { wrapper, commentsQuery } = setup({ comments: [{ id: 'one' }] });
+    await wrapper.find('.load-more-stub').trigger('click');
+    const previous = { getEventComments: { Comments: [{ id: 'one' }] } };
+    expect(
+      commentsQuery.fetchMore.mock.calls[0][0].updateQuery(previous, {})
+    ).toBe(previous);
+  });
+
+  it('enters and exits description editing from EventBody events', async () => {
+    const { wrapper } = setup();
+    const body = wrapper.findComponent({ name: 'EventBody' });
+    await body.vm.$emit('handle-click-edit-event-description');
+    const editing = body.props('eventDescriptionEditMode');
+    await body.vm.$emit('close-edit-event-description');
+    expect([editing, body.props('eventDescriptionEditMode')]).toEqual([
+      true,
+      false,
+    ]);
+  });
+
+  it('renders the edited timestamp when the event has an update time', () => {
+    const { wrapper } = setup({
+      event: makeEvent({ updatedAt: '2025-01-01T00:00:00.000Z' }),
+      usernameOnTop: true,
+    });
+    expect(wrapper.text()).toContain('Edited');
   });
 });

--- a/components/event/detail/EventHeader.actions.spec.ts
+++ b/components/event/detail/EventHeader.actions.spec.ts
@@ -155,8 +155,7 @@ const buildWrapper = (eventData: Record<string, unknown> = baseEvent()) =>
         NuxtLink: { template: '<a><slot /></a>' },
         ClientOnly: { template: '<div><slot /></div>' },
         MenuButton: {
-          template:
-            '<button data-testid="event-menu-button"><slot /></button>',
+          template: '<button data-testid="event-menu-button"><slot /></button>',
           props: ['items'],
         },
         WarningModal: {
@@ -224,6 +223,51 @@ describe('EventHeader — copy actions', () => {
 
     expect(wrapper.text()).toContain('Copied!');
   });
+
+  it('clears the copied-address confirmation after two seconds', async () => {
+    vi.useFakeTimers();
+    const wrapper = buildWrapper();
+    await wrapper
+      .get('button[aria-label="Copy address to clipboard"]')
+      .trigger('click');
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(wrapper.text()).not.toContain('Copied!');
+  });
+
+  it('handles clipboard rejection for addresses and permalinks', async () => {
+    clipboardWriteText.mockRejectedValue(new Error('clipboard denied'));
+    const wrapper = buildWrapper();
+    await wrapper
+      .get('button[aria-label="Copy address to clipboard"]')
+      .trigger('click');
+    await menu(wrapper).vm.$emit('copy-link');
+    expect(clipboardWriteText).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('EventHeader — direct menu actions', () => {
+  it('navigates to the event editor', async () => {
+    const wrapper = buildWrapper();
+    await menu(wrapper).vm.$emit('handle-edit');
+    expect(routerPush).toHaveBeenCalledWith('/forums/cats/events/edit/event-1');
+  });
+
+  it('closes cancel and scope modals from their close events', async () => {
+    const wrapper = buildWrapper({ ...baseEvent(), EventSeries: { id: 's1' } });
+    await menu(wrapper).vm.$emit('handle-cancel');
+    await wrapper
+      .findAllComponents('[data-testid="scope-modal"]')[0]
+      .vm.$emit('close');
+    await menu(wrapper).vm.$emit('handle-delete');
+    await wrapper
+      .findAllComponents('[data-testid="scope-modal"]')[1]
+      .vm.$emit('close');
+    expect(
+      wrapper
+        .findAll('[data-testid="scope-modal"]')
+        .map((modal) => modal.attributes('data-open'))
+    ).toEqual(['false', 'false']);
+  });
 });
 
 describe('EventHeader — cancel flow', () => {
@@ -246,7 +290,9 @@ describe('EventHeader — cancel flow', () => {
 
   it('cancels a series event when a scope is confirmed', async () => {
     const wrapper = buildWrapper({ ...baseEvent(), EventSeries: { id: 's1' } });
-    const scopeModal = wrapper.findAllComponents('[data-testid="scope-modal"]')[0]!;
+    const scopeModal = wrapper.findAllComponents(
+      '[data-testid="scope-modal"]'
+    )[0]!;
     await scopeModal.vm.$emit('confirm', 'thisEvent');
 
     expect(mutateSpies[2]).toHaveBeenCalledTimes(1);
@@ -273,7 +319,9 @@ describe('EventHeader — delete flow', () => {
 
   it('deletes a series event when a scope is confirmed', async () => {
     const wrapper = buildWrapper({ ...baseEvent(), EventSeries: { id: 's1' } });
-    const scopeModal = wrapper.findAllComponents('[data-testid="scope-modal"]')[1]!;
+    const scopeModal = wrapper.findAllComponents(
+      '[data-testid="scope-modal"]'
+    )[1]!;
     await scopeModal.vm.$emit('confirm', 'thisEvent');
 
     expect(mutateSpies[3]).toHaveBeenCalledWith({
@@ -324,7 +372,9 @@ describe('EventHeader — feedback flow', () => {
 
   it('submits feedback when text and a mod profile are present', async () => {
     const wrapper = buildWrapper();
-    const feedbackModal = wrapper.findComponent('[data-testid="feedback-modal"]');
+    const feedbackModal = wrapper.findComponent(
+      '[data-testid="feedback-modal"]'
+    );
     await feedbackModal.vm.$emit('update-feedback', 'Great event');
     await feedbackModal.vm.$emit('primary-button-click');
 
@@ -333,16 +383,41 @@ describe('EventHeader — feedback flow', () => {
 
   it('does not submit feedback without any text', async () => {
     const wrapper = buildWrapper();
-    const feedbackModal = wrapper.findComponent('[data-testid="feedback-modal"]');
+    const feedbackModal = wrapper.findComponent(
+      '[data-testid="feedback-modal"]'
+    );
     await feedbackModal.vm.$emit('primary-button-click');
 
     expect(mutateSpies[4]).not.toHaveBeenCalled();
   });
 
+  it('does not submit feedback when forum feedback is disabled', async () => {
+    feedbackEnabledFlag.value = false;
+    const wrapper = buildWrapper();
+    const feedbackModal = wrapper.findComponent(
+      '[data-testid="feedback-modal"]'
+    );
+    await feedbackModal.vm.$emit('update-feedback', 'Great event');
+    await feedbackModal.vm.$emit('primary-button-click');
+    expect(mutateSpies[4]).not.toHaveBeenCalled();
+  });
+
+  it('closes the feedback form from the modal close event', async () => {
+    const wrapper = buildWrapper();
+    const feedbackModal = wrapper.findComponent(
+      '[data-testid="feedback-modal"]'
+    );
+    await menu(wrapper).vm.$emit('handle-feedback');
+    await feedbackModal.vm.$emit('close');
+    expect(feedbackModal.attributes('data-open')).toBe('false');
+  });
+
   it('does not submit feedback without a mod profile name', async () => {
     modProfileName.value = '';
     const wrapper = buildWrapper();
-    const feedbackModal = wrapper.findComponent('[data-testid="feedback-modal"]');
+    const feedbackModal = wrapper.findComponent(
+      '[data-testid="feedback-modal"]'
+    );
     await feedbackModal.vm.$emit('update-feedback', 'Great event');
     await feedbackModal.vm.$emit('primary-button-click');
 
@@ -353,7 +428,9 @@ describe('EventHeader — feedback flow', () => {
     const wrapper = buildWrapper();
     onDoneCallbacks[4]!();
     await wrapper.vm.$nextTick();
-    const feedbackModal = wrapper.findComponent('[data-testid="feedback-modal"]');
+    const feedbackModal = wrapper.findComponent(
+      '[data-testid="feedback-modal"]'
+    );
 
     expect(feedbackModal.attributes('data-open')).toBe('false');
   });

--- a/components/event/form/CreateEvent.spec.ts
+++ b/components/event/form/CreateEvent.spec.ts
@@ -21,6 +21,12 @@ vi.mock('@/composables/useAuthState', () => ({
 const mockPush = vi.fn();
 const mockMutate = vi.fn();
 const onDoneCallbacks: Array<(result: CreateEventResult) => void> = [];
+const mutationOptions: Array<{
+  update?: (
+    cache: { modify: ReturnType<typeof vi.fn> },
+    result: unknown
+  ) => void;
+}> = [];
 const channelResult = ref({
   channels: [
     {
@@ -40,18 +46,31 @@ vi.mock('nuxt/app', () => ({
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
-  useMutation: vi.fn(() => ({
-    mutate: mockMutate,
-    error: ref(null),
-    onDone: (cb: (result: CreateEventResult) => void) => {
-      onDoneCallbacks.push(cb);
-    },
-  })),
-  useQuery: vi.fn(() => ({
-    result: channelResult,
-    loading: ref(false),
-    error: ref(null),
-  })),
+  useMutation: vi.fn((_query: unknown, options = {}) => {
+    mutationOptions.push(options);
+    return {
+      mutate: mockMutate,
+      error: ref(null),
+      onDone: (cb: (result: CreateEventResult) => void) => {
+        onDoneCallbacks.push(cb);
+      },
+    };
+  }),
+  useQuery: vi.fn(
+    (
+      _query: unknown,
+      variables: { value: unknown },
+      options: { enabled: { value: unknown } }
+    ) => {
+      void variables.value;
+      void options.enabled.value;
+      return {
+        result: channelResult,
+        loading: ref(false),
+        error: ref(null),
+      };
+    }
+  ),
 }));
 
 vi.mock('@/composables/useSuspensionNotice', () => ({
@@ -66,6 +85,7 @@ vi.mock('@/composables/useSuspensionNotice', () => ({
 describe('CreateEvent', () => {
   beforeEach(() => {
     onDoneCallbacks.length = 0;
+    mutationOptions.length = 0;
     mockPush.mockReset();
     mockMutate.mockReset();
     channelResult.value = {
@@ -86,7 +106,11 @@ describe('CreateEvent', () => {
           RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
           CreateEditEventFields: {
             name: 'CreateEditEventFields',
-            props: ['suspensionIssueNumber', 'submitError', 'lockedChannelName'],
+            props: [
+              'suspensionIssueNumber',
+              'submitError',
+              'lockedChannelName',
+            ],
             template:
               '<button data-testid="submit" @click="$emit(\'submit\')"></button>',
           },
@@ -169,6 +193,35 @@ describe('CreateEvent', () => {
     expect(stub.props('submitError')).toContain('Unable to create event');
   });
 
+  it('redirects after a single event is created', async () => {
+    const wrapper = await submitWithFormValues({
+      dateMode: 'single',
+      startTime: '2030-01-01T18:00:00.000Z',
+      endTime: '2030-01-01T21:00:00.000Z',
+    });
+    onDoneCallbacks[0]({
+      data: {
+        createEventWithChannelConnections: [{ id: 'event-1' }],
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(mockPush).toHaveBeenCalledWith({
+      name: 'forums-forumId-events-eventId',
+      params: { forumId: 'cats', eventId: 'event-1' },
+    });
+  });
+
+  it('updates the Apollo event list when creation returns an event', () => {
+    mountCreateEvent();
+    const cache = { modify: vi.fn() };
+    const created = { id: 'event-1' };
+    mutationOptions[0].update?.(cache, {
+      data: { createEventWithChannelConnections: created },
+    });
+    const fields = cache.modify.mock.calls[0][0].fields;
+    expect(fields.events([{ id: 'old' }])).toEqual([created, { id: 'old' }]);
+  });
+
   it('shows a submit error when routed forum events are disabled', () => {
     channelResult.value = {
       channels: [
@@ -183,6 +236,21 @@ describe('CreateEvent', () => {
 
     const stub = wrapper.findComponent({ name: 'CreateEditEventFields' });
     expect(stub.props('submitError')).toContain('events are not enabled');
+  });
+
+  it('does not submit when the routed forum is locked', async () => {
+    channelResult.value = {
+      channels: [
+        {
+          uniqueName: 'cats',
+          eventsEnabled: true,
+          locked: true,
+        },
+      ],
+    };
+    const wrapper = mountCreateEvent();
+    await wrapper.find('[data-testid="submit"]').trigger('click');
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
   it('does not submit when routed forum events are disabled', async () => {
@@ -203,9 +271,7 @@ describe('CreateEvent', () => {
 
   // Drives the form into a multi-date / recurring state and submits, exercising
   // the series-creation path (issue #229).
-  async function submitWithFormValues(
-    overrides: Record<string, unknown>
-  ) {
+  async function submitWithFormValues(overrides: Record<string, unknown>) {
     const wrapper = mountCreateEvent();
     const fields = wrapper.findComponent({ name: 'CreateEditEventFields' });
     fields.vm.$emit('updateFormValues', {
@@ -222,8 +288,14 @@ describe('CreateEvent', () => {
     await submitWithFormValues({
       dateMode: 'multiple',
       occurrences: [
-        { startTime: '2030-01-01T18:00:00.000Z', endTime: '2030-01-01T21:00:00.000Z' },
-        { startTime: '2030-01-08T18:00:00.000Z', endTime: '2030-01-08T21:00:00.000Z' },
+        {
+          startTime: '2030-01-01T18:00:00.000Z',
+          endTime: '2030-01-01T21:00:00.000Z',
+        },
+        {
+          startTime: '2030-01-08T18:00:00.000Z',
+          endTime: '2030-01-08T21:00:00.000Z',
+        },
       ],
     });
 
@@ -232,8 +304,14 @@ describe('CreateEvent', () => {
         title: 'Weekly meetup',
         channelConnections: ['cats'],
         occurrences: [
-          { startTime: '2030-01-01T18:00:00.000Z', endTime: '2030-01-01T21:00:00.000Z' },
-          { startTime: '2030-01-08T18:00:00.000Z', endTime: '2030-01-08T21:00:00.000Z' },
+          {
+            startTime: '2030-01-01T18:00:00.000Z',
+            endTime: '2030-01-01T21:00:00.000Z',
+          },
+          {
+            startTime: '2030-01-08T18:00:00.000Z',
+            endTime: '2030-01-08T21:00:00.000Z',
+          },
         ],
       }),
     });
@@ -253,6 +331,106 @@ describe('CreateEvent', () => {
     });
 
     expect(mockMutate.mock.calls[0][0].input.occurrences).toHaveLength(3);
+  });
+
+  it('includes location fields in a created event series', async () => {
+    await submitWithFormValues({
+      dateMode: 'multiple',
+      latitude: 33.4,
+      longitude: -111.9,
+      locationName: 'Phoenix',
+      address: '1 Main St',
+      occurrences: [
+        {
+          startTime: '2030-01-01T18:00:00.000Z',
+          endTime: '2030-01-01T21:00:00.000Z',
+        },
+      ],
+    });
+    expect(mockMutate).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        locationName: 'Phoenix',
+        latitude: 33.4,
+        longitude: -111.9,
+        address: '1 Main St',
+      }),
+    });
+  });
+
+  it('shows an error when a created event series has no occurrence id', async () => {
+    const wrapper = await submitWithFormValues({
+      dateMode: 'multiple',
+      occurrences: [
+        {
+          startTime: '2030-01-01T18:00:00.000Z',
+          endTime: '2030-01-01T21:00:00.000Z',
+        },
+      ],
+    });
+    onDoneCallbacks[1]({ data: {} });
+    await wrapper.vm.$nextTick();
+    expect(
+      wrapper
+        .findComponent({ name: 'CreateEditEventFields' })
+        .props('submitError')
+    ).toContain('Unable to create event series');
+  });
+
+  it('redirects to the first event in a created series', async () => {
+    await submitWithFormValues({
+      dateMode: 'multiple',
+      occurrences: [
+        {
+          startTime: '2030-01-01T18:00:00.000Z',
+          endTime: '2030-01-01T21:00:00.000Z',
+        },
+      ],
+    });
+    onDoneCallbacks[1]({
+      data: {
+        createEventSeriesWithChannelConnections: {
+          Occurrences: [{ id: 'occurrence-1' }],
+        },
+      },
+    } as CreateEventResult);
+    expect(mockPush).toHaveBeenCalledWith({
+      name: 'forums-forumId-events-eventId',
+      params: { forumId: 'cats', eventId: 'occurrence-1' },
+    });
+  });
+
+  it.each([
+    [{ title: '', selectedChannels: ['cats'] }, 'Title is required'],
+    [{ title: 'Event', selectedChannels: [] }, 'Channel is required'],
+  ])('guards invalid event form values', async (values, message) => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await submitWithFormValues({ dateMode: 'single', ...values });
+    const called = error.mock.calls.some((call) => call[0] === message);
+    error.mockRestore();
+    expect(called).toBe(true);
+  });
+
+  it('requires a signed-in username', async () => {
+    useUsername().value = '';
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await submitWithFormValues({ dateMode: 'single' });
+    const called = error.mock.calls.some(
+      (call) => call[0] === 'Username is required'
+    );
+    error.mockRestore();
+    expect(called).toBe(true);
+  });
+
+  it('requires at least one occurrence for a series', async () => {
+    const wrapper = await submitWithFormValues({
+      dateMode: 'multiple',
+      occurrences: [],
+    });
+    expect(
+      wrapper
+        .findComponent({ name: 'CreateEditEventFields' })
+        .props('submitError')
+    ).toContain('Please add at least one date');
   });
 
   it('uses the single-event mutation (occurrences nested in an array) for "single" date mode', async () => {
@@ -289,9 +467,24 @@ describe('CreateEvent', () => {
     await submitWithFormValues({
       dateMode: 'dateRange',
       dateRangeGroups: [
-        { startDate: '2030-03-06', endDate: '2030-03-06', startTimeOfDay: '12:00', endTimeOfDay: '19:30' },
-        { startDate: '2030-03-07', endDate: '2030-03-09', startTimeOfDay: '09:00', endTimeOfDay: '17:00' },
-        { startDate: '2030-03-10', endDate: '2030-03-10', startTimeOfDay: '09:00', endTimeOfDay: '12:00' },
+        {
+          startDate: '2030-03-06',
+          endDate: '2030-03-06',
+          startTimeOfDay: '12:00',
+          endTimeOfDay: '19:30',
+        },
+        {
+          startDate: '2030-03-07',
+          endDate: '2030-03-09',
+          startTimeOfDay: '09:00',
+          endTimeOfDay: '17:00',
+        },
+        {
+          startDate: '2030-03-10',
+          endDate: '2030-03-10',
+          startTimeOfDay: '09:00',
+          endTimeOfDay: '12:00',
+        },
       ],
     });
 

--- a/components/event/map/Map.spec.ts
+++ b/components/event/map/Map.spec.ts
@@ -11,6 +11,8 @@ const h = vi.hoisted(() => ({
     listeners: Record<string, () => void>;
     map: unknown;
     title?: string;
+    content?: unknown;
+    setMap: ReturnType<typeof vi.fn>;
   }>,
   markerElements: [] as Array<{
     listeners: Record<string, () => void>;
@@ -31,7 +33,13 @@ const h = vi.hoisted(() => ({
         setZoom: ReturnType<typeof vi.fn>;
       }
     ) => void;
+    renderer: {
+      render: (cluster: { count: number; position: unknown }) => unknown;
+    };
   },
+  clustererClear: vi.fn(),
+  mutationObserverCallback: null as
+    null | ((mutations: Array<{ attributeName: string }>) => void),
   infoWindow: {
     setContent: vi.fn(),
     open: vi.fn(),
@@ -65,7 +73,7 @@ vi.mock('@googlemaps/js-api-loader', () => ({
 vi.mock('@googlemaps/markerclusterer', () => ({
   MarkerClusterer: vi.fn().mockImplementation(function (config) {
     h.clusterConfig = config;
-    return { clearMarkers: vi.fn() };
+    return { clearMarkers: h.clustererClear };
   }),
 }));
 
@@ -107,8 +115,11 @@ describe('Map', () => {
     h.markerInstances = [];
     h.markerElements = [];
     h.clusterConfig = null;
+    h.mutationObserverCallback = null;
+    document.documentElement.classList.remove('dark');
 
-    global.MutationObserver = vi.fn().mockImplementation(function () {
+    global.MutationObserver = vi.fn().mockImplementation(function (callback) {
+      h.mutationObserverCallback = callback;
       return {
         observe: vi.fn(),
         disconnect: vi.fn(),
@@ -143,6 +154,7 @@ describe('Map', () => {
           AdvancedMarkerElement: vi.fn().mockImplementation(function (config) {
             const instance = {
               ...config,
+              setMap: vi.fn(),
               listeners: {} as Record<string, () => void>,
               addListener: vi.fn((name: string, cb: () => void) => {
                 instance.listeners[name] = cb;
@@ -165,10 +177,13 @@ describe('Map', () => {
       },
     } as any;
 
-    vi.stubGlobal('setTimeout', vi.fn((cb: () => void) => {
-      cb();
-      return 0 as unknown as ReturnType<typeof setTimeout>;
-    }));
+    vi.stubGlobal(
+      'setTimeout',
+      vi.fn((cb: () => void) => {
+        cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      })
+    );
   });
 
   afterEach(() => {
@@ -185,7 +200,9 @@ describe('Map', () => {
       },
     });
 
-    expect(wrapper.text()).toContain('Could not find any events with a location.');
+    expect(wrapper.text()).toContain(
+      'Could not find any events with a location.'
+    );
   });
 
   it('groups events by location before creating markers and emits the marker data', async () => {
@@ -222,8 +239,7 @@ describe('Map', () => {
     await waitForMap();
 
     const markerDataPayload = wrapper.emitted('setMarkerData')?.[0]?.[0] as
-      | { markerMap: MarkerMap }
-      | undefined;
+      { markerMap: MarkerMap } | undefined;
     const markerMap = markerDataPayload?.markerMap;
     expect({
       markerCount: h.markerInstances.length,
@@ -362,4 +378,176 @@ describe('Map', () => {
       setZoom: [17],
     });
   });
+
+  it('handles clicks and hover for a multi-event mobile marker', async () => {
+    const events = [
+      {
+        id: 'e1',
+        title: 'First',
+        locationName: 'Phoenix',
+        location: { latitude: 33.4, longitude: -111.9 },
+      },
+      {
+        id: 'e2',
+        title: 'Second',
+        locationName: 'Phoenix',
+        location: { latitude: 33.4, longitude: -111.9 },
+      },
+    ] as Event[];
+    h.fullPath = '/map/search#33.4-111.9';
+    const wrapper = mount(Map, {
+      props: {
+        events,
+        colorLocked: false,
+        previewIsOpen: false,
+        useMobileStyles: true,
+      },
+    });
+
+    await waitForMap();
+    h.markerInstances[0]?.listeners['gmp-click']?.();
+    h.markerElements[0]?.listeners.mouseenter?.();
+    h.markerElements[0]?.listeners.mouseleave?.();
+
+    expect({
+      clicked: wrapper.emitted('highlightEvent')?.[0],
+      hovered: wrapper.emitted('highlightEvent')?.[1],
+      previewed: wrapper.emitted('openPreview')?.[0],
+      locked: wrapper.emitted('lockColors')?.length,
+      tooltip: h.infoWindow.setContent.mock.calls.length,
+      unhighlighted: wrapper.emitted('unHighlight')?.length,
+    }).toEqual({
+      clicked: ['33.4-111.9', '', events[0], true, true],
+      hovered: ['33.4-111.9', 'e1', events[0], true, false],
+      previewed: [events[0], true],
+      locked: 1,
+      tooltip: 1,
+      unhighlighted: 1,
+    });
+  });
+
+  it('clears existing marker resources when the display mode changes', async () => {
+    const wrapper = mount(Map, {
+      props: {
+        events: [
+          {
+            id: 'e1',
+            title: 'First',
+            locationName: 'Phoenix',
+            location: { latitude: 33.4, longitude: -111.9 },
+          } as Event,
+        ],
+        colorLocked: false,
+        previewIsOpen: false,
+        useMobileStyles: false,
+      },
+    });
+    await waitForMap();
+
+    await wrapper.setProps({ useMobileStyles: true });
+    await waitForMap();
+
+    expect({
+      clusterClears: h.clustererClear.mock.calls.length,
+      legacyClears: h.markerInstances[0]?.setMap.mock.calls[0],
+      listenerClears: vi.mocked(
+        globalThis.google.maps.event.clearInstanceListeners
+      ).mock.calls.length,
+    }).toEqual({ clusterClears: 1, legacyClears: [null], listenerClears: 1 });
+  });
+
+  it('rerenders the map when the document theme changes', async () => {
+    mount(Map, {
+      props: {
+        events: [
+          {
+            id: 'e1',
+            title: 'First',
+            locationName: 'Phoenix',
+            location: { latitude: 33.4, longitude: -111.9 },
+          } as Event,
+        ],
+        colorLocked: false,
+        previewIsOpen: false,
+        useMobileStyles: false,
+      },
+    });
+    await waitForMap();
+    document.documentElement.classList.add('dark');
+
+    h.mutationObserverCallback?.([{ attributeName: 'class' }]);
+    await waitForMap();
+
+    expect(globalThis.google.maps.Map).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders an advanced marker for a cluster bubble', async () => {
+    mount(Map, {
+      props: {
+        events: [
+          {
+            id: 'e1',
+            title: 'First',
+            locationName: 'Phoenix',
+            location: { latitude: 33.4, longitude: -111.9 },
+          } as Event,
+        ],
+        colorLocked: false,
+        previewIsOpen: false,
+        useMobileStyles: false,
+      },
+    });
+    await waitForMap();
+    const before = h.markerInstances.length;
+
+    h.clusterConfig?.renderer.render({
+      count: 12,
+      position: { lat: 1, lng: 2 },
+    });
+
+    expect({
+      newMarkers: h.markerInstances.length - before,
+      label: (h.markerInstances.at(-1)?.content as HTMLElement).textContent,
+    }).toEqual({ newMarkers: 1, label: '12' });
+  });
+
+  it.each([
+    [true, [{ id: 'e1', title: 'First' }], 'e1'],
+    [
+      false,
+      [
+        { id: 'e1', title: 'First' },
+        { id: 'e2', title: 'Second' },
+      ],
+      '',
+    ],
+  ])(
+    'handles the remaining marker-click branch with mobile=%s',
+    async (useMobileStyles, seeds, highlightedId) => {
+      const events = seeds.map((seed) => ({
+        ...seed,
+        locationName: 'Phoenix',
+        location: { latitude: 33.4, longitude: -111.9 },
+      })) as Event[];
+      const wrapper = mount(Map, {
+        props: {
+          events,
+          colorLocked: false,
+          previewIsOpen: false,
+          useMobileStyles,
+        },
+      });
+      await waitForMap();
+
+      h.markerInstances[0]?.listeners['gmp-click']?.();
+
+      expect(wrapper.emitted('highlightEvent')?.[0]).toEqual([
+        '33.4-111.9',
+        highlightedId,
+        events[0],
+        true,
+        true,
+      ]);
+    }
+  );
 });

--- a/components/event/map/MapView.spec.ts
+++ b/components/event/map/MapView.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { ref } from 'vue';
+import { nextTick, reactive, ref } from 'vue';
 import MapView from '@/components/event/map/MapView.vue';
 
 const h = vi.hoisted(() => ({
@@ -12,11 +12,18 @@ const h = vi.hoisted(() => ({
   },
   push: vi.fn(),
   replace: vi.fn(),
-  result: null as unknown as { value: { events: unknown[]; eventsAggregate: { count: number } } },
+  result: null as unknown as {
+    value: { events: unknown[]; eventsAggregate: { count: number } };
+  },
   loading: null as unknown as { value: boolean },
   error: null as unknown as { value: null | { message: string } },
-  onResultCb: null as null | ((value: { data?: { events: Array<{ id: string }> } }) => void),
+  onResultCb: null as
+    null | ((value: { data?: { events: Array<{ id: string }> } }) => void),
   mdAndUp: null as unknown as { value: boolean },
+  queryVariables: null as null | {
+    where: { value: unknown };
+    resultsOrder: { value: unknown };
+  },
 }));
 
 vi.mock('@headlessui/vue', async (importOriginal) => ({
@@ -33,45 +40,86 @@ vi.mock('nuxt/app', () => ({
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
-  useQuery: () => ({
-    result: h.result,
-    loading: h.loading,
-    error: h.error,
-    onResult: (cb: typeof h.onResultCb) => {
-      h.onResultCb = cb;
-    },
-  }),
+  useQuery: (
+    _query: unknown,
+    variables: NonNullable<typeof h.queryVariables>
+  ) => {
+    h.queryVariables = variables;
+    void variables.where.value;
+    void variables.resultsOrder.value;
+    return {
+      result: h.result,
+      loading: h.loading,
+      error: h.error,
+      onResult: (cb: typeof h.onResultCb) => {
+        h.onResultCb = cb;
+      },
+    };
+  },
 }));
 
 h.result = ref({ events: [] as unknown[], eventsAggregate: { count: 0 } });
 h.loading = ref(false);
 h.error = ref(null);
 h.mdAndUp = ref(true);
+h.route = reactive(h.route);
 
 const EventFilterBar = {
   name: 'EventFilterBar',
   template: '<div class="event-filter-bar"><slot /></div>',
 };
-const TimeShortcuts = { name: 'TimeShortcuts', template: '<div class="time-shortcuts" />' };
-const LoadingSpinner = { name: 'LoadingSpinner', template: '<div class="spinner" />' };
-const ErrorBanner = { name: 'ErrorBanner', props: ['text'], template: '<div class="error">{{ text }}</div>' };
-const EventPreview = { name: 'EventPreview', props: ['isOpen'], template: '<div class="preview" :data-open="isOpen" />' };
+const TimeShortcuts = {
+  name: 'TimeShortcuts',
+  template: '<div class="time-shortcuts" />',
+};
+const LoadingSpinner = {
+  name: 'LoadingSpinner',
+  template: '<div class="spinner" />',
+};
+const ErrorBanner = {
+  name: 'ErrorBanner',
+  props: ['text'],
+  template: '<div class="error">{{ text }}</div>',
+};
+const EventPreview = {
+  name: 'EventPreview',
+  props: ['isOpen'],
+  emits: ['close-preview'],
+  template: '<div class="preview" :data-open="isOpen" />',
+};
 const PreviewContainer = {
   name: 'PreviewContainer',
   props: ['isOpen', 'header', 'topLayer'],
+  emits: ['close-preview'],
   template:
     '<div class="preview-container" :data-open="isOpen" :data-header="header"><slot /></div>',
 };
-const CloseButton = { name: 'CloseButton', emits: ['click'], template: '<button class="close-button" @click="$emit(\'click\')" />' };
+const CloseButton = {
+  name: 'CloseButton',
+  emits: ['click'],
+  template: '<button class="close-button" @click="$emit(\'click\')" />',
+};
 const EventList = {
   name: 'EventList',
-  props: ['events'],
-  emits: ['filter-by-tag', 'filter-by-channel', 'highlight-event', 'open-preview', 'unhighlight'],
+  props: [
+    'events',
+    'selectedTags',
+    'selectedChannels',
+    'highlightedEventId',
+    'highlightedEventLocationId',
+  ],
+  emits: [
+    'filter-by-tag',
+    'filter-by-channel',
+    'highlight-event',
+    'open-preview',
+    'unhighlight',
+  ],
   template: '<div class="event-list" />',
 };
 const EventMap = {
   name: 'EventMap',
-  props: ['events'],
+  props: ['events', 'colorLocked', 'previewIsOpen', 'useMobileStyles'],
   emits: ['highlight-event', 'open-preview', 'lock-colors', 'set-marker-data'],
   template: '<div class="event-map" />',
 };
@@ -98,6 +146,33 @@ const event = (id: string, title = `Event ${id}`) => ({
   location: { latitude: 33.4, longitude: -111.9 },
 });
 
+const markerData = (numberOfEvents = 1) => {
+  const infowindow = {
+    setContent: vi.fn(),
+    open: vi.fn(),
+    close: vi.fn(),
+  };
+  return {
+    infowindow,
+    data: {
+      map: { id: 'map' },
+      markerMap: {
+        markers: {
+          loc1: {
+            marker: { id: 'marker' },
+            numberOfEvents,
+            events: {
+              '1': event('1', 'First'),
+              ...(numberOfEvents > 1 ? { '2': event('2', 'Second') } : {}),
+            },
+          },
+        },
+        infowindow,
+      },
+    },
+  };
+};
+
 const mountView = () =>
   mount(MapView, {
     props: {},
@@ -106,11 +181,17 @@ const mountView = () =>
 
 beforeEach(() => {
   vi.clearAllMocks();
-  h.route = { path: '/map/search', name: 'map-search', query: {}, params: {} };
+  Object.assign(h.route, {
+    path: '/map/search',
+    name: 'map-search',
+    query: {},
+    params: {},
+  });
   h.result.value = { events: [], eventsAggregate: { count: 0 } };
   h.loading.value = false;
   h.error.value = null;
   h.onResultCb = null;
+  h.queryVariables = null;
   h.mdAndUp.value = true;
   vi.stubGlobal('CSS', { escape: (value: string) => value });
 });
@@ -145,7 +226,9 @@ describe('MapView', () => {
   it('updates the route query when filtering by channel', async () => {
     h.result.value = { events: [event('1')], eventsAggregate: { count: 1 } };
     const wrapper = mountView();
-    await wrapper.findComponent(EventList).vm.$emit('filter-by-channel', 'cats');
+    await wrapper
+      .findComponent(EventList)
+      .vm.$emit('filter-by-channel', 'cats');
     expect(h.replace).toHaveBeenCalled();
   });
 
@@ -161,8 +244,38 @@ describe('MapView', () => {
     });
   });
 
+  it.each([{ data: undefined }, { data: { events: [] } }])(
+    'does not navigate when the query callback has no event',
+    async (queryResult) => {
+      mountView();
+      h.onResultCb?.(queryResult);
+      await Promise.resolve();
+      expect(h.push).not.toHaveBeenCalled();
+    }
+  );
+
+  it('recomputes filters when the route query changes', async () => {
+    const wrapper = mountView();
+    h.route.query = { tags: ['music'] };
+    await nextTick();
+    expect(wrapper.findComponent(EventList).props('selectedTags')).toEqual([
+      'music',
+    ]);
+  });
+
+  it('uses reverse chronological order for past events', () => {
+    h.route.query = { timeShortcut: 'PAST_EVENTS' };
+    mountView();
+    expect(h.queryVariables?.resultsOrder.value).toEqual({
+      startTime: 'DESC',
+    });
+  });
+
   it('opens the multiple-event preview when a map marker represents more than one event', async () => {
-    h.result.value = { events: [event('1'), event('2')], eventsAggregate: { count: 2 } };
+    h.result.value = {
+      events: [event('1'), event('2')],
+      eventsAggregate: { count: 2 },
+    };
     const wrapper = mountView();
 
     await wrapper.findComponent(EventMap).vm.$emit('set-marker-data', {
@@ -185,19 +298,19 @@ describe('MapView', () => {
         },
       },
     });
-    await wrapper.findComponent(EventMap).vm.$emit(
-      'highlight-event',
-      'loc1',
-      '',
-      event('1', 'First'),
-      true,
-      false
-    );
-    await wrapper.findComponent(EventMap).vm.$emit(
-      'open-preview',
-      event('1', 'First'),
-      true
-    );
+    await wrapper
+      .findComponent(EventMap)
+      .vm.$emit(
+        'highlight-event',
+        'loc1',
+        '',
+        event('1', 'First'),
+        true,
+        false
+      );
+    await wrapper
+      .findComponent(EventMap)
+      .vm.$emit('open-preview', event('1', 'First'), true);
 
     expect(
       wrapper
@@ -206,10 +319,93 @@ describe('MapView', () => {
     ).toBe(true);
   });
 
+  it('opens a specific info window and navigates when a single marker is clicked', async () => {
+    h.result.value = { events: [event('1')], eventsAggregate: { count: 1 } };
+    const wrapper = mountView();
+    const marker = markerData();
+    const map = wrapper.findComponent(EventMap);
+    await map.vm.$emit('set-marker-data', marker.data);
+    await map.vm.$emit('highlight-event', 'loc1', '1', event('1'), true, true);
+    expect({
+      contentCalls: marker.infowindow.setContent.mock.calls.length,
+      openCalls: marker.infowindow.open.mock.calls.length,
+      route: h.push.mock.calls.at(-1)?.[0],
+    }).toEqual({
+      contentCalls: 2,
+      openCalls: 2,
+      route: {
+        name: 'map-search-eventId',
+        params: { eventId: '1' },
+        hash: '#loc1',
+        query: {},
+      },
+    });
+  });
+
+  it('uses supplied event data when a marker does not contain the event', async () => {
+    h.result.value = { events: [event('1')], eventsAggregate: { count: 1 } };
+    const wrapper = mountView();
+    const marker = markerData();
+    const suppliedEvent = event('missing', 'Supplied');
+    const map = wrapper.findComponent(EventMap);
+    await map.vm.$emit('set-marker-data', marker.data);
+    await map.vm.$emit(
+      'highlight-event',
+      'loc1',
+      'missing',
+      suppliedEvent,
+      false,
+      false
+    );
+    await wrapper
+      .findComponent(EventList)
+      .vm.$emit('open-preview', suppliedEvent);
+    expect(wrapper.findComponent(EventPreview).attributes('data-open')).toBe(
+      'true'
+    );
+  });
+
+  it('locks marker colors while a preview is open and unlocks them when it closes', async () => {
+    h.result.value = { events: [event('1')], eventsAggregate: { count: 1 } };
+    const wrapper = mountView();
+    const map = wrapper.findComponent(EventMap);
+    await map.vm.$emit('lock-colors');
+    await map.vm.$emit('open-preview', event('1'), true);
+    await wrapper.findComponent(EventPreview).vm.$emit('close-preview');
+    expect(map.props('colorLocked')).toBe(false);
+  });
+
+  it('closes the multiple-event preview and its marker info window', async () => {
+    h.result.value = {
+      events: [event('1'), event('2')],
+      eventsAggregate: { count: 2 },
+    };
+    const wrapper = mountView();
+    const marker = markerData(2);
+    const map = wrapper.findComponent(EventMap);
+    await map.vm.$emit('set-marker-data', marker.data);
+    await map.vm.$emit('highlight-event', 'loc1', '', event('1'), true, false);
+    await map.vm.$emit('open-preview', event('1'), true);
+    await wrapper.findComponent(CloseButton).vm.$emit('click');
+    expect({
+      previewOpen: wrapper.findComponent(PreviewContainer).props('isOpen'),
+      closeCalls: marker.infowindow.close.mock.calls.length,
+    }).toEqual({ previewOpen: false, closeCalls: 2 });
+  });
+
   it('renders the mobile map when the viewport is below md', () => {
     h.mdAndUp.value = false;
     h.result.value = { events: [event('1')], eventsAggregate: { count: 1 } };
     const wrapper = mountView();
     expect(wrapper.findAllComponents(EventMap)).toHaveLength(1);
+  });
+
+  it('locks marker colors from the mobile map', async () => {
+    h.mdAndUp.value = false;
+    h.result.value = { events: [event('1')], eventsAggregate: { count: 1 } };
+    const wrapper = mountView();
+    const map = wrapper.findComponent(EventMap);
+    await map.vm.$emit('lock-colors');
+    expect(map.props('colorLocked')).toBe(true);
   });
 });

--- a/components/mod/ActivityFeedListItem.spec.ts
+++ b/components/mod/ActivityFeedListItem.spec.ts
@@ -180,7 +180,9 @@ const NotificationStub = defineComponent({
   props: ['show', 'title'],
   setup(props) {
     return () =>
-      props.show ? h('div', { 'data-testid': 'notification-title' }, props.title) : null;
+      props.show
+        ? h('div', { 'data-testid': 'notification-title' }, props.title)
+        : null;
   },
 });
 
@@ -241,6 +243,7 @@ const mountWrapper = (overrides: Record<string, unknown> = {}) =>
         SuspendModButton: {
           name: 'SuspendModButton',
           props: ['issue', 'disabled', 'autoOpen'],
+          emits: ['modal-closed'],
           template: '<div data-testid="suspend-mod-button" />',
         },
         GenericButton: GenericButtonStub,
@@ -279,7 +282,9 @@ describe('ActivityFeedListItem', () => {
   it('shows a report action in the context menu for reportable mod comments', () => {
     const wrapper = mountWrapper();
 
-    expect(wrapper.find('[data-testid="Report Mod Comment"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="Report Mod Comment"]').exists()).toBe(
+      true
+    );
     expect(wrapper.find('[data-testid="Suspend Mod"]').exists()).toBe(true);
   });
 
@@ -294,7 +299,9 @@ describe('ActivityFeedListItem', () => {
     await wrapper.get('[data-testid="Suspend Mod"]').trigger('click');
     await nextTick();
 
-    expect(wrapper.find('[data-testid="suspend-mod-button"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="suspend-mod-button"]').exists()).toBe(
+      true
+    );
   });
 
   it('opens edit mode for the comment author and saves a change', async () => {
@@ -349,7 +356,9 @@ describe('ActivityFeedListItem', () => {
 
     expect(wrapper.find('li').classes()).toContain('border-orange-500');
     expect(wrapper.find('[data-testid="revision-diff"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="markdown-preview"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="markdown-preview"]').exists()).toBe(
+      false
+    );
     expect(wrapper.text()).toContain('Server Admin');
   });
 
@@ -383,6 +392,102 @@ describe('ActivityFeedListItem', () => {
       }),
     });
 
-    expect(wrapper.find('[data-testid="suspend-mod-button"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="suspend-mod-button"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('hides report actions when no user or moderation profile is active', () => {
+    authState.username = '';
+    authState.modProfileName = '';
+    const wrapper = mountWrapper();
+    expect(wrapper.find('[data-testid="Report Mod Comment"]').exists()).toBe(
+      false
+    );
+  });
+
+  it('renders paired discussion title and body revision diffs in order', () => {
+    const wrapper = mountWrapper({
+      relatedDiscussion: {
+        id: 'd1',
+        title: 'New title',
+        body: 'New body',
+        updatedAt: '2024-01-03T00:00:00.000Z',
+        Author: { username: 'alice' },
+      },
+      nextRevisionBody: 'Intermediate body',
+      pairedNextRevisionBody: null,
+      activityItem: makeActivityItem({
+        actionType: 'edit',
+        actionDescription: 'edited discussion body',
+        Comment: null,
+        Revision: {
+          id: 'body-old',
+          body: 'Old body',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      }),
+      pairedActivityItem: makeActivityItem({
+        actionType: 'edit',
+        actionDescription: 'edited discussion title',
+        Comment: null,
+        Revision: {
+          id: 'title-old',
+          body: 'Old title',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      }),
+    });
+    expect(wrapper.findAll('[data-testid="revision-diff"]')).toHaveLength(2);
+  });
+
+  it('ignores discussion revisions without a title or body description', () => {
+    const wrapper = mountWrapper({
+      relatedDiscussion: { id: 'd1', title: 'Title', body: 'Body' },
+      activityItem: makeActivityItem({
+        actionType: 'edit',
+        actionDescription: 'edited metadata',
+        Comment: null,
+        Revision: { id: 'old', body: 'Old', createdAt: '2024-01-01T00:00:00Z' },
+      }),
+    });
+    expect(wrapper.find('[data-testid="revision-diff"]').exists()).toBe(false);
+  });
+
+  it('uses the next newer past version for an older comment edit', () => {
+    const wrapper = mountWrapper({
+      activityItem: makeActivityItem({
+        actionType: 'edit',
+        actionDescription: 'edited the comment',
+        Comment: {
+          id: 'comment-1',
+          text: 'Current',
+          CommentAuthor: { displayName: 'mod-bob' },
+          PastVersions: [
+            { id: 'newer', body: 'Newer', createdAt: '2024-01-02T00:00:00Z' },
+            { id: 'older', body: 'Older', createdAt: '2024-01-01T00:00:00Z' },
+          ],
+        },
+      }),
+      commentEditIndex: 1,
+    });
+    expect(
+      wrapper.getComponent({ name: 'RevisionDiffInline' }).props('newVersion')
+    ).toMatchObject({ body: 'Newer', createdAt: '2024-01-02T00:00:00Z' });
+  });
+
+  it('closes the suspend-mod trigger after its modal closes', async () => {
+    const wrapper = mountWrapper();
+    await wrapper.get('[data-testid="Suspend Mod"]').trigger('click');
+    const suspendButtons = wrapper.findAllComponents({
+      name: 'SuspendModButton',
+    });
+    const openCount = suspendButtons.length;
+    await suspendButtons
+      .find((button) => button.props('autoOpen'))!
+      .vm.$emit('modal-closed');
+    expect(
+      wrapper.findAllComponents({ name: 'SuspendModButton' }).length
+    ).toBeLessThan(openCount);
   });
 });

--- a/components/mod/IssueDetail.spec.ts
+++ b/components/mod/IssueDetail.spec.ts
@@ -3,6 +3,12 @@ import { mount } from '@vue/test-utils';
 import { defineComponent, h, ref, nextTick } from 'vue';
 import IssueDetail from './IssueDetail.vue';
 import { useMutation, useQuery } from '@vue/apollo-composable';
+import { GET_ISSUE } from '@/graphQLData/issue/queries';
+import { GET_CHANNEL } from '@/graphQLData/channel/queries';
+import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
+import { GET_DISCUSSION } from '@/graphQLData/discussion/queries';
+import { GET_EVENT } from '@/graphQLData/event/queries';
+import { GET_COMMENT } from '@/graphQLData/comment/queries';
 
 const routerReplace = vi.fn();
 const refetchIssue = vi.fn();
@@ -43,6 +49,13 @@ const buildIssueResult = () => ({
 });
 
 const issueResult = ref(buildIssueResult());
+const channelResult = ref({ channels: [] });
+const serverResult = ref({ serverConfigs: [] });
+const relatedDiscussionResult = ref({
+  discussions: [] as Record<string, unknown>[],
+});
+const relatedEventResult = ref({ events: [] as Record<string, unknown>[] });
+const relatedCommentResult = ref({ comments: [] as Record<string, unknown>[] });
 
 // The auto-unsubscribe composable is exercised by its own spec and an e2e
 // test; here we stub it so mounting does not pull in the Pinia toast store.
@@ -233,15 +246,24 @@ describe('IssueDetail', () => {
     hasMoreActivityFeed.value = false;
     deleteReasonError.value = '';
 
+    const queryResults = new Map<unknown, unknown>([
+      [GET_ISSUE, issueResult],
+      [GET_CHANNEL, channelResult],
+      [GET_SERVER_CONFIG, serverResult],
+      [GET_DISCUSSION, relatedDiscussionResult],
+      [GET_EVENT, relatedEventResult],
+      [GET_COMMENT, relatedCommentResult],
+    ]);
     (useQuery as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      (_document, variables, options) => {
+      (document, variables, options) => {
         // Invoke the reactive variables/options factories so their bodies — and
         // the computeds they read (channelId, issueNumber, relatedDiscussionId,
         // relatedEventId, relatedCommentId, …) — are exercised.
         if (typeof variables === 'function') variables();
         if (typeof options === 'function') options();
+        const result = queryResults.get(document) ?? ref(null);
         return {
-          result: issueResult,
+          result,
           error: queryError,
           loading: queryLoading,
           refetch: refetchIssue,
@@ -251,17 +273,23 @@ describe('IssueDetail', () => {
       }
     );
 
+    relatedDiscussionResult.value = { discussions: [] };
+    relatedEventResult.value = { events: [] };
+    relatedCommentResult.value = { comments: [] };
+
     let mutationCallIndex = 0;
-    (useMutation as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
-      mutationCallIndex += 1;
-      if (mutationCallIndex === 1) {
-        return { mutate: subscribeMutate, loading: ref(false) };
+    (useMutation as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => {
+        mutationCallIndex += 1;
+        if (mutationCallIndex === 1) {
+          return { mutate: subscribeMutate, loading: ref(false) };
+        }
+        if (mutationCallIndex === 2) {
+          return { mutate: unsubscribeMutate, loading: ref(false) };
+        }
+        return { mutate: vi.fn(), loading: ref(false) };
       }
-      if (mutationCallIndex === 2) {
-        return { mutate: unsubscribeMutate, loading: ref(false) };
-      }
-      return { mutate: vi.fn(), loading: ref(false) };
-    });
+    );
   });
 
   const buildWrapper = () =>
@@ -307,7 +335,9 @@ describe('IssueDetail', () => {
   it('subscribes from the issue CTA and clears the route query', async () => {
     const wrapper = buildWrapper();
 
-    await wrapper.get('[data-testid="toggle-issue-subscription"]').trigger('click');
+    await wrapper
+      .get('[data-testid="toggle-issue-subscription"]')
+      .trigger('click');
 
     expect(subscribeMutate).toHaveBeenCalledWith({ issueId: 'issue-1' });
     expect(routerReplace).toHaveBeenCalledWith({ query: {} });
@@ -343,23 +373,27 @@ describe('IssueDetail', () => {
   it('shows the issue context channel tags', () => {
     const wrapper = buildWrapper();
 
-    expect(wrapper.get('[data-testid="issue-detail-channel-tags"]').text()).toContain(
-      'toDelete'
-    );
+    expect(
+      wrapper.get('[data-testid="issue-detail-channel-tags"]').text()
+    ).toContain('toDelete');
   });
 
   it('shows page not found when no issue is returned', () => {
     issueResult.value = { issues: [] };
     const wrapper = buildWrapper();
 
-    expect(wrapper.get('[data-testid="page-not-found"]').text()).toContain('not found');
+    expect(wrapper.get('[data-testid="page-not-found"]').text()).toContain(
+      'not found'
+    );
   });
 
   it('falls back to page not found when the issue query errors', () => {
     queryError.value = new Error('Issue failed');
     const wrapper = buildWrapper();
 
-    expect(wrapper.get('[data-testid="page-not-found"]').text()).toContain('not found');
+    expect(wrapper.get('[data-testid="page-not-found"]').text()).toContain(
+      'not found'
+    );
   });
 
   it('shows the lock banner when the issue is locked', () => {
@@ -367,7 +401,9 @@ describe('IssueDetail', () => {
     issueResult.value.issues[0].lockReason = 'Escalated';
     const wrapper = buildWrapper();
 
-    expect(wrapper.get('[data-testid="locked-banner"]').text()).toContain('Escalated');
+    expect(wrapper.get('[data-testid="locked-banner"]').text()).toContain(
+      'Escalated'
+    );
   });
 
   it('shows the related channel banner when present', () => {
@@ -393,5 +429,48 @@ describe('IssueDetail', () => {
     const wrapper = buildWrapper();
 
     expect(wrapper.text()).toContain('Cannot delete related content');
+  });
+
+  it('uses unique related-discussion channels as issue context', () => {
+    issueResult.value.issues[0].relatedDiscussionId = 'discussion-1';
+    relatedDiscussionResult.value = {
+      discussions: [
+        {
+          DiscussionChannels: [
+            { channelUniqueName: 'cats' },
+            { channelUniqueName: null },
+            { channelUniqueName: 'cats' },
+            { channelUniqueName: 'dogs' },
+          ],
+        },
+      ],
+    };
+    const wrapper = buildWrapper();
+    expect(
+      wrapper.get('[data-testid="issue-detail-channel-tags"]').text()
+    ).toBe('catsdogs');
+  });
+
+  it('falls back to related-event channels for issue context', () => {
+    issueResult.value.issues[0].relatedEventId = 'event-1';
+    relatedEventResult.value = {
+      events: [{ EventChannels: [{ channelUniqueName: 'events' }] }],
+    };
+    const wrapper = buildWrapper();
+    expect(
+      wrapper.get('[data-testid="issue-detail-channel-tags"]').text()
+    ).toBe('events');
+  });
+
+  it('renders an issue body written by the current moderation profile', () => {
+    issueResult.value.issues[0].body = 'Moderator note';
+    issueResult.value.issues[0].Author = {
+      __typename: 'ModerationProfile',
+      displayName: 'mod-alice',
+    } as never;
+    const wrapper = buildWrapper();
+    expect(wrapper.findComponent({ name: 'IssueBodyEditor' }).exists()).toBe(
+      true
+    );
   });
 });

--- a/components/mod/ModerationWizard.spec.ts
+++ b/components/mod/ModerationWizard.spec.ts
@@ -33,15 +33,26 @@ const setQueryState = (patch: Record<string, unknown>) => {
 vi.mock('@vue/apollo-composable', async () => {
   const { computed } = await import('vue');
   return {
-    useQuery: () => ({
-      result: computed(() => mockQueryState.value),
-    }),
+    useQuery: (
+      _query: unknown,
+      variables?: () => unknown,
+      options?: () => unknown
+    ) => {
+      variables?.();
+      options?.();
+      return {
+        result: computed(() => mockQueryState.value),
+      };
+    },
   };
 });
 
 vi.mock('@/composables/useAuthState', async () => {
   const { ref } = await import('vue');
-  return { useModProfileName: () => ref('mod-alice'), setModProfileName: vi.fn() };
+  return {
+    useModProfileName: () => ref('mod-alice'),
+    setModProfileName: vi.fn(),
+  };
 });
 
 describe('ModerationWizard', () => {
@@ -77,26 +88,36 @@ describe('ModerationWizard', () => {
           ScalesIcon: true,
           PencilIcon: true,
           CloseIssueAction: {
+            name: 'CloseIssueAction',
+            emits: ['close-issue'],
             template:
               '<button data-testid="close-issue-action" :disabled="false">Close</button>',
           },
           ArchiveButton: {
+            name: 'ArchiveButton',
+            emits: ['archived-successfully', 'unarchived-successfully'],
             template:
               '<div data-testid="archive-button" :data-disabled="String(disabled)"></div>',
             props: ['disabled'],
           },
           SuspendUserButton: {
+            name: 'SuspendUserButton',
+            emits: ['suspended-successfully', 'unsuspended-successfully'],
             template:
               '<div data-testid="suspend-user-button" :data-disabled="String(disabled)"></div>',
             props: ['disabled'],
           },
           SuspendModButton: {
+            name: 'SuspendModButton',
+            emits: ['suspended-successfully', 'unsuspended-successfully'],
             template:
               '<div data-testid="suspend-mod-button" :data-disabled="String(disabled)"></div>',
             props: ['disabled'],
           },
           EditContentModal: {
+            name: 'EditContentModal',
             props: ['open'],
+            emits: ['saved', 'close'],
             template:
               '<div data-testid="edit-modal" :data-open="String(open)" @click="$emit(\'saved\')" />',
           },
@@ -115,23 +136,27 @@ describe('ModerationWizard', () => {
   it('disables the archive button when the moderator is suspended', () => {
     const wrapper = mountWrapper();
 
-    expect(wrapper.get('[data-testid="archive-button"]').attributes('data-disabled')).toBe(
-      'true'
-    );
+    expect(
+      wrapper.get('[data-testid="archive-button"]').attributes('data-disabled')
+    ).toBe('true');
   });
 
   it('disables the suspend-user button when the moderator is suspended', () => {
     const wrapper = mountWrapper();
 
-    expect(wrapper.get('[data-testid="suspend-user-button"]').attributes('data-disabled')).toBe(
-      'true'
-    );
+    expect(
+      wrapper
+        .get('[data-testid="suspend-user-button"]')
+        .attributes('data-disabled')
+    ).toBe('true');
   });
 
   it('disables the edit action when the moderator is suspended', () => {
     const wrapper = mountWrapper();
 
-    expect(wrapper.get('[data-test="edit-comment"]').attributes('disabled')).toBeDefined();
+    expect(
+      wrapper.get('[data-test="edit-comment"]').attributes('disabled')
+    ).toBeDefined();
   });
 
   it('re-enables the archive button once the moderator is no longer suspended', () => {
@@ -187,7 +212,10 @@ describe('ModerationWizard', () => {
   });
 
   it('disables the edit action without edit permission', () => {
-    const wrapper = mountWrapper({ ...reportedComment, canEditComments: false });
+    const wrapper = mountWrapper({
+      ...reportedComment,
+      canEditComments: false,
+    });
 
     expect(
       wrapper.get('[data-test="edit-comment"]').attributes('disabled')
@@ -198,9 +226,9 @@ describe('ModerationWizard', () => {
     const wrapper = mountWrapper(reportedComment);
     await wrapper.get('[data-test="edit-comment"]').trigger('click');
 
-    expect(wrapper.get('[data-testid="edit-modal"]').attributes('data-open')).toBe(
-      'true'
-    );
+    expect(
+      wrapper.get('[data-testid="edit-modal"]').attributes('data-open')
+    ).toBe('true');
   });
 
   it('re-emits archived-successfully when the edit modal saves', async () => {
@@ -252,6 +280,103 @@ describe('ModerationWizard', () => {
     });
   });
 
+  it.each([
+    [
+      { commentId: undefined, discussionId: 'd1' },
+      { discussionChannels: [{ archived: true }] },
+    ],
+    [
+      { commentId: undefined, eventId: 'e1' },
+      { eventChannels: [{ archived: true }] },
+    ],
+  ])('resolves archived state for related content', (props, queryState) => {
+    setQueryState(queryState);
+    const wrapper = mountWrapper({ ...props, isSuspendedMod: false });
+    expect(wrapper.text()).toContain('Archive (Already Archived)');
+  });
+
+  it('forwards content and user moderation outcomes', async () => {
+    const wrapper = mountWrapper({ isSuspendedMod: false });
+    await wrapper
+      .findComponent({ name: 'CloseIssueAction' })
+      .vm.$emit('close-issue');
+    await wrapper
+      .findComponent({ name: 'ArchiveButton' })
+      .vm.$emit('archived-successfully');
+    await wrapper
+      .findComponent({ name: 'ArchiveButton' })
+      .vm.$emit('unarchived-successfully');
+    await wrapper
+      .findComponent({ name: 'SuspendUserButton' })
+      .vm.$emit('suspended-successfully');
+    await wrapper
+      .findComponent({ name: 'SuspendUserButton' })
+      .vm.$emit('unsuspended-successfully');
+    expect({
+      close: wrapper.emitted('close-issue'),
+      archived: wrapper.emitted('archived-successfully'),
+      unarchived: wrapper.emitted('unarchived-successfully'),
+      suspended: wrapper.emitted('suspended-user-successfully'),
+      unsuspended: wrapper.emitted('unsuspended-user-successfully'),
+    }).toEqual({
+      close: [[]],
+      archived: [[]],
+      unarchived: [[]],
+      suspended: [[]],
+      unsuspended: [[]],
+    });
+  });
+
+  it('forwards moderator suspension outcomes', async () => {
+    const wrapper = mountWrapper({
+      authorType: 'mod',
+      isSuspendedMod: false,
+    });
+    const button = wrapper.findComponent({ name: 'SuspendModButton' });
+    await button.vm.$emit('suspended-successfully');
+    await button.vm.$emit('unsuspended-successfully');
+    expect({
+      suspended: wrapper.emitted('suspended-mod-successfully'),
+      unsuspended: wrapper.emitted('unsuspended-mod-successfully'),
+    }).toEqual({ suspended: [[]], unsuspended: [[]] });
+  });
+
+  it('forwards outcomes from the archived-content restoration path', async () => {
+    setQueryState({ comments: [{ archived: true }] });
+    const wrapper = mountWrapper({ isSuspendedMod: false });
+    const archive = wrapper.findComponent({ name: 'ArchiveButton' });
+    await archive.vm.$emit('archived-successfully');
+    await archive.vm.$emit('unarchived-successfully');
+    await wrapper
+      .findComponent({ name: 'CloseIssueAction' })
+      .vm.$emit('close-issue');
+    expect({
+      archived: wrapper.emitted('archived-successfully'),
+      unarchived: wrapper.emitted('unarchived-successfully'),
+      close: wrapper.emitted('close-issue'),
+    }).toEqual({ archived: [[]], unarchived: [[]], close: [[]] });
+  });
+
+  it('forwards outcomes from the suspended-author restoration path', async () => {
+    setQueryState({ isOriginalPosterSuspended: true });
+    const wrapper = mountWrapper({ authorType: 'mod', isSuspendedMod: false });
+    const button = wrapper.findComponent({ name: 'SuspendModButton' });
+    await button.vm.$emit('suspended-successfully');
+    await button.vm.$emit('unsuspended-successfully');
+    expect({
+      suspended: wrapper.emitted('suspended-mod-successfully'),
+      unsuspended: wrapper.emitted('unsuspended-mod-successfully'),
+    }).toEqual({ suspended: [[]], unsuspended: [[]] });
+  });
+
+  it('closes the edit modal from the modal event', async () => {
+    const wrapper = mountWrapper(reportedComment);
+    await wrapper.get('[data-test="edit-comment"]').trigger('click');
+    const modal = wrapper.findComponent({ name: 'EditContentModal' });
+    await modal.vm.$emit('close');
+    expect(modal.props('open')).toBe(false);
+  });
+
   describe('unauthenticated fallback', () => {
     it('shows the log-in prompt when RequireAuth renders its no-auth slot', () => {
       const wrapper = mount(ModerationWizard, {
@@ -287,17 +412,30 @@ describe('ModerationWizard', () => {
     beforeEach(() => setQueryState({ isOriginalPosterSuspended: true }));
 
     it('offers to unsuspend a suspended mod author', () => {
-      const wrapper = mountWrapper({ authorType: 'mod', isSuspendedMod: false });
-      expect(wrapper.get('[data-testid="suspend-mod-button"]').exists()).toBe(true);
+      const wrapper = mountWrapper({
+        authorType: 'mod',
+        isSuspendedMod: false,
+      });
+      expect(wrapper.get('[data-testid="suspend-mod-button"]').exists()).toBe(
+        true
+      );
     });
 
     it('offers to unsuspend a suspended user author', () => {
-      const wrapper = mountWrapper({ authorType: 'user', isSuspendedMod: false });
-      expect(wrapper.get('[data-testid="suspend-user-button"]').exists()).toBe(true);
+      const wrapper = mountWrapper({
+        authorType: 'user',
+        isSuspendedMod: false,
+      });
+      expect(wrapper.get('[data-testid="suspend-user-button"]').exists()).toBe(
+        true
+      );
     });
 
     it('shows the "already suspended" state in the destructive section', () => {
-      const wrapper = mountWrapper({ authorType: 'user', isSuspendedMod: false });
+      const wrapper = mountWrapper({
+        authorType: 'user',
+        isSuspendedMod: false,
+      });
       expect(wrapper.text()).toContain('Suspend Author (Already Suspended)');
     });
   });

--- a/components/nav/ForumQuickSwitcher.spec.ts
+++ b/components/nav/ForumQuickSwitcher.spec.ts
@@ -163,6 +163,14 @@ describe('ForumQuickSwitcher lazy loading', () => {
 });
 
 describe('ForumQuickSwitcher content', () => {
+  it('builds account query variables from the signed-in username', () => {
+    mountSwitcher();
+    expect(h.variables.slice(1).map((variables) => variables.value)).toEqual([
+      { username: 'alice' },
+      { username: 'alice' },
+    ]);
+  });
+
   it('shows recent, favorite, collection, and top-forum sections', async () => {
     h.getRecentForums.mockReturnValue([
       { uniqueName: 'recent', displayName: 'Recent Forum', timestamp: 2 },
@@ -313,5 +321,68 @@ describe('ForumQuickSwitcher content', () => {
       name: 'forums-forumId-discussions',
       params: { forumId: 'dogs' },
     });
+  });
+
+  it('sorts, validates, and limits recently visited forums', async () => {
+    h.getRecentForums.mockReturnValue([
+      null,
+      { uniqueName: 'old', displayName: '', timestamp: 1 },
+      { uniqueName: 'new', displayName: null, timestamp: 5 },
+      { uniqueName: 'three', timestamp: 4 },
+      { uniqueName: 'four', timestamp: 3 },
+      { uniqueName: 'five', timestamp: 2 },
+      { uniqueName: 'six', timestamp: 0 },
+    ]);
+    const wrapper = mountSwitcher();
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+    expect(document.body.textContent).toEqual(
+      expect.stringMatching(/new.*three.*four.*five.*old/s)
+    );
+  });
+
+  it('closes and clears search when the trigger is clicked again', async () => {
+    const wrapper = mountSwitcher();
+    const trigger = wrapper.get('[data-testid="forum-quick-switcher-trigger"]');
+    await trigger.trigger('click');
+    const input = document.querySelector(
+      '[data-testid="search-stub"]'
+    ) as HTMLInputElement;
+    input.value = 'dogs';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await trigger.trigger('click');
+    expect([trigger.attributes('aria-expanded'), h.variables[0].value]).toEqual(
+      ['false', { channelWhere: { uniqueName_MATCHES: '.*' } }]
+    );
+  });
+
+  it('collapses an expanded forum collection on a second click', async () => {
+    h.collectionsResult.value = {
+      users: [
+        {
+          Collections: [
+            {
+              id: 'list-1',
+              name: 'My Forums',
+              Channels: [{ uniqueName: 'listed', displayName: 'Listed Forum' }],
+            },
+          ],
+        },
+      ],
+    };
+    const wrapper = mountSwitcher();
+    await wrapper
+      .get('[data-testid="forum-quick-switcher-trigger"]')
+      .trigger('click');
+    const collectionButton = Array.from(
+      document.querySelectorAll('button')
+    ).find((button) =>
+      button.textContent?.includes('My Forums')
+    ) as HTMLButtonElement;
+    collectionButton.click();
+    collectionButton.click();
+    await nextTick();
+    expect(document.body.textContent).not.toContain('Listed Forum');
   });
 });

--- a/components/plugins/BotProfilesEditor.spec.ts
+++ b/components/plugins/BotProfilesEditor.spec.ts
@@ -152,4 +152,100 @@ describe('BotProfilesEditor', () => {
     // Should show invoke command
     expect(wrapper.text()).toContain('Invoke with /bot/assistant-helper');
   });
+
+  it('combines server profiles with channel overrides', () => {
+    const wrapper = mount(BotProfilesEditor, {
+      props: {
+        profiles: [
+          { id: 'shared', label: 'Channel Override', prompt: 'channel' },
+        ],
+        serverProfiles: [
+          { id: 'shared', label: 'Server Shared', prompt: 'server' },
+          { id: 'server-only', label: 'Server Only', prompt: 'server only' },
+        ],
+        scope: 'channel',
+        channelUniqueName: 'Test Channel',
+        botName: 'Assistant Bot',
+        existingBots: [],
+      },
+      global: { stubs: { MarkdownPreview: true } },
+    });
+    expect(wrapper.text()).toEqual(
+      expect.stringMatching(
+        /Server-configured Profiles.*Server Only.*Channel Override/s
+      )
+    );
+  });
+
+  it('emits immutable profile updates from every editor field', async () => {
+    const wrapper = mount(BotProfilesEditor, {
+      props: {
+        profiles: mockProfiles,
+        channelUniqueName: 'testchannel',
+        botName: 'assistant',
+      },
+      global: { stubs: { MarkdownPreview: true } },
+    });
+    await wrapper.get('#profile-id-0').setValue('reviewer');
+    await wrapper.get('#profile-label-0').setValue('Reviewer');
+    await wrapper.get('#profile-prompt-0').setValue('Review code');
+    expect(
+      wrapper.emitted('update:profiles')?.map((event) => event[0])
+    ).toEqual([
+      [{ ...mockProfiles[0], id: 'reviewer' }],
+      [{ ...mockProfiles[0], label: 'Reviewer' }],
+      [{ ...mockProfiles[0], prompt: 'Review code' }],
+    ]);
+  });
+
+  it('adds and removes editable profiles', async () => {
+    const wrapper = mount(BotProfilesEditor, {
+      props: {
+        profiles: mockProfiles,
+        channelUniqueName: 'testchannel',
+        botName: 'assistant',
+      },
+      global: { stubs: { MarkdownPreview: true } },
+    });
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Add'))!
+      .trigger('click');
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Remove'))!
+      .trigger('click');
+    expect(
+      wrapper.emitted('update:profiles')?.map((event) => event[0])
+    ).toEqual([[...mockProfiles, { id: '', label: '', prompt: '' }], []]);
+  });
+
+  it('shows validation feedback when an ID normalizes to empty', () => {
+    const wrapper = mount(BotProfilesEditor, {
+      props: {
+        profiles: [{ id: '!!!', label: '', prompt: '' }],
+        channelUniqueName: 'testchannel',
+        botName: 'assistant',
+      },
+      global: { stubs: { MarkdownPreview: true } },
+    });
+    expect(wrapper.text()).toContain(
+      'Profile ID must contain only lowercase letters, numbers, hyphens, and underscores'
+    );
+  });
+
+  it('ignores existing bots belonging to a different plugin prefix', () => {
+    const wrapper = mount(BotProfilesEditor, {
+      props: {
+        profiles: [],
+        channelUniqueName: 'testchannel',
+        botName: 'assistant',
+        existingBots: [
+          { username: 'bot-other-plugin-helper', botProfileId: null },
+        ],
+      },
+      global: { stubs: { MarkdownPreview: true } },
+    });
+    expect(wrapper.text()).toContain('No bot users to preview');
+  });
 });

--- a/components/wiki/WikiRevisionDiffModal.spec.ts
+++ b/components/wiki/WikiRevisionDiffModal.spec.ts
@@ -1,6 +1,22 @@
-import { describe, it, expect } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
 import WikiRevisionDiffModal from './WikiRevisionDiffModal.vue';
+
+const mutation = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  done: undefined as undefined | (() => void),
+}));
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: () => ({
+    mutate: mutation.mutate,
+    loading: false,
+    error: null,
+    onDone: (callback: () => void) => {
+      mutation.done = callback;
+    },
+  }),
+}));
 
 vi.mock('@headlessui/vue', () => ({
   TransitionRoot: { name: 'TransitionRoot', template: '<div><slot /></div>' },
@@ -42,6 +58,12 @@ const newVersion = {
   createdAt: new Date().toISOString(),
   Author: { username: 'new-wiki-user' },
 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mutation.done = undefined;
+  mutation.mutate.mockResolvedValue({});
+});
 
 describe('WikiRevisionDiffModal', () => {
   it('uses a neutral primary action and a danger redaction action', () => {
@@ -129,5 +151,68 @@ describe('WikiRevisionDiffModal', () => {
       hasOldLine: true,
       hasNewLine: true,
     });
+  });
+
+  it('redacts the older revision after confirmation', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    const wrapper = mount(WikiRevisionDiffModal, {
+      props: { open: true, oldVersion, newVersion },
+    });
+
+    wrapper
+      .findComponent({ name: 'GenericModal' })
+      .vm.$emit('danger-button-click');
+    await flushPromises();
+
+    expect(mutation.mutate).toHaveBeenCalledWith({ textVersionId: 'w1' });
+  });
+
+  it('emits deletion and closure after the mutation completes', () => {
+    const wrapper = mount(WikiRevisionDiffModal, {
+      props: { open: true, oldVersion, newVersion },
+    });
+
+    mutation.done?.();
+
+    expect(wrapper.emitted()).toMatchObject({ deleted: [['w1']], close: [[]] });
+  });
+
+  it('restores the redaction action and logs a failed mutation', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    const failure = new Error('denied');
+    mutation.mutate.mockRejectedValue(failure);
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const wrapper = mount(WikiRevisionDiffModal, {
+      props: { open: true, oldVersion, newVersion },
+    });
+
+    wrapper
+      .findComponent({ name: 'GenericModal' })
+      .vm.$emit('danger-button-click');
+    await flushPromises();
+
+    expect({
+      loading: wrapper
+        .findComponent({ name: 'GenericModal' })
+        .props('dangerButtonLoading'),
+      log: consoleError.mock.calls[0],
+    }).toEqual({
+      loading: false,
+      log: ['Error deleting revision:', failure],
+    });
+  });
+
+  it('closes from the primary action', () => {
+    const wrapper = mount(WikiRevisionDiffModal, {
+      props: { open: true, oldVersion, newVersion },
+    });
+
+    wrapper
+      .findComponent({ name: 'GenericModal' })
+      .vm.$emit('primary-button-click');
+
+    expect(wrapper.emitted('close')).toEqual([[]]);
   });
 });

--- a/pages/account_settings.spec.ts
+++ b/pages/account_settings.spec.ts
@@ -6,6 +6,7 @@ import { useMutation, useQuery } from '@vue/apollo-composable';
 
 const updateUser = vi.fn();
 const refetchUser = vi.fn();
+let onDoneCallback: (() => void) | undefined;
 const getUserResult = ref({
   users: [
     {
@@ -46,7 +47,7 @@ vi.mock('@/composables/useAuthState', () => ({
 
 vi.mock('@/config', () => ({
   config: {
-    enableLanguagePicker: false,
+    enableLanguagePicker: true,
   },
 }));
 
@@ -77,19 +78,48 @@ describe('account_settings', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    onDoneCallback = undefined;
+    getUserResult.value = {
+      users: [
+        {
+          Email: { address: 'alice@example.com' },
+          profilePicURL: '',
+          displayName: 'Alice',
+          bio: '',
+          notifyOnReplyToCommentByDefault: false,
+          notifyOnReplyToDiscussionByDefault: false,
+          notifyOnReplyToEventByDefault: false,
+          notifyWhenTagged: false,
+          notifyOnSubscribedIssueUpdates: null,
+          notifyOnFeedback: false,
+          notifyOnSuspensionBlocks: null,
+          notificationBundleInterval: 'hourly',
+          notificationBundleEnabled: true,
+          enableSensitiveContentByDefault: false,
+        },
+      ],
+    };
 
-    (useQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      result: getUserResult,
-      loading: ref(false),
-      error: ref(null),
-      refetch: refetchUser,
-    });
+    (useQuery as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (_query: unknown, variables: () => unknown, options: () => unknown) => {
+        variables();
+        options();
+        return {
+          result: getUserResult,
+          loading: ref(false),
+          error: ref(null),
+          refetch: refetchUser,
+        };
+      }
+    );
 
     (useMutation as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       mutate: updateUser,
       loading: ref(false),
       error: ref(null),
-      onDone: vi.fn(),
+      onDone: (callback: () => void) => {
+        onDoneCallback = callback;
+      },
     });
   });
 
@@ -110,15 +140,21 @@ describe('account_settings', () => {
             },
           }),
           RequireAuth: RequireAuthStub,
-          EditAccountSettingsFields: true,
-          NotificationComponent: true,
+          EditAccountSettingsFields: {
+            name: 'EditAccountSettingsFields',
+            props: ['formValues'],
+            emits: ['submit', 'update-form-values'],
+            template: '<div class="account-fields" />',
+          },
+          NotificationComponent: {
+            name: 'NotificationComponent',
+            emits: ['close-notification'],
+            template: '<div class="saved-notification" />',
+          },
           FormRow: defineComponent({
             setup(_props, { slots }) {
               return () =>
-                h('div', [
-                  slots.content?.(),
-                  slots['sub-description']?.(),
-                ]);
+                h('div', [slots.content?.(), slots['sub-description']?.()]);
             },
           }),
           CheckBox: CheckBoxStub,
@@ -135,7 +171,9 @@ describe('account_settings', () => {
   it('autosaves subscribed issue email preference changes', async () => {
     const wrapper = buildWrapper();
 
-    await wrapper.get('[data-testid="notify-subscribed-issues"]').trigger('click');
+    await wrapper
+      .get('[data-testid="notify-subscribed-issues"]')
+      .trigger('click');
     await vi.advanceTimersByTimeAsync(900);
 
     expect(updateUser).toHaveBeenCalledWith({
@@ -155,7 +193,9 @@ describe('account_settings', () => {
   it('autosaves suspension block notification preference changes', async () => {
     const wrapper = buildWrapper();
 
-    await wrapper.get('[data-testid="notify-suspension-blocks"]').trigger('click');
+    await wrapper
+      .get('[data-testid="notify-suspension-blocks"]')
+      .trigger('click');
     await vi.advanceTimersByTimeAsync(900);
 
     expect(updateUser).toHaveBeenCalledWith({
@@ -164,5 +204,97 @@ describe('account_settings', () => {
         notifyOnSuspensionBlocks: false,
       }),
     });
+  });
+
+  it.each([
+    ['notify-comment-reply', 'notifyOnReplyToCommentByDefault'],
+    ['notify-discussion-reply', 'notifyOnReplyToDiscussionByDefault'],
+    ['notify-event-reply', 'notifyOnReplyToEventByDefault'],
+    ['notify-tagged', 'notifyWhenTagged'],
+    ['notify-feedback', 'notifyOnFeedback'],
+    ['enable-sensitive-content', 'enableSensitiveContentByDefault'],
+  ])('autosaves the %s preference', async (testId, field) => {
+    const wrapper = buildWrapper();
+    await wrapper.get(`[data-testid="${testId}"]`).trigger('click');
+    await vi.advanceTimersByTimeAsync(900);
+    expect(updateUser).toHaveBeenCalledWith({
+      where: { username: 'alice' },
+      update: expect.objectContaining({ [field]: true }),
+    });
+  });
+
+  it('updates and submits the basic account profile', async () => {
+    const wrapper = buildWrapper();
+    const fields = wrapper.findComponent({ name: 'EditAccountSettingsFields' });
+    await fields.vm.$emit('update-form-values', {
+      displayName: 'Alicia',
+      bio: 'Hello',
+      profilePicURL: '/alice.png',
+    });
+    await fields.vm.$emit('submit');
+    expect({
+      mutation: updateUser.mock.calls.at(-1)?.[0],
+      refetches: refetchUser.mock.calls.length,
+    }).toEqual({
+      mutation: {
+        where: { username: 'alice' },
+        update: {
+          displayName: 'Alicia',
+          bio: 'Hello',
+          profilePicURL: '/alice.png',
+        },
+      },
+      refetches: 1,
+    });
+  });
+
+  it('shows and dismisses the saved notification after mutation completion', async () => {
+    const wrapper = buildWrapper();
+    onDoneCallback?.();
+    await wrapper.vm.$nextTick();
+    const notification = wrapper.findComponent({
+      name: 'NotificationComponent',
+    });
+    await notification.vm.$emit('close-notification');
+    expect(wrapper.find('.saved-notification').exists()).toBe(false);
+  });
+
+  it('updates account fields when refreshed user data arrives', async () => {
+    const wrapper = buildWrapper();
+    getUserResult.value = {
+      users: [
+        {
+          ...getUserResult.value.users[0],
+          displayName: 'Updated Alice',
+          bio: 'Updated bio',
+        },
+      ],
+    };
+    await wrapper.vm.$nextTick();
+    expect(
+      wrapper
+        .findComponent({ name: 'EditAccountSettingsFields' })
+        .props('formValues')
+    ).toEqual(
+      expect.objectContaining({
+        displayName: 'Updated Alice',
+        bio: 'Updated bio',
+      })
+    );
+  });
+
+  it('changes the selected language', async () => {
+    const wrapper = buildWrapper();
+    const select = wrapper.get('select');
+    await select.setValue('es');
+    expect((select.element as HTMLSelectElement).value).toBe('es');
+  });
+
+  it('shows the no-email fallback for a user without an email', () => {
+    getUserResult.value = {
+      users: [{ ...getUserResult.value.users[0], Email: null }],
+    };
+    const wrapper = buildWrapper();
+    expect(wrapper.text()).toContain('accountSettings.noEmailAssociated');
   });
 });

--- a/pages/admin/plugins/aliases.spec.ts
+++ b/pages/admin/plugins/aliases.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+vi.stubGlobal('definePageMeta', vi.fn());
+
+const aliases = [
+  ['[pluginId].vue', () => import('./[pluginId].vue'), 'PluginDetailPage'],
+  ['docs.vue', () => import('./docs.vue'), 'PluginsDocsPage'],
+  ['index.vue', () => import('./index.vue'), 'PluginsIndexPage'],
+  ['pipelines.vue', () => import('./pipelines.vue'), 'PluginsPipelinesPage'],
+  ['registries.vue', () => import('./registries.vue'), 'PluginsRegistriesPage'],
+] as const;
+
+describe('legacy admin plugin route aliases', () => {
+  it.each(aliases)(
+    'renders the settings page for %s',
+    async (_file, loadPage, childName) => {
+      const Page = (await loadPage()).default;
+      const wrapper = shallowMount(Page);
+
+      expect(wrapper.findComponent({ name: childName }).exists()).toBe(true);
+    }
+  );
+});

--- a/pages/admin/settings.spec.ts
+++ b/pages/admin/settings.spec.ts
@@ -1,39 +1,73 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { defineComponent, h } from 'vue';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import { flushPromises } from '@vue/test-utils';
 
 import ServerSettingsPage from './settings.vue';
 
-const h = vi.hoisted(() => ({
+const harness = vi.hoisted(() => ({
   result: null as unknown as { value: unknown },
   error: null as unknown as { value: unknown },
   loading: null as unknown as { value: boolean },
   updateMutate: null as unknown as ReturnType<typeof vi.fn>,
   setFeaturedMutate: null as unknown as ReturnType<typeof vi.fn>,
   onResultCb: null as unknown as (r: unknown) => void,
+  updateOptions: null as unknown as { update: (...args: any[]) => void },
+  autosaves: [] as Array<{
+    save: (value: unknown) => unknown;
+    trigger: ReturnType<typeof vi.fn>;
+    setInitial: ReturnType<typeof vi.fn>;
+  }>,
 }));
+
+vi.mock('@/composables/useSettingAutosave', async () => {
+  const { ref } = await import('vue');
+  return {
+    useSettingAutosave: (options: { save: (value: unknown) => unknown }) => {
+      const autosave = {
+        save: options.save,
+        trigger: vi.fn(),
+        setInitial: vi.fn(),
+        status: ref('idle'),
+        error: ref(null),
+      };
+      harness.autosaves.push(autosave);
+      return autosave;
+    },
+  };
+});
 
 vi.mock('@vue/apollo-composable', async () => {
   const { ref } = await import('vue');
-  h.result = ref(null);
-  h.error = ref(null);
-  h.loading = ref(false);
-  h.updateMutate = vi.fn(async () => ({}));
-  h.setFeaturedMutate = vi.fn(async () => ({}));
+  harness.result = ref(null);
+  harness.error = ref(null);
+  harness.loading = ref(false);
+  harness.updateMutate = vi.fn(async () => ({}));
+  harness.setFeaturedMutate = vi.fn(async () => ({}));
   return {
     useQuery: () => ({
-      result: h.result,
-      error: h.error,
-      loading: h.loading,
+      result: harness.result,
+      error: harness.error,
+      loading: harness.loading,
       onResult: (cb: (r: unknown) => void) => {
-        h.onResultCb = cb;
+        harness.onResultCb = cb;
       },
     }),
-    useMutation: (document: string) => ({
-      mutate: document === 'setFeatured' ? h.setFeaturedMutate : h.updateMutate,
-      loading: ref(false),
-      error: ref(null),
-    }),
+    useMutation: (
+      document: string,
+      options?: { update: (...args: any[]) => void }
+    ) => {
+      if (document !== 'setFeatured' && options)
+        harness.updateOptions = options;
+      return {
+        mutate:
+          document === 'setFeatured'
+            ? harness.setFeaturedMutate
+            : harness.updateMutate,
+        loading: ref(false),
+        error: ref(null),
+      };
+    },
   };
 });
 
@@ -62,7 +96,11 @@ const mountPage = () =>
     global: {
       stubs: {
         CreateEditServerFields: FieldsStub,
-        Notification: { name: 'Notification', props: ['title'], template: '<div class="notification" />' },
+        Notification: {
+          name: 'Notification',
+          props: ['title'],
+          template: '<div class="notification" />',
+        },
       },
     },
   });
@@ -72,9 +110,9 @@ const fields = (wrapper: ReturnType<typeof mountPage>) =>
 
 beforeEach(() => {
   vi.clearAllMocks();
-  h.result.value = null;
-  h.error.value = null;
-  h.loading.value = false;
+  harness.result.value = null;
+  harness.error.value = null;
+  harness.loading.value = false;
 });
 
 describe('Admin server settings page', () => {
@@ -84,7 +122,7 @@ describe('Admin server settings page', () => {
 
   it('populates the form when the server config query resolves', async () => {
     const wrapper = mountPage();
-    h.onResultCb({
+    harness.onResultCb({
       data: {
         serverConfigs: [
           {
@@ -116,7 +154,9 @@ describe('Admin server settings page', () => {
     await fields(wrapper).vm.$emit('update-form-values', {
       serverDescription: 'Updated',
     });
-    expect(fields(wrapper).props('formValues').serverDescription).toBe('Updated');
+    expect(fields(wrapper).props('formValues').serverDescription).toBe(
+      'Updated'
+    );
   });
 
   it('submits the server update input built from the form values', async () => {
@@ -126,7 +166,7 @@ describe('Admin server settings page', () => {
       rules: [{ summary: 'Rule' }],
     });
     await fields(wrapper).vm.$emit('submit');
-    expect(h.updateMutate).toHaveBeenCalledWith(
+    expect(harness.updateMutate).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           serverDescription: 'Updated',
@@ -142,7 +182,7 @@ describe('Admin server settings page', () => {
       featuredWikiPageIds: ['w2', 'w1'],
     });
     await fields(wrapper).vm.$emit('submit');
-    expect(h.setFeaturedMutate).toHaveBeenCalledWith({
+    expect(harness.setFeaturedMutate).toHaveBeenCalledWith({
       serverName: 'test-server',
       wikiPageIds: ['w2', 'w1'],
     });
@@ -158,6 +198,98 @@ describe('Admin server settings page', () => {
       },
     });
 
-    expect(wrapper.text()).toContain("You don't have permission to see this page.");
+    expect(wrapper.text()).toContain(
+      "You don't have permission to see this page."
+    );
+  });
+
+  it('falls back to empty rules when the stored JSON is invalid', async () => {
+    const wrapper = mountPage();
+    harness.onResultCb({ data: { serverConfigs: [{ rules: '{invalid' }] } });
+    await wrapper.vm.$nextTick();
+    expect(fields(wrapper).props('formValues').rules).toEqual([]);
+  });
+
+  it('applies a successful mutation response to the form and cache', async () => {
+    const wrapper = mountPage();
+    const cache = { writeQuery: vi.fn(), evict: vi.fn() };
+    harness.updateOptions.update(cache, {
+      data: {
+        updateServerConfigs: {
+          serverConfigs: [
+            {
+              serverDescription: 'Saved',
+              rules: '[{"summary":"Rule"}]',
+              enableEvents: true,
+            },
+          ],
+        },
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect([
+      fields(wrapper).props('formValues'),
+      cache.writeQuery.mock.calls.length,
+    ]).toEqual([
+      expect.objectContaining({
+        serverDescription: 'Saved',
+        rules: [{ summary: 'Rule' }],
+        enableEvents: true,
+      }),
+      1,
+    ]);
+  });
+
+  it('recovers from malformed rules in a mutation response', () => {
+    const cache = { writeQuery: vi.fn(), evict: vi.fn() };
+    harness.updateOptions.update(cache, {
+      data: {
+        updateServerConfigs: {
+          serverConfigs: [
+            { rules: '{invalid', enableDownloads: false, enableEvents: false },
+          ],
+        },
+      },
+    });
+    expect(cache.writeQuery.mock.calls[0][0].data.serverConfigs[0].rules).toBe(
+      '{invalid'
+    );
+  });
+
+  it('evicts server config when writing the mutation result fails', () => {
+    const cache = {
+      writeQuery: vi.fn(() => {
+        throw new Error('cache unavailable');
+      }),
+      evict: vi.fn(),
+    };
+    harness.updateOptions.update(cache, {
+      data: { updateServerConfigs: { serverConfigs: [{ rules: '[]' }] } },
+    });
+    expect(cache.evict).toHaveBeenCalledWith({ fieldName: 'serverConfigs' });
+  });
+
+  it('autosaves scalar setting changes with scoped update inputs', async () => {
+    await harness.autosaves[0].save('Description');
+    await harness.autosaves[1].save(true);
+    expect(harness.updateMutate.mock.calls).toEqual([
+      [
+        {
+          input: { serverDescription: 'Description' },
+          serverName: 'test-server',
+        },
+      ],
+      [{ input: { enableEvents: true }, serverName: 'test-server' }],
+    ]);
+  });
+
+  it('closes the saved notification', async () => {
+    const wrapper = mountPage();
+    await fields(wrapper).vm.$emit('submit');
+    await flushPromises();
+    await wrapper
+      .getComponent({ name: 'Notification' })
+      .vm.$emit('close-notification');
+    expect(wrapper.find('.notification').exists()).toBe(false);
   });
 });

--- a/pages/admin/settings/plugins/[pluginId].spec.ts
+++ b/pages/admin/settings/plugins/[pluginId].spec.ts
@@ -13,7 +13,10 @@ const routeState = vi.hoisted(() => ({
 }));
 
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: { pluginId: PLUGIN_ID }, query: routeState.query }),
+  useRoute: () => ({
+    params: { pluginId: PLUGIN_ID },
+    query: routeState.query,
+  }),
 }));
 
 vi.mock('@/graphQLData/admin/queries', () => ({
@@ -39,17 +42,45 @@ const h = vi.hoisted(() => ({
       refetch: ReturnType<typeof vi.fn>;
     }
   >,
-  mutations: {} as Record<string, { mutate: ReturnType<typeof vi.fn>; loading: { value: boolean } }>,
+  mutations: {} as Record<
+    string,
+    { mutate: ReturnType<typeof vi.fn>; loading: { value: boolean } }
+  >,
 }));
 
 vi.mock('@vue/apollo-composable', async () => {
   const { ref } = await import('vue');
   h.q = {
-    AVAILABLE: { result: ref(null), loading: ref(false), error: ref(null), refetch: vi.fn() },
-    INSTALLED: { result: ref(null), loading: ref(false), error: ref(null), refetch: vi.fn() },
-    DETAIL: { result: ref(null), loading: ref(false), error: ref(null), refetch: vi.fn() },
-    SECRETS: { result: ref(null), loading: ref(false), error: ref(null), refetch: vi.fn() },
-    CONFIG_STATUS: { result: ref(null), loading: ref(false), error: ref(null), refetch: vi.fn() },
+    AVAILABLE: {
+      result: ref(null),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    },
+    INSTALLED: {
+      result: ref(null),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    },
+    DETAIL: {
+      result: ref(null),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    },
+    SECRETS: {
+      result: ref(null),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    },
+    CONFIG_STATUS: {
+      result: ref(null),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    },
   };
   return {
     useQuery: (doc: keyof typeof h.q) => h.q[doc],
@@ -65,41 +96,75 @@ vi.mock('@vue/apollo-composable', async () => {
 const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
 vi.mock('@/composables/useToast', () => ({ useToast: () => toast }));
 
-const sectionStub = (name: string) => ({ name, template: `<div data-stub="${name}" />` });
+const sectionStub = (name: string) => ({
+  name,
+  template: `<div data-stub="${name}" />`,
+});
 const stubs = {
-  PluginDetailHeader: { name: 'PluginDetailHeader', props: ['pluginDisplayName'], template: '<div class="header">{{ pluginDisplayName }}</div>' },
-  PluginStatusCards: { name: 'PluginStatusCards', props: ['isEnabled', 'canEnable', 'enabling', 'blockingConfigFields'], emits: ['toggle-enabled', 'focus-config-field'], template: '<button type="button" data-test="toggle-enabled" @click="$emit(\'toggle-enabled\', false)" />' },
-  PluginUpdateBanner: sectionStub('PluginUpdateBanner'),
+  PluginDetailHeader: {
+    name: 'PluginDetailHeader',
+    props: ['pluginDisplayName'],
+    template: '<div class="header">{{ pluginDisplayName }}</div>',
+  },
+  PluginStatusCards: {
+    name: 'PluginStatusCards',
+    props: ['isEnabled', 'canEnable', 'enabling', 'blockingConfigFields'],
+    emits: ['toggle-enabled', 'focus-config-field'],
+    template:
+      '<button type="button" data-test="toggle-enabled" @click="$emit(\'toggle-enabled\', false)" />',
+  },
+  PluginUpdateBanner: {
+    name: 'PluginUpdateBanner',
+    props: ['latestVersion', 'registryVersions', 'compatibility'],
+    emits: ['install-latest'],
+    template:
+      '<button type="button" data-test="install-latest" @click="$emit(\'install-latest\')">Update</button>',
+  },
   PluginUpgradePreviewModal: {
     name: 'PluginUpgradePreviewModal',
-    props: ['currentVersion', 'targetVersion', 'report', 'secrets', 'installing'],
+    props: [
+      'currentVersion',
+      'targetVersion',
+      'report',
+      'secrets',
+      'installing',
+    ],
     emits: ['carry-over', 'start-fresh', 'cancel'],
-    template: '<div data-test="upgrade-preview"><button data-test="carry-upgrade" @click="$emit(\'carry-over\')">Carry</button><button data-test="fresh-upgrade" @click="$emit(\'start-fresh\')">Fresh</button></div>',
+    template:
+      '<div data-test="upgrade-preview"><button data-test="carry-upgrade" @click="$emit(\'carry-over\')">Carry</button><button data-test="fresh-upgrade" @click="$emit(\'start-fresh\')">Fresh</button><button data-test="cancel-upgrade" @click="$emit(\'cancel\')">Cancel</button></div>',
   },
   PluginInstallSection: {
     name: 'PluginInstallSection',
     props: ['modelValue', 'canInstall', 'compatibilityByVersion'],
     emits: ['install', 'update:modelValue'],
-    template: '<button type="button" data-test="install" @click="$emit(\'install\')">Install</button>',
+    template:
+      '<button type="button" data-test="install" @click="$emit(\'install\')">Install</button>',
   },
   PluginSecretsSection: {
     name: 'PluginSecretsSection',
     props: ['secrets', 'orphanedSecrets', 'secretValues', 'showSecretInputs'],
     emits: ['set-secret', 'update:secretValues', 'update:showSecretInputs'],
-    template: '<button type="button" data-test="set-secret" @click="$emit(\'set-secret\', \'API_KEY\', \'xyz\')">Set secret</button>',
+    template:
+      '<div><button type="button" data-test="set-secret" @click="$emit(\'set-secret\', \'API_KEY\', \'xyz\')">Set secret</button><button type="button" data-test="edit-secret" @click="$emit(\'update:secretValues\', { API_KEY: \'edited\' }); $emit(\'update:showSecretInputs\', { API_KEY: true })">Edit secret</button></div>',
   },
   PluginSettingsSection: {
     name: 'PluginSettingsSection',
     props: ['modelValue', 'errors', 'saving', 'sections', 'secretStatuses'],
     emits: ['save', 'update:modelValue'],
-    template: '<button type="button" data-test="save-settings" @click="$emit(\'save\')">Save settings</button>',
+    template:
+      '<button type="button" data-test="save-settings" @click="$emit(\'save\')">Save settings</button>',
   },
   PluginManifestSection: sectionStub('PluginManifestSection'),
   PluginReadmeSection: sectionStub('PluginReadmeSection'),
-  ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="error-banner">{{ text }}</div>' },
+  ErrorBanner: {
+    name: 'ErrorBanner',
+    props: ['text'],
+    template: '<div class="error-banner">{{ text }}</div>',
+  },
 };
 
-const mountPage = () => mountWithDefaults(PluginDetailPage, { global: { stubs } });
+const mountPage = () =>
+  mountWithDefaults(PluginDetailPage, { global: { stubs } });
 
 const deferred = <T = unknown>() => {
   let resolve!: (value: T) => void;
@@ -185,7 +250,9 @@ describe('Plugin detail page', () => {
     setInstalledPlugin();
     const wrapper = mountPage();
 
-    expect(wrapper.findComponent({ name: 'PluginStatusCards' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'PluginStatusCards' }).exists()).toBe(
+      true
+    );
   });
 
   it.each([
@@ -233,13 +300,15 @@ describe('Plugin detail page', () => {
         secrets: [{ key: 'API_KEY', scope: 'server', required: true }],
         ui: {
           forms: {
-            server: [{
-              title: 'Settings',
-              fields: [
-                { key: 'API_KEY', label: 'API key', type: 'secret' },
-                { key: 'serviceUrl', label: 'Service URL', type: 'text' },
-              ],
-            }],
+            server: [
+              {
+                title: 'Settings',
+                fields: [
+                  { key: 'API_KEY', label: 'API key', type: 'secret' },
+                  { key: 'serviceUrl', label: 'Service URL', type: 'text' },
+                ],
+              },
+            ],
           },
         },
       },
@@ -247,8 +316,12 @@ describe('Plugin detail page', () => {
     const wrapper = mountPage();
 
     expect({
-      secrets: wrapper.findComponent({ name: 'PluginSecretsSection' }).props('secrets'),
-      fields: wrapper.findComponent({ name: 'PluginSettingsSection' }).props('sections')[0].fields,
+      secrets: wrapper
+        .findComponent({ name: 'PluginSecretsSection' })
+        .props('secrets'),
+      fields: wrapper
+        .findComponent({ name: 'PluginSettingsSection' })
+        .props('sections')[0].fields,
     }).toEqual({
       secrets: [{ key: 'API_KEY', status: 'NOT_SET', required: true }],
       fields: [{ key: 'serviceUrl', label: 'Service URL', type: 'text' }],
@@ -258,14 +331,14 @@ describe('Plugin detail page', () => {
   it('separates stored secrets that the installed version no longer declares', () => {
     setInstalledPlugin({ manifest: { secrets: [] } });
     h.q.SECRETS.result.value = {
-      getServerPluginSecrets: [
-        { key: 'OLD_API_KEY', status: 'SET_UNTESTED' },
-      ],
+      getServerPluginSecrets: [{ key: 'OLD_API_KEY', status: 'SET_UNTESTED' }],
     };
     const wrapper = mountPage();
 
     expect(
-      wrapper.findComponent({ name: 'PluginSecretsSection' }).props('orphanedSecrets')
+      wrapper
+        .findComponent({ name: 'PluginSecretsSection' })
+        .props('orphanedSecrets')
     ).toEqual([{ key: 'OLD_API_KEY', status: 'SET_UNTESTED' }]);
   });
 
@@ -274,7 +347,9 @@ describe('Plugin detail page', () => {
     h.q.INSTALLED.result.value = { getInstalledPlugins: [] };
     const wrapper = mountPage();
 
-    expect(wrapper.findComponent({ name: 'PluginStatusCards' }).exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'PluginStatusCards' }).exists()).toBe(
+      false
+    );
   });
 
   it('shows a missing-version install error', async () => {
@@ -289,9 +364,16 @@ describe('Plugin detail page', () => {
   });
 
   it('shows a compatibility install error', async () => {
-    setAvailablePlugin({ Versions: [{ version: '2.0.0', minServerVersion: '2.0.0' }] });
+    setAvailablePlugin({
+      Versions: [{ version: '2.0.0', minServerVersion: '2.0.0' }],
+    });
     h.q.DETAIL.result.value = {
-      plugins: [{ id: PLUGIN_ID, Versions: [{ version: '2.0.0', minServerVersion: '2.0.0' }] }],
+      plugins: [
+        {
+          id: PLUGIN_ID,
+          Versions: [{ version: '2.0.0', minServerVersion: '2.0.0' }],
+        },
+      ],
     };
     const wrapper = mountPage();
 
@@ -304,7 +386,12 @@ describe('Plugin detail page', () => {
   it('shows GraphQL install errors returned from the mutation', async () => {
     setAvailablePlugin();
     h.q.DETAIL.result.value = {
-      plugins: [{ id: PLUGIN_ID, Versions: [{ version: '1.0.0', readmeMarkdown: '# Readme' }] }],
+      plugins: [
+        {
+          id: PLUGIN_ID,
+          Versions: [{ version: '1.0.0', readmeMarkdown: '# Readme' }],
+        },
+      ],
     };
     h.mutations.INSTALL_M = {
       mutate: vi.fn().mockResolvedValue({ errors: [{ message: 'boom' }] }),
@@ -341,35 +428,47 @@ describe('Plugin detail page', () => {
       version: '1.0.0',
       settingsJson: { endpoint: 'https://custom.example', removed: true },
     });
-    setAvailablePlugin({ Versions: [{ version: '1.0.0' }, { version: '2.0.0' }] });
+    setAvailablePlugin({
+      Versions: [{ version: '1.0.0' }, { version: '2.0.0' }],
+    });
     h.q.DETAIL.result.value = {
-      plugins: [{
-        id: PLUGIN_ID,
-        Versions: [{
-          version: '2.0.0',
-          manifest: {
-            secrets: [{ key: 'API_KEY', scope: 'server', required: true }],
-            settingsDefaults: { server: { endpoint: 'default', added: true } },
-            ui: {
-              forms: {
-                server: [{
-                  title: 'Settings',
-                  fields: [
-                    { key: 'endpoint', label: 'Endpoint', type: 'text' },
-                    { key: 'added', label: 'Added', type: 'toggle' },
-                  ],
-                }],
+      plugins: [
+        {
+          id: PLUGIN_ID,
+          Versions: [
+            {
+              version: '2.0.0',
+              manifest: {
+                secrets: [{ key: 'API_KEY', scope: 'server', required: true }],
+                settingsDefaults: {
+                  server: { endpoint: 'default', added: true },
+                },
+                ui: {
+                  forms: {
+                    server: [
+                      {
+                        title: 'Settings',
+                        fields: [
+                          { key: 'endpoint', label: 'Endpoint', type: 'text' },
+                          { key: 'added', label: 'Added', type: 'toggle' },
+                        ],
+                      },
+                    ],
+                  },
+                },
               },
             },
-          },
-        }],
-      }],
+          ],
+        },
+      ],
     };
     h.q.SECRETS.result.value = {
       getServerPluginSecrets: [{ key: 'API_KEY', status: 'SET_UNTESTED' }],
     };
     const wrapper = mountPage();
-    const installSection = wrapper.findComponent({ name: 'PluginInstallSection' });
+    const installSection = wrapper.findComponent({
+      name: 'PluginInstallSection',
+    });
 
     installSection.vm.$emit('update:modelValue', '2.0.0');
     await flushPromises();
@@ -425,7 +524,9 @@ describe('Plugin detail page', () => {
     await wrapper.get('[data-test="toggle-enabled"]').trigger('click');
     await flushPromises();
 
-    expect(toast.error).toHaveBeenCalledWith('Cannot enable: missing required secrets');
+    expect(toast.error).toHaveBeenCalledWith(
+      'Cannot enable: missing required secrets'
+    );
   });
 
   it('sets a secret via the secrets section', async () => {
@@ -451,7 +552,14 @@ describe('Plugin detail page', () => {
               {
                 id: 'main',
                 title: 'Main',
-                fields: [{ key: 'endpoint', label: 'Endpoint', type: 'text', validation: { required: true } }],
+                fields: [
+                  {
+                    key: 'endpoint',
+                    label: 'Endpoint',
+                    type: 'text',
+                    validation: { required: true },
+                  },
+                ],
               },
             ],
           },
@@ -463,7 +571,9 @@ describe('Plugin detail page', () => {
     await wrapper.get('[data-test="save-settings"]').trigger('click');
     await flushPromises();
 
-    expect(wrapper.findComponent({ name: 'PluginSettingsSection' }).props('errors')).toEqual({
+    expect(
+      wrapper.findComponent({ name: 'PluginSettingsSection' }).props('errors')
+    ).toEqual({
       endpoint: 'Endpoint is required',
     });
   });
@@ -489,10 +599,12 @@ describe('Plugin detail page', () => {
     });
     const wrapper = mountPage();
 
-    await wrapper.findComponent({ name: 'PluginSettingsSection' }).vm.$emit('update:modelValue', {
-      endpoint: 'https://example.com',
-      apiKey: 'secret-value',
-    });
+    await wrapper
+      .findComponent({ name: 'PluginSettingsSection' })
+      .vm.$emit('update:modelValue', {
+        endpoint: 'https://example.com',
+        apiKey: 'secret-value',
+      });
     await wrapper.get('[data-test="save-settings"]').trigger('click');
     await flushPromises();
 
@@ -524,10 +636,12 @@ describe('Plugin detail page', () => {
     });
     const wrapper = mountPage();
 
-    await wrapper.findComponent({ name: 'PluginSettingsSection' }).vm.$emit('update:modelValue', {
-      endpoint: 'https://example.com',
-      apiKey: 'secret-value',
-    });
+    await wrapper
+      .findComponent({ name: 'PluginSettingsSection' })
+      .vm.$emit('update:modelValue', {
+        endpoint: 'https://example.com',
+        apiKey: 'secret-value',
+      });
     await wrapper.get('[data-test="save-settings"]').trigger('click');
     await flushPromises();
 
@@ -567,13 +681,12 @@ describe('Plugin detail page', () => {
     });
     const wrapper = mountPage();
 
-    await wrapper.findComponent({ name: 'PluginSettingsSection' }).vm.$emit(
-      'update:modelValue',
-      {
+    await wrapper
+      .findComponent({ name: 'PluginSettingsSection' })
+      .vm.$emit('update:modelValue', {
         endpoint: 'https://example.com',
         apiKey: 'secret-value',
-      }
-    );
+      });
     await wrapper.get('[data-test="save-settings"]').trigger('click');
     await flushPromises();
 
@@ -594,9 +707,9 @@ describe('Plugin detail page', () => {
     expect(h.q.INSTALLED.refetch).toHaveBeenCalled();
     expect(h.q.SECRETS.refetch).toHaveBeenCalled();
     expect(
-      wrapper.findComponent({ name: 'PluginSettingsSection' }).props(
-        'modelValue'
-      )
+      wrapper
+        .findComponent({ name: 'PluginSettingsSection' })
+        .props('modelValue')
     ).toEqual({
       endpoint: 'https://example.com',
       apiKey: '',
@@ -628,13 +741,12 @@ describe('Plugin detail page', () => {
     };
     const wrapper = mountPage();
 
-    await wrapper.findComponent({ name: 'PluginSettingsSection' }).vm.$emit(
-      'update:modelValue',
-      {
+    await wrapper
+      .findComponent({ name: 'PluginSettingsSection' })
+      .vm.$emit('update:modelValue', {
         endpoint: 'https://example.com',
         apiKey: 'secret-value',
-      }
-    );
+      });
     await wrapper.get('[data-test="save-settings"]').trigger('click');
     await flushPromises();
 
@@ -643,9 +755,9 @@ describe('Plugin detail page', () => {
       'Failed to save settings: Secret rejected'
     );
     expect(
-      wrapper.findComponent({ name: 'PluginSettingsSection' }).props(
-        'modelValue'
-      )
+      wrapper
+        .findComponent({ name: 'PluginSettingsSection' })
+        .props('modelValue')
     ).toEqual({
       endpoint: 'https://example.com',
       apiKey: 'secret-value',
@@ -675,12 +787,11 @@ describe('Plugin detail page', () => {
     };
     const wrapper = mountPage();
 
-    await wrapper.findComponent({ name: 'PluginSettingsSection' }).vm.$emit(
-      'update:modelValue',
-      {
+    await wrapper
+      .findComponent({ name: 'PluginSettingsSection' })
+      .vm.$emit('update:modelValue', {
         endpoint: 'https://example.com',
-      }
-    );
+      });
     await wrapper.get('[data-test="save-settings"]').trigger('click');
     await flushPromises();
 
@@ -694,5 +805,207 @@ describe('Plugin detail page', () => {
     expect(
       wrapper.findComponent({ name: 'PluginSettingsSection' }).props('saving')
     ).toBe(false);
+  });
+
+  it('uses the stored status for a declared secret', () => {
+    setInstalledPlugin({
+      manifest: {
+        secrets: [{ key: 'API_KEY', scope: 'server', required: false }],
+      },
+    });
+    h.q.SECRETS.result.value = {
+      getServerPluginSecrets: [
+        { key: 'API_KEY', status: 'SET_VALID', lastValidatedAt: 'today' },
+      ],
+    };
+
+    expect(
+      mountPage()
+        .findComponent({ name: 'PluginSecretsSection' })
+        .props('secrets')
+    ).toEqual([
+      {
+        key: 'API_KEY',
+        status: 'SET_VALID',
+        lastValidatedAt: 'today',
+        required: false,
+      },
+    ]);
+  });
+
+  it('shows an error when an upgrade manifest has not loaded', async () => {
+    setInstalledPlugin();
+    setAvailablePlugin({
+      Versions: [{ version: '1.0.0' }, { version: '2.0.0' }],
+    });
+    h.q.DETAIL.result.value = {
+      plugins: [{ id: PLUGIN_ID, Versions: [{ version: '2.0.0' }] }],
+    };
+    const wrapper = mountPage();
+
+    wrapper
+      .findComponent({ name: 'PluginInstallSection' })
+      .vm.$emit('update:modelValue', '2.0.0');
+    await flushPromises();
+    await wrapper.get('[data-test="install"]').trigger('click');
+
+    expect(wrapper.text()).toContain(
+      'Upgrade preview is unavailable because the target manifest has not loaded.'
+    );
+  });
+
+  it.each([
+    [
+      'PLUGIN_MISCONFIGURED_REQUIRED_SECRET_MISSING',
+      'Plugin misconfigured: required secrets missing',
+    ],
+    [
+      'PLUGIN_CONFIG_INCOMPLETE',
+      'Cannot enable: complete all required plugin configuration',
+    ],
+    ['unexpected failure', 'Disable failed: unexpected failure'],
+    [null, 'Disable failed: Unknown error'],
+  ])('maps enable failure %s to a useful toast', async (failure, message) => {
+    setInstalledPlugin();
+    h.mutations.ENABLE_M = {
+      mutate: vi.fn().mockRejectedValue(failure ? new Error(failure) : failure),
+      loading: { value: false },
+    };
+    const wrapper = mountPage();
+
+    await wrapper.get('[data-test="toggle-enabled"]').trigger('click');
+    await flushPromises();
+
+    expect(toast.error).toHaveBeenCalledWith(message);
+  });
+
+  it('reports failures while setting an individual secret', async () => {
+    setInstalledPlugin();
+    h.mutations.SET_SECRET_M = {
+      mutate: vi.fn().mockRejectedValue(new Error('Vault unavailable')),
+      loading: { value: false },
+    };
+    const wrapper = mountPage();
+
+    await wrapper.get('[data-test="set-secret"]').trigger('click');
+    await flushPromises();
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Failed to set secret "API_KEY": Vault unavailable'
+    );
+  });
+
+  it('accepts both secrets section v-model updates', async () => {
+    setInstalledPlugin();
+    const wrapper = mountPage();
+
+    await wrapper.get('[data-test="edit-secret"]').trigger('click');
+
+    expect(
+      wrapper.findComponent({ name: 'PluginSecretsSection' }).props()
+    ).toMatchObject({
+      secretValues: { API_KEY: 'edited' },
+      showSecretInputs: { API_KEY: true },
+    });
+  });
+
+  it('starts an upgrade without carrying settings', async () => {
+    setInstalledPlugin();
+    setAvailablePlugin({
+      Versions: [{ version: '1.0.0' }, { version: '2.0.0' }],
+    });
+    h.q.DETAIL.result.value = {
+      plugins: [
+        {
+          id: PLUGIN_ID,
+          Versions: [
+            {
+              version: '2.0.0',
+              manifest: { settingsDefaults: { server: {} } },
+            },
+          ],
+        },
+      ],
+    };
+    const wrapper = mountPage();
+
+    wrapper
+      .findComponent({ name: 'PluginInstallSection' })
+      .vm.$emit('update:modelValue', '2.0.0');
+    await flushPromises();
+    await wrapper.get('[data-test="install"]').trigger('click');
+    await wrapper.get('[data-test="fresh-upgrade"]').trigger('click');
+    await flushPromises();
+
+    expect(h.mutations.INSTALL_M?.mutate).toHaveBeenCalledWith({
+      pluginId: PLUGIN_ID,
+      version: '2.0.0',
+      carrySettings: false,
+    });
+  });
+
+  it('cancels an upgrade preview', async () => {
+    setInstalledPlugin();
+    setAvailablePlugin({
+      Versions: [{ version: '1.0.0' }, { version: '2.0.0' }],
+    });
+    h.q.DETAIL.result.value = {
+      plugins: [
+        { id: PLUGIN_ID, Versions: [{ version: '2.0.0', manifest: {} }] },
+      ],
+    };
+    const wrapper = mountPage();
+
+    wrapper
+      .findComponent({ name: 'PluginInstallSection' })
+      .vm.$emit('update:modelValue', '2.0.0');
+    await flushPromises();
+    await wrapper.get('[data-test="install"]').trigger('click');
+    await wrapper.get('[data-test="cancel-upgrade"]').trigger('click');
+
+    expect(wrapper.find('[data-test="upgrade-preview"]').exists()).toBe(false);
+  });
+
+  it('installs the latest compatible version from the update banner', async () => {
+    setInstalledPlugin({
+      hasUpdate: true,
+      latestVersion: '2.0.0',
+      availableVersions: ['1.0.0', '2.0.0'],
+    });
+    setAvailablePlugin({
+      Versions: [{ version: '1.0.0' }, { version: '2.0.0' }],
+    });
+    h.q.DETAIL.result.value = {
+      plugins: [
+        { id: PLUGIN_ID, Versions: [{ version: '2.0.0', manifest: {} }] },
+      ],
+    };
+    const wrapper = mountPage();
+
+    await wrapper.get('[data-test="install-latest"]').trigger('click');
+
+    expect(
+      wrapper
+        .findComponent({ name: 'PluginUpgradePreviewModal' })
+        .props('targetVersion')
+    ).toBe('2.0.0');
+  });
+
+  it('shows the permission message when authorization is denied', () => {
+    setAvailablePlugin();
+    const wrapper = mountWithDefaults(PluginDetailPage, {
+      global: {
+        stubs: {
+          ...stubs,
+          RequireAuth: {
+            template: '<div><slot name="does-not-have-auth" /></div>',
+          },
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain(
+      "You don't have permission to see this page."
+    );
   });
 });

--- a/pages/admin/settings/plugins/index.spec.ts
+++ b/pages/admin/settings/plugins/index.spec.ts
@@ -64,7 +64,8 @@ vi.mock('@vue/apollo-composable', async () => {
     },
   };
   return {
-    useQuery: (doc: keyof typeof apolloState.queries) => apolloState.queries[doc],
+    useQuery: (doc: keyof typeof apolloState.queries) =>
+      apolloState.queries[doc],
     useMutation: (doc: keyof typeof apolloState.mutations) => ({
       mutate: apolloState.mutations[doc],
     }),
@@ -115,7 +116,10 @@ const setPluginData = () => {
         id: 'incompatible-plugin',
         name: 'Incompatible Plugin',
         description: 'Needs a newer server',
-        Versions: [{ version: '1.0.0' }, { version: '2.0.0', minServerVersion: '2.0.0' }],
+        Versions: [
+          { version: '1.0.0' },
+          { version: '2.0.0', minServerVersion: '2.0.0' },
+        ],
       },
     ],
   };
@@ -178,7 +182,9 @@ describe('Plugins settings page', () => {
   });
 
   it('renders the error state', () => {
-    apolloState.queries.GET_PLUGIN_MANAGEMENT_DATA.error.value = new Error('boom');
+    apolloState.queries.GET_PLUGIN_MANAGEMENT_DATA.error.value = new Error(
+      'boom'
+    );
 
     expect(mountPage().text()).toContain('Error loading plugins: boom');
   });
@@ -204,7 +210,9 @@ describe('Plugins settings page', () => {
     setPluginData();
     const wrapper = mountPage();
 
-    await wrapper.get('input[placeholder="Search plugins..."]').setValue('missing');
+    await wrapper
+      .get('input[placeholder="Search plugins..."]')
+      .setValue('missing');
     const clearButton = wrapper
       .findAll('button')
       .find((button) => button.text() === 'Clear filters');
@@ -219,7 +227,9 @@ describe('Plugins settings page', () => {
     setPluginData();
     mountPage();
 
-    expect(apolloState.queries.GET_INSTALLED_PLUGINS.refetch).toHaveBeenCalled();
+    expect(
+      apolloState.queries.GET_INSTALLED_PLUGINS.refetch
+    ).toHaveBeenCalled();
   });
 
   it('allows an available plugin', async () => {
@@ -258,7 +268,11 @@ describe('Plugins settings page', () => {
 
     const upgradeButton = wrapper
       .findAll('button')
-      .find((button) => button.text().includes('Upgrade') && button.attributes('disabled') === undefined);
+      .find(
+        (button) =>
+          button.text().includes('Upgrade') &&
+          button.attributes('disabled') === undefined
+      );
 
     await upgradeButton!.trigger('click');
     await flushPromises();
@@ -275,7 +289,11 @@ describe('Plugins settings page', () => {
 
     const upgradeButton = wrapper
       .findAll('button')
-      .find((button) => button.text().includes('Upgrade') && button.attributes('title') === 'Requires server >= 2.0.0');
+      .find(
+        (button) =>
+          button.text().includes('Upgrade') &&
+          button.attributes('title') === 'Requires server >= 2.0.0'
+      );
 
     expect(upgradeButton?.attributes('disabled')).toBeDefined();
   });
@@ -287,6 +305,65 @@ describe('Plugins settings page', () => {
     await wrapper.get('[data-test="refresh-discovery"]').trigger('click');
     await flushPromises();
 
-    expect(apolloState.queries.GET_PLUGIN_MANAGEMENT_DATA.refetch).toHaveBeenCalledTimes(1);
+    expect(
+      apolloState.queries.GET_PLUGIN_MANAGEMENT_DATA.refetch
+    ).toHaveBeenCalledTimes(1);
   });
+
+  it('filters plugins by status', async () => {
+    setPluginData();
+    const wrapper = mountPage();
+    await wrapper
+      .get('select[aria-label="Filter plugins by status"]')
+      .setValue('enabled');
+    expect(wrapper.text()).toContain('Showing 1 of 4 plugins');
+  });
+
+  it('changes sort fields and reverses the active sort direction', async () => {
+    setPluginData();
+    const wrapper = mountPage();
+    const name = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Name'))!;
+    const status = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Status'))!;
+    await name.trigger('click');
+    await status.trigger('click');
+    await status.trigger('click');
+    expect(status.find('i').classes()).toContain('fa-arrow-down');
+  });
+
+  it.each([
+    ['ALLOW_PLUGIN', 'Allow', 'Error allowing plugin: allow failed'],
+    [
+      'DISALLOW_PLUGIN',
+      'Disallow',
+      'Error disallowing plugin: disallow failed',
+    ],
+    [
+      'INSTALL_PLUGIN_VERSION',
+      'Upgrade',
+      'Error upgrading plugin: upgrade failed',
+    ],
+  ] as const)(
+    'shows an error toast when %s fails',
+    async (mutation, buttonText, expectedMessage) => {
+      setPluginData();
+      apolloState.mutations[mutation].mockRejectedValueOnce(
+        new Error(expectedMessage.split(': ').at(-1))
+      );
+      const wrapper = mountPage();
+      const button = wrapper
+        .findAll('button')
+        .find(
+          (candidate) =>
+            candidate.text().includes(buttonText) &&
+            candidate.attributes('disabled') === undefined
+        )!;
+      await button.trigger('click');
+      await flushPromises();
+      expect(mockToast.error).toHaveBeenCalledWith(expectedMessage);
+    }
+  );
 });

--- a/pages/admin/suspensions/lists.spec.ts
+++ b/pages/admin/suspensions/lists.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import SuspendedModsPage from './suspended-mods.vue';
+import SuspendedUsersPage from './suspended-users.vue';
+
+const FormRow = {
+  template: '<section><slot name="content" /></section>',
+};
+
+describe('server suspension list pages', () => {
+  it('explains and renders the server-suspended moderator list', () => {
+    const wrapper = shallowMount(SuspendedModsPage, {
+      global: { stubs: { FormRow } },
+    });
+
+    expect({
+      heading: wrapper.text().includes('Server-Suspended Mods'),
+      guidance: wrapper.text().includes('open the related issue'),
+      list: wrapper.findComponent({ name: 'ServerSuspendedModList' }).exists(),
+    }).toEqual({ heading: true, guidance: true, list: true });
+  });
+
+  it('explains and renders the server-suspended user list', () => {
+    const wrapper = shallowMount(SuspendedUsersPage, {
+      global: { stubs: { FormRow } },
+    });
+
+    expect({
+      heading: wrapper.text().includes('Server-Suspended Users'),
+      guidance: wrapper.text().includes('open the related issue'),
+      list: wrapper.findComponent({ name: 'ServerSuspendedUserList' }).exists(),
+    }).toEqual({ heading: true, guidance: true, list: true });
+  });
+});

--- a/pages/comments/search.spec.ts
+++ b/pages/comments/search.spec.ts
@@ -1,14 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowMount, mount } from '@vue/test-utils';
-import { ref, defineComponent, h } from 'vue';
+import { ref, defineComponent, h, reactive } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 
-const routeQuery: Record<string, unknown> = {};
+const routeQuery: Record<string, unknown> = reactive({});
 const mockRouterPush = vi.fn();
+const mockRouterReplace = vi.fn();
+let fetchMore = vi.fn();
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ query: routeQuery }),
-  useRouter: () => ({ push: mockRouterPush, resolve: (r: unknown) => r }),
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: mockRouterReplace,
+    resolve: (r: unknown) => r,
+  }),
   useHead: vi.fn(),
 }));
 
@@ -28,6 +34,8 @@ const mountWith = async (opts: {
   searchInput?: string;
   comments?: unknown[];
   count?: number;
+  loading?: boolean;
+  error?: Error | null;
 }) => {
   routeQuery.searchInput = opts.searchInput;
   mockedUseQuery.mockReturnValue({
@@ -35,18 +43,46 @@ const mountWith = async (opts: {
       comments: opts.comments ?? [],
       commentsAggregate: { count: opts.count ?? 0 },
     }),
-    loading: ref(false),
-    error: ref(null),
-    fetchMore: vi.fn(),
+    loading: ref(opts.loading ?? false),
+    error: ref(opts.error ?? null),
+    fetchMore,
   });
   const Page = (await import('./search.vue')).default;
   return shallowMount(Page, {
-    global: { stubs: { NuxtLayout: NuxtLayoutStub } },
+    global: {
+      stubs: {
+        NuxtLayout: NuxtLayoutStub,
+        SearchBar: {
+          name: 'SearchBar',
+          emits: ['update-search-input'],
+          template: '<div />',
+        },
+        FilterChip: {
+          name: 'FilterChip',
+          template: '<div><slot name="content" /></div>',
+        },
+        SearchableForumList: {
+          name: 'SearchableForumList',
+          emits: ['toggle-selection'],
+          template: '<div />',
+        },
+        LoadMore: {
+          name: 'LoadMore',
+          emits: ['load-more'],
+          template: '<div />',
+        },
+      },
+    },
   });
 };
 
 beforeEach(() => {
   mockRouterPush.mockClear();
+  mockRouterReplace.mockClear();
+  fetchMore = vi.fn();
+  for (const key of Object.keys(routeQuery)) {
+    Reflect.deleteProperty(routeQuery, key);
+  }
 });
 
 describe('comment search page', () => {
@@ -71,6 +107,69 @@ describe('comment search page', () => {
       count: 0,
     });
     expect(wrapper.text()).toContain('No comments match your search.');
+  });
+
+  it('shows loading and error query states', async () => {
+    const loading = await mountWith({ searchInput: 'hello', loading: true });
+    const error = await mountWith({
+      searchInput: 'hello',
+      error: new Error('search failed'),
+    });
+    expect({ loading: loading.text(), error: error.text() }).toEqual({
+      loading: expect.stringContaining('Searching...'),
+      error: expect.stringContaining('search failed'),
+    });
+  });
+
+  it('updates search and channel filters from their controls', async () => {
+    const wrapper = await mountWith({ searchInput: 'hello' });
+    await wrapper
+      .findComponent({ name: 'SearchBar' })
+      .vm.$emit('update-search-input', 'updated');
+    await wrapper
+      .findComponent({ name: 'SearchableForumList' })
+      .vm.$emit('toggle-selection', 'cats');
+    expect(mockRouterReplace.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('adds and removes a selected forum filter', async () => {
+    routeQuery.channels = ['cats'];
+    const wrapper = await mountWith({ searchInput: 'hello' });
+    const forums = wrapper.findComponent({ name: 'SearchableForumList' });
+    await forums.vm.$emit('toggle-selection', 'cats');
+    await forums.vm.$emit('toggle-selection', 'dogs');
+    expect(mockRouterReplace).toHaveBeenCalled();
+  });
+
+  it('loads and merges the next page of comments', async () => {
+    const wrapper = await mountWith({
+      searchInput: 'hello',
+      comments: [{ id: 'c1' }],
+      count: 2,
+    });
+    await wrapper.findComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+    const options = fetchMore.mock.calls[0][0];
+    expect(
+      options.updateQuery(
+        { comments: [{ id: 'c1' }] },
+        { fetchMoreResult: { comments: [{ id: 'c2' }] } }
+      ).comments
+    ).toEqual([{ id: 'c1' }, { id: 'c2' }]);
+  });
+
+  it('keeps the current page when loading more returns no result', async () => {
+    const previous = { comments: [{ id: 'c1' }] };
+    const wrapper = await mountWith({
+      searchInput: 'hello',
+      comments: previous.comments,
+      count: 2,
+    });
+    await wrapper.findComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+    expect(
+      fetchMore.mock.calls[0][0].updateQuery(previous, {
+        fetchMoreResult: null,
+      })
+    ).toBe(previous);
   });
 });
 
@@ -97,7 +196,9 @@ describe('comment search result navigation', () => {
   };
 
   const RouterLinkStub = { props: ['to'], template: '<a><slot /></a>' };
-  const passthrough = (tag = 'div') => ({ template: `<${tag}><slot /></${tag}>` });
+  const passthrough = (tag = 'div') => ({
+    template: `<${tag}><slot /></${tag}>`,
+  });
 
   const mountResults = async () => {
     routeQuery.searchInput = 'matching';
@@ -177,4 +278,13 @@ describe('comment search result navigation', () => {
 
     expect(mockRouterPush).not.toHaveBeenCalled();
   });
+
+  it.each(['enter', 'space'])(
+    'opens the result with the %s key',
+    async (key) => {
+      const wrapper = await mountResults();
+      await wrapper.get('[role="link"]').trigger(`keydown.${key}`);
+      expect(mockRouterPush).toHaveBeenCalled();
+    }
+  );
 });

--- a/pages/forums/[forumId].spec.ts
+++ b/pages/forums/[forumId].spec.ts
@@ -3,21 +3,36 @@ import { shallowMount } from '@vue/test-utils';
 import { defineComponent, ref } from 'vue';
 import { setActivePinia, createPinia } from 'pinia';
 import { useQuery } from '@vue/apollo-composable';
+import { useUIStore } from '@/stores/uiStore';
 
 vi.stubGlobal('definePageMeta', vi.fn());
 
-const routeRef = { params: { forumId: 'cats' }, name: 'forums-forumId', query: {} };
+const mockState = vi.hoisted(() => ({
+  route: {
+    params: { forumId: 'cats' as unknown },
+    name: 'forums-forumId' as unknown,
+    query: {} as Record<string, unknown>,
+  },
+  routerPush: vi.fn(),
+  useHead: vi.fn(),
+  queryResultCallback: null as null | ((result: unknown) => void),
+  refetchChannel: vi.fn(),
+}));
 
 vi.mock('nuxt/app', () => ({
-  useRoute: () => routeRef,
-  useRouter: () => ({ push: vi.fn() }),
-  useHead: vi.fn(),
+  useRoute: () => mockState.route,
+  useRouter: () => ({ push: mockState.routerPush }),
+  useHead: mockState.useHead,
 }));
 
 vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
 
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => ref('viewer'),
+}));
+
+vi.mock('@/config', () => ({
+  config: { serverDisplayName: 'Multiforum', environment: 'test' },
 }));
 
 vi.mock('@/utils/localStorageUtils', () => ({
@@ -32,6 +47,7 @@ const ChannelHeaderMobileStub = defineComponent({
 
 const ChannelHeaderDesktopStub = defineComponent({
   name: 'ChannelHeaderDesktop',
+  props: { adminList: Array },
   template: '<div class="channel-header-desktop-stub" />',
 });
 
@@ -52,6 +68,7 @@ const IssueTitleEditFormStub = defineComponent({
 
 const DiscussionDetailContentStub = defineComponent({
   name: 'DiscussionDetailContent',
+  props: { discussionId: String },
   template: '<div class="discussion-detail-content-stub" />',
 });
 
@@ -62,6 +79,7 @@ const DiscussionDetailEmptyStateStub = defineComponent({
 
 const EventDetailStub = defineComponent({
   name: 'EventDetail',
+  props: { eventId: String },
   template: '<div class="event-detail-stub" />',
 });
 
@@ -72,11 +90,13 @@ const ChannelSidebarStub = defineComponent({
 
 const IssueDetailStub = defineComponent({
   name: 'IssueDetail',
+  props: { issueNumber: Number },
   template: '<div class="issue-detail-stub" />',
 });
 
 const ChannelLockedBannerStub = defineComponent({
   name: 'ChannelLockedBanner',
+  props: { lockReason: String },
   template: '<div class="channel-locked-banner-stub" />',
 });
 
@@ -92,6 +112,7 @@ const PageNotFoundStub = defineComponent({
 
 const ChannelTabsStub = defineComponent({
   name: 'ChannelTabs',
+  props: { downloadCount: Number },
   template: '<div class="channel-tabs-stub" />',
 });
 
@@ -153,15 +174,28 @@ vi.mock('@/components/BackLink.vue', () => ({
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
-const mountWith = async (channels: unknown[]) => {
+const mountWith = async (
+  channels: unknown[],
+  options: { loading?: boolean; downloadCount?: number } = {}
+) => {
   mockedUseQuery
     .mockReturnValueOnce({
       result: ref({ channels }),
-      onResult: vi.fn(),
-      loading: ref(false),
-      refetch: vi.fn(),
+      onResult: (callback: (result: unknown) => void) => {
+        mockState.queryResultCallback = callback;
+      },
+      loading: ref(options.loading ?? false),
+      refetch: mockState.refetchChannel,
     })
-    .mockReturnValueOnce({ result: ref(null) });
+    .mockReturnValueOnce({
+      result: ref({
+        channels: [
+          {
+            DiscussionChannelsAggregate: { count: options.downloadCount ?? 0 },
+          },
+        ],
+      }),
+    });
   const Page = (await import('./[forumId].vue')).default;
   return shallowMount(Page);
 };
@@ -169,7 +203,11 @@ const mountWith = async (channels: unknown[]) => {
 describe('forum shell page', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
-    routeRef.name = 'forums-forumId';
+    vi.clearAllMocks();
+    mockState.route.params = { forumId: 'cats' };
+    mockState.route.name = 'forums-forumId';
+    mockState.route.query = {};
+    mockState.queryResultCallback = null;
   });
 
   it('shows the not-found page when the channel does not exist', async () => {
@@ -178,7 +216,182 @@ describe('forum shell page', () => {
   });
 
   it('renders the channel tabs on the plain forum route', async () => {
-    const wrapper = await mountWith([{ uniqueName: 'cats', displayName: 'Cats' }]);
+    const wrapper = await mountWith([
+      { uniqueName: 'cats', displayName: 'Cats' },
+    ]);
     expect(wrapper.findComponent(ChannelTabsStub).exists()).toBe(true);
+  });
+
+  it('redirects the channel root after the query returns a channel', async () => {
+    await mountWith([{ uniqueName: 'cats', displayName: 'Cats' }]);
+
+    mockState.queryResultCallback?.({
+      data: { channels: [{ uniqueName: 'cats', displayName: 'Cats' }] },
+    });
+
+    expect(mockState.routerPush).toHaveBeenCalledWith({
+      name: 'forums-forumId-discussions',
+      params: { forumId: 'cats' },
+    });
+  });
+
+  it('does not redirect when the query returns no channel', async () => {
+    await mountWith([]);
+
+    mockState.queryResultCallback?.({ data: { channels: [] } });
+
+    expect(mockState.routerPush).not.toHaveBeenCalled();
+  });
+
+  it('renders channel chrome and counts', async () => {
+    const wrapper = await mountWith(
+      [
+        {
+          uniqueName: 'cats',
+          displayName: 'Cats',
+          channelBannerURL: 'https://img.test/banner.jpg',
+          locked: true,
+          lockedAt: '2026-01-01',
+          lockReason: 'Maintenance',
+          LockedBy: { displayName: 'Moderator' },
+          Admins: [{ username: 'alice' }],
+        },
+      ],
+      { downloadCount: 7 }
+    );
+
+    expect({
+      mobile: wrapper.findComponent(ChannelHeaderMobileStub).exists(),
+      desktopAdmins: wrapper
+        .findComponent(ChannelHeaderDesktopStub)
+        .props('adminList'),
+      locked: wrapper
+        .findComponent(ChannelLockedBannerStub)
+        .props('lockReason'),
+      downloadCount: wrapper
+        .findComponent(ChannelTabsStub)
+        .props('downloadCount'),
+    }).toEqual({
+      mobile: true,
+      desktopAdmins: ['alice'],
+      locked: 'Maintenance',
+      downloadCount: 7,
+    });
+  });
+
+  it.each([
+    ['forums-forumId-discussions-discussionId', DiscussionTitleEditFormStub],
+    ['forums-forumId-downloads-discussionId', DiscussionTitleEditFormStub],
+    ['forums-forumId-events-eventId', EventTitleEditFormStub],
+    ['forums-forumId-issues-issueNumber', IssueTitleEditFormStub],
+  ])(
+    'renders the correct title bar on %s',
+    async (routeName, titleComponent) => {
+      mockState.route.name = routeName;
+      const wrapper = await mountWith([
+        { uniqueName: 'cats', displayName: 'Cats' },
+      ]);
+
+      expect(wrapper.findComponent(titleComponent).exists()).toBe(true);
+    }
+  );
+
+  it('renders a selected discussion in the split panel', async () => {
+    mockState.route.name = 'forums-forumId-discussions';
+    mockState.route.query = { selectedDiscussionId: 'discussion-1' };
+    useUIStore().setSelectedChannelDiscussionSelection({
+      discussionId: 'discussion-1',
+      title: 'A discussion',
+    });
+    const wrapper = await mountWith([
+      { uniqueName: 'cats', displayName: 'Cats' },
+    ]);
+
+    expect({
+      title: wrapper.text().includes('A discussion'),
+      id: wrapper
+        .findComponent(DiscussionDetailContentStub)
+        .props('discussionId'),
+    }).toEqual({ title: true, id: 'discussion-1' });
+  });
+
+  it('renders the empty discussion selection state', async () => {
+    mockState.route.name = 'forums-forumId-discussions';
+    const wrapper = await mountWith([
+      { uniqueName: 'cats', displayName: 'Cats' },
+    ]);
+
+    expect(wrapper.findComponent(DiscussionDetailEmptyStateStub).exists()).toBe(
+      true
+    );
+  });
+
+  it('renders a selected event in the split panel', async () => {
+    mockState.route.name = 'forums-forumId-events';
+    useUIStore().setSelectedChannelEventSelection({
+      eventId: 'event-1',
+      title: 'Launch',
+    });
+    const wrapper = await mountWith([
+      { uniqueName: 'cats', displayName: 'Cats' },
+    ]);
+
+    expect({
+      title: wrapper.text().includes('Launch'),
+      id: wrapper.findComponent(EventDetailStub).props('eventId'),
+    }).toEqual({ title: true, id: 'event-1' });
+  });
+
+  it('renders a selected issue in the split panel', async () => {
+    mockState.route.name = 'forums-forumId-issues';
+    useUIStore().setSelectedIssueSelection({
+      issueNumber: 42,
+      title: 'Broken link',
+      channelId: 'cats',
+    });
+    const wrapper = await mountWith([
+      { uniqueName: 'cats', displayName: 'Cats' },
+    ]);
+
+    expect({
+      title: wrapper.text().includes('Broken link'),
+      number: wrapper.findComponent(IssueDetailStub).props('issueNumber'),
+    }).toEqual({ title: true, number: 42 });
+  });
+
+  it('refetches channel data from a detail sidebar', async () => {
+    mockState.route.name = 'forums-forumId-events-eventId';
+    const wrapper = await mountWith([
+      { uniqueName: 'cats', displayName: 'Cats' },
+    ]);
+
+    wrapper.findComponent(ChannelSidebarStub).vm.$emit('refetch-channel-data');
+
+    expect(mockState.refetchChannel).toHaveBeenCalledOnce();
+  });
+
+  it('builds SEO metadata from the loaded channel', async () => {
+    const description = 'x'.repeat(170);
+    await mountWith([
+      {
+        uniqueName: 'cats',
+        displayName: 'Cat Forum',
+        description,
+        channelIconURL: 'https://img.test/icon.jpg',
+      },
+    ]);
+    const head = mockState.useHead.mock.calls[0]?.[0];
+
+    expect({
+      title: head.value.title,
+      description: head.value.meta[0].content,
+      twitterCard: head.value.meta.find(
+        (item: { name?: string }) => item.name === 'twitter:card'
+      ).content,
+    }).toEqual({
+      title: 'Cat Forum | Multiforum',
+      description: `${'x'.repeat(160)}...`,
+      twitterCard: 'summary_large_image',
+    });
   });
 });

--- a/pages/forums/[forumId]/contributors.spec.ts
+++ b/pages/forums/[forumId]/contributors.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
@@ -13,18 +13,33 @@ vi.mock('@vue/apollo-composable', () => ({
 }));
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+let queryVariables: null | (() => unknown) = null;
 
-const mountWith = async (contributors: unknown[]) => {
-  mockedUseQuery.mockReturnValue({
-    result: ref({ getChannelContributions: contributors }),
-    loading: ref(false),
-    error: ref(null),
-  });
+const mountWith = async (
+  contributors: unknown[],
+  state: { loading?: boolean; error?: unknown } = {}
+) => {
+  mockedUseQuery.mockImplementation(
+    (_query: unknown, variables: () => unknown) => {
+      queryVariables = variables;
+      variables();
+      return {
+        result: ref({ getChannelContributions: contributors }),
+        loading: ref(state.loading ?? false),
+        error: ref(state.error ?? null),
+      };
+    }
+  );
   const Page = (await import('./contributors.vue')).default;
   return shallowMount(Page);
 };
 
 describe('contributors page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryVariables = null;
+  });
+
   it('shows the empty state when there are no contributors', async () => {
     const wrapper = await mountWith([]);
     expect(wrapper.text()).toContain('No results in the selected time period');
@@ -36,5 +51,48 @@ describe('contributors page', () => {
       { username: 'bob', dayData: [] },
     ]);
     expect(wrapper.findAllComponents(ChannelContributionChart)).toHaveLength(2);
+  });
+
+  it('shows the loading state', async () => {
+    const wrapper = await mountWith([], { loading: true });
+
+    expect(wrapper.text()).toContain('Loading contributors...');
+  });
+
+  it('shows the query error', async () => {
+    const wrapper = await mountWith([], { error: { message: 'Offline' } });
+
+    expect(wrapper.text()).toContain('Error loading contributors: Offline');
+  });
+
+  it('selects an all-time contribution range', async () => {
+    const wrapper = await mountWith([]);
+    const initial = queryVariables?.() as {
+      startDate: string;
+      endDate: string;
+    };
+    wrapper
+      .findComponent({ name: 'IconButtonDropdown' })
+      .vm.$emit('select-period', 'null');
+    const allTime = queryVariables?.() as {
+      startDate: string;
+      endDate: string;
+    };
+    await wrapper.vm.$nextTick();
+
+    expect({
+      startsEarlier: allTime.startDate < initial.startDate,
+      sameEnd: allTime.endDate === initial.endDate,
+    }).toEqual({ startsEarlier: true, sameEnd: true });
+  });
+
+  it('ignores invalid period selections', async () => {
+    const wrapper = await mountWith([]);
+    const initial = queryVariables?.();
+    wrapper
+      .findComponent({ name: 'IconButtonDropdown' })
+      .vm.$emit('select-period', 12);
+
+    expect(queryVariables?.()).toEqual(initial);
   });
 });

--- a/pages/forums/[forumId]/discussions/[discussionId]/comments/[commentId].spec.ts
+++ b/pages/forums/[forumId]/discussions/[discussionId]/comments/[commentId].spec.ts
@@ -11,7 +11,8 @@ const PermalinkedStub = defineComponent({
   name: 'PermalinkedComment',
   props: ['commentId'],
   setup(_props, { slots }) {
-    return () => h('div', slots.comment?.({ commentData: { id: 'comment-1' } }));
+    return () =>
+      h('div', slots.comment?.({ commentData: { id: 'comment-1' } }));
   },
 });
 
@@ -48,5 +49,38 @@ describe('discussion comment permalink page', () => {
   it('forwards the enableFeedback prop to the comment', async () => {
     const wrapper = await mountPage({ ...baseProps, enableFeedback: true });
     expect(wrapper.findComponent(Comment).props('enableFeedback')).toBe(true);
+  });
+
+  it.each([
+    'startCommentSave',
+    'openReplyEditor',
+    'hideReplyEditor',
+    'openEditCommentEditor',
+    'hideEditCommentEditor',
+    'clickEditComment',
+    'deleteComment',
+    'createComment',
+    'updateCreateReplyCommentInput',
+    'updateEditCommentInput',
+    'saveEdit',
+    'clickReport',
+    'clickFeedback',
+    'clickUndoFeedback',
+    'clickEditFeedback',
+    'updateFeedback',
+    'handleViewFeedback',
+    'showCopiedLinkNotification',
+  ])('forwards the %s event', async (eventName) => {
+    const wrapper = await mountPage(baseProps);
+    wrapper.findComponent(Comment).vm.$emit(eventName, 'payload');
+
+    expect(wrapper.emitted(eventName)?.[0]).toEqual(['payload']);
+  });
+
+  it('forwards scrollToTop without adding a payload', async () => {
+    const wrapper = await mountPage(baseProps);
+    wrapper.findComponent(Comment).vm.$emit('scrollToTop', 'ignored');
+
+    expect(wrapper.emitted('scrollToTop')?.[0]).toEqual([]);
   });
 });

--- a/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].spec.ts
+++ b/pages/forums/[forumId]/discussions/commentFeedback/[discussionId]/[commentId].spec.ts
@@ -1,26 +1,42 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
-import { ref } from 'vue';
-import { useQuery } from '@vue/apollo-composable';
+import { defineComponent, ref } from 'vue';
+import { useMutation, useQuery } from '@vue/apollo-composable';
 import CommentHeader from '@/components/comments/CommentHeader.vue';
 import PageNotFound from '@/components/PageNotFound.vue';
+import ErrorBanner from '@/components/ErrorBanner.vue';
+import FeedbackSection from '@/components/comments/FeedbackSection.vue';
+
+const mockState = vi.hoisted(() => ({
+  route: {
+    params: {
+      forumId: 'cats' as unknown,
+      discussionId: 'd1' as unknown,
+      commentId: 'c1' as unknown,
+      feedbackId: undefined as unknown,
+    },
+    query: {} as Record<string, unknown>,
+    name: 'forums-forumId-discussions-commentFeedback-discussionId-commentId' as unknown,
+  },
+  fetchMore: vi.fn(),
+  queryDone: null as null | (() => void),
+  mutationDone: null as null | (() => void),
+  mutationUpdate: null as null | ((cache: unknown, result: unknown) => void),
+  addFeedback: vi.fn(),
+  mutationError: null as unknown as { value: unknown },
+  mutationLoading: null as unknown as { value: boolean },
+}));
+
+mockState.mutationError = ref(null);
+mockState.mutationLoading = ref(false);
 
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({
-    params: { forumId: 'cats', discussionId: 'd1', commentId: 'c1' },
-    query: {},
-  }),
+  useRoute: () => mockState.route,
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
-  useMutation: () => ({
-    mutate: vi.fn(),
-    loading: ref(false),
-    error: ref(null),
-    onDone: vi.fn(),
-    onError: vi.fn(),
-  }),
+  useMutation: vi.fn(),
 }));
 
 vi.mock('@/composables/useAuthState', () => ({
@@ -28,32 +44,242 @@ vi.mock('@/composables/useAuthState', () => ({
 }));
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+const mockedUseMutation = useMutation as unknown as ReturnType<typeof vi.fn>;
 
-const mountWith = async (comment: unknown) => {
-  mockedUseQuery.mockReturnValue({
-    result: ref({ comments: comment ? [comment] : [] }),
-    error: ref(null),
-    loading: ref(false),
-    fetchMore: vi.fn(),
-    onResult: vi.fn(),
-  });
-  const Page = (await import('./[commentId].vue')).default;
-  return shallowMount(Page);
+const baseComment = {
+  id: 'c1',
+  text: 'Original comment',
+  FeedbackComments: [],
+  FeedbackCommentsAggregate: { count: 0 },
 };
+
+const NuxtLinkStub = defineComponent({
+  name: 'NuxtLink',
+  props: { to: { type: [String, Object], required: true } },
+  template: '<a><slot /></a>',
+});
+
+const mountWith = async (
+  comment: unknown,
+  options: { loading?: boolean; error?: unknown; noResult?: boolean } = {}
+) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref(
+      options.noResult ? null : { comments: comment ? [comment] : [] }
+    ),
+    error: ref(options.error ?? null),
+    loading: ref(options.loading ?? false),
+    fetchMore: mockState.fetchMore,
+    onResult: (callback: () => void) => {
+      mockState.queryDone = callback;
+    },
+  });
+  mockedUseMutation.mockImplementation(
+    (
+      _document: unknown,
+      options: { update: (cache: unknown, result: unknown) => void }
+    ) => {
+      mockState.mutationUpdate = options.update;
+      return {
+        mutate: mockState.addFeedback,
+        loading: mockState.mutationLoading,
+        error: mockState.mutationError,
+        onDone: (callback: () => void) => {
+          mockState.mutationDone = callback;
+        },
+      };
+    }
+  );
+  const Page = (await import('./[commentId].vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { 'nuxt-link': NuxtLinkStub } },
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState.route.params = {
+    forumId: 'cats',
+    discussionId: 'd1',
+    commentId: 'c1',
+    feedbackId: undefined,
+  };
+  mockState.route.query = {};
+  mockState.route.name =
+    'forums-forumId-discussions-commentFeedback-discussionId-commentId';
+  mockState.queryDone = null;
+  mockState.mutationDone = null;
+  mockState.mutationUpdate = null;
+  mockState.mutationError.value = null;
+  mockState.mutationLoading.value = false;
+});
 
 describe('comment feedback page', () => {
   it('renders the comment header when the comment loads', async () => {
-    const wrapper = await mountWith({
-      id: 'c1',
-      text: 'Original comment',
-      FeedbackComments: [],
-      FeedbackCommentsAggregate: { count: 0 },
-    });
+    const wrapper = await mountWith(baseComment);
     expect(wrapper.findComponent(CommentHeader).exists()).toBe(true);
   });
 
   it('shows the not-found page when the comment is missing', async () => {
     const wrapper = await mountWith(null);
     expect(wrapper.findComponent(PageNotFound).exists()).toBe(true);
+  });
+
+  it('shows loading before the first query result', async () => {
+    const wrapper = await mountWith(null, { loading: true, noResult: true });
+
+    expect(wrapper.text()).toContain('Loading...');
+  });
+
+  it('passes query errors to the error banner', async () => {
+    const wrapper = await mountWith(null, {
+      error: new Error('Feedback unavailable'),
+    });
+
+    expect(wrapper.findComponent(ErrorBanner).props('text')).toBe(
+      'Feedback unavailable'
+    );
+  });
+
+  it('links a feedback page back to its original comment', async () => {
+    const wrapper = await mountWith(baseComment);
+    mockState.queryDone?.();
+    await wrapper.vm.$nextTick();
+
+    const contextLink = wrapper
+      .findAllComponents(NuxtLinkStub)
+      .find((link) => link.text().includes('View original context'));
+    expect(contextLink?.props('to')).toEqual({
+      name: 'forums-forumId-discussions-discussionId-comments-commentId',
+      params: { discussionId: 'd1', commentId: 'c1' },
+    });
+  });
+
+  it('shows a parent-comment context link', async () => {
+    const wrapper = await mountWith({
+      ...baseComment,
+      ParentComment: { id: 'parent-1' },
+    });
+
+    expect(wrapper.text()).toContain('View Context');
+  });
+
+  it('reports feedback list state to the section', async () => {
+    const feedback = [{ id: 'f1' }, { id: 'f2' }];
+    const wrapper = await mountWith({
+      ...baseComment,
+      FeedbackComments: feedback,
+      FeedbackCommentsAggregate: { count: 2 },
+    });
+    const section = wrapper.findComponent(FeedbackSection);
+
+    expect({
+      comments: section.props('feedbackComments'),
+      count: section.props('feedbackCommentsAggregate'),
+      end: section.props('reachedEndOfResults'),
+    }).toEqual({ comments: feedback, count: 2, end: true });
+  });
+
+  it('loads and merges the next feedback page', async () => {
+    const wrapper = await mountWith({
+      ...baseComment,
+      FeedbackComments: [{ id: 'f1' }],
+      FeedbackCommentsAggregate: { count: 2 },
+    });
+    wrapper.findComponent(FeedbackSection).props('loadMore')();
+    const request = mockState.fetchMore.mock.calls[0]?.[0];
+    const previous = {
+      comments: [{ id: 'c1', FeedbackComments: [{ id: 'f1' }] }],
+    };
+    const next = { comments: [{ id: 'c1', FeedbackComments: [{ id: 'f2' }] }] };
+
+    expect({
+      variables: request.variables,
+      comments: request.updateQuery(previous, { fetchMoreResult: next })
+        .comments[0].FeedbackComments,
+    }).toEqual({
+      variables: { offset: 1 },
+      comments: [{ id: 'f1' }, { id: 'f2' }],
+    });
+  });
+
+  it('keeps prior feedback when fetch-more has no result', async () => {
+    const wrapper = await mountWith(baseComment);
+    wrapper.findComponent(FeedbackSection).props('loadMore')();
+    const updateQuery = mockState.fetchMore.mock.calls[0]?.[0].updateQuery;
+    const previous = { comments: [{ id: 'c1', FeedbackComments: [] }] };
+
+    expect(updateQuery(previous, { fetchMoreResult: null })).toBe(previous);
+  });
+
+  it('opens and closes the feedback form', async () => {
+    const wrapper = await mountWith(baseComment);
+    const section = wrapper.findComponent(FeedbackSection);
+    section.vm.$emit('open-feedback-form-modal');
+    await wrapper.vm.$nextTick();
+    const opened = section.props('showFeedbackFormModal');
+    section.vm.$emit('close-feedback-form-modal');
+    await wrapper.vm.$nextTick();
+
+    expect([opened, section.props('showFeedbackFormModal')]).toEqual([
+      true,
+      false,
+    ]);
+  });
+
+  it('submits feedback for the selected nested comment', async () => {
+    const wrapper = await mountWith(baseComment);
+    const section = wrapper.findComponent(FeedbackSection);
+    section.vm.$emit('update-comment-to-give-feedback-on', { id: 'f1' });
+    section.vm.$emit('add-feedback-comment-to-comment', { text: 'Helpful' });
+
+    expect(mockState.addFeedback).toHaveBeenCalledWith({ text: 'Helpful' });
+  });
+
+  it('closes the form and shows success after the mutation completes', async () => {
+    const wrapper = await mountWith(baseComment);
+    const section = wrapper.findComponent(FeedbackSection);
+    section.vm.$emit('open-feedback-form-modal');
+    mockState.mutationDone?.();
+    await wrapper.vm.$nextTick();
+
+    expect({
+      open: section.props('showFeedbackFormModal'),
+      success: section.props('showFeedbackSubmittedSuccessfully'),
+    }).toEqual({ open: false, success: true });
+  });
+
+  it('updates the cached nested feedback thread', async () => {
+    const nested = { id: 'f1', FeedbackComments: [{ id: 'old' }] };
+    const wrapper = await mountWith({
+      ...baseComment,
+      FeedbackComments: [nested, { id: 'f2' }],
+    });
+    wrapper
+      .findComponent(FeedbackSection)
+      .vm.$emit('update-comment-to-give-feedback-on', nested);
+    const cache = {
+      readQuery: vi.fn(() => ({
+        comments: [{ FeedbackCommentsAggregate: { count: 1 } }],
+      })),
+      writeQuery: vi.fn(),
+    };
+
+    mockState.mutationUpdate?.(cache, {
+      data: { createComments: { comments: [{ id: 'new' }] } },
+    });
+
+    const written = cache.writeQuery.mock.calls[0]?.[0].data.comments[0];
+    expect(written.FeedbackComments).toEqual([
+      { id: 'f2' },
+      {
+        id: 'f1',
+        FeedbackComments: [{ id: 'old' }, { id: 'new' }],
+        FeedbackCommentsAggregate: {
+          count: 2,
+          __typename: 'FeedbackCommentsAggregate',
+        },
+      },
+    ]);
   });
 });

--- a/pages/forums/[forumId]/discussions/edit/[discussionId].spec.ts
+++ b/pages/forums/[forumId]/discussions/edit/[discussionId].spec.ts
@@ -10,6 +10,8 @@ const hState = vi.hoisted(() => ({
   onResultCb: null as unknown as (value: unknown) => void,
   onDoneCb: null as unknown as () => void,
   mutate: vi.fn(),
+  queryResult: null as unknown as { value: unknown },
+  mutationOptions: null as null | (() => { variables: unknown }),
 }));
 
 vi.mock('nuxt/app', () => ({
@@ -41,8 +43,9 @@ vi.mock('@/utils/discussionEditForm', () => ({
     body: discussion.body || '',
     selectedTags: discussion.Tags?.map((tag) => tag.text) || [],
     selectedChannels:
-      discussion.DiscussionChannels?.map((dc) => dc.Channel?.uniqueName || '') ||
-      [],
+      discussion.DiscussionChannels?.map(
+        (dc) => dc.Channel?.uniqueName || ''
+      ) || [],
     author: discussion.Author?.username || '',
     album: {
       images: [],
@@ -53,6 +56,7 @@ vi.mock('@/utils/discussionEditForm', () => ({
 }));
 
 const RequireAuthStub = defineComponent({
+  props: ['owners'],
   setup(_props, { slots }) {
     return () => h('div', slots.hasAuth?.() || slots['has-auth']?.());
   },
@@ -92,31 +96,44 @@ const DiscussionFieldsStub = defineComponent({
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 const mockedUseMutation = useMutation as unknown as ReturnType<typeof vi.fn>;
+hState.queryResult = ref(null);
 
 beforeEach(() => {
   vi.clearAllMocks();
   hState.push.mockReset();
   hState.useHead.mockReset();
-  hState.mutate.mockReset();
+  hState.mutate.mockReset().mockImplementation(() => {
+    hState.mutationOptions?.();
+  });
+  hState.queryResult.value = null;
+  hState.mutationOptions = null;
   hState.onResultCb = null as unknown as (value: unknown) => void;
   hState.onDoneCb = null as unknown as () => void;
   mockedUseQuery.mockReturnValue({
-    result: ref(null),
+    result: hState.queryResult,
     onResult: (cb: (value: unknown) => void) => {
-      hState.onResultCb = cb;
+      hState.onResultCb = (value: unknown) => {
+        hState.queryResult.value = (value as { data?: unknown }).data ?? null;
+        cb(value);
+      };
     },
     loading: ref(false),
     error: ref(null),
   });
-  mockedUseMutation.mockReturnValue({
-    mutate: hState.mutate,
-    loading: ref(false),
-    error: ref(null),
-    onDone: (cb: () => void) => {
-      hState.onDoneCb = cb;
-    },
-    onError: vi.fn(),
-  });
+  mockedUseMutation.mockImplementation(
+    (_query: unknown, options: () => { variables: unknown }) => {
+      hState.mutationOptions = options;
+      return {
+        mutate: hState.mutate,
+        loading: ref(false),
+        error: ref(null),
+        onDone: (cb: () => void) => {
+          hState.onDoneCb = cb;
+        },
+        onError: vi.fn(),
+      };
+    }
+  );
 });
 
 describe('discussion edit page', () => {
@@ -154,7 +171,9 @@ describe('discussion edit page', () => {
     });
     await nextTick();
 
-    expect(wrapper.findComponent(CreateEditDiscussionFields).props('formValues')).toEqual(
+    expect(
+      wrapper.findComponent(CreateEditDiscussionFields).props('formValues')
+    ).toEqual(
       expect.objectContaining({
         title: 'Hello',
         selectedChannels: ['cats'],
@@ -251,6 +270,90 @@ describe('discussion edit page', () => {
       },
     });
 
-    expect(wrapper.text()).toContain("You don't have permission to see this page.");
+    expect(wrapper.text()).toContain(
+      "You don't have permission to see this page."
+    );
+  });
+
+  it('ignores query callback updates while the discussion is loading', async () => {
+    const wrapper = await mountPage();
+    hState.onResultCb({ loading: true, data: { discussions: [] } });
+    await nextTick();
+    expect(
+      wrapper.findComponent(CreateEditDiscussionFields).props('formValues')
+    ).toEqual(expect.objectContaining({ title: '' }));
+  });
+
+  it('builds tag and channel connection changes for the mutation', async () => {
+    const wrapper = await mountPage();
+    hState.onResultCb({
+      loading: false,
+      data: {
+        discussions: [
+          {
+            id: 'd1',
+            title: 'Hello',
+            body: 'Body',
+            Tags: [{ text: 'old-tag' }],
+            DiscussionChannels: [
+              { Channel: { uniqueName: 'cats' } },
+              { Channel: { uniqueName: 'dogs' } },
+            ],
+            Author: { username: 'alice' },
+            Album: { Images: [], imageOrder: [] },
+          },
+        ],
+      },
+    });
+    await nextTick();
+    await wrapper
+      .findComponent(CreateEditDiscussionFields)
+      .vm.$emit('update-form-values', {
+        selectedTags: ['new-tag'],
+        selectedChannels: ['cats'],
+      });
+    await wrapper.findComponent(CreateEditDiscussionFields).vm.$emit('submit');
+    expect(hState.mutationOptions?.().variables).toEqual({
+      where: { id: 'd1' },
+      updateDiscussionInput: {
+        title: 'Hello',
+        body: 'Body',
+        Tags: [
+          {
+            connectOrCreate: [
+              {
+                onCreate: { node: { text: 'new-tag' } },
+                where: { node: { text: 'new-tag' } },
+              },
+            ],
+            disconnect: [{ where: { node: { text: 'old-tag' } } }],
+          },
+        ],
+      },
+      channelConnections: ['cats'],
+      channelDisconnections: ['dogs'],
+    });
+  });
+
+  it('provides the discussion owner to the authorization wrapper', async () => {
+    const wrapper = await mountPage();
+    hState.onResultCb({
+      loading: false,
+      data: {
+        discussions: [
+          {
+            id: 'd1',
+            title: 'Hello',
+            Tags: [],
+            DiscussionChannels: [],
+            Author: { username: 'alice' },
+          },
+        ],
+      },
+    });
+    await nextTick();
+    expect(wrapper.findComponent(RequireAuthStub).props('owners')).toEqual([
+      'alice',
+    ]);
   });
 });

--- a/pages/forums/[forumId]/discussions/feedback/[discussionId].spec.ts
+++ b/pages/forums/[forumId]/discussions/feedback/[discussionId].spec.ts
@@ -1,62 +1,247 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
-import { useQuery } from '@vue/apollo-composable';
 import FeedbackSection from '@/components/comments/FeedbackSection.vue';
 
-vi.mock('nuxt/app', () => ({
-  useRoute: () => ({
+const h = vi.hoisted(() => ({
+  route: {
     name: 'forums-forumId-discussions-feedback-discussionId',
-    params: { forumId: 'cats', discussionId: 'd1', commentId: '', feedbackId: '' },
+    params: {
+      forumId: 'cats',
+      discussionId: 'd1',
+      commentId: '',
+      feedbackId: '',
+    } as Record<string, unknown>,
     query: {},
-  }),
+  },
+  discussionResult: null as unknown as { value: unknown },
+  commentResult: null as unknown as { value: unknown },
+  discussionError: null as unknown as { value: unknown },
+  commentError: null as unknown as { value: unknown },
+  discussionLoading: null as unknown as { value: boolean },
+  commentLoading: null as unknown as { value: boolean },
+  fetchMore: vi.fn(),
+  mutate: vi.fn(),
+  mutationOptions: undefined as
+    undefined | { update: (...args: any[]) => void },
+  mutationDone: undefined as undefined | (() => void),
 }));
 
-vi.mock('@vue/apollo-composable', () => ({
-  useQuery: vi.fn(),
-  useMutation: () => ({
-    mutate: vi.fn(),
-    loading: ref(false),
-    error: ref(null),
-    onDone: vi.fn(),
-  }),
-}));
+vi.mock('nuxt/app', async () => {
+  const { reactive: makeReactive } = await import('vue');
+  h.route = makeReactive(h.route);
+  return { useRoute: () => h.route };
+});
+
+vi.mock('@vue/apollo-composable', async () => {
+  const { ref: vref } = await import('vue');
+  h.discussionResult = vref(null);
+  h.commentResult = vref(null);
+  h.discussionError = vref(null);
+  h.commentError = vref(null);
+  h.discussionLoading = vref(false);
+  h.commentLoading = vref(false);
+  let queryIndex = 0;
+  return {
+    useQuery: () => {
+      const discussionQuery = queryIndex++ % 2 === 0;
+      return discussionQuery
+        ? {
+            result: h.discussionResult,
+            error: h.discussionError,
+            loading: h.discussionLoading,
+            fetchMore: h.fetchMore,
+          }
+        : {
+            result: h.commentResult,
+            error: h.commentError,
+            loading: h.commentLoading,
+          };
+    },
+    useMutation: (
+      _operation: unknown,
+      options: { update: (...args: any[]) => void }
+    ) => {
+      h.mutationOptions = options;
+      return {
+        mutate: h.mutate,
+        loading: vref(false),
+        error: vref(null),
+        onDone: (callback: () => void) => {
+          h.mutationDone = callback;
+        },
+      };
+    },
+  };
+});
 
 vi.mock('@/composables/useAuthState', () => ({
   useModProfileName: () => ref('mod-1'),
 }));
 
-const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+const discussion = (overrides: Record<string, unknown> = {}) => ({
+  id: 'd1',
+  title: 'Hello',
+  body: 'Body',
+  DownloadableFiles: [],
+  Album: { Images: [] },
+  FeedbackComments: [],
+  FeedbackCommentsAggregate: { count: 0 },
+  Author: { username: 'alice' },
+  ...overrides,
+});
+
+const mountPage = async () => {
+  const Page = (await import('./[discussionId].vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        DiscussionBody: { template: '<div><slot name="album-slot" /></div>' },
+      },
+    },
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.discussionResult.value = { discussions: [discussion()] };
+  h.commentResult.value = { comments: [] };
+  h.discussionError.value = null;
+  h.commentError.value = null;
+  h.discussionLoading.value = false;
+  h.commentLoading.value = false;
+  Object.assign(h.route.params, {
+    forumId: 'cats',
+    discussionId: 'd1',
+    commentId: '',
+    feedbackId: '',
+  });
+});
 
 describe('discussion feedback page', () => {
   it('renders the feedback section when the discussion loads', async () => {
-    mockedUseQuery
-      .mockReturnValueOnce({
-        result: ref({
-          discussions: [
-            {
-              id: 'd1',
-              title: 'Hello',
-              body: 'Body',
-              DownloadableFiles: [],
-              Album: { Images: [] },
-              FeedbackComments: [],
-              FeedbackCommentsAggregate: { count: 0 },
-              Author: { username: 'alice' },
-            },
+    const wrapper = await mountPage();
+    expect(wrapper.findComponent(FeedbackSection).exists()).toBe(true);
+  });
+
+  it('recognizes STL downloads as album content', async () => {
+    h.discussionResult.value = {
+      discussions: [
+        discussion({
+          DownloadableFiles: [
+            { id: 'f1', fileName: 'MODEL.STL', url: 'download' },
+            { id: 'f2', fileName: 'model.zip', url: 'https://cdn/model.stl' },
           ],
         }),
-        error: ref(null),
-        loading: ref(false),
-        fetchMore: vi.fn(),
-      })
-      .mockReturnValueOnce({
-        result: ref({ comments: [] }),
-        error: ref(null),
-        loading: ref(false),
-      });
-    const Page = (await import('./[discussionId].vue')).default;
-    const wrapper = shallowMount(Page);
-    expect(wrapper.findComponent(FeedbackSection).exists()).toBe(true);
+      ],
+    };
+    const wrapper = await mountPage();
+    expect(wrapper.html()).toContain('discussion-album-stub');
+  });
+
+  it('loads the next feedback page and appends its comments', async () => {
+    h.discussionResult.value = {
+      discussions: [
+        discussion({
+          FeedbackComments: [{ id: 'one' }],
+          FeedbackCommentsAggregate: { count: 2 },
+        }),
+      ],
+    };
+    const wrapper = await mountPage();
+    const loadMore = wrapper
+      .findComponent(FeedbackSection)
+      .props('loadMore') as () => void;
+    loadMore();
+    const options = h.fetchMore.mock.calls[0][0];
+    const updated = options.updateQuery(
+      { discussions: [{ FeedbackComments: [{ id: 'one' }] }] },
+      {
+        fetchMoreResult: {
+          discussions: [{ FeedbackComments: [{ id: 'two' }] }],
+        },
+      }
+    );
+    expect([
+      options.variables,
+      updated.discussions[0].FeedbackComments,
+    ]).toEqual([{ offset: 1 }, [{ id: 'one' }, { id: 'two' }]]);
+  });
+
+  it('keeps the previous page when fetchMore returns nothing', async () => {
+    const wrapper = await mountPage();
+    (wrapper.findComponent(FeedbackSection).props('loadMore') as () => void)();
+    const previous = { discussions: [{ FeedbackComments: [] }] };
+    expect(h.fetchMore.mock.calls[0][0].updateQuery(previous, {})).toBe(
+      previous
+    );
+  });
+
+  it('updates the cached nested feedback thread after a reply', async () => {
+    h.discussionResult.value = {
+      discussions: [
+        discussion({
+          FeedbackComments: [
+            { id: 'parent', FeedbackComments: [] },
+            { id: 'other' },
+          ],
+          FeedbackCommentsAggregate: { count: 2 },
+        }),
+      ],
+    };
+    const wrapper = await mountPage();
+    const section = wrapper.findComponent(FeedbackSection);
+    section.vm.$emit('update-comment-to-give-feedback-on', {
+      id: 'parent',
+      FeedbackComments: [{ id: 'existing' }],
+    });
+    const cache = {
+      readQuery: vi.fn().mockReturnValue({
+        discussions: [{ FeedbackCommentsAggregate: { count: 2 } }],
+      }),
+      writeQuery: vi.fn(),
+    };
+    h.mutationOptions?.update(cache, {
+      data: { createComments: { comments: [{ id: 'new' }] } },
+    });
+    expect(
+      cache.writeQuery.mock.calls[0][0].data.discussions[0].FeedbackComments
+    ).toEqual([
+      { id: 'other' },
+      {
+        id: 'parent',
+        FeedbackComments: [{ id: 'existing' }, { id: 'new' }],
+        FeedbackCommentsAggregate: {
+          count: 3,
+          __typename: 'FeedbackCommentsAggregate',
+        },
+      },
+    ]);
+  });
+
+  it('closes the form and shows success after feedback is saved', async () => {
+    const wrapper = await mountPage();
+    const section = wrapper.findComponent(FeedbackSection);
+    section.vm.$emit('open-feedback-form-modal');
+    h.mutationDone?.();
+    await wrapper.vm.$nextTick();
+    expect([
+      section.props('showFeedbackFormModal'),
+      section.props('showFeedbackSubmittedSuccessfully'),
+    ]).toEqual([false, true]);
+  });
+
+  it('updates route-derived state when route params change', async () => {
+    const wrapper = await mountPage();
+    h.route.params = {
+      forumId: 'dogs',
+      discussionId: 'd2',
+      commentId: 'c1',
+      feedbackId: 'f1',
+    };
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findComponent({ name: 'BackLink' }).props('link')).toBe(
+      '/forums/dogs/discussions/d1'
+    );
   });
 });

--- a/pages/forums/[forumId]/downloads/edit/[discussionId].spec.ts
+++ b/pages/forums/[forumId]/downloads/edit/[discussionId].spec.ts
@@ -8,9 +8,11 @@ import {
 } from '@/graphQLData/discussion/mutations';
 import CreateEditDiscussionFields from '@/components/discussion/form/CreateEditDiscussionFields.vue';
 
+const routeHarness = vi.hoisted(() => ({ routerPush: vi.fn() }));
+
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { forumId: 'cats', discussionId: 'd1' } }),
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: routeHarness.routerPush }),
   useHead: vi.fn(),
 }));
 
@@ -24,7 +26,7 @@ vi.mock('@vue/apollo-composable', async () => {
   const { ref: r } = await import('vue');
   return {
     useQuery: vi.fn(),
-    useMutation: (doc: unknown) => {
+    useMutation: (doc: unknown, options?: unknown) => {
       if (!mutationTrackers.has(doc)) {
         const tracker: Record<string, unknown> = {
           mutate: vi.fn(),
@@ -32,6 +34,7 @@ vi.mock('@vue/apollo-composable', async () => {
           error: r(null),
           onError: vi.fn(),
           onDoneCb: null,
+          options,
         };
         tracker.onDone = (cb: () => void) => {
           tracker.onDoneCb = cb;
@@ -96,7 +99,9 @@ const populatedDiscussion = () => ({
 // Captures the onResult callback the page registers, so we can fire it.
 let capturedOnResult: ((value: unknown) => void) | null = null;
 
-const setupQueries = (discussion: Record<string, unknown> = emptyDiscussion()) => {
+const setupQueries = (
+  discussion: Record<string, unknown> = emptyDiscussion()
+) => {
   capturedOnResult = null;
   mockedUseQuery
     .mockReturnValueOnce({
@@ -129,6 +134,7 @@ describe('download edit page', () => {
   beforeEach(() => {
     mutationTrackers.clear();
     mockedUseQuery.mockReset();
+    routeHarness.routerPush.mockReset();
   });
 
   it('renders the download edit form for authorized users', async () => {
@@ -151,9 +157,7 @@ describe('download edit page', () => {
   it('updates labels after the discussion update succeeds', async () => {
     const wrapper = await loadPage(RequireAuthStub);
 
-    await wrapper
-      .findComponent(CreateEditDiscussionFields)
-      .vm.$emit('submit');
+    await wrapper.findComponent(CreateEditDiscussionFields).vm.$emit('submit');
 
     const discussionUpdate = mutationTrackers.get(
       UPDATE_DISCUSSION_WITH_CHANNEL_CONNECTIONS
@@ -213,10 +217,111 @@ describe('download edit page', () => {
       .vm.$emit('update-form-values', { title: 'Renamed download' });
     expect(
       (
-        wrapper.findComponent(CreateEditDiscussionFields).props('formValues') as {
+        wrapper
+          .findComponent(CreateEditDiscussionFields)
+          .props('formValues') as {
           title: string;
         }
       ).title
     ).toBe('Renamed download');
+  });
+
+  it('builds update variables for changed tags, channels, and album data', async () => {
+    const discussion = populatedDiscussion();
+    discussion.Album = { ...discussion.Album, id: 'album-1' };
+    const wrapper = await loadPage(RequireAuthStub, discussion);
+    await wrapper
+      .findComponent(CreateEditDiscussionFields)
+      .vm.$emit('update-form-values', {
+        selectedTags: ['new-tag'],
+        selectedChannels: ['dogs'],
+      });
+    const tracker = mutationTrackers.get(
+      UPDATE_DISCUSSION_WITH_CHANNEL_CONNECTIONS
+    ) as {
+      options: () => { variables: Record<string, unknown> };
+    };
+    expect(tracker.options().variables).toMatchObject({
+      where: { id: 'd1' },
+      channelConnections: ['dogs'],
+      channelDisconnections: ['cats'],
+      updateDiscussionInput: {
+        title: 'Cool model',
+        Tags: [
+          {
+            connectOrCreate: [
+              {
+                onCreate: { node: { text: 'new-tag' } },
+                where: { node: { text: 'new-tag' } },
+              },
+            ],
+            disconnect: [
+              { where: { node: { text: 'art' } } },
+              { where: { node: { text: '3d' } } },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('builds label update variables from the channel filter groups', async () => {
+    setupQueries(populatedDiscussion());
+    mockedUseQuery.mockReset();
+    capturedOnResult = null;
+    mockedUseQuery
+      .mockReturnValueOnce({
+        result: ref({ discussions: [populatedDiscussion()] }),
+        onResult: (cb: (value: unknown) => void) => {
+          capturedOnResult = cb;
+        },
+        loading: ref(false),
+        error: ref(null),
+      })
+      .mockReturnValueOnce({
+        result: ref({
+          channels: [
+            {
+              FilterGroups: [
+                { key: 'type', options: [{ id: 'pdf-id', value: 'pdf' }] },
+              ],
+            },
+          ],
+        }),
+        loading: ref(false),
+        error: ref(null),
+      });
+    const Page = (await import('./[discussionId].vue')).default;
+    shallowMount(Page, { global: { stubs: { RequireAuth: RequireAuthStub } } });
+    const tracker = mutationTrackers.get(UPDATE_DOWNLOAD_LABELS) as {
+      options: () => { variables: Record<string, unknown> };
+    };
+    expect(tracker.options().variables).toEqual({
+      channelUniqueName: 'cats',
+      discussionId: 'd1',
+      labelOptionIds: ['pdf-id'],
+    });
+  });
+
+  it('navigates back to the download when editing is cancelled', async () => {
+    const wrapper = await loadPage(RequireAuthStub, populatedDiscussion());
+    await wrapper.findComponent(CreateEditDiscussionFields).vm.$emit('cancel');
+    expect(routeHarness.routerPush).toHaveBeenCalledWith({
+      name: 'forums-forumId-downloads-discussionId',
+      params: { forumId: 'cats', discussionId: 'd1' },
+    });
+  });
+
+  it('still redirects when the chained label update fails', async () => {
+    await loadPage(RequireAuthStub, populatedDiscussion());
+    const discussionUpdate = mutationTrackers.get(
+      UPDATE_DISCUSSION_WITH_CHANNEL_CONNECTIONS
+    ) as { onDoneCb: () => Promise<void> };
+    const labelUpdate = mutationTrackers.get(UPDATE_DOWNLOAD_LABELS) as {
+      mutate: ReturnType<typeof vi.fn>;
+    };
+    labelUpdate.mutate.mockRejectedValueOnce(new Error('labels unavailable'));
+    await discussionUpdate.onDoneCb();
+    expect(routeHarness.routerPush).toHaveBeenCalledOnce();
   });
 });

--- a/pages/forums/[forumId]/edit.spec.ts
+++ b/pages/forums/[forumId]/edit.spec.ts
@@ -7,7 +7,25 @@ import { FilterMode } from '@/__generated__/graphql';
 
 const h = vi.hoisted(() => ({
   mutate: vi.fn(),
+  doneCallbacks: [] as Array<() => void>,
+  errorCallbacks: [] as Array<(error: Error) => void>,
+  autosaves: [] as Array<{ save: (value: boolean) => unknown }>,
 }));
+
+vi.mock('@/composables/useSettingAutosave', async () => {
+  const { ref } = await import('vue');
+  return {
+    useSettingAutosave: (options: { save: (value: boolean) => unknown }) => {
+      h.autosaves.push(options);
+      return {
+        status: ref('idle'),
+        error: ref(null),
+        trigger: vi.fn(),
+        setInitial: vi.fn(),
+      };
+    },
+  };
+});
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({
@@ -24,8 +42,9 @@ vi.mock('@vue/apollo-composable', () => ({
     mutate: h.mutate,
     loading: ref(false),
     error: ref(null),
-    onDone: vi.fn(),
-    onError: vi.fn(),
+    onDone: (callback: () => void) => h.doneCallbacks.push(callback),
+    onError: (callback: (error: Error) => void) =>
+      h.errorCallbacks.push(callback),
   }),
 }));
 
@@ -124,29 +143,31 @@ describe('forum settings edit page', () => {
       global: { mocks: { $route: { fullPath: '/forums/cats/edit' } } },
     });
 
-    wrapper.findComponent(CreateEditChannelFields).vm.$emit('updateFormValues', {
-      downloadFilterGroups: [
-        {
-          ...channelData.FilterGroups[0],
-          displayName: 'Required Game Packs',
-          mode: FilterMode.Exclude,
-          options: [
-            {
-              id: 'option-1',
-              value: 'vampires',
-              displayName: 'Vampires Updated',
-              order: 0,
-            },
-            {
-              id: 'local-filter-option-1',
-              value: 'werewolves',
-              displayName: 'Werewolves',
-              order: 1,
-            },
-          ],
-        },
-      ],
-    });
+    wrapper
+      .findComponent(CreateEditChannelFields)
+      .vm.$emit('updateFormValues', {
+        downloadFilterGroups: [
+          {
+            ...channelData.FilterGroups[0],
+            displayName: 'Required Game Packs',
+            mode: FilterMode.Exclude,
+            options: [
+              {
+                id: 'option-1',
+                value: 'vampires',
+                displayName: 'Vampires Updated',
+                order: 0,
+              },
+              {
+                id: 'local-filter-option-1',
+                value: 'werewolves',
+                displayName: 'Werewolves',
+                order: 1,
+              },
+            ],
+          },
+        ],
+      });
     wrapper.findComponent(CreateEditChannelFields).vm.$emit('submit');
 
     const update = h.mutate.mock.calls[0][0].update;
@@ -198,5 +219,134 @@ describe('forum settings edit page', () => {
         },
       ])
     );
+  });
+
+  it('autosaves each toggle as a scoped channel update', async () => {
+    h.mutate.mockClear();
+    await Promise.all([
+      h.autosaves[0].save(false),
+      h.autosaves[1].save(false),
+      h.autosaves[2].save(false),
+      h.autosaves[3].save(false),
+      h.autosaves[4].save(false),
+    ]);
+    expect(h.mutate.mock.calls.map((call) => call[0].update)).toEqual([
+      { eventsEnabled: false },
+      { imageUploadsEnabled: false },
+      { markdownImagesEnabled: false },
+      { feedbackEnabled: false },
+      { emojiEnabled: false },
+    ]);
+  });
+
+  it('falls back to empty rules when the channel stores malformed JSON', async () => {
+    mockedUseQuery.mockReturnValue({
+      result: ref({ channels: [{ ...channelData, rules: '{invalid' }] }),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    });
+    const Page = (await import('./edit.vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: { mocks: { $route: { fullPath: '/forums/cats/edit' } } },
+    });
+    expect(
+      wrapper.findComponent(CreateEditChannelFields).props('formValues').rules
+    ).toEqual([]);
+  });
+
+  it('creates new filter groups and their options', async () => {
+    h.mutate.mockClear();
+    mockedUseQuery.mockReturnValue({
+      result: ref({ channels: [channelData] }),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    });
+    const Page = (await import('./edit.vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: { mocks: { $route: { fullPath: '/forums/cats/edit' } } },
+    });
+    wrapper
+      .findComponent(CreateEditChannelFields)
+      .vm.$emit('updateFormValues', {
+        downloadFilterGroups: [
+          {
+            id: 'local-group-1',
+            key: 'style',
+            displayName: 'Style',
+            mode: FilterMode.Include,
+            order: 0,
+            options: [
+              {
+                id: 'local-option-1',
+                value: 'modern',
+                displayName: 'Modern',
+                order: 0,
+              },
+            ],
+          },
+        ],
+      });
+    wrapper.findComponent(CreateEditChannelFields).vm.$emit('submit');
+    expect(h.mutate.mock.calls[0][0].update.FilterGroups).toEqual(
+      expect.arrayContaining([
+        {
+          create: [
+            expect.objectContaining({
+              node: expect.objectContaining({
+                key: 'style',
+                options: {
+                  create: [
+                    expect.objectContaining({ node: expect.any(Object) }),
+                  ],
+                },
+              }),
+            }),
+          ],
+        },
+      ])
+    );
+  });
+
+  it('shows the saved state and refetches after the update completes', async () => {
+    const refetch = vi.fn();
+    mockedUseQuery.mockReturnValue({
+      result: ref({ channels: [channelData] }),
+      loading: ref(false),
+      error: ref(null),
+      refetch,
+    });
+    const Page = (await import('./edit.vue')).default;
+    const wrapper = shallowMount(Page, {
+      global: {
+        mocks: { $route: { fullPath: '/forums/cats/edit' } },
+        stubs: {
+          Notification: {
+            name: 'Notification',
+            props: ['show'],
+            template: '<div />',
+          },
+        },
+      },
+    });
+    h.doneCallbacks.at(-1)?.();
+    await wrapper.vm.$nextTick();
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  it('handles update mutation errors', async () => {
+    mockedUseQuery.mockReturnValue({
+      result: ref({ channels: [channelData] }),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    });
+    const Page = (await import('./edit.vue')).default;
+    shallowMount(Page, {
+      global: { mocks: { $route: { fullPath: '/forums/cats/edit' } } },
+    });
+    h.errorCallbacks.at(-1)?.(new Error('update failed'));
+    expect(h.errorCallbacks).not.toHaveLength(0);
   });
 });

--- a/pages/forums/[forumId]/edit/basic.spec.ts
+++ b/pages/forums/[forumId]/edit/basic.spec.ts
@@ -1,38 +1,56 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { shallowMount, flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import TextInput from '@/components/TextInput.vue';
+import type * as UtilsModule from '@/utils';
+import type * as UtilsIndexModule from '@/utils/index';
 
 const h = vi.hoisted(() => ({
   createSignedStorageUrl: vi.fn(),
   removeForumOwner: vi.fn(),
   permanentlyDeleteChannelBanner: vi.fn(),
+  uploadAndGetEmbeddedLink: vi.fn(),
+  isFileSizeValid: vi.fn(),
+  username: null as unknown as { value: string | null },
+  deleteLoading: null as unknown as { value: boolean },
+  removeDone: undefined as undefined | (() => void),
+  routerPush: vi.fn(),
 }));
 
 vi.mock('nuxt/app', async () => {
   const { ref: vref } = await import('vue');
   return {
     useRoute: () => ({ params: { forumId: 'cats' } }),
-    useRouter: () => ({ push: vi.fn() }),
+    useRouter: () => ({ push: h.routerPush }),
     useState: (_key: string, init?: () => unknown) =>
       vref(init ? init() : undefined),
   };
 });
 
-vi.mock('@vue/apollo-composable', () => ({
-  useMutation: (operation: unknown) => ({
-    mutate:
-      operation === 'PERMANENTLY_DELETE_CHANNEL_BANNER'
-        ? h.permanentlyDeleteChannelBanner
-        : operation === 'REMOVE_FORUM_OWNER'
-          ? h.removeForumOwner
-          : h.createSignedStorageUrl,
-    loading: ref(false),
-    error: ref(null),
-    onDone: vi.fn(),
-    onError: vi.fn(),
-  }),
-}));
+vi.mock('@/composables/useAuthState', async () => {
+  const { ref: vref } = await import('vue');
+  h.username ??= vref('alice');
+  return { useUsername: () => h.username };
+});
+
+vi.mock('@/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof UtilsModule>();
+  return {
+    ...actual,
+    getUploadFileName: vi.fn(() => 'alice-banner.png'),
+    uploadAndGetEmbeddedLink: h.uploadAndGetEmbeddedLink,
+  };
+});
+
+vi.mock('@/utils/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof UtilsIndexModule>();
+  return {
+    ...actual,
+    getUploadFileName: vi.fn(() => 'alice-banner.png'),
+    uploadAndGetEmbeddedLink: h.uploadAndGetEmbeddedLink,
+    isFileSizeValid: h.isFileSizeValid,
+  };
+});
 
 vi.mock('@/graphQLData/channel/mutations', () => ({
   PERMANENTLY_DELETE_CHANNEL_BANNER: 'PERMANENTLY_DELETE_CHANNEL_BANNER',
@@ -42,19 +60,56 @@ vi.mock('@/graphQLData/mod/mutations', () => ({
   REMOVE_FORUM_OWNER: 'REMOVE_FORUM_OWNER',
 }));
 
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: (operation: unknown) => {
+    const loading =
+      operation === 'PERMANENTLY_DELETE_CHANNEL_BANNER'
+        ? (h.deleteLoading ??= ref(false))
+        : ref(false);
+    return {
+      mutate:
+        operation === 'PERMANENTLY_DELETE_CHANNEL_BANNER'
+          ? h.permanentlyDeleteChannelBanner
+          : operation === 'REMOVE_FORUM_OWNER'
+            ? h.removeForumOwner
+            : h.createSignedStorageUrl,
+      loading,
+      error: ref(null),
+      onDone: (callback: () => void) => {
+        if (operation === 'REMOVE_FORUM_OWNER') h.removeDone = callback;
+      },
+      onError: vi.fn(),
+    };
+  },
+}));
+
 const FormRowStub = { template: '<div><slot name="content" /></div>' };
-// The page auto-focuses the title input on mount; give the stub a focus method.
 const TextInputStub = {
   name: 'TextInput',
   template: '<input />',
   methods: { focus() {} },
 };
-
 const WarningModalStub = {
   name: 'WarningModal',
   props: ['open', 'loading', 'error'],
   emits: ['primary-button-click', 'close'],
   template: '<div />',
+};
+const AddImageStub = {
+  name: 'AddImage',
+  emits: ['file-change'],
+  template: '<button />',
+};
+const RemoveOwnerModalStub = {
+  name: 'RemoveOwnerModal',
+  props: ['open'],
+  emits: ['close', 'confirm'],
+  template: '<div />',
+};
+const PrimaryButtonStub = {
+  name: 'PrimaryButton',
+  emits: ['click'],
+  template: '<button />',
 };
 
 const buildWrapper = async (formValues: Record<string, unknown>) => {
@@ -80,27 +135,45 @@ const buildWrapper = async (formValues: Record<string, unknown>) => {
         FormRow: FormRowStub,
         TextInput: TextInputStub,
         WarningModal: WarningModalStub,
+        AddImage: AddImageStub,
+        RemoveOwnerModal: RemoveOwnerModalStub,
+        PrimaryButton: PrimaryButtonStub,
       },
     },
   });
 };
 
+const emitImage = (
+  wrapper: Awaited<ReturnType<typeof buildWrapper>>,
+  file: File
+) =>
+  wrapper.findComponent(AddImageStub).vm.$emit('file-change', {
+    event: { target: { files: [file] } },
+    fieldName: 'channelIconURL',
+  });
+
 beforeEach(() => {
   vi.clearAllMocks();
-  h.permanentlyDeleteChannelBanner.mockResolvedValue({
+  h.username ??= ref('alice');
+  h.deleteLoading ??= ref(false);
+  h.username.value = 'alice';
+  h.deleteLoading.value = false;
+  h.isFileSizeValid.mockReturnValue({ valid: true, message: '' });
+  h.uploadAndGetEmbeddedLink.mockReturnValue('https://cdn.example.com/new.png');
+  h.createSignedStorageUrl.mockResolvedValue({
     data: {
-      permanentlyDeleteChannelBanner: {
-        uniqueName: 'cats',
-        channelBannerURL: null,
+      createSignedStorageURL: {
+        url: 'https://upload.example.com',
+        storageUrl: 'https://cdn.example.com',
       },
     },
   });
+  h.permanentlyDeleteChannelBanner.mockResolvedValue({ data: {} });
 });
 
 describe('forum basic settings page', () => {
   it('renders the editable channel text fields', async () => {
     const wrapper = await buildWrapper({});
-
     expect(wrapper.findComponent(TextInput).exists()).toBe(true);
   });
 
@@ -108,13 +181,13 @@ describe('forum basic settings page', () => {
     const wrapper = await buildWrapper({
       channelBannerURL: 'https://cdn.example.com/banner.png',
     });
-
-    await wrapper.get('[data-testid="delete-channel-banner-button"]').trigger('click');
     await wrapper
-      .getComponent({ name: 'WarningModal' })
+      .get('[data-testid="delete-channel-banner-button"]')
+      .trigger('click');
+    await wrapper
+      .getComponent(WarningModalStub)
       .vm.$emit('primary-button-click');
     await flushPromises();
-
     expect(h.permanentlyDeleteChannelBanner).toHaveBeenCalledWith({
       channelUniqueName: 'cats',
       imageUrl: 'https://cdn.example.com/banner.png',
@@ -125,15 +198,92 @@ describe('forum basic settings page', () => {
     const wrapper = await buildWrapper({
       channelBannerURL: 'https://cdn.example.com/banner.png',
     });
-
-    await wrapper.get('[data-testid="delete-channel-banner-button"]').trigger('click');
     await wrapper
-      .getComponent({ name: 'WarningModal' })
+      .getComponent(WarningModalStub)
       .vm.$emit('primary-button-click');
     await flushPromises();
-
-    expect(wrapper.emitted('updateFormValues')?.at(-1)?.[0]).toEqual({
-      channelBannerURL: '',
+    expect(wrapper.emitted()).toMatchObject({
+      updateFormValues: [[{ channelBannerURL: '' }]],
+      submit: [[]],
     });
+  });
+
+  it('uploads an image and submits the resulting field update', async () => {
+    const wrapper = await buildWrapper({});
+    emitImage(
+      wrapper,
+      new File(['banner'], 'banner.png', { type: 'image/png' })
+    );
+    await flushPromises();
+    expect(wrapper.emitted()).toMatchObject({
+      updateFormValues: [
+        [{ channelIconURL: 'https://cdn.example.com/new.png' }],
+      ],
+      submit: [[]],
+    });
+  });
+
+  it('does not upload when no user is signed in', async () => {
+    h.username.value = null;
+    const wrapper = await buildWrapper({});
+    emitImage(wrapper, new File(['banner'], 'banner.png'));
+    await flushPromises();
+    expect(h.createSignedStorageUrl).not.toHaveBeenCalled();
+  });
+
+  it('rejects an oversized upload before requesting a signed URL', async () => {
+    h.isFileSizeValid.mockReturnValue({ valid: false, message: 'Too large' });
+    vi.stubGlobal('alert', vi.fn());
+    const wrapper = await buildWrapper({});
+    emitImage(wrapper, new File(['x'], 'large.png'));
+    await flushPromises();
+    expect(globalThis.alert).toHaveBeenCalledWith('Too large');
+  });
+
+  it('does not submit when signed URL creation fails', async () => {
+    h.createSignedStorageUrl.mockRejectedValueOnce(new Error('offline'));
+    const wrapper = await buildWrapper({});
+    emitImage(wrapper, new File(['x'], 'banner.png'));
+    await flushPromises();
+    expect(wrapper.emitted('submit')).toBeUndefined();
+  });
+
+  it('shows a permanent-delete rejection in the confirmation modal', async () => {
+    h.permanentlyDeleteChannelBanner.mockRejectedValueOnce(
+      new Error('Delete denied')
+    );
+    const wrapper = await buildWrapper({
+      channelBannerURL: 'https://cdn.example.com/banner.png',
+    });
+    await wrapper
+      .getComponent(WarningModalStub)
+      .vm.$emit('primary-button-click');
+    await flushPromises();
+    expect(wrapper.getComponent(WarningModalStub).props('error')).toBe(
+      'Delete denied'
+    );
+  });
+
+  it('keeps the delete modal open while a deletion is loading', async () => {
+    const wrapper = await buildWrapper({
+      channelBannerURL: 'https://cdn.example.com/banner.png',
+    });
+    await wrapper
+      .get('[data-testid="delete-channel-banner-button"]')
+      .trigger('click');
+    h.deleteLoading.value = true;
+    await wrapper.getComponent(WarningModalStub).vm.$emit('close');
+    expect(wrapper.getComponent(WarningModalStub).props('open')).toBe(true);
+  });
+
+  it('removes the signed-in owner and redirects after completion', async () => {
+    const wrapper = await buildWrapper({});
+    await wrapper.findComponent(PrimaryButtonStub).vm.$emit('click');
+    await wrapper.getComponent(RemoveOwnerModalStub).vm.$emit('confirm');
+    h.removeDone?.();
+    expect([h.removeForumOwner.mock.calls, h.routerPush.mock.calls]).toEqual([
+      [[{ username: 'alice', channelUniqueName: 'cats' }]],
+      [[{ name: 'forums-forumId', params: { forumId: 'cats' } }]],
+    ]);
   });
 });

--- a/pages/forums/[forumId]/edit/flairs.spec.ts
+++ b/pages/forums/[forumId]/edit/flairs.spec.ts
@@ -8,6 +8,8 @@ const harness = vi.hoisted(() => ({
   mutationDone: undefined as undefined | ((result: unknown) => void),
   mutate: vi.fn().mockResolvedValue(undefined),
   toastSuccess: vi.fn(),
+  queryVariables: undefined as undefined | Record<string, unknown>,
+  queryEnabled: undefined as undefined | boolean,
 }));
 
 vi.mock('nuxt/app', () => ({
@@ -19,13 +21,21 @@ vi.mock('@/composables/useToast', () => ({
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
-  useQuery: () => ({
-    loading: ref(false),
-    error: ref(null),
-    onResult: (callback: (result: unknown) => void) => {
-      harness.queryResult = callback;
-    },
-  }),
+  useQuery: (
+    _operation: unknown,
+    variables: () => Record<string, unknown>,
+    options: { enabled: { value: boolean } }
+  ) => {
+    harness.queryVariables = variables();
+    harness.queryEnabled = options.enabled.value;
+    return {
+      loading: ref(false),
+      error: ref(null),
+      onResult: (callback: (result: unknown) => void) => {
+        harness.queryResult = callback;
+      },
+    };
+  },
   useMutation: () => ({
     mutate: harness.mutate,
     loading: ref(false),
@@ -67,6 +77,14 @@ const buttonNamed = (wrapper: ReturnType<typeof mount>, name: string) => {
 };
 
 describe('forum post flair settings', () => {
+  it('queries the current forum including archived flairs', async () => {
+    await mountPage();
+    expect([harness.queryVariables, harness.queryEnabled]).toEqual([
+      { channelUniqueName: 'cats', includeArchived: true },
+      true,
+    ]);
+  });
+
   it('loads active and archived flairs from the management query', async () => {
     const wrapper = await mountPage([
       {
@@ -151,5 +169,141 @@ describe('forum post flair settings', () => {
       mutationCalls: 0,
       message: 'Add at least one active flair before requiring flairs.',
     });
+  });
+
+  it.each([
+    ['', 'Each active flair needs a name.'],
+    ['x'.repeat(41), 'Flair names must be 40 characters or fewer.'],
+  ])('rejects the invalid flair name %j', async (name, message) => {
+    const wrapper = await mountPage([
+      {
+        id: 'flair-1',
+        displayName: name,
+        color: '#2563EB',
+        order: 0,
+        archived: false,
+      },
+    ]);
+    await buttonNamed(wrapper, 'Save flair settings').trigger('click');
+    expect(wrapper.get('[data-testid="error-banner"]').text()).toBe(message);
+  });
+
+  it('rejects malformed flair colors', async () => {
+    const wrapper = await mountPage([
+      {
+        id: 'flair-1',
+        displayName: 'Question',
+        color: 'blue',
+        order: 0,
+        archived: false,
+      },
+    ]);
+    await buttonNamed(wrapper, 'Save flair settings').trigger('click');
+    expect(wrapper.get('[data-testid="error-banner"]').text()).toBe(
+      'Flair colors must use six-digit hex values such as #F97316.'
+    );
+  });
+
+  it('rejects duplicate active flair names case-insensitively', async () => {
+    const wrapper = await mountPage([
+      {
+        id: 'flair-1',
+        displayName: 'Question',
+        color: '#2563EB',
+        order: 0,
+        archived: false,
+      },
+      {
+        id: 'flair-2',
+        displayName: ' question ',
+        color: '#16A34A',
+        order: 1,
+        archived: false,
+      },
+    ]);
+    await buttonNamed(wrapper, 'Save flair settings').trigger('click');
+    expect(wrapper.get('[data-testid="error-banner"]').text()).toBe(
+      'Active flair names must be unique.'
+    );
+  });
+
+  it('adds and removes an unsaved flair', async () => {
+    const wrapper = await mountPage();
+    await buttonNamed(wrapper, 'Add flair').trigger('click');
+    await buttonNamed(wrapper, 'Archive').trigger('click');
+    expect(wrapper.findAll('[data-testid="active-flair-row"]')).toHaveLength(0);
+  });
+
+  it('moves active flairs and restores archived flairs', async () => {
+    const wrapper = await mountPage([
+      {
+        id: 'flair-1',
+        displayName: 'Question',
+        color: '#2563EB',
+        order: 0,
+        archived: false,
+      },
+      {
+        id: 'flair-2',
+        displayName: 'Guide',
+        color: '#16A34A',
+        order: 1,
+        archived: false,
+      },
+      {
+        id: 'flair-3',
+        displayName: 'Old',
+        color: null,
+        order: 2,
+        archived: true,
+      },
+    ]);
+    await wrapper
+      .get('button[aria-label="Move Question down"]')
+      .trigger('click');
+    await buttonNamed(wrapper, 'Restore').trigger('click');
+    expect(
+      wrapper
+        .findAll('[data-testid="active-flair-row"] input[type="text"]')
+        .filter((input) =>
+          input.attributes('aria-label')?.startsWith('Flair name')
+        )
+        .map((input) => input.element.value)
+    ).toEqual(['Guide', 'Question', 'Old']);
+  });
+
+  it('applies the saved response and announces success', async () => {
+    const wrapper = await mountPage();
+    harness.mutationDone?.(
+      configResult([
+        {
+          id: 'flair-1',
+          displayName: 'Saved',
+          color: '#2563EB',
+          order: 0,
+          archived: false,
+        },
+      ])
+    );
+    await nextTick();
+    expect([
+      wrapper.get('input[aria-label="Flair name 1"]').element.value,
+      harness.toastSuccess.mock.calls,
+    ]).toEqual(['Saved', [['Post flair settings saved']]]);
+  });
+
+  it('handles a rejected save through the Apollo mutation error state', async () => {
+    harness.mutate.mockRejectedValueOnce(new Error('network'));
+    const wrapper = await mountPage([
+      {
+        id: 'flair-1',
+        displayName: 'Question',
+        color: '',
+        order: 0,
+        archived: false,
+      },
+    ]);
+    await buttonNamed(wrapper, 'Save flair settings').trigger('click');
+    expect(harness.mutate).toHaveBeenCalledOnce();
   });
 });

--- a/pages/forums/[forumId]/edit/mods.spec.ts
+++ b/pages/forums/[forumId]/edit/mods.spec.ts
@@ -1,33 +1,175 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import ModList from '@/components/channel/form/ModList.vue';
 import PendingForumModList from '@/components/channel/form/PendingForumModList.vue';
 
+const h = vi.hoisted(() => ({
+  mutations: new Map<unknown, ReturnType<typeof vi.fn>>(),
+  options: new Map<unknown, { update?: (...args: unknown[]) => void }>(),
+  done: new Map<unknown, () => void>(),
+}));
+
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { forumId: 'cats' } }),
 }));
 
+vi.mock('@/graphQLData/mod/mutations', () => ({
+  INVITE_FORUM_MOD: 'invite',
+  CANCEL_INVITE_FORUM_MOD: 'cancel',
+  REMOVE_FORUM_MOD: 'remove',
+}));
+
 vi.mock('@vue/apollo-composable', () => ({
-  useMutation: () => ({
-    mutate: vi.fn(),
-    loading: ref(false),
-    error: ref(null),
-    onDone: vi.fn(),
-  }),
+  useMutation: (
+    operation: unknown,
+    options: { update?: (...args: unknown[]) => void }
+  ) => {
+    const mutate = vi.fn();
+    h.mutations.set(operation, mutate);
+    h.options.set(operation, options);
+    return {
+      mutate,
+      loading: ref(false),
+      error: ref(null),
+      onDone: (callback: () => void) => h.done.set(operation, callback),
+    };
+  },
 }));
 
 const FormRowStub = { template: '<div><slot name="content" /></div>' };
+const WarningModalStub = {
+  name: 'WarningModal',
+  props: ['open', 'body'],
+  emits: ['close', 'primary-button-click'],
+  template: '<div />',
+};
+const TextInputStub = {
+  name: 'TextInput',
+  emits: ['update'],
+  template: '<input />',
+};
+const PrimaryButtonStub = {
+  name: 'PrimaryButton',
+  emits: ['click'],
+  template: '<button />',
+};
+
+const mountPage = async () => {
+  const Page = (await import('./mods.vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        FormRow: FormRowStub,
+        WarningModal: WarningModalStub,
+        TextInput: TextInputStub,
+        PrimaryButton: PrimaryButtonStub,
+      },
+    },
+  });
+};
+
+beforeEach(() => {
+  h.mutations.clear();
+  h.options.clear();
+  h.done.clear();
+});
 
 describe('forum mods edit page', () => {
   it('renders the current and pending mod lists', async () => {
-    const Page = (await import('./mods.vue')).default;
-    const wrapper = shallowMount(Page, {
-      global: { stubs: { FormRow: FormRowStub } },
-    });
+    const wrapper = await mountPage();
     expect([
       wrapper.findComponent(ModList).exists(),
       wrapper.findComponent(PendingForumModList).exists(),
     ]).toEqual([true, true]);
+  });
+
+  it('invites the username entered in the form', async () => {
+    const wrapper = await mountPage();
+    wrapper.findComponent({ name: 'TextInput' }).vm.$emit('update', 'bob');
+    await wrapper.findComponent({ name: 'PrimaryButton' }).vm.$emit('click');
+    expect(h.mutations.get('invite')).toHaveBeenCalledWith({
+      inviteeUsername: 'bob',
+      channelUniqueName: 'cats',
+    });
+  });
+
+  it('cancels the selected pending invitation', async () => {
+    const wrapper = await mountPage();
+    wrapper
+      .findComponent(PendingForumModList)
+      .vm.$emit('click-cancel-invite', 'bob');
+    await wrapper
+      .findAllComponents(WarningModalStub)[0]
+      .vm.$emit('primary-button-click');
+    expect(h.mutations.get('cancel')).toHaveBeenCalledWith({
+      inviteeUsername: 'bob',
+      channelUniqueName: 'cats',
+    });
+  });
+
+  it('removes the selected forum moderator', async () => {
+    const wrapper = await mountPage();
+    wrapper.findComponent(ModList).vm.$emit('click-remove-mod', 'bob');
+    await wrapper
+      .findAllComponents(WarningModalStub)[1]
+      .vm.$emit('primary-button-click');
+    expect(h.mutations.get('remove')).toHaveBeenCalledWith({
+      username: 'bob',
+      channelUniqueName: 'cats',
+    });
+  });
+
+  it('updates cached pending invitations after an invite', async () => {
+    const wrapper = await mountPage();
+    wrapper.findComponent({ name: 'TextInput' }).vm.$emit('update', 'bob');
+    const cache = {
+      readQuery: vi.fn().mockReturnValue({
+        channels: [{ PendingModInvites: [{ username: 'alice' }] }],
+      }),
+      writeQuery: vi.fn(),
+    };
+    h.options.get('invite')?.update?.(cache);
+    expect(
+      cache.writeQuery.mock.calls[0][0].data.channels[0].PendingModInvites
+    ).toEqual([{ username: 'alice' }, { displayName: 'bob' }]);
+  });
+
+  it('filters cached invitations and moderators', async () => {
+    await mountPage();
+    const cache = {
+      readQuery: vi.fn().mockReturnValue({
+        channels: [
+          { PendingModInvites: [{ username: 'alice' }, { username: '' }] },
+        ],
+      }),
+      writeQuery: vi.fn(),
+    };
+    h.options.get('cancel')?.update?.(cache);
+    cache.readQuery.mockReturnValue({
+      channels: [{ Admins: [{ username: 'alice' }, { username: '' }] }],
+    });
+    h.options.get('remove')?.update?.(cache, { data: null });
+    expect(
+      cache.writeQuery.mock.calls.map((call) => call[0].data.channels[0])
+    ).toEqual([
+      { PendingModInvites: [{ username: 'alice' }] },
+      { Admins: [{ username: 'alice' }] },
+    ]);
+  });
+
+  it('closes action modals when mutations finish', async () => {
+    const wrapper = await mountPage();
+    wrapper
+      .findComponent(PendingForumModList)
+      .vm.$emit('click-cancel-invite', 'bob');
+    wrapper.findComponent(ModList).vm.$emit('click-remove-mod', 'bob');
+    h.done.get('cancel')?.();
+    h.done.get('remove')?.();
+    expect(
+      wrapper
+        .findAllComponents(WarningModalStub)
+        .map((modal) => modal.props('open'))
+    ).toEqual([false, false]);
   });
 });

--- a/pages/forums/[forumId]/edit/owners.spec.ts
+++ b/pages/forums/[forumId]/edit/owners.spec.ts
@@ -1,33 +1,178 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
 import ForumOwnerList from '@/components/channel/form/ForumOwnerList.vue';
 import PendingForumOwnerList from '@/components/channel/form/PendingForumOwnerList.vue';
 
+const h = vi.hoisted(() => ({
+  mutations: new Map<unknown, ReturnType<typeof vi.fn>>(),
+  options: new Map<unknown, { update?: (...args: unknown[]) => void }>(),
+  done: new Map<unknown, () => void>(),
+}));
+
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { forumId: 'cats' } }),
 }));
 
+vi.mock('@/graphQLData/mod/mutations', () => ({
+  INVITE_FORUM_OWNER: 'invite',
+  CANCEL_INVITE_FORUM_OWNER: 'cancel',
+  REMOVE_FORUM_OWNER: 'remove',
+}));
+
 vi.mock('@vue/apollo-composable', () => ({
-  useMutation: () => ({
-    mutate: vi.fn(),
-    loading: ref(false),
-    error: ref(null),
-    onDone: vi.fn(),
-  }),
+  useMutation: (
+    operation: unknown,
+    options: { update?: (...args: unknown[]) => void }
+  ) => {
+    const mutate = vi.fn();
+    h.mutations.set(operation, mutate);
+    h.options.set(operation, options);
+    return {
+      mutate,
+      loading: ref(false),
+      error: ref(null),
+      onDone: (callback: () => void) => h.done.set(operation, callback),
+    };
+  },
 }));
 
 const FormRowStub = { template: '<div><slot name="content" /></div>' };
+const WarningModalStub = {
+  name: 'WarningModal',
+  props: ['open', 'body'],
+  emits: ['close', 'primary-button-click'],
+  template: '<div />',
+};
+const TextInputStub = {
+  name: 'TextInput',
+  emits: ['update'],
+  template: '<input />',
+};
+const PrimaryButtonStub = {
+  name: 'PrimaryButton',
+  emits: ['click'],
+  template: '<button />',
+};
+
+const mountPage = async () => {
+  const Page = (await import('./owners.vue')).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        FormRow: FormRowStub,
+        WarningModal: WarningModalStub,
+        TextInput: TextInputStub,
+        PrimaryButton: PrimaryButtonStub,
+      },
+    },
+  });
+};
+
+beforeEach(() => {
+  h.mutations.clear();
+  h.options.clear();
+  h.done.clear();
+});
 
 describe('forum owners edit page', () => {
   it('renders the current and pending owner lists', async () => {
-    const Page = (await import('./owners.vue')).default;
-    const wrapper = shallowMount(Page, {
-      global: { stubs: { FormRow: FormRowStub } },
-    });
+    const wrapper = await mountPage();
     expect([
       wrapper.findComponent(ForumOwnerList).exists(),
       wrapper.findComponent(PendingForumOwnerList).exists(),
     ]).toEqual([true, true]);
+  });
+
+  it('invites the username entered in the form', async () => {
+    const wrapper = await mountPage();
+    wrapper.findComponent({ name: 'TextInput' }).vm.$emit('update', 'bob');
+    await wrapper.findComponent({ name: 'PrimaryButton' }).vm.$emit('click');
+    expect(h.mutations.get('invite')).toHaveBeenCalledWith({
+      inviteeUsername: 'bob',
+      channelUniqueName: 'cats',
+    });
+  });
+
+  it('cancels the selected pending invitation', async () => {
+    const wrapper = await mountPage();
+    wrapper
+      .findComponent(PendingForumOwnerList)
+      .vm.$emit('click-cancel-invite', 'bob');
+    await wrapper
+      .findAllComponents(WarningModalStub)[0]
+      .vm.$emit('primary-button-click');
+    expect(h.mutations.get('cancel')).toHaveBeenCalledWith({
+      inviteeUsername: 'bob',
+      channelUniqueName: 'cats',
+    });
+  });
+
+  it('removes the selected forum owner', async () => {
+    const wrapper = await mountPage();
+    wrapper.findComponent(ForumOwnerList).vm.$emit('click-remove-owner', 'bob');
+    await wrapper
+      .findAllComponents(WarningModalStub)[1]
+      .vm.$emit('primary-button-click');
+    expect(h.mutations.get('remove')).toHaveBeenCalledWith({
+      username: 'bob',
+      channelUniqueName: 'cats',
+    });
+  });
+
+  it('updates cached pending invitations after an invite', async () => {
+    const wrapper = await mountPage();
+    wrapper.findComponent({ name: 'TextInput' }).vm.$emit('update', 'bob');
+    const cache = {
+      readQuery: vi.fn().mockReturnValue({
+        channels: [
+          { PendingOwnerInvites: [{ username: 'alice' }], slug: 'cats' },
+        ],
+      }),
+      writeQuery: vi.fn(),
+    };
+    h.options.get('invite')?.update?.(cache);
+    expect(cache.writeQuery.mock.calls[0][0].data.channels[0]).toEqual({
+      slug: 'cats',
+      PendingOwnerInvites: [{ username: 'alice' }, { username: 'bob' }],
+    });
+  });
+
+  it('filters cached invitations and owners', async () => {
+    await mountPage();
+    const cache = {
+      readQuery: vi.fn().mockReturnValue({
+        channels: [
+          { PendingOwnerInvites: [{ username: 'alice' }, { username: '' }] },
+        ],
+      }),
+      writeQuery: vi.fn(),
+    };
+    h.options.get('cancel')?.update?.(cache);
+    cache.readQuery.mockReturnValue({
+      channels: [{ Admins: [{ username: 'alice' }, { username: '' }] }],
+    });
+    h.options.get('remove')?.update?.(cache);
+    expect(
+      cache.writeQuery.mock.calls.map((call) => call[0].data.channels[0])
+    ).toEqual([
+      { PendingOwnerInvites: [{ username: 'alice' }] },
+      { Admins: [{ username: 'alice' }] },
+    ]);
+  });
+
+  it('closes action modals when mutations finish', async () => {
+    const wrapper = await mountPage();
+    wrapper
+      .findComponent(PendingForumOwnerList)
+      .vm.$emit('click-cancel-invite', 'bob');
+    wrapper.findComponent(ForumOwnerList).vm.$emit('click-remove-owner', 'bob');
+    h.done.get('cancel')?.();
+    h.done.get('remove')?.();
+    expect(
+      wrapper
+        .findAllComponents(WarningModalStub)
+        .map((modal) => modal.props('open'))
+    ).toEqual([false, false]);
   });
 });

--- a/pages/forums/[forumId]/edit/plugins/index.spec.ts
+++ b/pages/forums/[forumId]/edit/plugins/index.spec.ts
@@ -15,6 +15,7 @@ const h = vi.hoisted(() => ({
   refetchQueries: vi.fn(),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
+  onDone: null as null | (() => void),
 }));
 
 h.channelResult = ref(null);
@@ -24,17 +25,22 @@ h.installedResult = ref(null);
 h.installedLoading = ref(false);
 h.mutationError = ref(null);
 
-vi.mock('nuxt/app', () => ({ useRoute: () => ({ params: { forumId: 'cats' } }) }));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' } }),
+}));
 
 vi.mock('@vue/apollo-composable', () => ({
   useApolloClient: () => ({ client: { refetchQueries: h.refetchQueries } }),
   useMutation: () => ({
     mutate: h.mutate,
     error: h.mutationError,
-    onDone: vi.fn(),
+    onDone: (callback: () => void) => {
+      h.onDone = callback;
+    },
   }),
-  useQuery: (doc: string) =>
-    doc === 'CHANNEL_SETTINGS'
+  useQuery: (doc: string, variables?: null | (() => unknown)) => {
+    variables?.();
+    return doc === 'CHANNEL_SETTINGS'
       ? {
           result: h.channelResult,
           loading: h.channelLoading,
@@ -45,18 +51,23 @@ vi.mock('@vue/apollo-composable', () => ({
           result: h.installedResult,
           loading: h.installedLoading,
           error: ref(null),
-        },
+        };
+  },
 }));
 
 vi.mock('@/composables/useToast', () => ({
   useToast: () => ({ success: h.toastSuccess, error: h.toastError }),
 }));
-vi.mock('@/graphQLData/admin/queries', () => ({ GET_INSTALLED_PLUGINS: 'INSTALLED' }));
+vi.mock('@/graphQLData/admin/queries', () => ({
+  GET_INSTALLED_PLUGINS: 'INSTALLED',
+}));
 vi.mock('@/graphQLData/channel/queries', () => ({
   GET_CHANNEL: 'CHANNEL',
   GET_CHANNEL_PLUGIN_SETTINGS: 'CHANNEL_SETTINGS',
 }));
-vi.mock('@/graphQLData/channel/mutations', () => ({ UPDATE_CHANNEL_ENABLED_PLUGINS: 'UPDATE' }));
+vi.mock('@/graphQLData/channel/mutations', () => ({
+  UPDATE_CHANNEL_ENABLED_PLUGINS: 'UPDATE',
+}));
 
 const mountPage = () => mountWithDefaults(ForumPluginsPage);
 
@@ -79,6 +90,7 @@ beforeEach(() => {
   h.installedResult.value = null;
   h.installedLoading.value = false;
   h.mutationError.value = null;
+  h.onDone = null;
 });
 
 describe('Forum plugins page', () => {
@@ -109,7 +121,9 @@ describe('Forum plugins page', () => {
       },
     ]);
     h.installedResult.value = { getInstalledPlugins: [] };
-    expect(mountPage().text()).toContain('Some plugins are enabled for this forum');
+    expect(mountPage().text()).toContain(
+      'Some plugins are enabled for this forum'
+    );
   });
 
   it('lists a consolidated plugin card and enables the plugin when the checkbox is checked', async () => {
@@ -165,5 +179,127 @@ describe('Forum plugins page', () => {
       },
       success: 'Plugin enabled for this forum.',
     });
+  });
+
+  it('disables a plugin already enabled for the forum', async () => {
+    setChannel([
+      {
+        node: {
+          version: '1.0.0',
+          Plugin: { id: 'scanner', displayName: 'Scanner' },
+        },
+        properties: { settingsJson: '{"strict":false}' },
+      },
+    ]);
+    h.installedResult.value = {
+      getInstalledPlugins: [
+        {
+          plugin: { id: 'scanner', displayName: 'Scanner' },
+          version: '1.0.0',
+          enabled: true,
+          manifest: { settingsDefaults: { channel: { strict: true } } },
+        },
+      ],
+    };
+    const wrapper = mountPage();
+    await wrapper.get('input[type="checkbox"]').setValue(false);
+    expect(h.mutate).toHaveBeenCalledWith({
+      channelUniqueName: 'cats',
+      enabledPlugins: [
+        {
+          disconnect: [
+            {
+              where: {
+                node: { Plugin: { id: 'scanner' }, version: '1.0.0' },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('switches from the enabled plugin version to a newer version', async () => {
+    setChannel([
+      {
+        node: {
+          version: '1.0.0',
+          Plugin: { id: 'scanner', displayName: 'Scanner' },
+        },
+      },
+    ]);
+    h.installedResult.value = {
+      getInstalledPlugins: [
+        {
+          plugin: { id: 'scanner', displayName: 'Scanner' },
+          version: '1.0.0',
+          enabled: true,
+          latestVersion: '2.0.0',
+          availableVersions: ['1.0.0', '2.0.0'],
+        },
+        {
+          plugin: { id: 'scanner', displayName: 'Scanner' },
+          version: '2.0.0',
+          enabled: true,
+          latestVersion: '2.0.0',
+          availableVersions: ['1.0.0', '2.0.0'],
+        },
+      ],
+    };
+    const wrapper = mountPage();
+    await nextTick();
+    await wrapper.get('select').setValue('2.0.0');
+    expect(h.mutate).toHaveBeenCalled();
+  });
+
+  it('shows an error toast when updating a plugin fails', async () => {
+    setChannel();
+    h.installedResult.value = {
+      getInstalledPlugins: [
+        {
+          plugin: { id: 'scanner', displayName: 'Scanner' },
+          version: '1.0.0',
+          enabled: true,
+        },
+      ],
+    };
+    h.mutate.mockRejectedValueOnce(new Error('network down'));
+    const wrapper = mountPage();
+    await wrapper.get('input[type="checkbox"]').setValue(true);
+    expect(h.toastError).toHaveBeenCalledWith(
+      'Failed to update plugin: network down'
+    );
+  });
+
+  it.each(['not-json', 42, { strict: false }])(
+    'tolerates plugin settings stored as %j',
+    (settingsJson) => {
+      setChannel([
+        {
+          node: {
+            version: '1.0.0',
+            Plugin: { id: 'scanner', displayName: 'Scanner' },
+          },
+          properties: { settingsJson },
+        },
+      ]);
+      h.installedResult.value = {
+        getInstalledPlugins: [
+          {
+            plugin: { id: 'scanner', displayName: 'Scanner' },
+            version: '1.0.0',
+            enabled: true,
+          },
+        ],
+      };
+      expect(mountPage().text()).toContain('Scanner');
+    }
+  );
+
+  it('clears the mutation error after the mutation completes', () => {
+    h.mutationError.value = { message: 'old error' };
+    mountPage();
+    h.onDone?.();
+    expect(h.mutationError.value).toBeNull();
   });
 });

--- a/pages/forums/[forumId]/events/[eventId]/comments/[commentId].spec.ts
+++ b/pages/forums/[forumId]/events/[eventId]/comments/[commentId].spec.ts
@@ -11,7 +11,8 @@ const PermalinkedStub = defineComponent({
   name: 'PermalinkedComment',
   props: ['commentId'],
   setup(_props, { slots }) {
-    return () => h('div', slots.comment?.({ commentData: { id: 'comment-1' } }));
+    return () =>
+      h('div', slots.comment?.({ commentData: { id: 'comment-1' } }));
   },
 });
 
@@ -39,5 +40,26 @@ describe('event comment permalink page', () => {
   it('disables feedback for event comments', async () => {
     const wrapper = await mountPage();
     expect(wrapper.findComponent(Comment).props('enableFeedback')).toBe(false);
+  });
+
+  it.each([
+    'startCommentSave',
+    'openReplyEditor',
+    'hideReplyEditor',
+    'openEditCommentEditor',
+    'hideEditCommentEditor',
+    'clickEditComment',
+    'deleteComment',
+    'createComment',
+    'updateCreateReplyCommentInput',
+    'updateEditCommentInput',
+    'saveEdit',
+    'scrollToTop',
+    'clickReport',
+  ])('forwards the %s event', async (eventName) => {
+    const wrapper = await mountPage();
+    wrapper.findComponent(Comment).vm.$emit(eventName, 'payload');
+
+    expect(wrapper.emitted(eventName)?.[0]).toEqual(['payload']);
   });
 });

--- a/pages/forums/[forumId]/events/edit/[eventId].spec.ts
+++ b/pages/forums/[forumId]/events/edit/[eventId].spec.ts
@@ -1,23 +1,37 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
-import { ref, defineComponent, h } from 'vue';
-import { useQuery } from '@vue/apollo-composable';
+import { ref, defineComponent, h as createElement } from 'vue';
+import { useMutation, useQuery } from '@vue/apollo-composable';
 import CreateEditEventFields from '@/components/event/form/CreateEditEventFields.vue';
+import EditScopeModal from '@/components/event/form/EditScopeModal.vue';
+
+const mockState = vi.hoisted(() => ({
+  routeParams: { forumId: 'cats' as unknown, eventId: 'e1' as unknown },
+  routerPush: vi.fn(),
+  queryResultCallback: null as null | ((value: unknown) => void),
+  updateEvent: vi.fn(),
+  updateSeries: vi.fn(),
+  updateDone: null as null | (() => void),
+  seriesDone: null as null | (() => void),
+  updateError: null as unknown as { value: unknown },
+  seriesError: null as unknown as { value: unknown },
+  updateLoading: null as unknown as { value: boolean },
+  seriesLoading: null as unknown as { value: boolean },
+}));
+
+mockState.updateError = ref(null);
+mockState.seriesError = ref(null);
+mockState.updateLoading = ref(false);
+mockState.seriesLoading = ref(false);
 
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({ params: { forumId: 'cats', eventId: 'e1' } }),
-  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ params: mockState.routeParams }),
+  useRouter: () => ({ push: mockState.routerPush }),
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
-  useMutation: () => ({
-    mutate: vi.fn(),
-    loading: ref(false),
-    error: ref(null),
-    onDone: vi.fn(),
-    onError: vi.fn(),
-  }),
+  useMutation: vi.fn(),
 }));
 
 vi.mock('@/composables/useAuthState', () => ({
@@ -25,38 +39,225 @@ vi.mock('@/composables/useAuthState', () => ({
 }));
 
 const RequireAuthStub = defineComponent({
+  props: { owners: { type: Array, default: () => [] } },
   setup(_props, { slots }) {
-    return () => h('div', slots['has-auth']?.());
+    return () => createElement('div', slots['has-auth']?.());
   },
 });
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+const mockedUseMutation = useMutation as unknown as ReturnType<typeof vi.fn>;
+
+const baseEvent = {
+  id: 'e1',
+  title: 'Meetup',
+  description: '',
+  Tags: [{ text: 'old-tag' }],
+  EventChannels: [{ channelUniqueName: 'cats' }, { channelUniqueName: 'dogs' }],
+  Poster: { username: 'owner' },
+  startTime: '2024-01-01T18:00:00Z',
+  endTime: '2024-01-01T20:00:00Z',
+  canceled: false,
+};
+
+const mountWith = async (
+  event: Record<string, unknown> = baseEvent,
+  options: { loading?: boolean; queryError?: unknown } = {}
+) => {
+  mockedUseQuery.mockReturnValue({
+    result: ref({ events: [event] }),
+    onResult: (callback: (value: unknown) => void) => {
+      mockState.queryResultCallback = callback;
+    },
+    loading: ref(options.loading ?? false),
+    error: ref(options.queryError ?? null),
+  });
+  mockedUseMutation
+    .mockReturnValueOnce({
+      mutate: mockState.updateEvent,
+      loading: mockState.updateLoading,
+      error: mockState.updateError,
+      onDone: (callback: () => void) => {
+        mockState.updateDone = callback;
+      },
+    })
+    .mockReturnValueOnce({
+      mutate: mockState.updateSeries,
+      loading: mockState.seriesLoading,
+      error: mockState.seriesError,
+      onDone: (callback: () => void) => {
+        mockState.seriesDone = callback;
+      },
+    });
+  const Page = (await import('./[eventId].vue')).default;
+  return shallowMount(Page, {
+    global: { stubs: { RequireAuth: RequireAuthStub } },
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState.routeParams = { forumId: 'cats', eventId: 'e1' };
+  mockState.queryResultCallback = null;
+  mockState.updateDone = null;
+  mockState.seriesDone = null;
+  mockState.updateError.value = null;
+  mockState.seriesError.value = null;
+  mockState.updateLoading.value = false;
+  mockState.seriesLoading.value = false;
+});
 
 describe('event edit page', () => {
   it('renders the event edit form for authenticated users', async () => {
-    mockedUseQuery.mockReturnValue({
-      result: ref({
-        events: [
-          {
-            id: 'e1',
-            title: 'Meetup',
-            description: '',
-            Tags: [],
-            EventChannels: [],
-            startTime: '2024-01-01T18:00:00Z',
-            endTime: '2024-01-01T20:00:00Z',
-            canceled: false,
-          },
-        ],
-      }),
-      onResult: vi.fn(),
-      loading: ref(false),
-      error: ref(null),
-    });
-    const Page = (await import('./[eventId].vue')).default;
-    const wrapper = shallowMount(Page, {
-      global: { stubs: { RequireAuth: RequireAuthStub } },
-    });
+    const wrapper = await mountWith();
     expect(wrapper.findComponent(CreateEditEventFields).exists()).toBe(true);
+  });
+
+  it('provides the event owner to the auth boundary', async () => {
+    const wrapper = await mountWith();
+
+    expect(wrapper.findComponent(RequireAuthStub).props('owners')).toEqual([
+      'owner',
+    ]);
+  });
+
+  it('replaces default form values when the query finishes', async () => {
+    const wrapper = await mountWith({}, { loading: true });
+
+    mockState.queryResultCallback?.({
+      loading: false,
+      data: { events: [baseEvent] },
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.findComponent(CreateEditEventFields).props('formValues').title
+    ).toBe('Meetup');
+  });
+
+  it('does not replace form values for an intermediate loading result', async () => {
+    const wrapper = await mountWith({}, { loading: true });
+    const initialValues = wrapper
+      .findComponent(CreateEditEventFields)
+      .props('formValues');
+
+    mockState.queryResultCallback?.({
+      loading: true,
+      data: { events: [baseEvent] },
+    });
+
+    expect(
+      wrapper.findComponent(CreateEditEventFields).props('formValues')
+    ).toBe(initialValues);
+  });
+
+  it('updates one event with channel and tag changes', async () => {
+    const wrapper = await mountWith();
+    const form = wrapper.findComponent(CreateEditEventFields);
+    form.vm.$emit('update-form-values', {
+      selectedChannels: ['cats', 'birds'],
+      selectedTags: ['new-tag'],
+      latitude: 33.45,
+      longitude: -112.07,
+      locationName: 'Library',
+      address: '1 Main St',
+    });
+    await wrapper.vm.$nextTick();
+    form.vm.$emit('submit');
+
+    const variables = mockState.updateEvent.mock.calls[0]?.[0];
+    expect({
+      channelConnections: variables.channelConnections,
+      channelDisconnections: variables.channelDisconnections,
+      tagConnection:
+        variables.updateEventInput.Tags[0].connectOrCreate[0].where.node.text,
+      tagDisconnection:
+        variables.updateEventInput.Tags[0].disconnect[0].where.node.text,
+      location: variables.updateEventInput.location,
+    }).toEqual({
+      channelConnections: ['cats', 'birds'],
+      channelDisconnections: ['dogs'],
+      tagConnection: 'new-tag',
+      tagDisconnection: 'old-tag',
+      location: { latitude: 33.45, longitude: -112.07 },
+    });
+  });
+
+  it('opens the scope modal instead of immediately updating a series event', async () => {
+    const wrapper = await mountWith({
+      ...baseEvent,
+      EventSeries: { id: 'series-1' },
+    });
+
+    wrapper.findComponent(CreateEditEventFields).vm.$emit('submit');
+    await wrapper.vm.$nextTick();
+
+    expect({
+      modalOpen: wrapper.findComponent(EditScopeModal).props('isOpen'),
+      directUpdates: mockState.updateEvent.mock.calls.length,
+    }).toEqual({ modalOpen: true, directUpdates: 0 });
+  });
+
+  it('updates a series using the selected edit scope', async () => {
+    const wrapper = await mountWith({
+      ...baseEvent,
+      EventSeries: { id: 'series-1' },
+    });
+    wrapper.findComponent(CreateEditEventFields).vm.$emit('submit');
+    await wrapper.vm.$nextTick();
+
+    wrapper.findComponent(EditScopeModal).vm.$emit('confirm', 'future');
+
+    expect(mockState.updateSeries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: 'e1',
+        scope: 'future',
+      })
+    );
+  });
+
+  it('closes the series edit modal without updating', async () => {
+    const wrapper = await mountWith({
+      ...baseEvent,
+      EventSeries: { id: 'series-1' },
+    });
+    wrapper.findComponent(CreateEditEventFields).vm.$emit('submit');
+    await wrapper.vm.$nextTick();
+    wrapper.findComponent(EditScopeModal).vm.$emit('close');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent(EditScopeModal).props('isOpen')).toBe(false);
+  });
+
+  it('redirects to the selected channel after a successful update', async () => {
+    await mountWith();
+
+    mockState.updateDone?.();
+
+    expect(mockState.routerPush).toHaveBeenCalledWith({
+      name: 'forums-forumId-events-eventId',
+      params: { forumId: 'cats', eventId: 'e1' },
+    });
+  });
+
+  it('does not redirect after a failed series update', async () => {
+    mockState.seriesError.value = new Error('failed');
+    await mountWith({ ...baseEvent, EventSeries: { id: 'series-1' } });
+
+    mockState.seriesDone?.();
+
+    expect(mockState.routerPush).not.toHaveBeenCalled();
+  });
+
+  it('combines mutation loading and error state for the form', async () => {
+    mockState.seriesLoading.value = true;
+    mockState.updateError.value = new Error('failed');
+    const wrapper = await mountWith();
+    const form = wrapper.findComponent(CreateEditEventFields);
+
+    expect({
+      loading: form.props('updateEventLoading'),
+      error: (form.props('updateEventError') as Error).message,
+    }).toEqual({ loading: true, error: 'failed' });
   });
 });

--- a/pages/forums/[forumId]/wiki/index.spec.ts
+++ b/pages/forums/[forumId]/wiki/index.spec.ts
@@ -10,12 +10,15 @@ import SuspensionNotice from '@/components/SuspensionNotice.vue';
 const suspension = vi.hoisted(() => ({
   active: null as unknown,
   issueNumber: null as number | null,
+  routerPush: vi.fn(),
+  useHead: vi.fn(),
+  onResult: null as null | ((result: unknown) => void),
 }));
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { forumId: 'cats' } }),
-  useRouter: () => ({ push: vi.fn() }),
-  useHead: vi.fn(),
+  useRouter: () => ({ push: suspension.routerPush }),
+  useHead: suspension.useHead,
 }));
 
 vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
@@ -36,14 +39,22 @@ vi.mock('@/composables/useSuspensionNotice', () => ({
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
-const mountWith = async (channel: unknown, stubs: Record<string, unknown> = {}) => {
+const mountWith = async (
+  channel: unknown,
+  stubs: Record<string, unknown> = {},
+  queryState: { loading?: boolean; error?: unknown } = {}
+) => {
   mockedUseQuery
     .mockReturnValueOnce({
       result: ref({ channels: [channel] }),
-      loading: ref(false),
-      error: ref(null),
+      loading: ref(queryState.loading ?? false),
+      error: ref(queryState.error ?? null),
     })
-    .mockReturnValueOnce({ onResult: vi.fn() });
+    .mockReturnValueOnce({
+      onResult: (callback: (result: unknown) => void) => {
+        suspension.onResult = callback;
+      },
+    });
   const Page = (await import('./index.vue')).default;
   return shallowMount(Page, { global: { stubs } });
 };
@@ -51,8 +62,10 @@ const mountWith = async (channel: unknown, stubs: Record<string, unknown> = {}) 
 describe('wiki home page', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    vi.clearAllMocks();
     suspension.active = null;
     suspension.issueNumber = null;
+    suspension.onResult = null;
     mockedUseQuery.mockReset();
   });
 
@@ -80,10 +93,12 @@ describe('wiki home page', () => {
       { RequireAuth: { template: '<div><slot name="has-auth" /></div>' } }
     );
 
-    expect(wrapper.findComponent(SuspensionNotice).exists()).toBe(true);
     const buttons = wrapper.findAllComponents(GenericButton);
-    expect(buttons.length).toBeGreaterThan(0);
-    expect(buttons.every((b) => b.props('disabled') === true)).toBe(true);
+    expect({
+      notice: wrapper.findComponent(SuspensionNotice).exists(),
+      buttonCount: buttons.length,
+      disabled: buttons.every((button) => button.props('disabled') === true),
+    }).toEqual({ notice: true, buttonCount: 2, disabled: true });
   });
 
   it('gives the mobile wiki title its own wrapping row', async () => {
@@ -92,9 +107,9 @@ describe('wiki home page', () => {
       WikiHomePage: { title: 'A very long wiki title', body: 'Welcome' },
     });
 
-    expect(
-      wrapper.get('[data-testid="wiki-page-title"]').classes()
-    ).toEqual(expect.arrayContaining(['min-w-0', 'break-words']));
+    expect(wrapper.get('[data-testid="wiki-page-title"]').classes()).toEqual(
+      expect.arrayContaining(['min-w-0', 'break-words'])
+    );
   });
 
   it('places the mobile font-size picker after the wiki body', async () => {
@@ -130,5 +145,80 @@ describe('wiki home page', () => {
     });
 
     expect(wrapper.text()).toContain('Child Guide');
+  });
+
+  it('shows the loading state', async () => {
+    const wrapper = await mountWith(null, {}, { loading: true });
+
+    expect(wrapper.findComponent({ name: 'LoadingSpinner' }).exists()).toBe(
+      true
+    );
+  });
+
+  it('shows the query error', async () => {
+    const wrapper = await mountWith(
+      null,
+      {},
+      { error: { message: 'Offline' } }
+    );
+
+    expect(wrapper.text()).toContain('Offline');
+  });
+
+  it('shows the disabled state when the forum wiki is unavailable', async () => {
+    const wrapper = await mountWith({ wikiEnabled: false });
+
+    expect(wrapper.text()).toContain(
+      'The wiki feature is not enabled for this forum.'
+    );
+  });
+
+  it.each([
+    ['Create Wiki Page', '/forums/cats/wiki/create'],
+    ['Add Page', '/forums/cats/wiki/create-child'],
+    ['Edit Wiki', '/forums/cats/wiki/edit/home'],
+  ])('routes the %s action', async (buttonText, expectedRoute) => {
+    const wrapper = await mountWith(
+      {
+        wikiEnabled: true,
+        WikiHomePage:
+          buttonText === 'Create Wiki Page'
+            ? null
+            : { title: 'Home', slug: 'home', body: 'Welcome' },
+      },
+      { RequireAuth: { template: '<div><slot name="has-auth" /></div>' } }
+    );
+    await wrapper
+      .findAllComponents(GenericButton)
+      .find((button) => button.props('text') === buttonText)
+      ?.vm.$emit('click');
+
+    expect(suspension.routerPush).toHaveBeenCalledWith(expectedRoute);
+  });
+
+  it('does not route an edit action while the user is suspended', async () => {
+    suspension.active = { suspendedIndefinitely: true };
+    const wrapper = await mountWith(
+      {
+        wikiEnabled: true,
+        WikiHomePage: { title: 'Home', slug: 'home', body: 'Welcome' },
+      },
+      { RequireAuth: { template: '<div><slot name="has-auth" /></div>' } }
+    );
+    await wrapper
+      .findAllComponents(GenericButton)
+      .find((button) => button.props('text') === 'Edit Wiki')
+      ?.vm.$emit('click');
+
+    expect(suspension.routerPush).not.toHaveBeenCalled();
+  });
+
+  it('applies SEO metadata when the channel query completes', async () => {
+    await mountWith({ wikiEnabled: true, WikiHomePage: null });
+    suspension.onResult?.({
+      data: { channels: [{ WikiHomePage: { title: 'Home' } }] },
+    });
+
+    expect(suspension.useHead).toHaveBeenCalledOnce();
   });
 });

--- a/pages/forums/index.spec.ts
+++ b/pages/forums/index.spec.ts
@@ -1,12 +1,26 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref, defineComponent, h } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import ChannelList from '@/components/channel/ChannelList.vue';
+import SearchBar from '@/components/SearchBar.vue';
+import SearchableTagList from '@/components/SearchableTagList.vue';
+import ErrorBanner from '@/components/ErrorBanner.vue';
+
+const mockState = vi.hoisted(() => ({
+  route: { query: {} as Record<string, unknown> },
+  routerPush: vi.fn(),
+  routerReplace: vi.fn(),
+  fetchMoreChannels: vi.fn(),
+  fetchMoreDownloads: vi.fn(),
+}));
 
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({ query: {} }),
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRoute: () => mockState.route,
+  useRouter: () => ({
+    push: mockState.routerPush,
+    replace: mockState.routerReplace,
+  }),
   useHead: vi.fn(),
 }));
 vi.mock('@/composables/useAuthState', () => ({
@@ -21,39 +35,69 @@ const SlotStub = defineComponent({
   },
 });
 
+const FilterChipStub = defineComponent({
+  name: 'FilterChip',
+  props: { label: String, highlighted: Boolean },
+  setup(_props, { slots }) {
+    return () => h('div', slots.content?.());
+  },
+});
+
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
 const mountWith = async (opts: {
-  channels: unknown[];
+  channels?: unknown[];
   total?: number;
   downloads?: unknown[];
+  loading?: boolean;
+  error?: unknown;
+  noResult?: boolean;
 }) => {
+  const channels = opts.channels ?? [];
   mockedUseQuery
     .mockReturnValueOnce({
-      result: ref({
-        getSortedChannels: {
-          channels: opts.channels,
-          aggregateChannelCount: opts.total ?? opts.channels.length,
-        },
-      }),
-      loading: ref(false),
-      error: ref(null),
-      fetchMore: vi.fn(),
+      result: ref(
+        opts.noResult
+          ? undefined
+          : {
+              getSortedChannels: {
+                channels,
+                aggregateChannelCount: opts.total ?? channels.length,
+              },
+            }
+      ),
+      loading: ref(opts.loading ?? false),
+      error: ref(opts.error ?? null),
+      fetchMore: mockState.fetchMoreChannels,
     })
     .mockReturnValueOnce({
       result: ref({ getSortedChannels: { channels: opts.downloads ?? [] } }),
-      fetchMore: vi.fn(),
+      fetchMore: mockState.fetchMoreDownloads,
     });
   const Page = (await import('./index.vue')).default;
   return shallowMount(Page, {
-    global: { stubs: { NuxtLayout: SlotStub, ClientOnly: SlotStub, RequireAuth: true } },
+    global: {
+      stubs: {
+        NuxtLayout: SlotStub,
+        ClientOnly: SlotStub,
+        RequireAuth: true,
+        FilterChip: FilterChipStub,
+      },
+    },
   });
 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState.route.query = {};
+});
 
 describe('forums index page', () => {
   it('renders the channel list with the result count', async () => {
     const wrapper = await mountWith({
-      channels: [{ uniqueName: 'cats', DiscussionChannelsAggregate: { count: 0 } }],
+      channels: [
+        { uniqueName: 'cats', DiscussionChannelsAggregate: { count: 0 } },
+      ],
       total: 1,
     });
     expect(wrapper.findComponent(ChannelList).props('resultCount')).toBe(1);
@@ -61,10 +105,16 @@ describe('forums index page', () => {
 
   it('merges download counts onto the channels', async () => {
     const wrapper = await mountWith({
-      channels: [{ uniqueName: 'cats', DiscussionChannelsAggregate: { count: 0 } }],
-      downloads: [{ uniqueName: 'cats', DiscussionChannelsAggregate: { count: 2 } }],
+      channels: [
+        { uniqueName: 'cats', DiscussionChannelsAggregate: { count: 0 } },
+      ],
+      downloads: [
+        { uniqueName: 'cats', DiscussionChannelsAggregate: { count: 2 } },
+      ],
     });
-    const channels = wrapper.findComponent(ChannelList).props('channels') as Array<{
+    const channels = wrapper
+      .findComponent(ChannelList)
+      .props('channels') as Array<{
       downloadCount: number;
     }>;
     expect(channels[0].downloadCount).toBe(2);
@@ -80,9 +130,128 @@ describe('forums index page', () => {
         },
       ],
     });
-    const channels = wrapper.findComponent(ChannelList).props('channels') as Array<{
+    const channels = wrapper
+      .findComponent(ChannelList)
+      .props('channels') as Array<{
       isFavorited: boolean;
     }>;
     expect(channels[0].isFavorited).toBe(true);
+  });
+
+  it('initializes search and tag filters from the route', async () => {
+    mockState.route.query = { searchInput: 'space', tag: 'science' };
+    const wrapper = await mountWith({ channels: [] });
+
+    expect({
+      search: wrapper.findComponent(SearchBar).props('initialValue'),
+      tags: wrapper.findComponent(SearchableTagList).props('selectedTags'),
+    }).toEqual({ search: 'space', tags: ['science'] });
+  });
+
+  it('writes search changes to the route query', async () => {
+    mockState.route.query = { tag: 'science' };
+    const wrapper = await mountWith({ channels: [] });
+
+    wrapper
+      .findComponent(SearchBar)
+      .vm.$emit('update-search-input', 'astronomy');
+
+    expect(mockState.routerReplace).toHaveBeenCalledWith({
+      query: { tag: 'science', searchInput: 'astronomy' },
+    });
+  });
+
+  it('removes an empty search from the route query', async () => {
+    mockState.route.query = { searchInput: 'old' };
+    const wrapper = await mountWith({ channels: [] });
+
+    wrapper.findComponent(SearchBar).vm.$emit('update-search-input', '');
+
+    expect(mockState.routerReplace).toHaveBeenCalledWith({
+      query: { searchInput: undefined },
+    });
+  });
+
+  it('toggles a selected tag into the route', async () => {
+    const wrapper = await mountWith({ channels: [] });
+
+    wrapper
+      .findComponent(SearchableTagList)
+      .vm.$emit('toggle-selection', 'science');
+
+    expect(mockState.routerPush).toHaveBeenCalledWith({
+      query: { tag: ['science'] },
+    });
+  });
+
+  it('normalizes array tag query values', async () => {
+    mockState.route.query = { tag: ['science', null, 42] };
+    const wrapper = await mountWith({ channels: [] });
+
+    expect(
+      wrapper.findComponent(SearchableTagList).props('selectedTags')
+    ).toEqual(['science', '', '42']);
+  });
+
+  it('renders the query error', async () => {
+    const wrapper = await mountWith({
+      error: new Error('Channels unavailable'),
+    });
+
+    expect(wrapper.findComponent(ErrorBanner).props('text')).toBe(
+      'Channels unavailable'
+    );
+  });
+
+  it('renders a loading skeleton while the first result is pending', async () => {
+    const wrapper = await mountWith({ loading: true, noResult: true });
+
+    expect(wrapper.find('.animate-pulse').exists()).toBe(true);
+  });
+
+  it('loads the next page for both channel count queries', async () => {
+    const wrapper = await mountWith({
+      channels: [{ uniqueName: 'cats' }, { uniqueName: 'dogs' }],
+    });
+
+    wrapper.findComponent(ChannelList).vm.$emit('load-more');
+
+    expect({
+      channels: mockState.fetchMoreChannels.mock.calls[0]?.[0].variables,
+      downloads: mockState.fetchMoreDownloads.mock.calls[0]?.[0].variables,
+    }).toEqual({ channels: { offset: 2 }, downloads: { offset: 2 } });
+  });
+
+  it('appends fetch-more results to both channel lists', async () => {
+    const wrapper = await mountWith({ channels: [{ uniqueName: 'cats' }] });
+    wrapper.findComponent(ChannelList).vm.$emit('load-more');
+    const updateChannels =
+      mockState.fetchMoreChannels.mock.calls[0]?.[0].updateQuery;
+    const updateDownloads =
+      mockState.fetchMoreDownloads.mock.calls[0]?.[0].updateQuery;
+    const previous = {
+      getSortedChannels: { channels: [{ uniqueName: 'cats' }] },
+    };
+    const next = { getSortedChannels: { channels: [{ uniqueName: 'dogs' }] } };
+
+    expect({
+      channels: updateChannels(previous, { fetchMoreResult: next })
+        .getSortedChannels.channels,
+      downloads: updateDownloads(previous, { fetchMoreResult: next })
+        .getSortedChannels.channels,
+    }).toEqual({
+      channels: [{ uniqueName: 'cats' }, { uniqueName: 'dogs' }],
+      downloads: [{ uniqueName: 'cats' }, { uniqueName: 'dogs' }],
+    });
+  });
+
+  it('keeps previous results when fetch-more returns nothing', async () => {
+    const wrapper = await mountWith({ channels: [] });
+    wrapper.findComponent(ChannelList).vm.$emit('load-more');
+    const updateChannels =
+      mockState.fetchMoreChannels.mock.calls[0]?.[0].updateQuery;
+    const previous = { getSortedChannels: { channels: [] } };
+
+    expect(updateChannels(previous, { fetchMoreResult: null })).toBe(previous);
   });
 });

--- a/pages/library.spec.ts
+++ b/pages/library.spec.ts
@@ -12,12 +12,17 @@ const h = vi.hoisted(() => ({
   collections: null as unknown as { value: unknown },
   route: { path: '/library', params: {} as Record<string, unknown> },
   qi: 0,
+  username: null as unknown as { value: string },
+  authenticated: null as unknown as { value: boolean },
+  refetches: [] as ReturnType<typeof vi.fn>[],
+  queryInputs: [] as unknown[],
 }));
 
-vi.mock('nuxt/app', () => ({
-  useHead: vi.fn(),
-  useRoute: () => h.route,
-}));
+vi.mock('nuxt/app', async () => {
+  const { reactive } = await import('vue');
+  h.route = reactive(h.route);
+  return { useHead: vi.fn(), useRoute: () => h.route };
+});
 
 vi.mock('@vue/apollo-composable', async () => {
   const { ref } = await import('vue');
@@ -28,15 +33,26 @@ vi.mock('@vue/apollo-composable', async () => {
   h.collections = ref(null);
   const order = [h.counts, h.downloads, h.owned, h.uploaded, h.collections];
   return {
-    useQuery: () => ({ result: order[h.qi++] ?? ref(null), refetch: vi.fn() }),
+    useQuery: (
+      _document: unknown,
+      variables?: () => unknown,
+      options?: () => unknown
+    ) => {
+      h.queryInputs.push([variables?.(), options?.()]);
+      const refetch = vi.fn();
+      h.refetches.push(refetch);
+      return { result: order[h.qi++] ?? ref(null), refetch };
+    },
   };
 });
 
 vi.mock('@/composables/useAuthState', async () => {
   const { ref } = await import('vue');
+  h.username = ref('alice');
+  h.authenticated = ref(true);
   return {
-    useUsername: () => ref('alice'),
-    useIsAuthenticated: () => ref(true),
+    useUsername: () => h.username,
+    useIsAuthenticated: () => h.authenticated,
   };
 });
 
@@ -51,10 +67,7 @@ const PopperStub = defineComponent({
   name: 'Popper',
   setup(_p, { slots }) {
     return () =>
-      createEl('div', [
-        slots.default?.(),
-        createEl('div', slots.content?.()),
-      ]);
+      createEl('div', [slots.default?.(), createEl('div', slots.content?.())]);
   },
 });
 
@@ -62,7 +75,12 @@ const mountLibrary = (extraStubs: Record<string, unknown> = {}) =>
   mountWithDefaults(LibraryPage, {
     global: {
       mocks: {
-        $route: { query: {}, params: {}, path: '/library', fullPath: '/library' },
+        $route: {
+          query: {},
+          params: {},
+          path: '/library',
+          fullPath: '/library',
+        },
       },
       stubs: { NuxtPage: true, Popper: PopperStub, ...extraStubs },
     },
@@ -79,7 +97,9 @@ const setCounts = (channels: number, discussions: number, images: number) => {
       },
     ],
   };
-  h.downloads.value = { users: [{ FavoriteDiscussionsAggregate: { count: 0 } }] };
+  h.downloads.value = {
+    users: [{ FavoriteDiscussionsAggregate: { count: 0 } }],
+  };
   h.owned.value = { users: [{ OwnedDownloadsAggregate: { count: 0 } }] };
   h.uploaded.value = { getUploadedDownloadableFiles: [] };
   h.collections.value = { users: [{ Collections: [] }] };
@@ -88,6 +108,8 @@ const setCounts = (channels: number, discussions: number, images: number) => {
 beforeEach(() => {
   vi.clearAllMocks();
   h.qi = 0;
+  h.refetches = [];
+  h.queryInputs = [];
   h.route.path = '/library';
   h.route.params = {};
   h.counts.value = null;
@@ -95,6 +117,8 @@ beforeEach(() => {
   h.owned.value = null;
   h.uploaded.value = null;
   h.collections.value = null;
+  h.username.value = 'alice';
+  h.authenticated.value = true;
 });
 
 describe('Library page', () => {
@@ -136,9 +160,9 @@ describe('Library page', () => {
     setCounts(0, 0, 0);
     const wrapper = mountLibrary();
     expect(
-      wrapper.get('input[aria-label="Search library collections"]').attributes(
-        'placeholder'
-      )
+      wrapper
+        .get('input[aria-label="Search library collections"]')
+        .attributes('placeholder')
     ).toBe('Search collections');
   });
 
@@ -151,7 +175,8 @@ describe('Library page', () => {
             {
               id: 'downloads-1',
               name: 'Downloaded Items',
-              description: 'Items appear here automatically when you download them.',
+              description:
+                'Items appear here automatically when you download them.',
               collectionType: 'DOWNLOADS',
               visibility: 'PRIVATE',
               itemCount: 7,
@@ -232,9 +257,9 @@ describe('Library page', () => {
     h.route.path = '/library/favorite-discussions';
 
     const wrapper = mountLibrary();
-    expect(wrapper.get('[data-testid="mobile-library-nav-dropdown"]').text()).toContain(
-      'Favorite Discussions'
-    );
+    expect(
+      wrapper.get('[data-testid="mobile-library-nav-dropdown"]').text()
+    ).toContain('Favorite Discussions');
   });
 
   it('renders collection links inside the mobile dropdown', async () => {
@@ -257,15 +282,17 @@ describe('Library page', () => {
     };
 
     const wrapper = mountLibrary();
-    await wrapper.get('[data-testid="mobile-library-nav-dropdown"]').trigger('click');
+    await wrapper
+      .get('[data-testid="mobile-library-nav-dropdown"]')
+      .trigger('click');
     expect(
-      wrapper.get('[data-testid="mobile-library-item-favorite-channels"]').attributes(
-        'href'
-      )
+      wrapper
+        .get('[data-testid="mobile-library-item-favorite-channels"]')
+        .attributes('href')
     ).toBe('/library/favorite-channels');
-    expect(wrapper.get('[data-testid="mobile-library-item-c1"]').text()).toContain(
-      'My Reading List'
-    );
+    expect(
+      wrapper.get('[data-testid="mobile-library-item-c1"]').text()
+    ).toContain('My Reading List');
   });
 
   it('links to uploaded files management from the sidebar', () => {
@@ -281,26 +308,95 @@ describe('Library page', () => {
 
     const wrapper = mountLibrary();
 
-    expect(wrapper.get('[data-testid="library-item-uploaded-files"]').text()).toContain(
-      '(1)'
-    );
+    expect(
+      wrapper.get('[data-testid="library-item-uploaded-files"]').text()
+    ).toContain('(1)');
   });
 
   it('opens the mobile library navigation when the dropdown is clicked', async () => {
     setCounts(3, 1, 2);
     const wrapper = mountLibrary();
 
-    expect(wrapper.find('[data-testid="mobile-library-item-favorite-channels"]').exists()).toBe(
-      false
-    );
+    expect(
+      wrapper
+        .find('[data-testid="mobile-library-item-favorite-channels"]')
+        .exists()
+    ).toBe(false);
 
-    await wrapper.get('[data-testid="mobile-library-nav-dropdown"]').trigger('click');
+    await wrapper
+      .get('[data-testid="mobile-library-nav-dropdown"]')
+      .trigger('click');
 
-    expect(wrapper.get('[data-testid="mobile-library-nav-dropdown"]').attributes('aria-expanded')).toBe(
-      'true'
+    expect(
+      wrapper
+        .get('[data-testid="mobile-library-nav-dropdown"]')
+        .attributes('aria-expanded')
+    ).toBe('true');
+    expect(
+      wrapper
+        .get('[data-testid="mobile-library-item-favorite-channels"]')
+        .exists()
+    ).toBe(true);
+  });
+
+  it('enables each library query for the signed-in username', () => {
+    setCounts(0, 0, 0);
+    mountLibrary();
+    expect(h.queryInputs).toEqual(
+      Array.from({ length: 5 }, () => [
+        { username: 'alice' },
+        { enabled: true, fetchPolicy: 'cache-and-network' },
+      ])
     );
-    expect(wrapper.get('[data-testid="mobile-library-item-favorite-channels"]').exists()).toBe(
-      true
-    );
+  });
+
+  it('refetches every library query when the username changes', async () => {
+    setCounts(0, 0, 0);
+    const wrapper = mountLibrary();
+    h.username.value = 'bob';
+    await wrapper.vm.$nextTick();
+    expect(h.refetches.map((refetch) => refetch.mock.calls.length)).toEqual([
+      1, 1, 1, 1, 1,
+    ]);
+  });
+
+  it.each([
+    ['/library/my-downloads', 'My Downloads'],
+    ['/library/uploads', 'Uploaded Files'],
+  ])('shows the active mobile label for %s', (path, label) => {
+    setCounts(0, 0, 0);
+    h.route.path = path;
+    expect(
+      mountLibrary().get('[data-testid="mobile-library-nav-dropdown"]').text()
+    ).toContain(label);
+  });
+
+  it('closes the mobile menu when the route changes', async () => {
+    setCounts(0, 0, 0);
+    const wrapper = mountLibrary();
+    await wrapper
+      .get('[data-testid="mobile-library-nav-dropdown"]')
+      .trigger('click');
+    h.route.path = '/library/uploads';
+    await wrapper.vm.$nextTick();
+    expect(
+      wrapper
+        .get('[data-testid="mobile-library-nav-dropdown"]')
+        .attributes('aria-expanded')
+    ).toBe('false');
+  });
+
+  it('counts every uploaded file across discussion groups', () => {
+    setCounts(0, 0, 0);
+    h.uploaded.value = {
+      getUploadedDownloadableFiles: [
+        { files: [{ id: 'one' }, { id: 'two' }] },
+        { files: [{ id: 'three' }] },
+        {},
+      ],
+    };
+    expect(
+      mountLibrary().get('[data-testid="library-item-uploaded-files"]').text()
+    ).toContain('(3)');
   });
 });

--- a/pages/library/[collectionId].spec.ts
+++ b/pages/library/[collectionId].spec.ts
@@ -124,7 +124,11 @@ const mountWith = async (collection: unknown) => {
       stubs: {
         RequireAuth: RequireAuthStub,
         NuxtLink: { template: '<a><slot /></a>' },
-        LibraryDownloadCard: true,
+        LibraryDownloadCard: {
+          name: 'LibraryDownloadCard',
+          props: ['previewImageUrl'],
+          template: '<div class="download-card" />',
+        },
         LibraryDiscussionCard: LibraryDiscussionCardStub,
         LibraryChannelCard: true,
         LibraryCommentCard: LibraryCommentCardStub,
@@ -138,12 +142,7 @@ const mountWith = async (collection: unknown) => {
         },
         GenericModal: {
           name: 'GenericModal',
-          props: [
-            'open',
-            'title',
-            'primaryButtonDisabled',
-            'error',
-          ],
+          props: ['open', 'title', 'primaryButtonDisabled', 'error'],
           emits: ['primary-button-click', 'close'],
           template:
             '<section v-if="open" :data-title="title"><slot name="content" /><p v-if="error">{{ error }}</p><button data-testid="modal-primary" :disabled="primaryButtonDisabled" @click="$emit(\'primary-button-click\')">primary</button></section>',
@@ -157,7 +156,8 @@ const mountWith = async (collection: unknown) => {
         },
         Breadcrumbs: {
           props: ['links'],
-          template: '<nav>{{ links.map((link) => link.label).join(" > ") }}</nav>',
+          template:
+            '<nav>{{ links.map((link) => link.label).join(" > ") }}</nav>',
         },
       },
     },
@@ -182,7 +182,9 @@ describe('library collection detail page', () => {
   it('shows a not found state when the collection is missing', async () => {
     const wrapper = await mountWith(null);
 
-    expect(wrapper.text()).toContain("This collection doesn't exist or you don't have access to it.");
+    expect(wrapper.text()).toContain(
+      "This collection doesn't exist or you don't have access to it."
+    );
   });
 
   it('shows the collection name when it loads', async () => {
@@ -237,7 +239,9 @@ describe('library collection detail page', () => {
       itemCount: 0,
     });
 
-    const shareButton = wrapper.find('button[title="Make this collection public before sharing it to a forum"]');
+    const shareButton = wrapper.find(
+      'button[title="Make this collection public before sharing it to a forum"]'
+    );
     expect(shareButton.exists()).toBe(true);
     expect(shareButton.attributes('disabled')).toBeDefined();
     expect(wrapper.text()).toContain(
@@ -278,7 +282,9 @@ describe('library collection detail page', () => {
       itemCount: 0,
     });
 
-    await wrapper.find('button[title="Share this public collection to a forum discussion"]').element;
+    await wrapper.find(
+      'button[title="Share this public collection to a forum discussion"]'
+    ).element;
     await wrapper
       .findAll('button')
       .find((button) => button.text().includes('Make Private'))!
@@ -324,7 +330,9 @@ describe('library collection detail page', () => {
     });
 
     await wrapper
-      .find('button[title="Share this public collection to a forum discussion"]')
+      .find(
+        'button[title="Share this public collection to a forum discussion"]'
+      )
       .trigger('click');
     await wrapper.find('[data-testid="forum-picker"]').trigger('click');
     await wrapper.find('[data-testid="modal-primary"]').trigger('click');
@@ -353,7 +361,9 @@ describe('library collection detail page', () => {
     });
 
     await wrapper
-      .find('button[title="Share this public collection to a forum discussion"]')
+      .find(
+        'button[title="Share this public collection to a forum discussion"]'
+      )
       .trigger('click');
     await wrapper.find('[data-testid="forum-picker"]').trigger('click');
     await wrapper.find('[data-testid="modal-primary"]').trigger('click');
@@ -440,6 +450,122 @@ describe('library collection detail page', () => {
     expect(refetchCollection).toHaveBeenCalled();
   });
 
+  it.each([
+    [
+      'CHANNELS',
+      'Move Cats down',
+      {
+        Channels: [
+          { id: 'ch1', uniqueName: 'cats', displayName: 'Cats' },
+          { id: 'ch2', uniqueName: 'dogs', displayName: 'Dogs' },
+        ],
+        itemOrder: ['ch1', 'ch2'],
+        expectedId: 'ch1',
+      },
+    ],
+    [
+      'IMAGES',
+      'Move First image down',
+      {
+        Images: [
+          { id: 'i1', alt: 'First image', url: '/first.png' },
+          { id: 'i2', alt: 'Second image', url: '/second.png' },
+        ],
+        itemOrder: ['i1', 'i2'],
+        expectedId: 'i1',
+      },
+    ],
+    [
+      'COMMENTS',
+      'Move comment down',
+      {
+        Comments: [
+          { id: 'c1', text: 'First comment' },
+          { id: 'c2', text: 'Second comment' },
+        ],
+        itemOrder: ['c1', 'c2'],
+        expectedId: 'c1',
+      },
+    ],
+  ])('reorders %s collection items', async (collectionType, label, data) => {
+    const wrapper = await mountWith({
+      id: 'col-1',
+      name: 'Ordered items',
+      collectionType,
+      visibility: 'PRIVATE',
+      itemCount: 2,
+      ...data,
+    });
+    await wrapper.find(`button[aria-label="${label}"]`).trigger('click');
+    expect(mutationMocks.reorder).toHaveBeenCalledWith({
+      collectionId: 'col-1',
+      itemId: data.expectedId,
+      newPosition: 1,
+    });
+  });
+
+  it('renders a download preview using album image order', async () => {
+    const wrapper = await mountWith({
+      id: 'col-1',
+      name: 'Downloads',
+      collectionType: 'DOWNLOADS',
+      visibility: 'PRIVATE',
+      itemCount: 1,
+      Downloads: [
+        {
+          id: 'd1',
+          title: 'House',
+          Album: {
+            imageOrder: ['i2', 'i1'],
+            Images: [
+              { id: 'i1', url: '/first.png' },
+              { id: 'i2', url: '/second.png' },
+            ],
+          },
+          DiscussionChannels: [{ channelUniqueName: 'builds' }],
+        },
+      ],
+    });
+    expect(
+      wrapper.findComponent({ name: 'LibraryDownloadCard' }).props()
+    ).toEqual(expect.objectContaining({ previewImageUrl: '/second.png' }));
+  });
+
+  it('keeps the rename modal open when updating the name fails', async () => {
+    mutationMocks.update.mockRejectedValueOnce(new Error('rename failed'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = await mountWith({
+      id: 'col-1',
+      name: 'Old Name',
+      collectionType: 'DISCUSSIONS',
+      visibility: 'PUBLIC',
+      Discussions: [],
+    });
+    await wrapper.find('button[title="Edit collection"]').trigger('click');
+    await wrapper.get('#collection-name').setValue('New Name');
+    await wrapper.get('[data-testid="modal-primary"]').trigger('click');
+    error.mockRestore();
+    expect(wrapper.find('[data-title="Rename Collection"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('does not redirect when deleting the collection fails', async () => {
+    mutationMocks.delete.mockRejectedValueOnce(new Error('delete failed'));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = await mountWith({
+      id: 'col-1',
+      name: 'Public list',
+      collectionType: 'DISCUSSIONS',
+      visibility: 'PUBLIC',
+      Discussions: [],
+    });
+    await wrapper.find('button[title="Delete collection"]').trigger('click');
+    await wrapper.get('[data-testid="warning-primary"]').trigger('click');
+    error.mockRestore();
+    expect(h.routerPush).not.toHaveBeenCalled();
+  });
+
   const commentsCollection = {
     id: 'col-2',
     name: 'Saved comments',
@@ -466,15 +592,15 @@ describe('library collection detail page', () => {
   // MarkdownRenderer which cannot expand images.
   it('renders comment bodies via MarkdownPreview', async () => {
     const wrapper = await mountWith(commentsCollection);
-    expect(wrapper.findComponent(LibraryCommentCardStub).props('comment')).toEqual(
-      commentsCollection.Comments[0]
-    );
+    expect(
+      wrapper.findComponent(LibraryCommentCardStub).props('comment')
+    ).toEqual(commentsCollection.Comments[0]);
   });
 
   it('enables the image lightbox for comment bodies', async () => {
     const wrapper = await mountWith(commentsCollection);
-    expect(wrapper.findComponent(LibraryCommentCardStub).props('contextType')).toBe(
-      'Discussion'
-    );
+    expect(
+      wrapper.findComponent(LibraryCommentCardStub).props('contextType')
+    ).toBe('Discussion');
   });
 });

--- a/pages/u/[username]/comments.spec.ts
+++ b/pages/u/[username]/comments.spec.ts
@@ -4,6 +4,11 @@ import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import Comment from '@/components/comments/Comment.vue';
 
+const channelState = vi.hoisted(() => ({
+  selectedChannels: { value: [] as string[] },
+  hasSelectedChannels: { value: false },
+}));
+
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { username: 'alice' }, query: {} }),
 }));
@@ -14,21 +19,33 @@ vi.mock('@vue/apollo-composable', () => ({
 
 vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
   useSelectedChannelsFromQuery: () => ({
-    selectedChannels: ref([]),
-    hasSelectedChannels: ref(false),
+    selectedChannels: channelState.selectedChannels,
+    hasSelectedChannels: channelState.hasSelectedChannels,
   }),
 }));
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+const fetchMore = vi.fn();
 
-const mountWith = async (comments: unknown[]) => {
+const mountWith = async (
+  comments: unknown[],
+  options: { loading?: boolean; error?: unknown; aggregateCount?: number } = {}
+) => {
+  fetchMore.mockReset();
   mockedUseQuery.mockReturnValue({
     result: ref({
-      users: [{ Comments: comments, CommentsAggregate: { count: comments.length } }],
+      users: [
+        {
+          Comments: comments,
+          CommentsAggregate: {
+            count: options.aggregateCount ?? comments.length,
+          },
+        },
+      ],
     }),
-    loading: ref(false),
-    error: ref(null),
-    fetchMore: vi.fn(),
+    loading: ref(options.loading ?? false),
+    error: ref(options.error ?? null),
+    fetchMore,
   });
   const Page = (await import('./comments.vue')).default;
   return shallowMount(Page);
@@ -42,9 +59,151 @@ describe('user comments page', () => {
 
   it('renders a Comment for each non-archived comment', async () => {
     const wrapper = await mountWith([
-      { id: 'c1', archived: false, ParentComment: null, Event: {}, DiscussionChannel: {} },
-      { id: 'c2', archived: false, ParentComment: null, Event: {}, DiscussionChannel: {} },
+      {
+        id: 'c1',
+        archived: false,
+        ParentComment: null,
+        Event: {},
+        DiscussionChannel: {},
+      },
+      {
+        id: 'c2',
+        archived: false,
+        ParentComment: null,
+        Event: {},
+        DiscussionChannel: {},
+      },
     ]);
     expect(wrapper.findAllComponents(Comment)).toHaveLength(2);
+  });
+
+  it('builds channel filters into the comments query', async () => {
+    channelState.selectedChannels.value = ['cats', 'dogs'];
+    channelState.hasSelectedChannels.value = true;
+    await mountWith([]);
+    const variables = mockedUseQuery.mock.calls.at(-1)?.[1]();
+
+    expect(variables).toEqual({
+      username: 'alice',
+      limit: 25,
+      offset: 0,
+      where: {
+        OR: [
+          { Channel: { uniqueName_IN: ['cats', 'dogs'] } },
+          { DiscussionChannel: { channelUniqueName_IN: ['cats', 'dogs'] } },
+          {
+            Event: {
+              EventChannels_SOME: { channelUniqueName_IN: ['cats', 'dogs'] },
+            },
+          },
+        ],
+      },
+    });
+    channelState.selectedChannels.value = [];
+    channelState.hasSelectedChannels.value = false;
+  });
+
+  it('marks comments from deleted events with a warning', async () => {
+    const wrapper = await mountWith([
+      {
+        id: 'c1',
+        archived: false,
+        ParentComment: null,
+        Event: null,
+        DiscussionChannel: null,
+      },
+    ]);
+
+    expect(wrapper.findComponent({ name: 'InfoBanner' }).props('text')).toBe(
+      'This comment was on an event that has been deleted.'
+    );
+  });
+
+  it('renders archived comments with their channel context', async () => {
+    const wrapper = await mountWith([
+      {
+        id: 'c1',
+        archived: true,
+        Channel: { uniqueName: 'cats' },
+        Event: {},
+        DiscussionChannel: {},
+      },
+    ]);
+
+    expect(
+      wrapper.findComponent({ name: 'ArchivedCommentText' }).props()
+    ).toMatchObject({ channelId: 'cats', commentId: 'c1' });
+  });
+
+  it('requests the next page of comments', async () => {
+    const wrapper = await mountWith(
+      [
+        {
+          id: 'c1',
+          archived: false,
+          ParentComment: null,
+          Event: {},
+          DiscussionChannel: {},
+        },
+      ],
+      { aggregateCount: 2 }
+    );
+
+    wrapper.findComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+
+    expect(fetchMore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: {
+          username: 'alice',
+          limit: 25,
+          offset: 1,
+          where: undefined,
+        },
+      })
+    );
+  });
+
+  it('merges a fetched page into the existing comments', async () => {
+    const wrapper = await mountWith(
+      [
+        {
+          id: 'c1',
+          archived: false,
+          ParentComment: null,
+          Event: {},
+          DiscussionChannel: {},
+        },
+      ],
+      { aggregateCount: 2 }
+    );
+    wrapper.findComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+    const updateQuery = fetchMore.mock.calls[0][0].updateQuery;
+
+    expect(
+      updateQuery(
+        { users: [{ Comments: [{ id: 'c1' }] }] },
+        { fetchMoreResult: { users: [{ Comments: [{ id: 'c2' }] }] } }
+      )
+    ).toEqual({ users: [{ Comments: [{ id: 'c1' }, { id: 'c2' }] }] });
+  });
+
+  it('preserves the previous result when fetch-more returns nothing', async () => {
+    const wrapper = await mountWith(
+      [
+        {
+          id: 'c1',
+          archived: false,
+          ParentComment: null,
+          Event: {},
+          DiscussionChannel: {},
+        },
+      ],
+      { aggregateCount: 2 }
+    );
+    wrapper.findComponent({ name: 'LoadMore' }).vm.$emit('load-more');
+    const updateQuery = fetchMore.mock.calls[0][0].updateQuery;
+    const previous = { users: [{ Comments: [{ id: 'c1' }] }] };
+
+    expect(updateQuery(previous, { fetchMoreResult: null })).toBe(previous);
   });
 });

--- a/pages/u/[username]/discussions.spec.ts
+++ b/pages/u/[username]/discussions.spec.ts
@@ -4,6 +4,11 @@ import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import DiscussionItemInProfile from '@/components/user/DiscussionItemInProfile.vue';
 
+const channelState = vi.hoisted(() => ({
+  selectedChannels: { value: [] as string[] },
+  hasSelectedChannels: { value: false },
+}));
+
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { username: 'alice' }, query: {} }),
 }));
@@ -14,8 +19,8 @@ vi.mock('@vue/apollo-composable', () => ({
 
 vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
   useSelectedChannelsFromQuery: () => ({
-    selectedChannels: ref([]),
-    hasSelectedChannels: ref(false),
+    selectedChannels: channelState.selectedChannels,
+    hasSelectedChannels: channelState.hasSelectedChannels,
   }),
 }));
 
@@ -42,5 +47,23 @@ describe('user discussions profile page', () => {
       users: [{ Discussions: [{ id: 'd1' }, { id: 'd2' }] }],
     });
     expect(wrapper.findAllComponents(DiscussionItemInProfile)).toHaveLength(2);
+  });
+
+  it('adds selected channels to the discussion query', async () => {
+    channelState.selectedChannels.value = ['cats'];
+    channelState.hasSelectedChannels.value = true;
+    await mountWith({ users: [{ Discussions: [] }] });
+
+    expect(mockedUseQuery.mock.calls.at(-1)?.[1]()).toEqual({
+      username: 'alice',
+      where: {
+        AND: [
+          { OR: [{ hasDownload: false }, { hasDownload: null }] },
+          {
+            DiscussionChannels_SOME: { channelUniqueName_IN: ['cats'] },
+          },
+        ],
+      },
+    });
   });
 });

--- a/pages/u/[username]/downloads.spec.ts
+++ b/pages/u/[username]/downloads.spec.ts
@@ -4,6 +4,11 @@ import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import SitewideDownloadListItem from '@/components/discussion/list/SitewideDownloadListItem.vue';
 
+const channelState = vi.hoisted(() => ({
+  selectedChannels: { value: [] as string[] },
+  hasSelectedChannels: { value: false },
+}));
+
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { username: 'alice' }, query: {} }),
 }));
@@ -14,8 +19,8 @@ vi.mock('@vue/apollo-composable', () => ({
 
 vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
   useSelectedChannelsFromQuery: () => ({
-    selectedChannels: ref([]),
-    hasSelectedChannels: ref(false),
+    selectedChannels: channelState.selectedChannels,
+    hasSelectedChannels: channelState.hasSelectedChannels,
   }),
 }));
 
@@ -28,7 +33,24 @@ const mountWith = async (result: unknown) => {
     error: ref(null),
   });
   const Page = (await import('./downloads.vue')).default;
-  return shallowMount(Page);
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        DiscussionAlbum: {
+          name: 'DiscussionAlbum',
+          props: [
+            'album',
+            'discussionId',
+            'discussionAuthor',
+            'showEditAlbum',
+            'startInLightbox',
+          ],
+          emits: ['close-lightbox'],
+          template: '<div />',
+        },
+      },
+    },
+  });
 };
 
 describe('user downloads profile page', () => {
@@ -42,5 +64,67 @@ describe('user downloads profile page', () => {
       users: [{ Discussions: [{ id: 'd1' }, { id: 'd2' }] }],
     });
     expect(wrapper.findAllComponents(SitewideDownloadListItem)).toHaveLength(2);
+  });
+
+  it('adds selected channels to the downloads query', async () => {
+    channelState.selectedChannels.value = ['downloads'];
+    channelState.hasSelectedChannels.value = true;
+    await mountWith({ users: [{ Discussions: [] }] });
+
+    expect(mockedUseQuery.mock.calls.at(-1)?.[1]()).toEqual({
+      username: 'alice',
+      where: {
+        AND: [
+          { hasDownload: true },
+          {
+            DiscussionChannels_SOME: {
+              channelUniqueName_IN: ['downloads'],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('opens an album emitted by a download card', async () => {
+    const discussion = {
+      id: 'd1',
+      Author: { username: 'alice' },
+      Album: { id: 'album-1' },
+    };
+    const wrapper = await mountWith({ users: [{ Discussions: [discussion] }] });
+
+    wrapper
+      .findComponent(SitewideDownloadListItem)
+      .vm.$emit('open-album', { discussion, album: discussion.Album });
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.findComponent({ name: 'DiscussionAlbum' }).props()
+    ).toMatchObject({
+      album: { id: 'album-1' },
+      discussionId: 'd1',
+      discussionAuthor: 'alice',
+      showEditAlbum: false,
+      startInLightbox: true,
+    });
+  });
+
+  it('closes an open download album', async () => {
+    const discussion = { id: 'd1', Author: null, Album: { id: 'album-1' } };
+    const wrapper = await mountWith({ users: [{ Discussions: [discussion] }] });
+    wrapper
+      .findComponent(SitewideDownloadListItem)
+      .vm.$emit('open-album', { discussion, album: discussion.Album });
+    await wrapper.vm.$nextTick();
+
+    wrapper
+      .findComponent({ name: 'DiscussionAlbum' })
+      .vm.$emit('close-lightbox');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'DiscussionAlbum' }).exists()).toBe(
+      false
+    );
   });
 });

--- a/pages/u/[username]/events.spec.ts
+++ b/pages/u/[username]/events.spec.ts
@@ -4,6 +4,11 @@ import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import EventItemInProfile from '@/components/user/EventItemInProfile.vue';
 
+const channelState = vi.hoisted(() => ({
+  selectedChannels: { value: [] as string[] },
+  hasSelectedChannels: { value: false },
+}));
+
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({ params: { username: 'alice' }, query: {} }),
 }));
@@ -14,8 +19,8 @@ vi.mock('@vue/apollo-composable', () => ({
 
 vi.mock('@/composables/useSelectedChannelsFromQuery', () => ({
   useSelectedChannelsFromQuery: () => ({
-    selectedChannels: ref([]),
-    hasSelectedChannels: ref(false),
+    selectedChannels: channelState.selectedChannels,
+    hasSelectedChannels: channelState.hasSelectedChannels,
   }),
 }));
 
@@ -42,5 +47,18 @@ describe('user events profile page', () => {
       users: [{ Events: [{ id: 'e1' }, { id: 'e2' }] }],
     });
     expect(wrapper.findAllComponents(EventItemInProfile)).toHaveLength(2);
+  });
+
+  it('adds selected channels to the event query', async () => {
+    channelState.selectedChannels.value = ['events'];
+    channelState.hasSelectedChannels.value = true;
+    await mountWith({ users: [{ Events: [] }] });
+
+    expect(mockedUseQuery.mock.calls.at(-1)?.[1]()).toEqual({
+      username: 'alice',
+      where: {
+        EventChannels_SOME: { channelUniqueName_IN: ['events'] },
+      },
+    });
   });
 });

--- a/pages/u/[username]/images/[imageId].spec.ts
+++ b/pages/u/[username]/images/[imageId].spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { ref } from 'vue';
-import { useQuery } from '@vue/apollo-composable';
+import { useMutation, useQuery } from '@vue/apollo-composable';
 import { createPinia, setActivePinia } from 'pinia';
 
 vi.stubGlobal('definePageMeta', vi.fn());
@@ -13,6 +13,10 @@ const h = vi.hoisted(() => ({
   routeParams: { username: 'alice', imageId: 'img1' },
   isLightboxOpen: null as unknown as { value: boolean },
   closeLightbox: vi.fn(),
+  addImageToAlbum: vi.fn(),
+  refetchAlbumUsage: vi.fn(),
+  refetchUserAlbums: vi.fn(),
+  updateDone: null as null | (() => void),
 }));
 
 h.username = ref('alice');
@@ -26,11 +30,7 @@ vi.mock('nuxt/app', () => ({
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
-  useMutation: () => ({
-    mutate: h.updateImage,
-    loading: ref(false),
-    onDone: vi.fn(),
-  }),
+  useMutation: vi.fn(),
 }));
 
 vi.mock('@/config', () => ({
@@ -69,16 +69,53 @@ vi.mock('@/composables/useImageZoomPan', () => ({
 }));
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
+const mockedUseMutation = useMutation as unknown as ReturnType<typeof vi.fn>;
+
+const baseImage = {
+  id: 'img1',
+  url: 'https://img.test/photo.jpg',
+  caption: 'A photo',
+  Uploader: { username: 'alice' },
+  Album: { Images: [], imageOrder: [] },
+};
 
 const mountWith = async (
   image: unknown,
-  options: { loading?: boolean; error?: unknown } = {}
+  options: {
+    loading?: boolean;
+    error?: unknown;
+    albumUsage?: unknown;
+    userAlbums?: unknown[];
+    userAlbumsLoading?: boolean;
+  } = {}
 ) => {
-  mockedUseQuery.mockReturnValue({
-    result: ref({ images: image ? [image] : [] }),
-    error: ref(options.error ?? null),
-    loading: ref(options.loading ?? false),
-  });
+  mockedUseQuery
+    .mockReturnValueOnce({
+      result: ref({ images: image ? [image] : [] }),
+      error: ref(options.error ?? null),
+      loading: ref(options.loading ?? false),
+    })
+    .mockReturnValueOnce({
+      result: ref({ getImageAlbumUsage: options.albumUsage ?? null }),
+      refetch: h.refetchAlbumUsage,
+    })
+    .mockReturnValueOnce({
+      result: ref({ albums: options.userAlbums ?? [] }),
+      loading: ref(options.userAlbumsLoading ?? false),
+      refetch: h.refetchUserAlbums,
+    });
+  mockedUseMutation
+    .mockReturnValueOnce({
+      mutate: h.addImageToAlbum,
+      loading: ref(false),
+    })
+    .mockReturnValueOnce({
+      mutate: h.updateImage,
+      loading: ref(false),
+      onDone: (callback: () => void) => {
+        h.updateDone = callback;
+      },
+    });
   const Page = (await import('./[imageId].vue')).default;
   return shallowMount(Page);
 };
@@ -89,15 +126,24 @@ beforeEach(() => {
   h.username.value = 'alice';
   h.routeParams = { username: 'alice', imageId: 'img1' };
   h.isLightboxOpen = ref(false);
+  h.updateDone = null;
+  h.updateImage.mockResolvedValue(undefined);
+  h.addImageToAlbum.mockResolvedValue(undefined);
+  h.refetchAlbumUsage.mockResolvedValue(undefined);
+  h.refetchUserAlbums.mockResolvedValue(undefined);
 });
 
 describe('user image detail page', () => {
   it('shows the loading state', async () => {
-    expect((await mountWith(null, { loading: true })).text()).toContain('Loading image...');
+    expect((await mountWith(null, { loading: true })).text()).toContain(
+      'Loading image...'
+    );
   });
 
   it('shows the not-found state when the image query fails', async () => {
-    expect((await mountWith(null, { error: { message: 'boom' } })).text()).toContain('Image Not Found');
+    expect(
+      (await mountWith(null, { error: { message: 'boom' } })).text()
+    ).toContain('Image Not Found');
   });
 
   it('shows the invalid-url state when the image belongs to another uploader', async () => {
@@ -107,18 +153,16 @@ describe('user image detail page', () => {
       Uploader: { username: 'bob' },
       Album: { Images: [], imageOrder: [] },
     });
-    expect(wrapper.text()).toContain('This image was uploaded by bob, not alice.');
+    expect(wrapper.text()).toContain(
+      'This image was uploaded by bob, not alice.'
+    );
   });
 
   it('renders the image with its url', async () => {
-    const wrapper = await mountWith({
-      id: 'img1',
-      url: 'https://img.test/photo.jpg',
-      caption: 'A photo',
-      Uploader: { username: 'alice' },
-      Album: { Images: [], imageOrder: [] },
-    });
-    expect(wrapper.find('img').attributes('src')).toBe('https://img.test/photo.jpg');
+    const wrapper = await mountWith(baseImage);
+    expect(wrapper.find('img').attributes('src')).toBe(
+      'https://img.test/photo.jpg'
+    );
   });
 
   it('saves an updated caption for the uploader', async () => {
@@ -130,14 +174,286 @@ describe('user image detail page', () => {
       Album: { Images: [], imageOrder: [] },
     });
 
-    await wrapper.findAll('button').find((node) => node.text().includes('Edit'))?.trigger('click');
-    await wrapper.findComponent({ name: 'TextEditor' }).vm.$emit('update', 'New caption');
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Edit'))
+      ?.trigger('click');
+    await wrapper
+      .findComponent({ name: 'TextEditor' })
+      .vm.$emit('update', 'New caption');
     await wrapper.findComponent({ name: 'SaveButton' }).vm.$emit('click');
 
     expect(h.updateImage).toHaveBeenCalledWith({
       imageId: 'img1',
       caption: 'New caption',
     });
+  });
+
+  it('saves updated alt text for the uploader', async () => {
+    const wrapper = await mountWith({ ...baseImage, alt: 'Old alt text' });
+
+    await wrapper
+      .findAll('button')
+      .find(
+        (node) =>
+          node.text().includes('Edit') &&
+          node.element.parentElement?.textContent?.includes('Alt Text')
+      )
+      ?.trigger('click');
+    await wrapper.get('textarea').setValue('New alt text');
+    await wrapper
+      .findAllComponents({ name: 'SaveButton' })
+      .at(-1)
+      ?.vm.$emit('click');
+
+    expect(h.updateImage).toHaveBeenCalledWith({
+      imageId: 'img1',
+      alt: 'New alt text',
+    });
+  });
+
+  it('clears the active editor after an update completes', async () => {
+    const wrapper = await mountWith(baseImage);
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Edit'))
+      ?.trigger('click');
+
+    h.updateDone?.();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'TextEditor' }).exists()).toBe(false);
+  });
+
+  it('opens the album picker and refreshes the album list', async () => {
+    const wrapper = await mountWith(baseImage);
+
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Save to album'))
+      ?.trigger('click');
+
+    expect({
+      dialog: wrapper.find('[aria-labelledby="save-to-album-title"]').exists(),
+      refreshed: h.refetchUserAlbums.mock.calls.length,
+    }).toEqual({ dialog: true, refreshed: 1 });
+  });
+
+  it('shows the empty album state', async () => {
+    const wrapper = await mountWith(baseImage, { userAlbums: [] });
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Save to album'))
+      ?.trigger('click');
+
+    expect(wrapper.text()).toContain('You do not have any albums yet.');
+  });
+
+  it('marks albums that already contain the image as saved', async () => {
+    const album = { id: 'album-1', Owner: { username: 'alice' } };
+    const wrapper = await mountWith(baseImage, {
+      albumUsage: { uploaderOwnedAlbums: [album], otherAlbums: [] },
+      userAlbums: [{ ...album, ImagesAggregate: { count: 1 } }],
+    });
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Save to album'))
+      ?.trigger('click');
+    const albumButton = wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Already saved'));
+
+    expect(albumButton?.attributes('disabled')).toBeDefined();
+  });
+
+  it('saves the image to a new album', async () => {
+    const wrapper = await mountWith(baseImage, {
+      userAlbums: [{ id: 'album-2', Discussions: [{ title: 'Favorites' }] }],
+    });
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Save to album'))
+      ?.trigger('click');
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Favorites'))
+      ?.trigger('click');
+
+    expect({
+      mutation: h.addImageToAlbum.mock.calls[0]?.[0],
+      usageRefreshes: h.refetchAlbumUsage.mock.calls.length,
+      albumRefreshes: h.refetchUserAlbums.mock.calls.length,
+    }).toEqual({
+      mutation: { albumId: 'album-2', imageId: 'img1' },
+      usageRefreshes: 1,
+      albumRefreshes: 2,
+    });
+  });
+
+  it('surfaces an album save failure', async () => {
+    h.addImageToAlbum.mockRejectedValueOnce(new Error('Album unavailable'));
+    const wrapper = await mountWith(baseImage, {
+      userAlbums: [{ id: 'album-2' }],
+    });
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Save to album'))
+      ?.trigger('click');
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Album album-2'))
+      ?.trigger('click');
+
+    expect(wrapper.text()).toContain('Album unavailable');
+  });
+
+  it('shows a generic message for a non-Error album failure', async () => {
+    h.addImageToAlbum.mockRejectedValueOnce('unavailable');
+    const wrapper = await mountWith(baseImage, {
+      userAlbums: [{ id: 'album-2' }],
+    });
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Save to album'))
+      ?.trigger('click');
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Album album-2'))
+      ?.trigger('click');
+
+    expect(wrapper.text()).toContain('Could not save image to album.');
+  });
+
+  it('reports a caption save failure', async () => {
+    const alert = vi.fn();
+    vi.stubGlobal('alert', alert);
+    h.updateImage.mockRejectedValueOnce(new Error('Offline'));
+    const wrapper = await mountWith(baseImage);
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Edit'))
+      ?.trigger('click');
+    await wrapper.findComponent({ name: 'SaveButton' }).vm.$emit('click');
+
+    expect(alert).toHaveBeenCalledWith(
+      'Error saving caption. Please try again.'
+    );
+  });
+
+  it('reports an alt-text save failure', async () => {
+    const alert = vi.fn();
+    vi.stubGlobal('alert', alert);
+    h.updateImage.mockRejectedValueOnce(new Error('Offline'));
+    const wrapper = await mountWith({ ...baseImage, alt: 'Description' });
+    await wrapper
+      .findAll('button')
+      .find(
+        (node) =>
+          node.text().includes('Edit') &&
+          node.element.parentElement?.textContent?.includes('Alt Text')
+      )
+      ?.trigger('click');
+    await wrapper
+      .findAllComponents({ name: 'SaveButton' })
+      .at(-1)
+      ?.vm.$emit('click');
+
+    expect(alert).toHaveBeenCalledWith(
+      'Error saving alt text. Please try again.'
+    );
+  });
+
+  it('downloads the displayed image through a temporary object URL', async () => {
+    vi.useFakeTimers();
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+    const blob = new Blob(['image']);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ blob: () => blob }));
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:image'),
+      revokeObjectURL: vi.fn(),
+    });
+    const wrapper = await mountWith(baseImage);
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Download'))
+      ?.trigger('click');
+    await Promise.resolve();
+    await Promise.resolve();
+    vi.runAllTimers();
+
+    expect(click).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+
+  it('sets descriptive metadata for an image', async () => {
+    await mountWith({
+      ...baseImage,
+      alt: 'A tabby cat',
+      longDescription: 'Sitting by a window',
+      Uploader: { username: 'alice', displayName: 'Alice' },
+    });
+
+    expect(h.useHead).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'A photo by Alice | Multiforum' })
+    );
+  });
+
+  it('opens and closes the collection picker', async () => {
+    const wrapper = await mountWith(baseImage);
+    await wrapper
+      .findAll('button')
+      .find((node) => node.text().includes('Save to collection'))
+      ?.trigger('click');
+    const picker = wrapper.findComponent({ name: 'AddToListPopover' });
+    picker.vm.$emit('close');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'AddToListPopover' }).exists()).toBe(
+      false
+    );
+  });
+
+  it('renders ordered sibling images from the uploader album', async () => {
+    const wrapper = await mountWith(
+      {
+        ...baseImage,
+        Albums: [
+          {
+            id: 'album-1',
+            Owner: { username: 'alice' },
+            imageOrder: ['img2', 'img1'],
+            Images: [
+              baseImage,
+              { id: 'img2', url: 'https://img.test/two.jpg' },
+            ],
+          },
+        ],
+      },
+      {
+        albumUsage: {
+          uploaderOwnedAlbums: [
+            { id: 'album-1', Owner: { username: 'alice' } },
+          ],
+          otherAlbums: [],
+        },
+      }
+    );
+
+    expect(
+      wrapper.findComponent({ name: 'AlbumThumbnailGrid' }).props('images')
+    ).toEqual([{ id: 'img2', url: 'https://img.test/two.jpg' }]);
+  });
+
+  it.each([
+    ['https://img.test/model.glb', 'ModelViewer'],
+    ['https://img.test/model.stl', 'StlViewer'],
+  ])('renders %s with the specialized viewer', async (url, componentName) => {
+    const wrapper = await mountWith({ ...baseImage, url });
+
+    expect(wrapper.findComponent({ name: componentName }).exists()).toBe(true);
   });
 
   it('exposes the open lightbox as a named modal dialog', async () => {
@@ -154,9 +470,8 @@ describe('user image detail page', () => {
     expect({
       modal: dialog.attributes('aria-modal'),
       label: dialog.attributes('aria-label'),
-      closeControl: wrapper
-        .get('[aria-label="Close image lightbox"]')
-        .element.tagName,
+      closeControl: wrapper.get('[aria-label="Close image lightbox"]').element
+        .tagName,
     }).toEqual({
       modal: 'true',
       label: 'Image lightbox',

--- a/pages/u/[username]/moddedForums.spec.ts
+++ b/pages/u/[username]/moddedForums.spec.ts
@@ -5,8 +5,10 @@ import { useQuery } from '@vue/apollo-composable';
 import ModdedForumsPage from './moddedForums.vue';
 import ChannelList from '@/components/channel/ChannelList.vue';
 
+const routeState = vi.hoisted(() => ({ username: 'alice' as unknown }));
+
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({ params: { username: 'alice' } }),
+  useRoute: () => ({ params: { username: routeState.username } }),
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
@@ -15,7 +17,10 @@ vi.mock('@vue/apollo-composable', () => ({
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
-const mountWith = (result: unknown, options: { loading?: boolean; error?: unknown } = {}) => {
+const mountWith = (
+  result: unknown,
+  options: { loading?: boolean; error?: unknown } = {}
+) => {
   mockedUseQuery.mockReturnValue({
     result: ref(result),
     loading: ref(options.loading ?? false),
@@ -34,7 +39,9 @@ describe('user modded forums page', () => {
   });
 
   it('shows the error state', () => {
-    expect(mountWith(null, { error: { message: 'boom' } }).text()).toContain('Error');
+    expect(mountWith(null, { error: { message: 'boom' } }).text()).toContain(
+      'Error'
+    );
   });
 
   it('shows an empty-state message when the user mods no forums', () => {
@@ -59,6 +66,18 @@ describe('user modded forums page', () => {
       searchInput: '',
       selectedTags: [],
       loading: false,
+    });
+  });
+
+  it.each([
+    ['alice', 'alice'],
+    [['alice'], ''],
+  ])('uses %j as the query username', (routeUsername, expected) => {
+    routeState.username = routeUsername;
+    mountWith({ users: [] });
+
+    expect(mockedUseQuery.mock.calls.at(-1)?.[1]()).toEqual({
+      username: expected,
     });
   });
 });

--- a/pages/u/[username]/ownedForums.spec.ts
+++ b/pages/u/[username]/ownedForums.spec.ts
@@ -5,8 +5,10 @@ import { useQuery } from '@vue/apollo-composable';
 import OwnedForumsPage from './ownedForums.vue';
 import ChannelList from '@/components/channel/ChannelList.vue';
 
+const routeState = vi.hoisted(() => ({ username: 'alice' as unknown }));
+
 vi.mock('nuxt/app', () => ({
-  useRoute: () => ({ params: { username: 'alice' } }),
+  useRoute: () => ({ params: { username: routeState.username } }),
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
@@ -15,7 +17,10 @@ vi.mock('@vue/apollo-composable', () => ({
 
 const mockedUseQuery = useQuery as unknown as ReturnType<typeof vi.fn>;
 
-const mountWith = (result: unknown, options: { loading?: boolean; error?: unknown } = {}) => {
+const mountWith = (
+  result: unknown,
+  options: { loading?: boolean; error?: unknown } = {}
+) => {
   mockedUseQuery.mockReturnValue({
     result: ref(result),
     loading: ref(options.loading ?? false),
@@ -34,7 +39,9 @@ describe('user owned forums page', () => {
   });
 
   it('shows the error state', () => {
-    expect(mountWith(null, { error: { message: 'boom' } }).text()).toContain('Error');
+    expect(mountWith(null, { error: { message: 'boom' } }).text()).toContain(
+      'Error'
+    );
   });
 
   it('shows an empty-state message when the user owns no forums', () => {
@@ -59,6 +66,18 @@ describe('user owned forums page', () => {
       searchInput: '',
       selectedTags: [],
       loading: false,
+    });
+  });
+
+  it.each([
+    ['alice', 'alice'],
+    [['alice'], ''],
+  ])('uses %j as the query username', (routeUsername, expected) => {
+    routeState.username = routeUsername;
+    mountWith({ users: [] });
+
+    expect(mockedUseQuery.mock.calls.at(-1)?.[1]()).toEqual({
+      username: expected,
     });
   });
 });

--- a/pages/u/[username]/profileNotes.spec.ts
+++ b/pages/u/[username]/profileNotes.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+const routeState = vi.hoisted(() => ({ username: 'alice' as unknown }));
+
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { username: routeState.username } }),
+}));
+
+const pages = [
+  ['kudos.vue', () => import('./kudos.vue'), 'Kudos'],
+  ['scratchpad.vue', () => import('./scratchpad.vue'), 'Kudos'],
+] as const;
+
+const mountPage = async (loadPage: (typeof pages)[number][1]) => {
+  const Page = (await loadPage()).default;
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        BackLink: {
+          name: 'BackLink',
+          props: ['link', 'text'],
+          template: '<a />',
+        },
+        ScratchpadSection: {
+          name: 'ScratchpadSection',
+          props: ['username'],
+          template: '<section />',
+        },
+      },
+    },
+  });
+};
+
+beforeEach(() => {
+  routeState.username = 'alice';
+});
+
+describe('profile notes pages', () => {
+  it.each(pages)(
+    'passes the profile username through on %s',
+    async (_file, loadPage, title) => {
+      const wrapper = await mountPage(loadPage);
+
+      expect({
+        title: wrapper.text().includes(title),
+        backLink: wrapper.findComponent({ name: 'BackLink' }).props('link'),
+        username: wrapper
+          .findComponent({ name: 'ScratchpadSection' })
+          .props('username'),
+      }).toEqual({ title: true, backLink: '/u/alice', username: 'alice' });
+    }
+  );
+
+  it.each(pages)(
+    'handles a non-string username on %s',
+    async (_file, loadPage) => {
+      routeState.username = ['alice'];
+
+      expect(
+        (await mountPage(loadPage))
+          .findComponent({ name: 'ScratchpadSection' })
+          .props('username')
+      ).toBe('');
+    }
+  );
+});

--- a/tests/unit/composables/useAlbumImageUpload.spec.ts
+++ b/tests/unit/composables/useAlbumImageUpload.spec.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
 import { useAlbumImageUpload } from '@/composables/useAlbumImageUpload';
 
 const mockCreateSignedStorageUrl = vi.fn();
 const mockCreateImage = vi.fn();
+const { mockUploadAndGetEmbeddedLink, mockIsFileSizeValid, mockUsername } =
+  vi.hoisted(() => ({
+    mockUploadAndGetEmbeddedLink: vi.fn(),
+    mockIsFileSizeValid: vi.fn(),
+    mockUsername: { value: 'testuser' },
+  }));
 
 vi.mock('@vue/apollo-composable', () => ({
   useMutation: (doc: unknown) => {
@@ -27,18 +34,18 @@ vi.mock('@/graphQLData/discussion/mutations', () => ({
 }));
 
 vi.mock('@/composables/useAuthState', () => ({
-  useUsername: () => ({ value: 'testuser' }),
+  useUsername: () => mockUsername,
 }));
 
 vi.mock('@/utils', () => ({
   getUploadFileName: vi.fn(() => 'test-file-123.jpg'),
-  uploadAndGetEmbeddedLink: vi.fn(() => Promise.resolve('https://storage.example.com/test-file-123.jpg')),
+  uploadAndGetEmbeddedLink: mockUploadAndGetEmbeddedLink,
 }));
 
 vi.mock('@/utils/index', () => ({
   getUploadFileName: vi.fn(() => 'test-file-123.jpg'),
-  uploadAndGetEmbeddedLink: vi.fn(() => Promise.resolve('https://storage.example.com/test-file-123.jpg')),
-  isFileSizeValid: vi.fn(() => ({ valid: true })),
+  uploadAndGetEmbeddedLink: mockUploadAndGetEmbeddedLink,
+  isFileSizeValid: mockIsFileSizeValid,
 }));
 
 describe('useAlbumImageUpload', () => {
@@ -48,6 +55,13 @@ describe('useAlbumImageUpload', () => {
   beforeEach(() => {
     mockCreateSignedStorageUrl.mockClear();
     mockCreateImage.mockClear();
+    mockUploadAndGetEmbeddedLink.mockReset();
+    mockUploadAndGetEmbeddedLink.mockResolvedValue(
+      'https://storage.example.com/test-file-123.jpg'
+    );
+    mockIsFileSizeValid.mockReset();
+    mockIsFileSizeValid.mockReturnValue({ valid: true, message: '' });
+    mockUsername.value = 'testuser';
     onImageUploaded = vi.fn(() => {});
     currentImageCount = () => 0;
     // happy-dom does not implement window.alert, and vitest 4's vi.spyOn
@@ -177,7 +191,9 @@ describe('useAlbumImageUpload', () => {
 
       // Mock successful upload flow
       mockCreateSignedStorageUrl.mockResolvedValue({
-        data: { createSignedStorageURL: { url: 'https://signed-url.example.com' } },
+        data: {
+          createSignedStorageURL: { url: 'https://signed-url.example.com' },
+        },
       });
       mockCreateImage.mockResolvedValue({
         data: {
@@ -260,6 +276,140 @@ describe('useAlbumImageUpload', () => {
 
       alertMock.mockRestore();
     });
+  });
+
+  describe('uploadFile failures', () => {
+    const file = new File(['content'], 'file.jpg', { type: 'image/jpeg' });
+
+    it('stops when no user is logged in', async () => {
+      mockUsername.value = '';
+      const { uploadFile } = useAlbumImageUpload({
+        maxImages: 25,
+        currentImageCount,
+        onImageUploaded,
+      });
+
+      expect(await uploadFile(file)).toBe(false);
+    });
+
+    it('stops when the file is too large', async () => {
+      mockIsFileSizeValid.mockReturnValue({
+        valid: false,
+        message: 'File is too large',
+      });
+      const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
+      const { uploadFile } = useAlbumImageUpload({
+        maxImages: 25,
+        currentImageCount,
+        onImageUploaded,
+      });
+      await uploadFile(file);
+
+      expect(alertMock).toHaveBeenCalledWith('File is too large');
+    });
+
+    it('fails when no signed upload URL is returned', async () => {
+      mockCreateSignedStorageUrl.mockResolvedValue({ data: {} });
+      const { uploadFile } = useAlbumImageUpload({
+        maxImages: 25,
+        currentImageCount,
+        onImageUploaded,
+      });
+
+      expect(await uploadFile(file)).toBe(false);
+    });
+
+    it('fails when storage does not return a file URL', async () => {
+      mockCreateSignedStorageUrl.mockResolvedValue({
+        data: { createSignedStorageURL: { url: 'https://signed.test' } },
+      });
+      mockUploadAndGetEmbeddedLink.mockResolvedValue('');
+      const { uploadFile } = useAlbumImageUpload({
+        maxImages: 25,
+        currentImageCount,
+        onImageUploaded,
+      });
+
+      expect(await uploadFile(file)).toBe(false);
+    });
+
+    it('fails when the image record is missing', async () => {
+      mockCreateSignedStorageUrl.mockResolvedValue({
+        data: { createSignedStorageURL: { url: 'https://signed.test' } },
+      });
+      mockCreateImage.mockResolvedValue({ data: {} });
+      const { uploadFile } = useAlbumImageUpload({
+        maxImages: 25,
+        currentImageCount,
+        onImageUploaded,
+      });
+
+      expect(await uploadFile(file)).toBe(false);
+    });
+  });
+
+  describe('file input handling', () => {
+    it('ignores file selection when uploads are disabled', () => {
+      const { handleFileInputChange } = useAlbumImageUpload({
+        maxImages: 25,
+        currentImageCount,
+        onImageUploaded,
+      });
+      handleFileInputChange({ target: {} } as Event, false);
+
+      expect(mockCreateSignedStorageUrl).not.toHaveBeenCalled();
+    });
+
+    it('ignores a file input without files', () => {
+      const { handleFileInputChange } = useAlbumImageUpload({
+        maxImages: 25,
+        currentImageCount,
+        onImageUploaded,
+      });
+      handleFileInputChange({ target: {} } as Event, true);
+
+      expect(mockCreateSignedStorageUrl).not.toHaveBeenCalled();
+    });
+
+    it('clears a populated input after starting its upload', async () => {
+      mockCreateSignedStorageUrl.mockResolvedValue({
+        data: { createSignedStorageURL: { url: 'https://signed.test' } },
+      });
+      mockCreateImage.mockResolvedValue({
+        data: {
+          createImageWithUploader: {
+            id: 'image-1',
+            url: 'https://storage.example.com/test-file-123.jpg',
+          },
+        },
+      });
+      const input = {
+        files: [new File(['content'], 'file.jpg', { type: 'image/jpeg' })],
+        value: 'selected',
+      };
+      const { handleFileInputChange } = useAlbumImageUpload({
+        maxImages: 25,
+        currentImageCount,
+        onImageUploaded,
+      });
+      handleFileInputChange({ target: input } as unknown as Event, true);
+      await flushPromises();
+
+      expect(input.value).toBe('');
+    });
+  });
+
+  it('returns null when creating a URL image without a user', async () => {
+    mockUsername.value = '';
+    const { createImageFromUrl } = useAlbumImageUpload({
+      maxImages: 25,
+      currentImageCount,
+      onImageUploaded,
+    });
+
+    expect(
+      await createImageFromUrl('https://example.com/image.jpg')
+    ).toBeNull();
   });
 
   describe('handleDrop', () => {


### PR DESCRIPTION
## Summary

- expand behavior-focused unit coverage across components, pages, moderation, events, discussions, profiles, admin settings, maps, and upload flows
- add regression coverage for async success, failure, empty, loading, navigation, and event-forwarding paths
- fix StlViewer cleanup so it removes only the Three.js canvas and preserves Vue-managed children

## Coverage

- origin/main unit baseline: 21,059 / 24,550 lines (85.78%)
- this branch unit result: 22,228 / 24,551 lines (90.54%)
- 1,203 newly unit-covered lines; 138 were already covered by Playwright
- 1,065 newly covered lines are unique beyond existing Playwright coverage
- merged unit + Playwright covered-line union increases by 1,031 lines, exceeding the 1,024-line increase required to move the current 87.08% Codecov baseline up three percentage points

Codecov uses its own carried-forward flag totals, so CI remains the authoritative combined percentage.

## Verification

- pnpm exec vitest run: 780 files, 7,458 tests passed cleanly
- V8 coverage collection: all 780 files and 7,458 tests passed and the report reached 90.54% unit line coverage; Vitest then reported two late environment-teardown import errors from the existing discussion-feedback spec, which did not recur in the clean non-instrumented run
- pnpm run tsc
- pnpm run build:playwright:mocked with source-map instrumentation
- Playwright coverage collection produced 163 raw coverage traces: 162 passed, 1 skipped, and the nested-comments case timed out under instrumentation; the coverage workflow is configured to continue on test errors
- git diff --check
