### PR TITLE
fix: allow vertical scrolling over discussion albums

### DIFF
--- a/components/discussion/detail/DiscussionAlbum.spec.ts
+++ b/components/discussion/detail/DiscussionAlbum.spec.ts
@@ -215,6 +215,15 @@ describe('DiscussionAlbum — lightbox', () => {
 describe('DiscussionAlbum — carousel navigation', () => {
   beforeEach(() => vi.clearAllMocks());
 
+  const carousel = (wrapper: ReturnType<typeof mountAlbum>) =>
+    wrapper.get('[data-testid="discussion-album-carousel"]');
+
+  it('allows native vertical scrolling over the carousel', () => {
+    expect(carousel(mountAlbum({ carouselFormat: true })).classes()).toContain(
+      'touch-pan-y'
+    );
+  });
+
   it('advances to the next image', async () => {
     const wrapper = mountAlbum({ carouselFormat: true });
     await wrapper.get('[aria-label="Next image"]').trigger('click');
@@ -247,7 +256,7 @@ describe('DiscussionAlbum — carousel navigation', () => {
 
   it('navigates by swiping the image container', async () => {
     const wrapper = mountAlbum({ carouselFormat: true });
-    const container = wrapper.find('.touch-pan-x');
+    const container = carousel(wrapper);
     await container.trigger('touchstart', { touches: [{ clientX: 200 }] });
     await container.trigger('touchend', { changedTouches: [{ clientX: 100 }] });
 
@@ -256,7 +265,7 @@ describe('DiscussionAlbum — carousel navigation', () => {
 
   it('navigates backward on a right swipe', async () => {
     const wrapper = mountAlbum({ carouselFormat: true });
-    const container = wrapper.find('.touch-pan-x');
+    const container = carousel(wrapper);
     await container.trigger('touchstart', { touches: [{ clientX: 100 }] });
     await container.trigger('touchend', { changedTouches: [{ clientX: 200 }] });
     expect(wrapper.text()).toContain('3 of 3');
@@ -279,7 +288,7 @@ describe('DiscussionAlbum — carousel navigation', () => {
 
   it('opens the lightbox from the active carousel image', async () => {
     const wrapper = mountAlbum({ carouselFormat: true });
-    await wrapper.get('.touch-pan-x > div.h-full').trigger('click');
+    await carousel(wrapper).get('div.h-full').trigger('click');
     expect(document.body.querySelector('.lightbox-stub')).not.toBeNull();
   });
 
@@ -290,6 +299,6 @@ describe('DiscussionAlbum — carousel navigation', () => {
       downloadMode: true,
     });
 
-    expect(wrapper.find('.touch-pan-x').attributes('style')).toContain('500px');
+    expect(carousel(wrapper).attributes('style')).toContain('500px');
   });
 });

--- a/components/discussion/detail/DiscussionAlbum.vue
+++ b/components/discussion/detail/DiscussionAlbum.vue
@@ -435,7 +435,8 @@ onMounted(() => {
           <!-- Image container -->
           <div class="flex items-center justify-center">
             <div
-              class="relative touch-pan-x overflow-hidden rounded-lg dark:text-white"
+              data-testid="discussion-album-carousel"
+              class="relative touch-pan-y overflow-hidden rounded-lg dark:text-white"
               :class="{
                 'w-full min-w-0 max-w-full': expandedView,
                 'max-w-96': !expandedView,

--- a/tests/playwright/mocked/discussions/discussionAlbumMobileScroll.spec.ts
+++ b/tests/playwright/mocked/discussions/discussionAlbumMobileScroll.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '../../helpers/testFixture';
+import {
+  buildDiscussion,
+  buildDiscussionChannel,
+} from '../../helpers/graphqlFixtures';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import type { Album } from '@/__generated__/graphql';
+
+const TEST_CHANNEL = 'cats';
+const DISCUSSION_ID = 'discussion-with-album';
+const DISCUSSION_CHANNEL_ID = 'discussion-channel-with-album';
+
+const album = {
+  id: 'album-1',
+  imageOrder: ['image-1', 'image-2'],
+  Images: [
+    {
+      id: 'image-1',
+      url: '/favicon.ico',
+      alt: 'First album image',
+      caption: '',
+      __typename: 'Image' as const,
+    },
+    {
+      id: 'image-2',
+      url: '/favicon.ico',
+      alt: 'Second album image',
+      caption: '',
+      __typename: 'Image' as const,
+    },
+  ],
+  __typename: 'Album' as const,
+} as unknown as Album;
+
+test('continues vertical page scrolling when a touch starts on a discussion album', async ({
+  page,
+  setupMockedPage,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  await setupMockedPage({
+    handlers: {
+      ...createBaseHandlers({
+        channelId: TEST_CHANNEL,
+        discussionsCount: 1,
+      }),
+      getDiscussion: () => ({
+        data: {
+          discussions: [
+            buildDiscussion({
+              id: DISCUSSION_ID,
+              discussionChannelId: DISCUSSION_CHANNEL_ID,
+              channelUniqueName: TEST_CHANNEL,
+              body: 'Mobile album scrolling regression test.',
+              overrides: { Album: album },
+            }),
+          ],
+        },
+      }),
+      getCommentSection: () => ({
+        data: {
+          getCommentSection: {
+            DiscussionChannel: buildDiscussionChannel({
+              id: DISCUSSION_CHANNEL_ID,
+              discussionId: DISCUSSION_ID,
+              channelUniqueName: TEST_CHANNEL,
+            }),
+            Comments: [],
+          },
+        },
+      }),
+    },
+  });
+
+  await page.goto(`/forums/${TEST_CHANNEL}/discussions/${DISCUSSION_ID}`);
+
+  const carousel = page.getByTestId('discussion-album-carousel');
+  await expect(carousel).toBeVisible({ timeout: 30_000 });
+
+  await page.evaluate(() => {
+    const spacer = document.createElement('div');
+    spacer.style.height = '1200px';
+    document.body.append(spacer);
+  });
+  await carousel.scrollIntoViewIfNeeded();
+
+  const box = await carousel.boundingBox();
+  if (!box) throw new Error('Discussion album carousel has no bounding box');
+
+  const client = await page.context().newCDPSession(page);
+  await client.send('Emulation.setTouchEmulationEnabled', {
+    enabled: true,
+    maxTouchPoints: 1,
+  });
+
+  const x = box.x + box.width / 2;
+  const y = Math.min(box.y + box.height / 2, 760);
+  const initialScrollY = await page.evaluate(() => window.scrollY);
+
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x, y }],
+  });
+  for (const distance of [30, 60, 90, 120, 150]) {
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x, y: y - distance }],
+    });
+  }
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchEnd',
+    touchPoints: [],
+  });
+
+  await expect
+    .poll(() => page.evaluate(() => window.scrollY))
+    .toBeGreaterThan(initialScrollY);
+});


### PR DESCRIPTION
## Summary

- allow native vertical panning when a touch starts on `DiscussionAlbum`
- preserve the existing horizontal swipe navigation behavior
- cover the behavior with component tests and a real mobile touch Playwright regression

Because discussion lists, discussion detail pages, and download detail pages all use the shared `DiscussionAlbum` carousel, the change applies consistently across all three views.

## Root cause

The carousel used `touch-action: pan-x`, which prevented the browser from performing native vertical page scrolling over the album. The carousel now uses `touch-action: pan-y`, leaving horizontal gestures to the existing carousel handler while allowing vertical gestures to scroll the document.

## Verification

- `npx vitest run components/discussion/detail/DiscussionAlbum.spec.ts`
- `PLAYWRIGHT_FRONTEND_PORT=3113 PLAYWRIGHT_BACKEND_PORT=4113 npx playwright test tests/playwright/mocked/discussions/discussionAlbumMobileScroll.spec.ts`
- `npm run tsc`
- ESLint on changed files
- `git diff --check`