### PR TITLE
feat: support flairs in sitewide discussion creation

### DIFF
--- a/components/discussion/form/CreateDiscussion.spec.ts
+++ b/components/discussion/form/CreateDiscussion.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { ref } from 'vue';
 import CreateDiscussion from '@/components/discussion/form/CreateDiscussion.vue';
 import { useUsername } from '@/composables/useAuthState';
@@ -23,11 +23,18 @@ type CreateMutationOptions = {
   update: (cache: unknown, result: unknown) => void;
 };
 
-const { mockUsername, mockFlairConfigResult } = await vi.hoisted(async () => {
+const {
+  mockUsername,
+  mockFlairConfigResult,
+  mockRouteForumId,
+  mockApolloClientQuery,
+} = await vi.hoisted(async () => {
   const { ref } = await import('vue');
   return {
     mockUsername: ref('alice'),
     mockFlairConfigResult: ref<Record<string, unknown> | null>(null),
+    mockRouteForumId: ref('cats'),
+    mockApolloClientQuery: vi.fn(),
   };
 });
 vi.mock('@/composables/useAuthState', () => ({
@@ -42,7 +49,7 @@ let capturedCreateOptions: (() => CreateMutationOptions) | null = null;
 
 vi.mock('nuxt/app', () => ({
   useRoute: () => ({
-    params: { forumId: 'cats' },
+    params: { forumId: mockRouteForumId.value || undefined },
     query: {},
   }),
   useRouter: () => ({
@@ -71,6 +78,9 @@ vi.mock('@vue/apollo-composable', () => ({
     loading: ref(false),
     error: ref(null),
   })),
+  useApolloClient: () => ({
+    resolveClient: () => ({ query: mockApolloClientQuery }),
+  }),
 }));
 
 vi.mock('@/composables/useSuspensionNotice', () => ({
@@ -87,6 +97,8 @@ describe('CreateDiscussion', () => {
     onDoneCallbacks.length = 0;
     mockPush.mockReset();
     mockFlairConfigResult.value = null;
+    mockRouteForumId.value = 'cats';
+    mockApolloClientQuery.mockReset();
     useUsername().value = 'alice';
   });
 
@@ -167,6 +179,8 @@ describe('CreateDiscussion — builder, cache, handlers', () => {
     createMutate.mockReset();
     capturedCreateOptions = null;
     mockFlairConfigResult.value = null;
+    mockRouteForumId.value = 'cats';
+    mockApolloClientQuery.mockReset();
     useUsername().value = 'alice';
   });
 
@@ -178,6 +192,9 @@ describe('CreateDiscussion — builder, cache, handlers', () => {
       'lockedChannelName',
       'discussionFlairs',
       'discussionFlairRequired',
+      'discussionFlairConfigs',
+      'discussionFlairsLoadingChannels',
+      'discussionFlairsErrorsByChannel',
     ],
     template:
       '<button data-testid="submit" @click="$emit(\'submit\')"></button>',
@@ -296,6 +313,123 @@ describe('CreateDiscussion — builder, cache, handlers', () => {
     }).toEqual({
       mutationCalls: 0,
       error: 'Select at least one flair for cats.',
+    });
+  });
+
+  it('loads and submits independent flair selections for sitewide forums', async () => {
+    mockRouteForumId.value = '';
+    mockApolloClientQuery.mockImplementation(({ variables }) =>
+      Promise.resolve({
+        data: {
+          getChannelDiscussionFlairConfig: {
+            channelUniqueName: variables.channelUniqueName,
+            flairRequired: variables.channelUniqueName !== 'birds',
+            flairs: [
+              {
+                id: `${variables.channelUniqueName}-flair`,
+                displayName: `${variables.channelUniqueName} flair`,
+                color: null,
+              },
+            ],
+          },
+        },
+      })
+    );
+    const wrapper = mountCD();
+    await fields(wrapper).vm.$emit('update-form-values', {
+      selectedChannels: ['cats', 'dogs', 'birds'],
+    });
+    await flushPromises();
+    await fields(wrapper).vm.$emit('update-form-values', {
+      selectedFlairIdsByChannel: {
+        cats: ['cats-flair'],
+        dogs: ['dogs-flair'],
+      },
+    });
+
+    expect({
+      configs: fields(wrapper)
+        .props('discussionFlairConfigs')
+        .map((config: { channelUniqueName: string }) =>
+          config.channelUniqueName
+        ),
+      selections: buildChannelFlairSelections(),
+    }).toEqual({
+      configs: ['cats', 'dogs', 'birds'],
+      selections: [
+        { channelUniqueName: 'cats', flairIds: ['cats-flair'] },
+        { channelUniqueName: 'dogs', flairIds: ['dogs-flair'] },
+      ],
+    });
+  });
+
+  it('blocks sitewide submission for each missing required forum', async () => {
+    mockRouteForumId.value = '';
+    mockApolloClientQuery.mockImplementation(({ variables }) =>
+      Promise.resolve({
+        data: {
+          getChannelDiscussionFlairConfig: {
+            channelUniqueName: variables.channelUniqueName,
+            flairRequired: true,
+            flairs: [
+              {
+                id: `${variables.channelUniqueName}-flair`,
+                displayName: `${variables.channelUniqueName} flair`,
+                color: null,
+              },
+            ],
+          },
+        },
+      })
+    );
+    const wrapper = mountCD();
+    await fields(wrapper).vm.$emit('update-form-values', {
+      selectedChannels: ['cats', 'dogs'],
+    });
+    await flushPromises();
+    await fields(wrapper).vm.$emit('update-form-values', {
+      selectedFlairIdsByChannel: { cats: ['cats-flair'] },
+    });
+    await wrapper.find('[data-testid="submit"]').trigger('click');
+
+    expect({
+      mutationCalls: createMutate.mock.calls.length,
+      error: fields(wrapper).props('submitError'),
+    }).toEqual({
+      mutationCalls: 0,
+      error: 'Select at least one flair for dogs.',
+    });
+  });
+
+  it('drops flair selections when a sitewide forum is removed', async () => {
+    mockRouteForumId.value = '';
+    mockApolloClientQuery.mockImplementation(({ variables }) =>
+      Promise.resolve({
+        data: {
+          getChannelDiscussionFlairConfig: {
+            channelUniqueName: variables.channelUniqueName,
+            flairRequired: false,
+            flairs: [],
+          },
+        },
+      })
+    );
+    const wrapper = mountCD();
+    await fields(wrapper).vm.$emit('update-form-values', {
+      selectedChannels: ['cats', 'dogs'],
+    });
+    await fields(wrapper).vm.$emit('update-form-values', {
+      selectedFlairIdsByChannel: {
+        cats: ['cats-flair'],
+        dogs: ['dogs-flair'],
+      },
+    });
+    await fields(wrapper).vm.$emit('update-form-values', {
+      selectedChannels: ['cats'],
+    });
+
+    expect(fields(wrapper).props('formValues').selectedFlairIdsByChannel).toEqual({
+      cats: ['cats-flair'],
     });
   });
 

--- a/components/discussion/form/CreateDiscussion.vue
+++ b/components/discussion/form/CreateDiscussion.vue
@@ -23,7 +23,10 @@ import { useChannelSuspensionNotice } from '@/composables/useSuspensionNotice';
 import { useForumLock } from '@/composables/useForumLock';
 import { useUsername } from '@/composables/useAuthState';
 import { GET_CHANNEL_DISCUSSION_FLAIR_CONFIG } from '@/graphQLData/channel/queries';
-import type { DiscussionFlairOption } from '@/components/discussion/form/DiscussionFlairPicker.vue';
+import {
+  useChannelDiscussionFlairConfigs,
+  type ChannelDiscussionFlairConfig,
+} from '@/composables/useChannelDiscussionFlairConfigs';
 
 const usernameVar = useUsername();
 
@@ -62,16 +65,10 @@ const createDiscussionDefaultValues: CreateEditDiscussionFormValues = {
 
 const formValues = ref(createDiscussionDefaultValues);
 
-type ChannelDiscussionFlairConfig = {
-  channelUniqueName: string;
-  flairRequired: boolean;
-  flairs: DiscussionFlairOption[];
-};
-
 const {
   result: flairConfigResult,
-  loading: discussionFlairsLoading,
-  error: discussionFlairsQueryError,
+  loading: scopedDiscussionFlairsLoading,
+  error: scopedDiscussionFlairsQueryError,
 } = useQuery(
   GET_CHANNEL_DISCUSSION_FLAIR_CONFIG,
   () => ({
@@ -85,13 +82,55 @@ const flairConfig = computed<ChannelDiscussionFlairConfig | null>(
   () => flairConfigResult.value?.getChannelDiscussionFlairConfig || null
 );
 
-const channelFlairSelections = computed(() => {
-  const flairIds =
-    formValues.value.selectedFlairIdsByChannel?.[channelId.value] || [];
-  return flairIds.length > 0
-    ? [{ channelUniqueName: channelId.value, flairIds }]
-    : [];
+const sitewideSelectedChannels = computed(() =>
+  channelId.value ? [] : formValues.value.selectedChannels
+);
+const {
+  configs: sitewideFlairConfigs,
+  loadingChannels: sitewideFlairsLoadingChannels,
+  errorsByChannel: sitewideFlairsErrorsByChannel,
+} = useChannelDiscussionFlairConfigs(sitewideSelectedChannels);
+
+const effectiveFlairConfigs = computed(() =>
+  channelId.value
+    ? flairConfig.value
+      ? [flairConfig.value]
+      : []
+    : sitewideFlairConfigs.value
+);
+
+const flairLoadingChannels = computed(() =>
+  channelId.value && scopedDiscussionFlairsLoading.value
+    ? [channelId.value]
+    : sitewideFlairsLoadingChannels.value
+);
+
+const flairErrorsByChannel = computed<Record<string, string>>(() => {
+  if (channelId.value && scopedDiscussionFlairsQueryError.value) {
+    return {
+      [channelId.value]: scopedDiscussionFlairsQueryError.value.message,
+    };
+  }
+  return sitewideFlairsErrorsByChannel.value;
 });
+
+const channelFlairSelections = computed(() => {
+  return formValues.value.selectedChannels.flatMap((channelUniqueName) => {
+    const flairIds =
+      formValues.value.selectedFlairIdsByChannel?.[channelUniqueName] || [];
+    return flairIds.length > 0 ? [{ channelUniqueName, flairIds }] : [];
+  });
+});
+
+const missingRequiredFlairConfig = computed(() =>
+  effectiveFlairConfigs.value.find(
+    (config) =>
+      config.flairRequired &&
+      (formValues.value.selectedFlairIdsByChannel?.[
+        config.channelUniqueName
+      ]?.length || 0) === 0
+  )
+);
 
 watch(
   () => crosspostDiscussionId.value,
@@ -322,26 +361,35 @@ function submit() {
     submitError.value = lockError.value;
     return;
   }
-  if (discussionFlairsLoading.value) {
+  if (flairLoadingChannels.value.length > 0) {
     submitError.value = 'Wait for the forum flair options to finish loading.';
     return;
   }
-  if (discussionFlairsQueryError.value) {
+  if (Object.keys(flairErrorsByChannel.value).length > 0) {
     submitError.value =
       'Unable to load the forum flair options. Please try again.';
     return;
   }
-  if (
-    flairConfig.value?.flairRequired &&
-    channelFlairSelections.value.length === 0
-  ) {
-    submitError.value = `Select at least one flair for ${channelId.value}.`;
+  if (missingRequiredFlairConfig.value) {
+    submitError.value = `Select at least one flair for ${missingRequiredFlairConfig.value.channelUniqueName}.`;
     return;
   }
   createDiscussion();
 }
 
 function updateFormValues(data: Partial<CreateEditDiscussionFormValues>) {
+
+  if (data.selectedChannels) {
+    const selectedChannels = new Set(data.selectedChannels);
+    data = {
+      ...data,
+      selectedFlairIdsByChannel: Object.fromEntries(
+        Object.entries(
+          formValues.value.selectedFlairIdsByChannel || {}
+        ).filter(([channel]) => selectedChannels.has(channel))
+      ),
+    };
+  }
 
   // Handle album updates specially to avoid overwriting the entire album object
   if (data.album) {
@@ -401,8 +449,15 @@ function updateFormValues(data: Partial<CreateEditDiscussionFormValues>) {
         :locked-channel-label="channelId || undefined"
         :discussion-flairs="flairConfig?.flairs || []"
         :discussion-flair-required="flairConfig?.flairRequired || false"
-        :discussion-flairs-loading="discussionFlairsLoading"
-        :discussion-flairs-error="discussionFlairsQueryError?.message"
+        :discussion-flairs-loading="scopedDiscussionFlairsLoading"
+        :discussion-flairs-error="scopedDiscussionFlairsQueryError?.message"
+        :discussion-flair-configs="sitewideFlairConfigs"
+        :discussion-flairs-loading-channels="
+          sitewideFlairsLoadingChannels
+        "
+        :discussion-flairs-errors-by-channel="
+          sitewideFlairsErrorsByChannel
+        "
         @submit="submit"
         @update-form-values="updateFormValues"
       />

--- a/components/discussion/form/CreateEditDiscussionFields.spec.ts
+++ b/components/discussion/form/CreateEditDiscussionFields.spec.ts
@@ -239,6 +239,56 @@ describe('CreateEditDiscussionFields Component', () => {
       });
     });
 
+    it('renders and updates a flair selector for each selected sitewide forum', async () => {
+      const wrapper = mount(CreateEditDiscussionFields, {
+        props: {
+          editMode: false,
+          downloadMode: false,
+          formValues: {
+            ...defaultFormValues,
+            title: 'A multi-forum question',
+            selectedChannels: ['cats', 'dogs'],
+            selectedFlairIdsByChannel: { cats: ['question'] },
+          },
+          discussionFlairConfigs: [
+            {
+              channelUniqueName: 'cats',
+              flairRequired: true,
+              flairs: [{ id: 'question', displayName: 'Question' }],
+            },
+            {
+              channelUniqueName: 'dogs',
+              flairRequired: false,
+              flairs: [{ id: 'guide', displayName: 'Guide' }],
+            },
+          ],
+        },
+        global: { stubs: mockComponents },
+      });
+      const pickers = wrapper.findAllComponents({
+        name: 'DiscussionFlairPicker',
+      });
+      pickers[1].vm.$emit('update:modelValue', ['guide']);
+      await nextTick();
+
+      expect({
+        channels: pickers.map((picker) => picker.props('channelUniqueName')),
+        selected: pickers.map((picker) => picker.props('modelValue')),
+        update: wrapper.emitted('updateFormValues')?.[0],
+      }).toEqual({
+        channels: ['cats', 'dogs'],
+        selected: [['question'], []],
+        update: [
+          {
+            selectedFlairIdsByChannel: {
+              cats: ['question'],
+              dogs: ['guide'],
+            },
+          },
+        ],
+      });
+    });
+
     it('validates that title is required', async () => {
       const wrapper = mountComponent({
         ...defaultFormValues,

--- a/components/discussion/form/CreateEditDiscussionFields.vue
+++ b/components/discussion/form/CreateEditDiscussionFields.vue
@@ -24,6 +24,7 @@ import type { Channel, Discussion } from '@/__generated__/graphql';
 import CrosspostedDiscussionEmbed from '@/components/discussion/detail/CrosspostedDiscussionEmbed.vue';
 import DiscussionFlairPicker from '@/components/discussion/form/DiscussionFlairPicker.vue';
 import type { DiscussionFlairOption } from '@/components/discussion/form/DiscussionFlairPicker.vue';
+import type { ChannelDiscussionFlairConfig } from '@/composables/useChannelDiscussionFlairConfigs';
 
 const props = defineProps<{
   editMode: boolean;
@@ -51,6 +52,9 @@ const props = defineProps<{
   discussionFlairRequired?: boolean;
   discussionFlairsLoading?: boolean;
   discussionFlairsError?: string;
+  discussionFlairConfigs?: ChannelDiscussionFlairConfig[];
+  discussionFlairsLoadingChannels?: string[];
+  discussionFlairsErrorsByChannel?: Record<string, string>;
 }>();
 
 defineEmits(['submit', 'updateFormValues', 'cancel']);
@@ -72,35 +76,79 @@ const formTitle = computed(() => {
 const touched = ref(false);
 const titleInputRef = ref<HTMLElement | null>(null);
 
+const effectiveFlairConfigs = computed<ChannelDiscussionFlairConfig[]>(() => {
+  if (props.lockedChannelName) {
+    return [
+      {
+        channelUniqueName: props.lockedChannelName,
+        flairRequired: props.discussionFlairRequired || false,
+        flairs: props.discussionFlairs || [],
+      },
+    ];
+  }
+  return props.discussionFlairConfigs || [];
+});
+
+const flairConfigsByChannel = computed(() =>
+  Object.fromEntries(
+    effectiveFlairConfigs.value.map((config) => [
+      config.channelUniqueName,
+      config,
+    ])
+  )
+);
+
+const flairLoadingChannels = computed(() =>
+  props.lockedChannelName && props.discussionFlairsLoading
+    ? [props.lockedChannelName]
+    : props.discussionFlairsLoadingChannels || []
+);
+
+const flairErrorsByChannel = computed<Record<string, string>>(() => {
+  if (props.lockedChannelName && props.discussionFlairsError) {
+    return { [props.lockedChannelName]: props.discussionFlairsError };
+  }
+  return props.discussionFlairsErrorsByChannel || {};
+});
+
+const missingRequiredFlairConfig = computed(() =>
+  effectiveFlairConfigs.value.find(
+    (config) =>
+      config.flairRequired &&
+      (props.formValues?.selectedFlairIdsByChannel?.[
+        config.channelUniqueName
+      ]?.length || 0) === 0
+  )
+);
+
 const discussionFormValidationInput = computed(() => ({
   selectedChannelsCount: props.formValues?.selectedChannels?.length || 0,
   title: props.formValues?.title || '',
   body: props.formValues?.body || '',
-  flairSelectionPending: props.discussionFlairsLoading,
-  flairSelectionUnavailable: Boolean(props.discussionFlairsError),
-  missingRequiredFlair:
-    props.discussionFlairRequired === true &&
-    (props.formValues?.selectedFlairIdsByChannel?.[
-      props.lockedChannelName || ''
-    ]?.length || 0) === 0,
-  requiredFlairChannelName: props.lockedChannelLabel || props.lockedChannelName,
+  flairSelectionPending: flairLoadingChannels.value.length > 0,
+  flairSelectionUnavailable:
+    Object.keys(flairErrorsByChannel.value).length > 0,
+  missingRequiredFlair: Boolean(missingRequiredFlairConfig.value),
+  requiredFlairChannelName:
+    missingRequiredFlairConfig.value?.channelUniqueName,
 }));
 
-const selectedFlairIds = computed(
-  () =>
-    props.formValues?.selectedFlairIdsByChannel?.[
-      props.lockedChannelName || ''
-    ] || []
+const flairPickerChannels = computed(() =>
+  (props.formValues?.selectedChannels || []).filter((channel) => {
+    const config = flairConfigsByChannel.value[channel];
+    return (
+      flairLoadingChannels.value.includes(channel) ||
+      Boolean(flairErrorsByChannel.value[channel]) ||
+      config?.flairRequired ||
+      (config?.flairs.length || 0) > 0
+    );
+  })
 );
 
-const showDiscussionFlairs = computed(
-  () =>
-    Boolean(props.lockedChannelName) &&
-    (props.discussionFlairsLoading ||
-      props.discussionFlairsError ||
-      props.discussionFlairRequired ||
-      (props.discussionFlairs?.length || 0) > 0)
-);
+const flairChannelLabel = (channel: string) =>
+  channel === props.lockedChannelName
+    ? props.lockedChannelLabel || channel
+    : channel;
 
 const needsChanges = computed(() =>
   discussionFormNeedsChanges(discussionFormValidationInput.value)
@@ -340,22 +388,27 @@ onMounted(() => {
             </FormRow>
 
             <FormRow
-              v-if="showDiscussionFlairs"
-              :required="discussionFlairRequired"
+              v-for="flairChannel in flairPickerChannels"
+              :key="flairChannel"
+              :required="flairConfigsByChannel[flairChannel]?.flairRequired"
             >
               <template #content>
                 <DiscussionFlairPicker
-                  :channel-unique-name="lockedChannelLabel || lockedChannelName || ''"
-                  :flairs="discussionFlairs || []"
-                  :model-value="selectedFlairIds"
-                  :required="discussionFlairRequired"
-                  :loading="discussionFlairsLoading"
-                  :error-message="discussionFlairsError"
+                  :channel-unique-name="flairChannelLabel(flairChannel)"
+                  :flairs="flairConfigsByChannel[flairChannel]?.flairs || []"
+                  :model-value="
+                    formValues.selectedFlairIdsByChannel?.[flairChannel] || []
+                  "
+                  :required="
+                    flairConfigsByChannel[flairChannel]?.flairRequired
+                  "
+                  :loading="flairLoadingChannels.includes(flairChannel)"
+                  :error-message="flairErrorsByChannel[flairChannel]"
                   @update:model-value="
                     $emit('updateFormValues', {
                       selectedFlairIdsByChannel: {
                         ...(formValues.selectedFlairIdsByChannel || {}),
-                        [lockedChannelName || '']: $event,
+                        [flairChannel]: $event,
                       },
                     })
                   "

--- a/composables/useChannelDiscussionFlairConfigs.spec.ts
+++ b/composables/useChannelDiscussionFlairConfigs.spec.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { ref } from 'vue';
+import { useChannelDiscussionFlairConfigs } from './useChannelDiscussionFlairConfigs';
+
+const query = vi.hoisted(() => vi.fn());
+
+vi.mock('@vue/apollo-composable', () => ({
+  useApolloClient: () => ({ resolveClient: () => ({ query }) }),
+}));
+
+const responseFor = (channelUniqueName: string, flairRequired = false) => ({
+  data: {
+    getChannelDiscussionFlairConfig: {
+      channelUniqueName,
+      flairRequired,
+      flairs: [
+        {
+          id: `${channelUniqueName}-flair`,
+          displayName: `${channelUniqueName} flair`,
+          color: null,
+        },
+      ],
+    },
+  },
+});
+
+describe('useChannelDiscussionFlairConfigs', () => {
+  beforeEach(() => {
+    query.mockReset();
+    query.mockImplementation(({ variables }) =>
+      Promise.resolve(responseFor(variables.channelUniqueName))
+    );
+  });
+
+  it('loads every selected channel and preserves selection order', async () => {
+    const channels = ref(['cats', 'dogs']);
+    const state = useChannelDiscussionFlairConfigs(channels);
+    await flushPromises();
+
+    expect({
+      requested: query.mock.calls.map((call) => call[0].variables),
+      configs: state.configs.value.map((config) => config.channelUniqueName),
+    }).toEqual({
+      requested: [
+        { channelUniqueName: 'cats', includeArchived: false },
+        { channelUniqueName: 'dogs', includeArchived: false },
+      ],
+      configs: ['cats', 'dogs'],
+    });
+  });
+
+  it('removes configuration state when a channel is deselected', async () => {
+    const channels = ref(['cats', 'dogs']);
+    const state = useChannelDiscussionFlairConfigs(channels);
+    await flushPromises();
+    channels.value = ['dogs'];
+    await flushPromises();
+
+    expect(Object.keys(state.configsByChannel.value)).toEqual(['dogs']);
+  });
+
+  it('exposes a channel-specific load error', async () => {
+    query.mockRejectedValueOnce(new Error('Network unavailable'));
+    const state = useChannelDiscussionFlairConfigs(ref(['cats']));
+    await flushPromises();
+
+    expect({
+      errors: state.errorsByChannel.value,
+      loading: state.loadingChannels.value,
+    }).toEqual({ errors: { cats: 'Network unavailable' }, loading: [] });
+  });
+
+  it('stays loading when a channel is reselected during its request', async () => {
+    let resolveRequest: (value: ReturnType<typeof responseFor>) => void =
+      () => {};
+    query.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      })
+    );
+    const channels = ref(['cats']);
+    const state = useChannelDiscussionFlairConfigs(channels);
+    channels.value = [];
+    await flushPromises();
+    channels.value = ['cats'];
+    await flushPromises();
+    const loadingWhileReselected = state.loadingChannels.value;
+    resolveRequest(responseFor('cats'));
+    await flushPromises();
+
+    expect({
+      loadingWhileReselected,
+      loadedConfig: state.configs.value[0]?.channelUniqueName,
+    }).toEqual({ loadingWhileReselected: ['cats'], loadedConfig: 'cats' });
+  });
+});

--- a/composables/useChannelDiscussionFlairConfigs.ts
+++ b/composables/useChannelDiscussionFlairConfigs.ts
@@ -1,0 +1,115 @@
+import { computed, ref, watch, type Ref } from 'vue';
+import { useApolloClient } from '@vue/apollo-composable';
+import { GET_CHANNEL_DISCUSSION_FLAIR_CONFIG } from '@/graphQLData/channel/queries';
+import type { DiscussionFlairOption } from '@/components/discussion/form/DiscussionFlairPicker.vue';
+
+export type ChannelDiscussionFlairConfig = {
+  channelUniqueName: string;
+  flairRequired: boolean;
+  flairs: DiscussionFlairOption[];
+};
+
+type FlairConfigQueryResult = {
+  getChannelDiscussionFlairConfig?: ChannelDiscussionFlairConfig;
+};
+
+export const useChannelDiscussionFlairConfigs = (
+  channelNames: Ref<string[]>
+) => {
+  const { resolveClient } = useApolloClient();
+  const configsByChannel = ref<Record<string, ChannelDiscussionFlairConfig>>(
+    {}
+  );
+  const errorsByChannel = ref<Record<string, string>>({});
+  const loadingChannelSet = ref(new Set<string>());
+  const requestedChannels = new Set<string>();
+
+  const loadConfig = async (channelUniqueName: string) => {
+    requestedChannels.add(channelUniqueName);
+    loadingChannelSet.value = new Set([
+      ...loadingChannelSet.value,
+      channelUniqueName,
+    ]);
+    try {
+      const response = await resolveClient().query<FlairConfigQueryResult>({
+        query: GET_CHANNEL_DISCUSSION_FLAIR_CONFIG,
+        variables: { channelUniqueName, includeArchived: false },
+        fetchPolicy: 'cache-first',
+      });
+      const config = response.data?.getChannelDiscussionFlairConfig;
+      if (!config) {
+        throw new Error('The forum did not return a flair configuration.');
+      }
+      if (channelNames.value.includes(channelUniqueName)) {
+        configsByChannel.value = {
+          ...configsByChannel.value,
+          [channelUniqueName]: config,
+        };
+        errorsByChannel.value = Object.fromEntries(
+          Object.entries(errorsByChannel.value).filter(
+            ([channel]) => channel !== channelUniqueName
+          )
+        );
+      }
+    } catch (error: unknown) {
+      if (channelNames.value.includes(channelUniqueName)) {
+        errorsByChannel.value = {
+          ...errorsByChannel.value,
+          [channelUniqueName]:
+            error instanceof Error ? error.message : String(error),
+        };
+      }
+    } finally {
+      requestedChannels.delete(channelUniqueName);
+      const nextLoading = new Set(loadingChannelSet.value);
+      nextLoading.delete(channelUniqueName);
+      loadingChannelSet.value = nextLoading;
+    }
+  };
+
+  watch(
+    channelNames,
+    (nextChannels) => {
+      const selected = new Set(nextChannels);
+      configsByChannel.value = Object.fromEntries(
+        Object.entries(configsByChannel.value).filter(([channel]) =>
+          selected.has(channel)
+        )
+      );
+      errorsByChannel.value = Object.fromEntries(
+        Object.entries(errorsByChannel.value).filter(([channel]) =>
+          selected.has(channel)
+        )
+      );
+      loadingChannelSet.value = new Set(
+        [...loadingChannelSet.value].filter((channel) => selected.has(channel))
+      );
+
+      for (const channel of nextChannels) {
+        if (requestedChannels.has(channel)) {
+          loadingChannelSet.value = new Set([
+            ...loadingChannelSet.value,
+            channel,
+          ]);
+          continue;
+        }
+        if (
+          !configsByChannel.value[channel] &&
+          !errorsByChannel.value[channel]
+        ) {
+          void loadConfig(channel);
+        }
+      }
+    },
+    { immediate: true }
+  );
+
+  const configs = computed(() =>
+    channelNames.value
+      .map((channel) => configsByChannel.value[channel])
+      .filter((config): config is ChannelDiscussionFlairConfig => Boolean(config))
+  );
+  const loadingChannels = computed(() => [...loadingChannelSet.value]);
+
+  return { configs, configsByChannel, loadingChannels, errorsByChannel };
+};

--- a/tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts
+++ b/tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts
@@ -148,3 +148,79 @@ test('requires and submits a flair in the channel-scoped form', async ({
     { channelUniqueName: TEST_CHANNEL, flairIds: ['question'] },
   ]);
 });
+
+test('requires flair selections independently in the sitewide form', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createDiscussionState();
+  const flairByChannel = {
+    cats: { id: 'cat-question', displayName: 'Cat question', required: true },
+    dogs: { id: 'dog-topic', displayName: 'Dog topic', required: true },
+    birds: { id: 'bird-note', displayName: 'Bird note', required: false },
+  };
+  await setupMockedPage({
+    handlers: {
+      ...createDiscussionHandlers(state, {
+        channelId: TEST_CHANNEL,
+        username: 'cluse',
+      }),
+      getChannelNames: () => ({
+        data: {
+          channels: Object.keys(flairByChannel).map((uniqueName) => ({
+            uniqueName,
+            displayName: uniqueName,
+            channelIconURL: '',
+            description: '',
+          })),
+        },
+      }),
+      getChannelDiscussionFlairConfig: ({ body }) => {
+        const channelUniqueName = String(body.variables?.channelUniqueName);
+        const flair =
+          flairByChannel[channelUniqueName as keyof typeof flairByChannel];
+        return {
+          data: {
+            getChannelDiscussionFlairConfig: {
+              channelUniqueName,
+              flairRequired: flair.required,
+              flairs: [
+                {
+                  id: flair.id,
+                  channelUniqueName,
+                  displayName: flair.displayName,
+                  color: '#2563EB',
+                  order: 0,
+                  archived: false,
+                },
+              ],
+            },
+          },
+        };
+      },
+    },
+  });
+
+  await page.goto('/discussions/create');
+  await page.getByTestId('title-input').fill(TEST_DISCUSSION);
+  const channelPicker = page.getByTestId('channel-input');
+  await channelPicker.click();
+  await page.getByText('cats', { exact: true }).click();
+  await page.getByText('dogs', { exact: true }).click();
+  await page.getByText('birds', { exact: true }).click();
+  await page.getByTestId('title-input').click();
+
+  const saveButton = page.getByRole('button', { name: 'Save' }).first();
+  await expect(saveButton).toBeDisabled();
+  await page.getByRole('button', { name: 'Select Cat question flair' }).click();
+  await expect(saveButton).toBeDisabled();
+  await page.getByRole('button', { name: 'Select Dog topic flair' }).click();
+  await expect(saveButton).toBeEnabled();
+  await saveButton.click();
+
+  await expect(page).toHaveURL('/forums/cats/discussions/discussion-1');
+  expect(state.lastChannelFlairSelections).toEqual([
+    { channelUniqueName: 'cats', flairIds: ['cat-question'] },
+    { channelUniqueName: 'dogs', flairIds: ['dog-topic'] },
+  ]);
+});


### PR DESCRIPTION
## Summary
- load active flair configuration for every forum selected in the sitewide discussion form
- render and validate independent per-forum flair selectors, preserving selections while forums remain selected
- submit channel-specific flair mappings and omit optional forums without selections

## Test plan
- `pnpm run tsc`
- `pnpm exec eslint composables/useChannelDiscussionFlairConfigs.ts composables/useChannelDiscussionFlairConfigs.spec.ts components/discussion/form/CreateDiscussion.vue components/discussion/form/CreateDiscussion.spec.ts components/discussion/form/CreateEditDiscussionFields.vue components/discussion/form/CreateEditDiscussionFields.spec.ts tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts`
- `pnpm run test:unit:run` (779 files, 7,072 tests)
- `pnpm exec playwright test tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts` (new channel-scoped and sitewide flair cases passed; existing case had a transient Nuxt module fetch failure)
- `pnpm exec playwright test tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts -g "creates, edits and deletes a discussion"` (rerun passed)

## Dependency
- Stacked on #432; change the base to `main` after Phase 4 merges.