### PR TITLE
feat: display and edit discussion flairs

### DIFF
--- a/components/discussion/DiscussionFlairBadges.spec.ts
+++ b/components/discussion/DiscussionFlairBadges.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import DiscussionFlairBadges from './DiscussionFlairBadges.vue';
+
+const flairs = [
+  {
+    id: 'help',
+    channelUniqueName: 'cats',
+    displayName: 'Help',
+    color: '#112233',
+    order: 1,
+    archived: true,
+  },
+  {
+    id: 'question',
+    channelUniqueName: 'cats',
+    displayName: 'Question',
+    color: null,
+    order: 0,
+    archived: false,
+  },
+];
+
+describe('DiscussionFlairBadges', () => {
+  it('renders flairs in configured order', () => {
+    const wrapper = mount(DiscussionFlairBadges, { props: { flairs } });
+    expect(
+      wrapper.findAll('[data-testid="discussion-flair"]').map((item) => item.text())
+    ).toEqual(['Question', 'Help']);
+  });
+
+  it('keeps archived historical flairs visible and marks them', () => {
+    const wrapper = mount(DiscussionFlairBadges, { props: { flairs } });
+    expect(wrapper.get('[title="Archived flair"]').text()).toBe('Help');
+  });
+
+  it('can identify the owning forum in sitewide contexts', () => {
+    const wrapper = mount(DiscussionFlairBadges, {
+      props: { flairs, channelName: 'cats', showChannelName: true },
+    });
+    expect(wrapper.text()).toContain('cats: Question');
+    expect(wrapper.get('ul').attributes('aria-label')).toBe(
+      'Post flairs for cats'
+    );
+  });
+
+  it('uses a color dot without making arbitrary flair colors the text background', () => {
+    const wrapper = mount(DiscussionFlairBadges, { props: { flairs } });
+    expect(wrapper.get('[style]').attributes('style')).toContain(
+      'background-color: #112233'
+    );
+  });
+});

--- a/components/discussion/DiscussionFlairBadges.vue
+++ b/components/discussion/DiscussionFlairBadges.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { DiscussionFlairData } from '@/types/Discussion';
+
+const props = withDefaults(
+  defineProps<{
+    flairs: DiscussionFlairData[];
+    channelName?: string;
+    showChannelName?: boolean;
+  }>(),
+  {
+    channelName: '',
+    showChannelName: false,
+  }
+);
+
+const orderedFlairs = computed(() =>
+  [...props.flairs].sort(
+    (left, right) =>
+      left.order - right.order || left.displayName.localeCompare(right.displayName)
+  )
+);
+</script>
+
+<template>
+  <ul
+    v-if="orderedFlairs.length"
+    class="flex flex-wrap gap-1.5"
+    :aria-label="
+      channelName ? `Post flairs for ${channelName}` : 'Post flairs'
+    "
+  >
+    <li
+      v-for="flair in orderedFlairs"
+      :key="flair.id"
+      data-testid="discussion-flair"
+      class="inline-flex items-center gap-1.5 rounded-full border border-gray-300 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+      :title="flair.archived ? 'Archived flair' : undefined"
+    >
+      <span
+        v-if="flair.color"
+        aria-hidden="true"
+        class="h-2.5 w-2.5 shrink-0 rounded-full border border-black/10"
+        :style="{ backgroundColor: flair.color }"
+      />
+      <span>{{
+        showChannelName && channelName
+          ? `${channelName}: ${flair.displayName}`
+          : flair.displayName
+      }}</span>
+    </li>
+  </ul>
+</template>

--- a/components/discussion/detail/DiscussionDetailContent.spec.ts
+++ b/components/discussion/detail/DiscussionDetailContent.spec.ts
@@ -235,6 +235,28 @@ describe('DiscussionDetailContent', () => {
     expect(wrapper.find('.discussion-header-stub').exists()).toBe(true);
   });
 
