### PR TITLE
test: cover download Activity tab end to end

### DIFF
--- a/tests/playwright/mocked/downloads/downloadLabels.spec.ts
+++ b/tests/playwright/mocked/downloads/downloadLabels.spec.ts
@@ -1,186 +1,218 @@
 import { expect, test } from '../../helpers/testFixture';
 import {
-  buildBasicUser,
-  buildChannel,
-  buildServerConfig,
+  buildDiscussion,
+  buildDiscussionChannel,
+  buildUser,
 } from '../../helpers/graphqlFixtures';
-import { installMockAuth } from '../../helpers/mockAuth';
-import { installGraphqlMocks, waitForGraphqlOperation } from '../../helpers/mockGraphql';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
 
 const TEST_CHANNEL = 'downloads-forum';
 const TEST_USER = 'alice';
 const DISCUSSION_ID = 'download-1';
+const DISCUSSION_CHANNEL_ID = 'download-channel-1';
+const DOWNLOAD_TITLE = 'Test Download';
 
-const getBaseMocks = (username: string) => ({
-  getBasicUserInfo: () => ({
-    data: {
-      users: [
-        buildBasicUser({
-          username,
-          displayName: username,
-        }),
-      ],
-    },
-  }),
-  getUser: () => ({
-    data: {
-      users: [
-        {
-          username,
-          notifyOnReplyToDiscussionByDefault: true,
-          notifyOnReplyToEventByDefault: true,
-        },
-      ],
-    },
-  }),
-  getUserFavorites: () => ({
-    data: {
-      users: [{ username, FavoriteChannels: [], Collections: [] }],
-    },
-  }),
-  GetUserFavoriteChannels: () => ({
-    data: {
-      users: [{ username, FavoriteChannels: [] }],
-    },
-  }),
-  GetUserChannelCollectionsWithChannels: () => ({
-    data: {
-      users: [{ username, Collections: [] }],
-    },
-  }),
-  getServerConfig: () => ({
-    data: {
-      serverConfigs: [
-        buildServerConfig({
-          serverName: 'Listical',
-          enableEvents: true,
-        }),
-      ],
-    },
-  }),
-  getChannelTags: () => ({
-    data: {
-      channels: [{ uniqueName: TEST_CHANNEL, Tags: [] }],
-    },
-  }),
-  getTags: () => ({
-    data: { tags: [] },
-  }),
-  userIsModInChannel: () => ({
-    data: {
-      channels: [
-        {
-          uniqueName: TEST_CHANNEL,
-          Admins: [],
-          SuspendedUsers: [],
-          Moderators: [{ displayName: username }],
-          SuspendedMods: [],
-        },
-      ],
-    },
-  }),
-});
-
-const buildDownload = (overrides = {}) => ({
-  __typename: 'Discussion',
-  id: DISCUSSION_ID,
-  title: 'Test Download',
-  body: 'This is a test download with files',
-  hasDownload: true,
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-01-15T00:00:00Z',
-  Author: { username: TEST_USER, displayName: 'Alice' },
-  Tags: [],
-  DiscussionChannels: [
-    {
-      id: 'dc-1',
-      Channel: { uniqueName: TEST_CHANNEL },
-      LabelOptions: [
-        {
-          id: 'label-1',
-          value: 'tools',
-          displayName: 'Tools',
-          group: { key: 'category' },
-        },
-      ],
-    },
-  ],
-  DownloadableFiles: [
-    {
-      id: 'file-1',
-      fileName: 'model.stl',
-      url: 'https://example.com/model.stl',
-      kind: 'MODEL',
-      size: 1024000,
-      priceModel: 'FREE',
-    },
-  ],
-  Album: null,
-  ...overrides,
-});
-
-test.describe('Download labels moderation', () => {
-  // Skip: requires many additional mocks (collections, etc.) - functionality covered by unit tests
-  test.skip('download detail page loads without errors', async ({
-    context,
-    page,
-  }, testInfo) => {
-    await installMockAuth(context, page, {
-      username: TEST_USER,
-      email: 'alice@example.com',
-    });
-
-    const diagnostics = await installGraphqlMocks(page, {
-      ...getBaseMocks(TEST_USER),
-      getChannel: () => ({
-        data: {
-          channels: [
-            buildChannel({
-              uniqueName: TEST_CHANNEL,
-              displayName: 'Downloads Forum',
-              overrides: {
-                eventsEnabled: false,
-                downloadsEnabled: true,
-              },
+const buildDownload = ({ withActivity }: { withActivity: boolean }) => {
+  const discussionChannel = {
+    ...buildDiscussionChannel({
+      id: DISCUSSION_CHANNEL_ID,
+      discussionId: DISCUSSION_ID,
+      channelUniqueName: TEST_CHANNEL,
+      title: DOWNLOAD_TITLE,
+    }),
+    LabelChangeHistory: withActivity
+      ? [
+          {
+            id: 'label-change-1',
+            createdAt: '2024-02-01T12:00:00.000Z',
+            actionType: 'added',
+            labelDisplayName: 'Tools',
+            labelValue: 'tools',
+            ActorUser: buildUser({
+              username: TEST_USER,
+              displayName: 'Alice',
             }),
-          ],
-        },
+            ActorMod: null,
+          },
+        ]
+      : [],
+  };
+
+  return buildDiscussion({
+    id: DISCUSSION_ID,
+    discussionChannelId: DISCUSSION_CHANNEL_ID,
+    channelUniqueName: TEST_CHANNEL,
+    title: DOWNLOAD_TITLE,
+    body: 'This is a test download.',
+    overrides: {
+      hasDownload: true,
+      Author: buildUser({
+        username: TEST_USER,
+        displayName: 'Alice',
       }),
-      getDiscussion: () => ({
-        data: {
-          discussions: [buildDownload()],
-        },
-      }),
-      getDiscussionsInChannel: () => ({
-        data: {
-          getDiscussionsInChannel: [buildDownload()],
-        },
-      }),
-      getChannelDownloadCount: () => ({
-        data: {
-          channels: [
+      DiscussionChannels: [discussionChannel],
+      PastTitleVersions: withActivity
+        ? [
             {
-              uniqueName: TEST_CHANNEL,
-              DiscussionChannelsAggregate: { count: 1 },
+              id: 'title-version-1',
+              body: 'Old Download Title',
+              editReason: 'Clarified the title',
+              createdAt: '2024-01-15T12:00:00.000Z',
+              Author: null,
+              AuthorConnection: {
+                edges: [],
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                },
+                totalCount: 0,
+              },
+            },
+          ]
+        : [],
+    },
+  });
+};
+
+const createDownloadHandlers = ({
+  withActivity,
+}: {
+  withActivity: boolean;
+}) => ({
+  ...createBaseHandlers({
+    username: TEST_USER,
+    channelId: TEST_CHANNEL,
+    discussionId: DISCUSSION_ID,
+    discussionChannelId: DISCUSSION_CHANNEL_ID,
+    discussionTitle: DOWNLOAD_TITLE,
+    discussionsCount: 1,
+    channelOverrides: {
+      displayName: 'Downloads Forum',
+      eventsEnabled: false,
+      downloadsEnabled: true,
+    },
+  }),
+  getDiscussion: () => ({
+    data: { discussions: [buildDownload({ withActivity })] },
+  }),
+  getDiscussionChannelRootCommentAggregate: () => ({
+    data: {
+      discussionChannels: [
+        {
+          id: DISCUSSION_CHANNEL_ID,
+          discussionId: DISCUSSION_ID,
+          channelUniqueName: TEST_CHANNEL,
+          archived: false,
+          answered: false,
+          locked: false,
+          CommentsAggregate: { count: 0 },
+        },
+      ],
+    },
+  }),
+  isDiscussionAnswered: () => ({
+    data: {
+      discussionChannels: [
+        {
+          id: DISCUSSION_CHANNEL_ID,
+          discussionId: DISCUSSION_ID,
+          channelUniqueName: TEST_CHANNEL,
+          weightedVotesCount: 1,
+          archived: false,
+          answered: false,
+          locked: false,
+          Channel: { uniqueName: TEST_CHANNEL },
+        },
+      ],
+    },
+  }),
+  getDiscussionCommentIssue: () => ({
+    data: {
+      discussionChannels: [{ id: DISCUSSION_CHANNEL_ID, Comments: [] }],
+    },
+  }),
+  GetPublicCollectionsForDownload: () => ({
+    data: { publicCollectionsContaining: [] },
+  }),
+  getDownloadLabels: () => ({
+    data: {
+      discussions: [
+        {
+          id: DISCUSSION_ID,
+          DiscussionChannels: [
+            {
+              channelUniqueName: TEST_CHANNEL,
+              LabelOptions: [],
             },
           ],
         },
-      }),
+      ],
+    },
+  }),
+});
+
+test.describe('Download detail Activity tab', () => {
+  test('navigates to Activity and renders title and label history', async ({
+    page,
+    setupMockedPage,
+  }) => {
+    const { diagnostics } = await setupMockedPage({
+      username: TEST_USER,
+      email: 'alice@example.com',
+      handlers: createDownloadHandlers({ withActivity: true }),
     });
 
-    try {
-      await page.goto(`/forums/${TEST_CHANNEL}/downloads/${DISCUSSION_ID}`);
+    await page.goto(`/forums/${TEST_CHANNEL}/downloads/${DISCUSSION_ID}`);
 
-      // Wait for discussion data to load
-      await waitForGraphqlOperation(diagnostics.completedOperations, 'getDiscussion');
+    const activityTab = page.getByRole('link', {
+      name: 'Activity',
+      exact: true,
+    });
+    await expect(activityTab).toBeVisible({ timeout: 30000 });
+    await expect(
+      page.getByRole('link', { name: 'Description', exact: true })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Comments (0)', exact: true })
+    ).toBeVisible();
 
-      // Page should load without JavaScript errors
-      expect(diagnostics.pageErrors).toEqual([]);
-    } finally {
-      await testInfo.attach('graphql-operations.json', {
-        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
-        contentType: 'application/json',
-      });
-    }
+    await activityTab.click();
+    await expect(page).toHaveURL(
+      `/forums/${TEST_CHANNEL}/downloads/${DISCUSSION_ID}/activity`
+    );
+
+    await expect(
+      page.getByText('Title Edit History', { exact: true })
+    ).toBeVisible();
+    await expect(
+      page.getByText('Old Download Title', { exact: true })
+    ).toBeVisible();
+    await expect(
+      page.getByText('Label Change History', { exact: true })
+    ).toBeVisible();
+    await expect(page.getByText('Tools', { exact: true })).toBeVisible();
+    expect(diagnostics.pageErrors).toEqual([]);
+  });
+
+  test('shows the empty state when the download has no activity', async ({
+    page,
+    setupMockedPage,
+  }) => {
+    const { diagnostics } = await setupMockedPage({
+      username: TEST_USER,
+      email: 'alice@example.com',
+      handlers: createDownloadHandlers({ withActivity: false }),
+    });
+
+    await page.goto(
+      `/forums/${TEST_CHANNEL}/downloads/${DISCUSSION_ID}/activity`
+    );
+
+    await expect(
+      page.getByText('No activity to display yet.', { exact: true })
+    ).toBeVisible({
+      timeout: 30000,
+    });
+    expect(diagnostics.pageErrors).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- replace the skipped download-detail Playwright test with working mocked coverage
- verify the Description, Comments, and Activity tabs render and navigate correctly
- assert title-edit and label-change history render on the Activity tab
- cover the empty-activity state
- migrate the spec to the shared mocked-page fixture and handle every GraphQL operation used by the route

## Why

The download Activity tab was covered only by unit tests. The existing browser spec was skipped because its hand-built fixture did not mock the complete download-detail route, leaving tab navigation and composed activity rendering unverified.

## Validation

- `PLAYWRIGHT_FRONTEND_PORT=3104 npx playwright test tests/playwright/mocked/downloads/downloadLabels.spec.ts` — 2 passed
- `pnpm run tsc`
- ESLint and Prettier on the changed spec
- `git diff --check`

Closes #187