### PR TITLE
ci: enforce 90 percent project coverage floor

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,9 +6,10 @@ coverage:
     # Overall project coverage check
     project:
       default:
-        # Don't fail the check based on absolute coverage
-        # Just report the coverage level
-        informational: true
+        # Keep combined unit + E2E coverage at or above the project floor.
+        target: 90%
+        threshold: 0%
+        informational: false
     # Per-PR coverage change check
     patch:
       default:


### PR DESCRIPTION
## Summary

- set the Codecov project target to 90%
- enforce the target with a zero-percent threshold
- turn the overall project status from informational into a blocking check
- preserve the existing 80% patch-coverage requirement

## Merge order

Depends on #433. This policy PR should merge after #433 raises combined unit + Playwright coverage above 90%. Before then, a project-coverage failure is expected and demonstrates that the floor is active.

## Verification

- Codecov official YAML validation endpoint: Valid
- pnpm exec prettier --check codecov.yml
- git diff --check

Official behavior: Codecov project status uses target as the minimum project coverage and informational false allows the status to block when the target is missed.