+  it('renders the flairs assigned in the active forum', () => {
+    const discussion = makeDiscussion();
+    Object.assign(discussion.DiscussionChannels[0], {
+      Flairs: [
+        {
+          id: 'question',
+          channelUniqueName: 'cats',
+          displayName: 'Question',
+          color: null,
+          order: 0,
+          archived: false,
+        },
+      ],
+    });
+    const { wrapper } = setup({
+      discussions: [discussion],
+    });
+    expect(wrapper.get('[data-testid="discussion-flair"]').text()).toBe(
+      'Question'
+    );
+  });
+
   it('does not show page-not-found for a loaded discussion', () => {
     const { wrapper } = setup();
     expect(wrapper.find('.page-not-found-stub').exists()).toBe(false);

--- a/components/discussion/detail/DiscussionDetailContent.vue
+++ b/components/discussion/detail/DiscussionDetailContent.vue
@@ -25,7 +25,9 @@ import InfoBanner from '@/components/InfoBanner.vue';
 import DiscussionHeader from '@/components/discussion/detail/DiscussionHeader.vue';
 import DiscussionCommentsWrapper from '@/components/discussion/detail/DiscussionCommentsWrapper.vue';
 import DiscussionChannelLinks from '@/components/discussion/detail/DiscussionChannelLinks.vue';
+import DiscussionFlairBadges from '@/components/discussion/DiscussionFlairBadges.vue';
 import PageNotFound from '@/components/PageNotFound.vue';
+import type { DiscussionChannelWithFlairs } from '@/types/Discussion';
 import { getSortFromQuery } from '@/utils/getSortFromQuery';
 import { useRoute } from 'nuxt/app';
 import ArchivedDiscussionInfoBanner from './ArchivedDiscussionInfoBanner.vue';
@@ -605,6 +607,14 @@ const handleEditAlbum = () => {
                 @handle-click-add-album="handleClickAddAlbum"
                 @handle-click-edit-body="handleClickEditDiscussionBody"
                 @handle-click-give-feedback="handleClickGiveFeedback"
+              />
+              <DiscussionFlairBadges
+                v-if="formDiscussionChannel"
+                :flairs="
+                  (formDiscussionChannel as DiscussionChannelWithFlairs)
+                    .Flairs || []
+                "
+                :channel-name="formDiscussionChannel.channelUniqueName"
               />
               <div class="w-full">
                 <DiscussionBodyEditForm

--- a/components/discussion/list/ChannelDiscussionListItem.spec.ts
+++ b/components/discussion/list/ChannelDiscussionListItem.spec.ts
@@ -37,7 +37,10 @@ vi.mock('@/composables/useAuthState', () =>
   createAuthStateMock({ username: 'alice' })
 );
 
-const mountItem = (title: string) => {
+const mountItem = (
+  title: string,
+  flairs: Array<Record<string, unknown>> = []
+) => {
   asMock(useQuery).mockReturnValue(createQueryMock({ users: [] }));
   const discussion = makeDiscussion({
     title,
@@ -48,6 +51,7 @@ const mountItem = (title: string) => {
     channelUniqueName: 'cats',
     Discussion: discussion,
     CommentsAggregate: { count: 0 },
+    Flairs: flairs,
   } as unknown as DiscussionChannel;
 
   return mountWithDefaults(ChannelDiscussionListItem, {
@@ -74,5 +78,21 @@ describe('ChannelDiscussionListItem', () => {
 
   it('reflects an overridden title', () => {
     expect(mountItem('Another One').text()).toContain('Another One');
+  });
+
+  it('renders the flairs assigned in this forum', () => {
+    const wrapper = mountItem('Flair post', [
+      {
+        id: 'question',
+        channelUniqueName: 'cats',
+        displayName: 'Question',
+        color: '#112233',
+        order: 0,
+        archived: false,
+      },
+    ]);
+    expect(wrapper.get('[data-testid="discussion-flair"]').text()).toBe(
+      'Question'
+    );
   });
 });

--- a/components/discussion/list/ChannelDiscussionListItem.vue
+++ b/components/discussion/list/ChannelDiscussionListItem.vue
@@ -16,7 +16,11 @@ import type {
   DiscussionChannel,
   Tag,
 } from '@/__generated__/graphql';
-import type { DiscussionChannelWithFavorited } from '@/types/Discussion';
+import type {
+  DiscussionChannelWithFavorited,
+  DiscussionChannelWithFlairs,
+} from '@/types/Discussion';
+import DiscussionFlairBadges from '@/components/discussion/DiscussionFlairBadges.vue';
 import CheckCircleIcon from '@/components/icons/CheckCircleIcon.vue';
 import CommentIcon from '@/components/icons/CommentIcon.vue';
 import ExpandIcon from '@/components/icons/ExpandIcon.vue';
@@ -168,6 +172,10 @@ const relativeTimeAgo = computed(() =>
 );
 const tags = computed(
   () => props.discussion?.Tags?.map((tag: Tag) => tag.text) || []
+);
+const flairs = computed(
+  () =>
+    (props.discussionChannel as DiscussionChannelWithFlairs).Flairs || []
 );
 
 const filteredQuery = computed(() => {
@@ -453,6 +461,11 @@ const revealSensitiveContent = () => {
                 @click="$emit('filterByTag', tag)"
               />
             </div>
+            <DiscussionFlairBadges
+              class="my-1"
+              :flairs="flairs"
+              :channel-name="discussionChannel.channelUniqueName"
+            />
             <div class="flex items-center gap-2 dark:text-white">
               <DiscussionVotes
                 v-if="discussionChannel"

--- a/components/discussion/list/SitewideDiscussionListItem.spec.ts
+++ b/components/discussion/list/SitewideDiscussionListItem.spec.ts
@@ -45,12 +45,14 @@ const discussion = (overrides: DeepPartial<Discussion> = {}): Discussion =>
 
 const channel = (
   uniqueName: string,
-  channelIconURL = ''
+  channelIconURL = '',
+  flairs: Array<Record<string, unknown>> = []
 ): Partial<DiscussionChannel> => ({
   channelUniqueName: uniqueName,
   Channel: { uniqueName, displayName: uniqueName, channelIconURL },
   CommentsAggregate: { count: 0 },
-});
+  Flairs: flairs,
+}) as Partial<DiscussionChannel>;
 
 const album = (
   images: { id: string; url: string }[],
@@ -73,6 +75,28 @@ describe('SitewideDiscussionListItem', () => {
   it('reflects an overridden title', () => {
     const wrapper = mountItem(discussion({ title: 'Another One' }));
     expect(wrapper.text()).toContain('Another One');
+  });
+
+  it('identifies each assigned flair by its forum', () => {
+    const flair = (id: string, channelUniqueName: string, displayName: string) => ({
+      id,
+      channelUniqueName,
+      displayName,
+      color: null,
+      order: 0,
+      archived: false,
+    });
+    const wrapper = mountItem(
+      discussion({
+        DiscussionChannels: [
+          channel('cats', '', [flair('question', 'cats', 'Question')]),
+          channel('dogs', '', [flair('showcase', 'dogs', 'Showcase')]),
+        ],
+      })
+    );
+    expect(
+      wrapper.findAll('[data-testid="discussion-flair"]').map((item) => item.text())
+    ).toEqual(['cats: Question', 'dogs: Showcase']);
   });
 });
 

--- a/components/discussion/list/SitewideDiscussionListItem.vue
+++ b/components/discussion/list/SitewideDiscussionListItem.vue
@@ -6,7 +6,11 @@ import type {
   Discussion,
   DiscussionChannel,
 } from '@/__generated__/graphql';
-import type { DiscussionWithFavorited } from '@/types/Discussion';
+import type {
+  DiscussionChannelWithFlairs,
+  DiscussionWithFavorited,
+} from '@/types/Discussion';
+import DiscussionFlairBadges from '@/components/discussion/DiscussionFlairBadges.vue';
 import { safeArrayFirst } from '@/utils/ssrSafetyUtils';
 import ChannelIconStack from '@/components/channel/ChannelIconStack.vue';
 import HighlightedSearchTerms from '@/components/HighlightedSearchTerms.vue';
@@ -183,6 +187,15 @@ const isSelected = computed(() => {
   return discussionIdInParams.value === discussionId.value;
 });
 const title = computed(() => props.discussion?.title || '[Deleted]');
+const flairGroups = computed(() =>
+  (props.discussion?.DiscussionChannels || [])
+    .map((discussionChannel) => ({
+      channelName: discussionChannel.channelUniqueName,
+      flairs:
+        (discussionChannel as DiscussionChannelWithFlairs).Flairs || [],
+    }))
+    .filter((group) => group.flairs.length > 0)
+);
 const authorUsername = computed(
   () => props.discussion?.Author?.username || 'Deleted'
 );
@@ -495,6 +508,15 @@ const revealSensitiveContent = () => {
               </div>
             </div>
           </template>
+        </div>
+        <div v-if="flairGroups.length" class="mt-1 flex flex-wrap gap-1.5">
+          <DiscussionFlairBadges
+            v-for="group in flairGroups"
+            :key="group.channelName"
+            :flairs="group.flairs"
+            :channel-name="group.channelName"
+            :show-channel-name="true"
+          />
         </div>
     </div>
   </li>

--- a/graphQLData/discussion/mutations.js
+++ b/graphQLData/discussion/mutations.js
@@ -314,12 +314,14 @@ export const UPDATE_DISCUSSION_WITH_CHANNEL_CONNECTIONS = gql`
     $where: DiscussionWhere!
     $channelConnections: [String!]
     $channelDisconnections: [String!]
+    $channelFlairSelections: [DiscussionChannelFlairSelectionInput!]
   ) {
     updateDiscussionWithChannelConnections(
       discussionUpdateInput: $updateDiscussionInput
       where: $where
       channelConnections: $channelConnections
       channelDisconnections: $channelDisconnections
+      channelFlairSelections: $channelFlairSelections
     ) {
       id
       title
@@ -328,6 +330,14 @@ export const UPDATE_DISCUSSION_WITH_CHANNEL_CONNECTIONS = gql`
         id
         channelUniqueName
         discussionId
+        Flairs {
+          id
+          channelUniqueName
+          displayName
+          color
+          order
+          archived
+        }
         Channel {
           uniqueName
         }

--- a/graphQLData/discussion/queries.js
+++ b/graphQLData/discussion/queries.js
@@ -1,6 +1,17 @@
 import { gql } from '@apollo/client/core';
 import { AUTHOR_FIELDS } from '../fragments';
 
+const DISCUSSION_FLAIR_FIELDS = gql`
+  fragment DiscussionFlairFields on DiscussionFlair {
+    id
+    channelUniqueName
+    displayName
+    color
+    order
+    archived
+  }
+`;
+
 // Re-exported for backward compatibility; the canonical definition now lives in
 // graphQLData/fragments.js.
 export { AUTHOR_FIELDS };
@@ -85,6 +96,9 @@ export const GET_DISCUSSIONS_WITH_DISCUSSION_CHANNEL_DATA = gql`
         discussionId
         channelUniqueName
         isFavorited
+        Flairs {
+          ...DiscussionFlairFields
+        }
         CommentsAggregate {
           count
         }
@@ -144,6 +158,7 @@ export const GET_DISCUSSIONS_WITH_DISCUSSION_CHANNEL_DATA = gql`
       }
     }
   }
+  ${DISCUSSION_FLAIR_FIELDS}
 `;
 
 // For site wide list view
@@ -187,6 +202,9 @@ export const GET_SITE_WIDE_DISCUSSION_LIST = gql`
           archived
           answered
           locked
+          Flairs {
+            ...DiscussionFlairFields
+          }
           UpvotedByUsers {
             username
           }
@@ -225,6 +243,7 @@ export const GET_SITE_WIDE_DISCUSSION_LIST = gql`
     }
   }
   ${AUTHOR_FIELDS}
+  ${DISCUSSION_FLAIR_FIELDS}
 `;
 
 export const IS_DISCUSSION_ANSWERED = gql`
@@ -294,6 +313,9 @@ export const GET_DISCUSSION = gql`
         archived
         answered
         locked
+        Flairs {
+          ...DiscussionFlairFields
+        }
         UpvotedByUsers {
           username
         }
@@ -424,6 +446,7 @@ export const GET_DISCUSSION = gql`
       }
     }
   }
+  ${DISCUSSION_FLAIR_FIELDS}
 `;
 
 export const GET_CROSSPOST_PREVIEW = gql`

--- a/pages/forums/[forumId]/discussions/edit/[discussionId].spec.ts
+++ b/pages/forums/[forumId]/discussions/edit/[discussionId].spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { shallowMount } from '@vue/test-utils';
+import { flushPromises, shallowMount } from '@vue/test-utils';
 import { defineComponent, h, nextTick, ref } from 'vue';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 import CreateEditDiscussionFields from '@/components/discussion/form/CreateEditDiscussionFields.vue';
@@ -12,6 +12,11 @@ const hState = vi.hoisted(() => ({
   mutate: vi.fn(),
   queryResult: null as unknown as { value: unknown },
   mutationOptions: null as null | (() => { variables: unknown }),
+  flairConfigs: {} as Record<
+    string,
+    { flairRequired: boolean; flairs: Array<Record<string, unknown>> }
+  >,
+  flairQuery: vi.fn(),
 }));
 
 vi.mock('nuxt/app', () => ({
@@ -23,36 +28,13 @@ vi.mock('nuxt/app', () => ({
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
   useMutation: vi.fn(),
+  useApolloClient: () => ({
+    resolveClient: () => ({ query: hState.flairQuery }),
+  }),
 }));
 
 vi.mock('@/composables/useAuthState', () => ({
   useModProfileName: () => ref('mod-1'),
-}));
-
-vi.mock('@/utils/discussionEditForm', () => ({
-  buildDiscussionEditFormValues: (discussion: {
-    title: string;
-    body?: string;
-    DiscussionChannels?: Array<{ Channel?: { uniqueName?: string } }>;
-    Tags?: Array<{ text: string }>;
-    Album?: { Images: unknown[]; imageOrder: string[] };
-    Author?: { username?: string };
-    CrosspostedDiscussion?: { id?: string } | null;
-  }) => ({
-    title: discussion.title,
-    body: discussion.body || '',
-    selectedTags: discussion.Tags?.map((tag) => tag.text) || [],
-    selectedChannels:
-      discussion.DiscussionChannels?.map(
-        (dc) => dc.Channel?.uniqueName || ''
-      ) || [],
-    author: discussion.Author?.username || '',
-    album: {
-      images: [],
-      imageOrder: [],
-    },
-    crosspostId: discussion.CrosspostedDiscussion?.id || null,
-  }),
 }));
 
 const RequireAuthStub = defineComponent({
@@ -69,7 +51,14 @@ const ClientOnlyStub = defineComponent({
 });
 
 const DiscussionFieldsStub = defineComponent({
-  props: ['formValues', 'editMode'],
+  props: [
+    'formValues',
+    'editMode',
+    'submitError',
+    'discussionFlairConfigs',
+    'discussionFlairsLoadingChannels',
+    'discussionFlairsErrorsByChannel',
+  ],
   emits: ['submit', 'update-form-values', 'cancel'],
   setup(_props, { emit }) {
     return () =>
@@ -109,6 +98,23 @@ beforeEach(() => {
   hState.mutationOptions = null;
   hState.onResultCb = null as unknown as (value: unknown) => void;
   hState.onDoneCb = null as unknown as () => void;
+  hState.flairConfigs = {};
+  hState.flairQuery.mockReset().mockImplementation(
+    ({ variables }: { variables: { channelUniqueName: string } }) => {
+      const config = hState.flairConfigs[variables.channelUniqueName] || {
+        flairRequired: false,
+        flairs: [],
+      };
+      return Promise.resolve({
+        data: {
+          getChannelDiscussionFlairConfig: {
+            channelUniqueName: variables.channelUniqueName,
+            ...config,
+          },
+        },
+      });
+    }
+  );
   mockedUseQuery.mockReturnValue({
     result: hState.queryResult,
     onResult: (cb: (value: unknown) => void) => {
@@ -207,6 +213,7 @@ describe('discussion edit page', () => {
       .vm.$emit('update-form-values', {
         selectedChannels: ['science'],
       });
+    await flushPromises();
     await wrapper.findComponent(CreateEditDiscussionFields).vm.$emit('submit');
 
     expect(hState.mutate).toHaveBeenCalled();
@@ -332,7 +339,161 @@ describe('discussion edit page', () => {
       },
       channelConnections: ['cats'],
       channelDisconnections: ['dogs'],
+      channelFlairSelections: [],
     });
+  });
+
+  it('submits the existing active selection for a required forum', async () => {
+    hState.flairConfigs.cats = {
+      flairRequired: true,
+      flairs: [
+        {
+          id: 'question',
+          displayName: 'Question',
+          color: null,
+          order: 0,
+          archived: false,
+        },
+      ],
+    };
+    const wrapper = await mountPage();
+    hState.onResultCb({
+      loading: false,
+      data: {
+        discussions: [
+          {
+            id: 'd1',
+            title: 'Hello',
+            body: '',
+            Tags: [],
+            DiscussionChannels: [
+              {
+                channelUniqueName: 'cats',
+                Channel: { uniqueName: 'cats' },
+                Flairs: [
+                  {
+                    id: 'question',
+                    channelUniqueName: 'cats',
+                    displayName: 'Question',
+                    color: null,
+                    order: 0,
+                    archived: false,
+                  },
+                ],
+              },
+            ],
+            Author: { username: 'alice' },
+            Album: { Images: [], imageOrder: [] },
+          },
+        ],
+      },
+    });
+    await flushPromises();
+
+    await wrapper.findComponent(CreateEditDiscussionFields).vm.$emit('submit');
+
+    expect(
+      (hState.mutationOptions?.().variables as {
+        channelFlairSelections: unknown;
+      }).channelFlairSelections
+    ).toEqual([
+      { channelUniqueName: 'cats', flairIds: ['question'] },
+    ]);
+  });
+
+  it('submits an explicit empty selection when an optional flair is cleared', async () => {
+    const wrapper = await mountPage();
+    hState.onResultCb({
+      loading: false,
+      data: {
+        discussions: [
+          {
+            id: 'd1',
+            title: 'Hello',
+            body: '',
+            Tags: [],
+            DiscussionChannels: [
+              {
+                channelUniqueName: 'cats',
+                Channel: { uniqueName: 'cats' },
+                Flairs: [
+                  {
+                    id: 'question',
+                    channelUniqueName: 'cats',
+                    displayName: 'Question',
+                    color: null,
+                    order: 0,
+                    archived: false,
+                  },
+                ],
+              },
+            ],
+            Author: { username: 'alice' },
+            Album: { Images: [], imageOrder: [] },
+          },
+        ],
+      },
+    });
+    await flushPromises();
+    await wrapper
+      .findComponent(CreateEditDiscussionFields)
+      .vm.$emit('update-form-values', {
+        selectedFlairIdsByChannel: { cats: [] },
+      });
+    await wrapper.findComponent(CreateEditDiscussionFields).vm.$emit('submit');
+
+    expect(
+      (hState.mutationOptions?.().variables as {
+        channelFlairSelections: unknown;
+      }).channelFlairSelections
+    ).toEqual([{ channelUniqueName: 'cats', flairIds: [] }]);
+  });
+
+  it('blocks an edit when a required forum has no active flair selection', async () => {
+    hState.flairConfigs.cats = {
+      flairRequired: true,
+      flairs: [
+        {
+          id: 'question',
+          displayName: 'Question',
+          color: null,
+          order: 0,
+          archived: false,
+        },
+      ],
+    };
+    const wrapper = await mountPage();
+    hState.onResultCb({
+      loading: false,
+      data: {
+        discussions: [
+          {
+            id: 'd1',
+            title: 'Hello',
+            body: '',
+            Tags: [],
+            DiscussionChannels: [
+              {
+                channelUniqueName: 'cats',
+                Channel: { uniqueName: 'cats' },
+                Flairs: [],
+              },
+            ],
+            Author: { username: 'alice' },
+            Album: { Images: [], imageOrder: [] },
+          },
+        ],
+      },
+    });
+    await flushPromises();
+
+    await wrapper.findComponent(CreateEditDiscussionFields).vm.$emit('submit');
+    await nextTick();
+
+    expect(hState.mutate).not.toHaveBeenCalled();
+    expect(
+      wrapper.findComponent(CreateEditDiscussionFields).props('submitError')
+    ).toBe('Select at least one flair for cats.');
   });
 
   it('provides the discussion owner to the authorization wrapper', async () => {

--- a/pages/forums/[forumId]/discussions/edit/[discussionId].vue
+++ b/pages/forums/[forumId]/discussions/edit/[discussionId].vue
@@ -18,7 +18,11 @@ import type {
   Image,
 } from '@/__generated__/graphql';
 import { useModProfileName } from '@/composables/useAuthState';
-import { buildDiscussionEditFormValues } from '@/utils/discussionEditForm';
+import {
+  buildDiscussionEditFormValues,
+  getActiveDiscussionFlairIdsByChannel,
+} from '@/utils/discussionEditForm';
+import { useChannelDiscussionFlairConfigs } from '@/composables/useChannelDiscussionFlairConfigs';
 
 const modProfileNameVar = useModProfileName();
 
@@ -112,6 +116,8 @@ const getDefaultFormValues = (): CreateEditDiscussionFormValues => {
           return discussionChannel?.Channel?.uniqueName || '';
         }
       ),
+      selectedFlairIdsByChannel:
+        getActiveDiscussionFlairIdsByChannel(discussion.value),
       author: discussion.value.Author?.username || '',
       album: {
         images: orderedImages.value,
@@ -125,6 +131,7 @@ const getDefaultFormValues = (): CreateEditDiscussionFormValues => {
     body: '',
     selectedTags: [],
     selectedChannels: [],
+    selectedFlairIdsByChannel: {},
     author: '',
     album: {
       images: [],
@@ -139,6 +146,63 @@ const formValues = ref<CreateEditDiscussionFormValues>(
 );
 
 const dataLoaded = ref(false);
+
+const selectedChannelsForFlairConfig = computed(
+  () => formValues.value.selectedChannels
+);
+const {
+  configs: discussionFlairConfigs,
+  loadingChannels: discussionFlairsLoadingChannels,
+  errorsByChannel: discussionFlairsErrorsByChannel,
+} = useChannelDiscussionFlairConfigs(selectedChannelsForFlairConfig);
+
+const flairConfigsByChannel = computed(() =>
+  Object.fromEntries(
+    discussionFlairConfigs.value.map((config) => [
+      config.channelUniqueName,
+      config,
+    ])
+  )
+);
+
+const initialFlairIdsByChannel = computed(() =>
+  discussion.value
+    ? getActiveDiscussionFlairIdsByChannel(discussion.value)
+    : {}
+);
+
+const sameFlairIds = (left: string[], right: string[]) => {
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+  return (
+    sortedLeft.length === sortedRight.length &&
+    sortedLeft.every((id, index) => id === sortedRight[index])
+  );
+};
+
+const channelFlairSelections = computed(() =>
+  formValues.value.selectedChannels.flatMap((channelUniqueName) => {
+    const flairIds =
+      formValues.value.selectedFlairIdsByChannel?.[channelUniqueName] || [];
+    const initialFlairIds =
+      initialFlairIdsByChannel.value[channelUniqueName] || [];
+    const flairRequired =
+      flairConfigsByChannel.value[channelUniqueName]?.flairRequired || false;
+    return flairRequired || !sameFlairIds(flairIds, initialFlairIds)
+      ? [{ channelUniqueName, flairIds }]
+      : [];
+  })
+);
+
+const missingRequiredFlairConfig = computed(() =>
+  discussionFlairConfigs.value.find(
+    (config) =>
+      config.flairRequired &&
+      (formValues.value.selectedFlairIdsByChannel?.[
+        config.channelUniqueName
+      ]?.length || 0) === 0
+  )
+);
 
 onGetDiscussionResult((value) => {
   if (value.loading === true) {
@@ -255,6 +319,7 @@ const {
       .map((dc) => {
         return dc.Channel?.uniqueName;
       }),
+    channelFlairSelections: channelFlairSelections.value,
   },
 }));
 
@@ -269,11 +334,38 @@ onDone(() => {
 });
 
 // Methods converted to regular functions
+const submitError = ref<string | null>(null);
+
 async function submit() {
+  submitError.value = null;
+  if (discussionFlairsLoadingChannels.value.length > 0) {
+    submitError.value = 'Wait for the forum flair options to finish loading.';
+    return;
+  }
+  if (Object.keys(discussionFlairsErrorsByChannel.value).length > 0) {
+    submitError.value =
+      'Unable to load the forum flair options. Please try again.';
+    return;
+  }
+  if (missingRequiredFlairConfig.value) {
+    submitError.value = `Select at least one flair for ${missingRequiredFlairConfig.value.channelUniqueName}.`;
+    return;
+  }
   updateDiscussion();
 }
 
-function updateFormValues(data: CreateEditDiscussionFormValues) {
+function updateFormValues(data: Partial<CreateEditDiscussionFormValues>) {
+  if (data.selectedChannels) {
+    const selectedChannels = new Set(data.selectedChannels);
+    data = {
+      ...data,
+      selectedFlairIdsByChannel: Object.fromEntries(
+        Object.entries(
+          formValues.value.selectedFlairIdsByChannel || {}
+        ).filter(([channel]) => selectedChannels.has(channel))
+      ),
+    };
+  }
   const existingValues = formValues.value;
   formValues.value = {
     ...existingValues,
@@ -307,12 +399,20 @@ function handleCancel() {
           :discussion="discussion"
           :get-discussion-error="getDiscussionError"
           :update-discussion-error="updateDiscussionError"
+          :submit-error="submitError"
           :form-values="formValues"
           :update-discussion-loading="updateDiscussionLoading"
           :download-mode="false"
           :crossposted-discussion="discussion?.CrosspostedDiscussion || null"
           :crosspost-error="getDiscussionError"
           :crosspost-loading="getDiscussionLoading"
+          :discussion-flair-configs="discussionFlairConfigs"
+          :discussion-flairs-loading-channels="
+            discussionFlairsLoadingChannels
+          "
+          :discussion-flairs-errors-by-channel="
+            discussionFlairsErrorsByChannel
+          "
           @submit="submit"
           @update-form-values="updateFormValues"
           @cancel="handleCancel"

--- a/tests/playwright/helpers/mockedDiscussionHandlers.ts
+++ b/tests/playwright/helpers/mockedDiscussionHandlers.ts
@@ -28,7 +28,17 @@ export type MockDiscussionState = {
   title: string;
   body: string;
   tags: string[];
+  flairs?: MockDiscussionFlair[];
   deleted: boolean;
+};
+
+export type MockDiscussionFlair = {
+  id: string;
+  channelUniqueName: string;
+  displayName: string;
+  color: string;
+  order: number;
+  archived: boolean;
 };
 
 export type DiscussionState = {
@@ -52,6 +62,10 @@ type CreateDiscussionVariables = {
 
 type UpdateDiscussionVariables = {
   updateDiscussionInput?: DiscussionUpdateInput;
+  channelFlairSelections?: Array<{
+    channelUniqueName: string;
+    flairIds: string[];
+  }>;
 };
 
 const buildDiscussionResponse = (
@@ -62,14 +76,25 @@ const buildDiscussionResponse = (
     discussions: discussion.deleted
       ? []
       : [
-          buildDiscussion({
-            id: discussion.id,
-            discussionChannelId: discussion.discussionChannelId,
-            channelUniqueName: channelId,
-            title: discussion.title,
-            body: discussion.body,
-            tags: discussion.tags,
-          }),
+          {
+            ...buildDiscussion({
+              id: discussion.id,
+              discussionChannelId: discussion.discussionChannelId,
+              channelUniqueName: channelId,
+              title: discussion.title,
+              body: discussion.body,
+              tags: discussion.tags,
+            }),
+            DiscussionChannels: buildDiscussion({
+              id: discussion.id,
+              discussionChannelId: discussion.discussionChannelId,
+              channelUniqueName: channelId,
+              title: discussion.title,
+            }).DiscussionChannels.map((discussionChannel) => ({
+              ...discussionChannel,
+              Flairs: discussion.flairs ?? [],
+            })),
+          },
         ],
   },
 });
@@ -89,6 +114,7 @@ const buildDiscussionListResponse = (
               discussionId: discussion.id,
               channelUniqueName: channelId,
               isFavorited: false,
+              Flairs: discussion.flairs ?? [],
               CommentsAggregate: { count: 0 },
               weightedVotesCount: 1,
               createdAt: MOCK_DATE,
@@ -285,6 +311,7 @@ export const createDiscussionHandlers = (
                   locked: false,
                   discussionId: newDiscussion.id,
                   channelUniqueName: config.channelId,
+                  Flairs: [],
                   CommentsAggregate: { count: 0 },
                   weightedVotesCount: 1,
                   createdAt: MOCK_DATE,
@@ -323,6 +350,18 @@ export const createDiscussionHandlers = (
           ?.map((tag) => tag.where.node.text)
           .filter((tag): tag is string => Boolean(tag)) || discussion.tags;
 
+      const channelFlairSelections =
+        body.variables?.channelFlairSelections ?? [];
+      state.lastChannelFlairSelections = channelFlairSelections;
+      const selection = channelFlairSelections.find(
+        ({ channelUniqueName }) => channelUniqueName === config.channelId
+      );
+      if (selection) {
+        discussion.flairs = (discussion.flairs ?? []).filter((flair) =>
+          selection.flairIds.includes(flair.id)
+        );
+      }
+
       return {
         data: {
           updateDiscussionWithChannelConnections: {
@@ -334,6 +373,7 @@ export const createDiscussionHandlers = (
                 id: discussion.discussionChannelId,
                 channelUniqueName: config.channelId,
                 discussionId: discussion.id,
+                Flairs: discussion.flairs ?? [],
                 Channel: { uniqueName: config.channelId },
                 archived: false,
                 answered: false,

--- a/tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts
+++ b/tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts
@@ -149,6 +149,81 @@ test('requires and submits a flair in the channel-scoped form', async ({
   ]);
 });
 
+test('shows, hydrates, and clears an existing optional flair', async ({
+  page,
+  setupMockedPage,
+}) => {
+  const state = createDiscussionState();
+  state.discussions = [
+    {
+      id: 'discussion-with-flair',
+      discussionChannelId: 'discussion-channel-with-flair',
+      title: TEST_DISCUSSION,
+      body: TEST_BODY,
+      tags: [],
+      flairs: [
+        {
+          id: 'question',
+          channelUniqueName: TEST_CHANNEL,
+          displayName: 'Question',
+          color: '#2563EB',
+          order: 0,
+          archived: false,
+        },
+      ],
+      deleted: false,
+    },
+  ];
+
+  await setupMockedPage({
+    handlers: {
+      ...createDiscussionHandlers(state, {
+        channelId: TEST_CHANNEL,
+        username: 'cluse',
+      }),
+      getChannelDiscussionFlairConfig: () => ({
+        data: {
+          getChannelDiscussionFlairConfig: {
+            channelUniqueName: TEST_CHANNEL,
+            flairRequired: false,
+            flairs: [
+              {
+                id: 'question',
+                channelUniqueName: TEST_CHANNEL,
+                displayName: 'Question',
+                color: '#2563EB',
+                order: 0,
+                archived: false,
+              },
+            ],
+          },
+        },
+      }),
+    },
+  });
+
+  const discussionPath =
+    `/forums/${TEST_CHANNEL}/discussions/discussion-with-flair`;
+  await page.goto(discussionPath);
+  await expect(page.getByTestId('discussion-flair')).toHaveText('Question');
+
+  await page.goto(
+    `/forums/${TEST_CHANNEL}/discussions/edit/discussion-with-flair`
+  );
+  const selectedFlair = page.getByRole('button', {
+    name: 'Remove Question flair',
+  });
+  await expect(selectedFlair).toHaveAttribute('aria-pressed', 'true');
+  await selectedFlair.click();
+  await page.getByRole('button', { name: 'Save' }).first().click();
+
+  await expect(page).toHaveURL(discussionPath);
+  expect(state.lastChannelFlairSelections).toEqual([
+    { channelUniqueName: TEST_CHANNEL, flairIds: [] },
+  ]);
+  await expect(page.getByTestId('discussion-flair')).toHaveCount(0);
+});
+
 test('requires flair selections independently in the sitewide form', async ({
   page,
   setupMockedPage,

--- a/types/Discussion.ts
+++ b/types/Discussion.ts
@@ -1,3 +1,18 @@
+import type { DiscussionChannel } from '@/__generated__/graphql';
+
+export interface DiscussionFlairData {
+  id: string;
+  channelUniqueName: string;
+  displayName: string;
+  color?: string | null;
+  order: number;
+  archived: boolean;
+}
+
+export type DiscussionChannelWithFlairs = DiscussionChannel & {
+  Flairs?: DiscussionFlairData[];
+};
+
 export interface CreateEditDiscussionFormValues {
   title: string;
   body: string;

--- a/utils/discussionEditForm.spec.ts
+++ b/utils/discussionEditForm.spec.ts
@@ -29,6 +29,35 @@ describe('buildDiscussionEditFormValues', () => {
     expect(values.selectedChannels).toEqual(['cats']);
   });
 
+  it('maps active assigned flairs by forum and excludes archived assignments', () => {
+    const values = buildDiscussionEditFormValues({
+      DiscussionChannels: [
+        {
+          Channel: { uniqueName: 'cats' },
+          Flairs: [
+            {
+              id: 'help',
+              channelUniqueName: 'cats',
+              displayName: 'Help',
+              color: null,
+              order: 1,
+              archived: false,
+            },
+            {
+              id: 'old',
+              channelUniqueName: 'cats',
+              displayName: 'Old',
+              color: null,
+              order: 0,
+              archived: true,
+            },
+          ],
+        },
+      ],
+    });
+    expect(values.selectedFlairIdsByChannel).toEqual({ cats: ['help'] });
+  });
+
   it('keeps only images with both an id and a url', () => {
     const values = buildDiscussionEditFormValues({
       Album: {
@@ -60,6 +89,7 @@ describe('buildDiscussionEditFormValues', () => {
       author: '',
       selectedTags: [],
       selectedChannels: [],
+      selectedFlairIdsByChannel: {},
       crosspostId: null,
     });
   });

--- a/utils/discussionEditForm.ts
+++ b/utils/discussionEditForm.ts
@@ -1,4 +1,7 @@
-import type { CreateEditDiscussionFormValues } from '@/types/Discussion';
+import type {
+  CreateEditDiscussionFormValues,
+  DiscussionFlairData,
+} from '@/types/Discussion';
 
 /**
  * Map a loaded discussion into the edit form's values. Extracted from
@@ -20,7 +23,11 @@ export type DiscussionEditSource = {
   body?: string | null;
   Tags?: { text: string }[] | null;
   DiscussionChannels?:
-    | { Channel?: { uniqueName?: string | null } | null }[]
+    | {
+        channelUniqueName?: string | null;
+        Channel?: { uniqueName?: string | null } | null;
+        Flairs?: DiscussionFlairData[] | null;
+      }[]
     | null;
   Author?: { username?: string | null } | null;
   Album?: {
@@ -29,6 +36,30 @@ export type DiscussionEditSource = {
   } | null;
   CrosspostedDiscussion?: { id?: string | null } | null;
 };
+
+export function getActiveDiscussionFlairIdsByChannel(
+  discussion: DiscussionEditSource
+): Record<string, string[]> {
+  return Object.fromEntries(
+    (discussion.DiscussionChannels ?? [])
+      .map((discussionChannel) => {
+        const channelUniqueName =
+          discussionChannel.Channel?.uniqueName ??
+          discussionChannel.channelUniqueName ??
+          '';
+        const flairIds = (discussionChannel.Flairs ?? [])
+          .filter((flair) => !flair.archived)
+          .sort(
+            (left, right) =>
+              left.order - right.order ||
+              left.displayName.localeCompare(right.displayName)
+          )
+          .map((flair) => flair.id);
+        return [channelUniqueName, flairIds] as const;
+      })
+      .filter(([channelUniqueName]) => Boolean(channelUniqueName))
+  );
+}
 
 export function buildDiscussionEditFormValues(
   discussion: DiscussionEditSource
@@ -56,9 +87,16 @@ export function buildDiscussionEditFormValues(
     title: discussion.title ?? '',
     body: discussion.body ?? '',
     selectedTags: (discussion.Tags ?? []).map((tag) => tag.text),
-    selectedChannels: (discussion.DiscussionChannels ?? []).map(
-      (discussionChannel) => discussionChannel?.Channel?.uniqueName ?? ''
-    ),
+    selectedChannels: (discussion.DiscussionChannels ?? [])
+      .map(
+        (discussionChannel) =>
+          discussionChannel.Channel?.uniqueName ??
+          discussionChannel.channelUniqueName ??
+          ''
+      )
+      .filter(Boolean),
+    selectedFlairIdsByChannel:
+      getActiveDiscussionFlairIdsByChannel(discussion),
     author: discussion.Author?.username ?? '',
     album: {
       images: validImages,


### PR DESCRIPTION
## Summary
- render assigned discussion flairs in channel lists, sitewide lists, and discussion detail views
- preserve archived flair labels for historical display and include forum context in sitewide results
- hydrate active flair assignments in the edit form, enforce required flair configuration, and submit changed optional selections (including explicit clears)
- add unit and mocked Playwright coverage for display and edit lifecycle behavior

## Backend dependency
- Requires merged backend PR #188 for assigned flair projections and update support

## Verification
- pnpm run tsc
- pnpm run test:unit:run (783 files, 7,488 tests)
- pnpm exec playwright test tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts (4 tests)
- pnpm run build

## Scope
- Discussion flair filtering remains out of scope for this phase.