### PR TITLE
test: fix duplicate top-level identifiers that Vite 8 oxc rejects

### DIFF
--- a/components/comments/Comment.realmount.spec.ts
+++ b/components/comments/Comment.realmount.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { ref } from 'vue';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import { makeComment } from '@/tests/utils/factories';
-import type { Comment } from '@/__generated__/graphql';
+import type { Comment as CommentType } from '@/__generated__/graphql';
 
 import Comment from '@/components/comments/Comment.vue';
 
@@ -84,7 +84,7 @@ const stubs = {
   MenuButton: { template: '<button><slot /></button>' },
 };
 
-const baseComment = (overrides: Partial<Comment> = {}): Comment =>
+const baseComment = (overrides: Partial<CommentType> = {}): CommentType =>
   makeComment({
     id: 'c1',
     text: 'Hello world',
@@ -95,9 +95,9 @@ const baseComment = (overrides: Partial<Comment> = {}): Comment =>
     },
     Channel: { uniqueName: 'cats' },
     ...overrides,
-  } as Partial<Comment>);
+  } as Partial<CommentType>);
 
-const mountComment = (commentData: Comment) =>
+const mountComment = (commentData: CommentType) =>
   mountWithDefaults(Comment, {
     props: { commentData, depth: 1 },
     global: { stubs },
@@ -111,14 +111,14 @@ describe('Comment (real mount)', () => {
 
   it('renders the comment text via the markdown preview', () => {
     const wrapper = mountComment(
-      baseComment({ text: 'A unique body' } as Partial<Comment>)
+      baseComment({ text: 'A unique body' } as Partial<CommentType>)
     );
     expect(wrapper.text()).toContain('A unique body');
   });
 
   it('shows the archived text for an archived comment', () => {
     const wrapper = mountComment(
-      baseComment({ archived: true } as Partial<Comment>)
+      baseComment({ archived: true } as Partial<CommentType>)
     );
     expect(wrapper.find('.archived-stub').exists()).toBe(true);
   });
@@ -126,7 +126,7 @@ describe('Comment (real mount)', () => {
   it('shows the edit form and edit error for the active comment', () => {
     const wrapper = mountWithDefaults(Comment, {
       props: {
-        commentData: baseComment({ text: 'Original body' } as Partial<Comment>),
+        commentData: baseComment({ text: 'Original body' } as Partial<CommentType>),
         depth: 1,
         editFormOpenAtCommentID: 'c1',
         editCommentError: { message: 'Could not save' },
@@ -146,7 +146,7 @@ describe('Comment (real mount)', () => {
   it('emits edit text updates from the active edit form', async () => {
     const wrapper = mountWithDefaults(Comment, {
       props: {
-        commentData: baseComment({ text: 'Original body' } as Partial<Comment>),
+        commentData: baseComment({ text: 'Original body' } as Partial<CommentType>),
         depth: 1,
         editFormOpenAtCommentID: 'c1',
       },
@@ -172,7 +172,7 @@ describe('Comment (real mount)', () => {
       baseComment({
         Channel: undefined,
         DiscussionChannel: { channelUniqueName: 'dogs' },
-      } as unknown as Partial<Comment>)
+      } as unknown as Partial<CommentType>)
     );
     expect(wrapper.find('.comment-buttons-stub').exists()).toBe(true);
   });
@@ -183,7 +183,7 @@ describe('Comment (real mount)', () => {
         Channel: undefined,
         DiscussionChannel: undefined,
         Event: undefined,
-      } as unknown as Partial<Comment>)
+      } as unknown as Partial<CommentType>)
     );
     expect(wrapper.find('.comment-buttons-stub').exists()).toBe(false);
   });
@@ -205,7 +205,7 @@ describe('Comment (real mount)', () => {
     const wrapper = mountComment(
       baseComment({
         ChildCommentsAggregate: { count: 1 },
-      } as unknown as Partial<Comment>)
+      } as unknown as Partial<CommentType>)
     );
 
     expect(wrapper.text()).toContain('Child body');
@@ -215,7 +215,7 @@ describe('Comment (real mount)', () => {
     const wrapper = mountComment(
       baseComment({
         ChildCommentsAggregate: { count: 1 },
-      } as unknown as Partial<Comment>)
+      } as unknown as Partial<CommentType>)
     );
     const child = wrapper.findAllComponents(Comment)[0];
     await child.vm.$emit('start-comment-save');
@@ -278,7 +278,7 @@ describe('Comment (real mount)', () => {
     const wrapper = mountComment(
       baseComment({
         ChildCommentsAggregate: { count: 1 },
-      } as unknown as Partial<Comment>)
+      } as unknown as Partial<CommentType>)
     );
     const children = wrapper.findComponent({ name: 'ChildComments' });
     await children.trigger('mouseenter');
@@ -291,7 +291,7 @@ describe('Comment (real mount)', () => {
       props: {
         commentData: baseComment({
           ChildCommentsAggregate: { count: 1 },
-        } as unknown as Partial<Comment>),
+        } as unknown as Partial<CommentType>),
         depth: 5,
       },
       global: { stubs },

--- a/pages/library/[collectionId].spec.ts
+++ b/pages/library/[collectionId].spec.ts
@@ -4,13 +4,13 @@ import { ref, defineComponent, h } from 'vue';
 import { useQuery, useMutation } from '@vue/apollo-composable';
 vi.mock('nuxt/app', () => ({ useHead: vi.fn() }));
 
-const h = vi.hoisted(() => ({
+const harness = vi.hoisted(() => ({
   routerPush: undefined as unknown as ReturnType<typeof vi.fn>,
 }));
 
 vi.mock('vue-router', () => ({
   useRoute: () => ({ params: { collectionId: 'col-1' } }),
-  useRouter: () => ({ push: h.routerPush }),
+  useRouter: () => ({ push: harness.routerPush }),
 }));
 
 vi.mock('@vue/apollo-composable', () => ({
@@ -73,7 +73,7 @@ let queryError: Error | null = null;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  h.routerPush = vi.fn();
+  harness.routerPush = vi.fn();
   queryLoading = false;
   queryError = null;
 });
@@ -343,7 +343,7 @@ describe('library collection detail page', () => {
       title: 'Shared collection: Public list',
       shareMessage: null,
     });
-    expect(h.routerPush).toHaveBeenCalledWith(
+    expect(harness.routerPush).toHaveBeenCalledWith(
       '/forums/sims4_builds/discussions/discussion-1'
     );
   });
@@ -400,7 +400,7 @@ describe('library collection detail page', () => {
         awaitRefetchQueries: true,
       })
     );
-    expect(h.routerPush).toHaveBeenCalledWith('/library');
+    expect(harness.routerPush).toHaveBeenCalledWith('/library');
   });
 
   it('renders discussion collection items in stored order', async () => {
@@ -563,7 +563,7 @@ describe('library collection detail page', () => {
     await wrapper.find('button[title="Delete collection"]').trigger('click');
     await wrapper.get('[data-testid="warning-primary"]').trigger('click');
     error.mockRestore();
-    expect(h.routerPush).not.toHaveBeenCalled();
+    expect(harness.routerPush).not.toHaveBeenCalled();
   });
 
   const commentsCollection = {

--- a/pages/u/[username].spec.ts
+++ b/pages/u/[username].spec.ts
@@ -6,7 +6,7 @@ import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
 import UserProfileContainer from './[username].vue';
 
 // Controllable route + nuxt helpers.
-const h = vi.hoisted(() => ({
+const harness = vi.hoisted(() => ({
   route: { path: '/u/alice/comments', params: { username: 'alice' } as Record<string, unknown> },
   useHead: null as unknown as ReturnType<typeof vi.fn>,
   resultRef: null as unknown as { value: unknown },
@@ -20,37 +20,37 @@ const h = vi.hoisted(() => ({
 vi.stubGlobal('definePageMeta', vi.fn());
 
 vi.mock('nuxt/app', () => {
-  h.useHead = vi.fn();
+  harness.useHead = vi.fn();
   return {
-    useRoute: () => h.route,
-    useHead: (...args: unknown[]) => h.useHead(...args),
+    useRoute: () => harness.route,
+    useHead: (...args: unknown[]) => harness.useHead(...args),
   };
 });
 
 vi.mock('@vue/apollo-composable', async () => {
   const { ref } = await import('vue');
-  h.resultRef = ref(null);
-  h.loadingRef = ref(false);
-  h.errorRef = ref(null);
+  harness.resultRef = ref(null);
+  harness.loadingRef = ref(false);
+  harness.errorRef = ref(null);
   return {
     useQuery: () => ({
-      result: h.resultRef,
-      loading: h.loadingRef,
-      error: h.errorRef,
+      result: harness.resultRef,
+      loading: harness.loadingRef,
+      error: harness.errorRef,
     }),
   };
 });
 
 vi.mock('@/composables/useServerRoleMembership', async () => {
   const { ref } = await import('vue');
-  h.admins = ref([]);
-  h.mods = ref([]);
-  h.modProfiles = ref([]);
+  harness.admins = ref([]);
+  harness.mods = ref([]);
+  harness.modProfiles = ref([]);
   return {
     useServerRoleMembership: () => ({
-      serverAdminUsernames: h.admins,
-      serverModUsernames: h.mods,
-      serverModProfileNames: h.modProfiles,
+      serverAdminUsernames: harness.admins,
+      serverModUsernames: harness.mods,
+      serverModProfileNames: harness.modProfiles,
     }),
   };
 });
@@ -109,13 +109,13 @@ const mountContainer = async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  h.route = { path: '/u/alice/comments', params: { username: 'alice' } };
-  h.resultRef.value = { users: [makeUser()] };
-  h.loadingRef.value = false;
-  h.errorRef.value = null;
-  h.admins.value = [];
-  h.mods.value = [];
-  h.modProfiles.value = [];
+  harness.route = { path: '/u/alice/comments', params: { username: 'alice' } };
+  harness.resultRef.value = { users: [makeUser()] };
+  harness.loadingRef.value = false;
+  harness.errorRef.value = null;
+  harness.admins.value = [];
+  harness.mods.value = [];
+  harness.modProfiles.value = [];
 });
 
 describe('User profile container', () => {
@@ -125,7 +125,7 @@ describe('User profile container', () => {
   });
 
   it('shows the channel filter on a filterable tab', async () => {
-    h.route = { path: '/u/alice/comments', params: { username: 'alice' } };
+    harness.route = { path: '/u/alice/comments', params: { username: 'alice' } };
     const wrapper = await mountContainer();
     expect(
       wrapper.findComponent({ name: 'UserProfileChannelFilter' }).exists()
@@ -133,7 +133,7 @@ describe('User profile container', () => {
   });
 
   it('hides the channel filter on a non-filterable tab', async () => {
-    h.route = { path: '/u/alice/kudos', params: { username: 'alice' } };
+    harness.route = { path: '/u/alice/kudos', params: { username: 'alice' } };
     const wrapper = await mountContainer();
     expect(
       wrapper.findComponent({ name: 'UserProfileChannelFilter' }).exists()
@@ -149,7 +149,7 @@ describe('User profile container', () => {
   });
 
   it('uses the full-width image layout on an image detail page', async () => {
-    h.route = {
+    harness.route = {
       path: '/u/alice/images/img-1',
       params: { username: 'alice' },
     };
@@ -162,7 +162,7 @@ describe('User profile container', () => {
   });
 
   it('passes a server-role badge to the sidebar for an admin user', async () => {
-    h.admins.value = ['alice'];
+    harness.admins.value = ['alice'];
     const wrapper = await mountContainer();
     expect(
       wrapper.findComponent({ name: 'UserProfileSidebar' }).props('serverRoleBadge')
@@ -177,7 +177,7 @@ describe('User profile container', () => {
   });
 
   it('passes the dedicated wiki edits count through to the tabs', async () => {
-    h.resultRef.value = {
+    harness.resultRef.value = {
       getUserWikiEditsCount: 3,
       users: [makeUser({ AuthoredWikiPageVersionsAggregate: { count: 11 } })],
     };


### PR DESCRIPTION
## Why

Unblocks the Vite 8 bump (#411). Vite 8 replaces **esbuild** with the stricter **oxc** transformer, which no longer tolerates duplicate top-level identifier declarations that esbuild silently resolved. Three unit specs relied on that leniency and failed under Vite 8 (26 failing tests + one file that failed to load entirely).

These fixes are **transformer-agnostic latent-bug cleanups** — they pass under both the current Vite 7 and Vite 8, so they can land on `main` independently. Once merged, rebasing #411 turns its unit-tests check green with no further changes.

## What

| File | Collision | Symptom under oxc |
|------|-----------|-------------------|
| `components/comments/Comment.realmount.spec.ts` | `import type { Comment }` collided with the `import Comment` component import | `[PARSE_ERROR] Identifier 'Comment' has already been declared` → whole file failed to load |
| `pages/library/[collectionId].spec.ts` | a hoisted `const h = vi.hoisted(...)` shadowed `import { h } from 'vue'` | `TypeError: h is not a function` on render (23 tests) |
| `pages/u/[username].spec.ts` | same `h` collision | `TypeError: h is not a function` on render (8 tests) |

Fixes:
- Alias the type import as `CommentType` (the `.vue` component keeps the `Comment` name).
- Rename the hoisted state object `h` → `harness`, leaving Vue's `h` import intact. This matches the convention already used in `pages/admin/settings.spec.ts`, which had already been migrated on `main`.

No production code and no dependency changes.

## Verification

- Full unit suite under **Vite 8.1.5**: 783 files / 7488 tests, all passing.
- The three fixed files under the current **Vite 7**: passing.
- `pnpm run tsc`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)