### PR TITLE
feat: surface download quarantine workflows

### DIFF
--- a/components/admin/DownloadScanReviewQueue.spec.ts
+++ b/components/admin/DownloadScanReviewQueue.spec.ts
@@ -4,6 +4,7 @@ import { ref } from 'vue';
 import DownloadScanReviewQueue from './DownloadScanReviewQueue.vue';
 
 const mockClear = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const mockRetry = vi.hoisted(() => vi.fn(() => Promise.resolve()));
 const mockRefetch = vi.hoisted(() => vi.fn(() => Promise.resolve()));
 
 vi.mock('@vue/apollo-composable', () => ({
@@ -26,8 +27,10 @@ vi.mock('@vue/apollo-composable', () => ({
     error: ref(null),
     refetch: mockRefetch,
   })),
-  useMutation: vi.fn(() => ({
-    mutate: mockClear,
+  useMutation: vi.fn((document) => ({
+    mutate: document.definitions?.[0]?.name?.value === 'retryDownloadableFileScan'
+      ? mockRetry
+      : mockClear,
     loading: ref(false),
     error: ref(null),
   })),
@@ -56,7 +59,7 @@ describe('DownloadScanReviewQueue', () => {
   it('clears a reviewed file and refreshes the queue', async () => {
     const wrapper = mountQueue();
     await wrapper.get('input').setValue('Reviewed archive contents');
-    await wrapper.get('button').trigger('click');
+    await wrapper.get('[data-testid="release-quarantine"]').trigger('click');
     await flushPromises();
 
     expect({
@@ -69,5 +72,22 @@ describe('DownloadScanReviewQueue', () => {
       },
       refetched: true,
     });
+  });
+
+  it('keeps quarantine release disabled until an audit reason is entered', () => {
+    const wrapper = mountQueue();
+
+    expect(wrapper.get('[data-testid="release-quarantine"]').attributes('disabled')).toBe('');
+  });
+
+  it('retries a scan from the moderation queue', async () => {
+    const wrapper = mountQueue();
+    const retryButton = wrapper.findAll('button').find((button) =>
+      button.text() === 'Retry scan'
+    );
+    await retryButton?.trigger('click');
+    await flushPromises();
+
+    expect(mockRetry).toHaveBeenCalledWith({ downloadableFileId: 'file-1' });
   });
 });

--- a/components/admin/DownloadScanReviewQueue.vue
+++ b/components/admin/DownloadScanReviewQueue.vue
@@ -3,12 +3,15 @@ import { ref } from 'vue';
 import { useMutation, useQuery } from '@vue/apollo-composable';
 import { ShieldCheck } from 'lucide-vue-next';
 import { GET_DOWNLOAD_SCAN_REVIEW_QUEUE } from '@/graphQLData/admin/queries';
-import { CLEAR_DOWNLOADABLE_FILE_SCAN } from '@/graphQLData/discussion/mutations';
+import {
+  CLEAR_DOWNLOADABLE_FILE_SCAN,
+  RETRY_DOWNLOADABLE_FILE_SCAN,
+} from '@/graphQLData/discussion/mutations';
 
 type ReviewItem = {
   downloadableFileId: string;
   fileName: string;
-  scanStatus: 'SUSPICIOUS' | 'INFECTED';
+  scanStatus: 'SUSPICIOUS' | 'INFECTED' | 'FAILED';
   scanReason?: string | null;
   reviewRequestedAt?: string | null;
   reviewRequestReason?: string | null;
@@ -20,6 +23,7 @@ type ReviewItem = {
 
 const reviewNotes = ref<Record<string, string>>({});
 const clearingFileId = ref('');
+const retryingFileId = ref('');
 
 const {
   result,
@@ -37,13 +41,20 @@ const {
   error: clearError,
 } = useMutation(CLEAR_DOWNLOADABLE_FILE_SCAN);
 
+const {
+  mutate: retryDownloadableFileScan,
+  loading: retrying,
+  error: retryError,
+} = useMutation(RETRY_DOWNLOADABLE_FILE_SCAN);
+
 const clearReview = async (item: ReviewItem) => {
-  if (clearing.value) return;
+  const reason = reviewNotes.value[item.downloadableFileId]?.trim();
+  if (clearing.value || !reason) return;
   clearingFileId.value = item.downloadableFileId;
   try {
     await clearDownloadableFileScan({
       downloadableFileId: item.downloadableFileId,
-      reason: reviewNotes.value[item.downloadableFileId]?.trim() || null,
+      reason,
     });
     await refetch();
   } catch {
@@ -53,9 +64,29 @@ const clearReview = async (item: ReviewItem) => {
   }
 };
 
+const retryScan = async (item: ReviewItem) => {
+  if (retrying.value) return;
+  retryingFileId.value = item.downloadableFileId;
+  try {
+    await retryDownloadableFileScan({
+      downloadableFileId: item.downloadableFileId,
+    });
+    await refetch();
+  } catch {
+    // Apollo exposes the mutation error through retryError below.
+  } finally {
+    retryingFileId.value = '';
+  }
+};
+
 const discussionPath = (item: ReviewItem) => {
   if (!item.channelUniqueName) return null;
   return `/forums/${item.channelUniqueName}/downloads/${item.discussionId}`;
+};
+
+const pipelinePath = (item: ReviewItem) => {
+  const path = discussionPath(item);
+  return path ? `${path}/pipelines` : null;
 };
 </script>
 
@@ -70,7 +101,7 @@ const discussionPath = (item: ReviewItem) => {
           Download security review queue
         </h2>
         <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
-          Suspicious and infected files remain unavailable until a reviewer clears them.
+          Quarantined files remain unavailable until a scan passes or a reviewer releases them with an audit reason.
         </p>
       </div>
       <ShieldCheck class="h-5 w-5 text-orange-600 dark:text-orange-300" />
@@ -109,6 +140,8 @@ const discussionPath = (item: ReviewItem) => {
             class="rounded-full px-2 py-1 text-xs font-medium"
             :class="item.scanStatus === 'INFECTED'
               ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200'
+            : item.scanStatus === 'FAILED'
+              ? 'bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-200'
               : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200'"
           >
             {{ item.scanStatus }}
@@ -127,12 +160,12 @@ const discussionPath = (item: ReviewItem) => {
 
         <div class="mt-3 flex flex-col gap-2 md:flex-row md:items-end">
           <label class="flex-1 text-sm text-gray-700 dark:text-gray-200">
-            Review note
+            Required release reason
             <input
               v-model="reviewNotes[item.downloadableFileId]"
               :aria-label="`Review note for ${item.fileName}`"
               class="mt-1 w-full rounded-md border-gray-300 text-sm dark:border-gray-700 dark:bg-gray-800"
-              placeholder="Why this file is safe"
+              placeholder="Evidence supporting release"
             >
           </label>
           <NuxtLink
@@ -140,15 +173,31 @@ const discussionPath = (item: ReviewItem) => {
             :to="discussionPath(item) || ''"
             class="text-sm font-medium text-orange-700 underline dark:text-orange-200"
           >
-            Open download
+            Open download page
+          </NuxtLink>
+          <NuxtLink
+            v-if="pipelinePath(item)"
+            :to="pipelinePath(item) || ''"
+            class="text-sm font-medium text-orange-700 underline dark:text-orange-200"
+          >
+            Review pipeline
           </NuxtLink>
           <button
             type="button"
+            class="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-60 dark:border-gray-600 dark:text-gray-100 dark:hover:bg-gray-800"
+            :disabled="retrying"
+            @click="retryScan(item)"
+          >
+            {{ retrying && retryingFileId === item.downloadableFileId ? 'Retrying…' : 'Retry scan' }}
+          </button>
+          <button
+            type="button"
+            data-testid="release-quarantine"
             class="rounded-md bg-green-700 px-3 py-2 text-sm font-medium text-white hover:bg-green-800 disabled:opacity-60"
-            :disabled="clearing"
+            :disabled="clearing || !reviewNotes[item.downloadableFileId]?.trim()"
             @click="clearReview(item)"
           >
-            {{ clearing && clearingFileId === item.downloadableFileId ? 'Clearing…' : 'Clear as clean' }}
+            {{ clearing && clearingFileId === item.downloadableFileId ? 'Releasing…' : 'Release quarantine' }}
           </button>
         </div>
       </article>
@@ -156,6 +205,9 @@ const discussionPath = (item: ReviewItem) => {
 
     <p v-if="clearError" class="mt-3 text-sm text-red-700 dark:text-red-300">
       {{ clearError.message }}
+    </p>
+    <p v-if="retryError" class="mt-3 text-sm text-red-700 dark:text-red-300">
+      {{ retryError.message }}
     </p>
   </section>
 </template>

--- a/components/channel/DownloadSidebar.spec.ts
+++ b/components/channel/DownloadSidebar.spec.ts
@@ -218,12 +218,12 @@ describe('DownloadSidebar', () => {
       message: wrapper.get('[data-testid="download-scan-status"]').text(),
       disabled: wrapper.get('button').attributes('disabled'),
     }).toEqual({
-      message: expect.stringContaining('Security scan in progress'),
+      message: expect.stringContaining('Quarantined: security check pending'),
       disabled: '',
     });
   });
 
-  it('gives the creator cause-aware blocked copy and review actions', () => {
+  it('gives the creator cause-aware quarantine copy without a direct download', () => {
     authState.value = true;
     mockUsernameRef.value = 'author';
     const wrapper = mount(DownloadSidebar, {
@@ -245,14 +245,16 @@ describe('DownloadSidebar', () => {
 
     expect({
       status: wrapper.get('[data-testid="download-scan-status"]').text(),
-      button: wrapper.findAll('button').find((button) =>
+      directReviewDownload: wrapper.findAll('button').some((button) =>
         button.text() === 'Download for review'
-      )?.text(),
+      ),
+      downloadDisabled: wrapper.findAll('button').at(-1)?.attributes('disabled'),
     }).toEqual({
       status: expect.stringContaining(
         'This upload was blocked by the security scan: Known malware signature.'
       ),
-      button: 'Download for review',
+      directReviewDownload: false,
+      downloadDisabled: '',
     });
   });
 

--- a/components/channel/DownloadSidebar.vue
+++ b/components/channel/DownloadSidebar.vue
@@ -122,16 +122,24 @@ const hasReviewAccess = computed(
 const downloadDisabled = computed(
   () =>
     !hasDownloadableFile.value ||
-    (scanStatus.value !== 'CLEAN' && !hasReviewAccess.value)
+    scanStatus.value !== 'CLEAN'
 );
 
-const downloadLabel = computed(() =>
-  hasReviewAccess.value ? 'Download for review' : 'Download Now'
-);
+const downloadLabel = 'Download Now';
 
 const replaceFilePath = computed(
   () => `/forums/${props.channelUniqueName}/downloads/edit/${props.discussionId}`
 );
+
+const pipelinePath = computed(
+  () => `/forums/${props.channelUniqueName}/downloads/${props.discussionId}/pipelines`
+);
+
+const scanCheckedDisplay = computed(() => {
+  if (!primaryFile.value?.scanCheckedAt) return '';
+  const checkedAt = new Date(primaryFile.value.scanCheckedAt);
+  return Number.isNaN(checkedAt.getTime()) ? '' : checkedAt.toLocaleString();
+});
 
 // Format price display
 const priceDisplay = computed(() => {
@@ -278,12 +286,14 @@ const groupedLabels = computed(() => {
           </p>
           <p v-else-if="scanStatus === 'PENDING'" class="font-medium">
             <i class="fa-solid fa-spinner mr-1 animate-spin" />
-            {{ creatorIsViewing ? 'Scanning your upload…' : 'Security scan in progress' }}
+            Quarantined: security check pending
           </p>
           <template v-else-if="scanStatus === 'INFECTED' || scanStatus === 'SUSPICIOUS'">
             <p class="font-medium">
               <i class="fa-solid fa-shield-halved mr-1" />
-              Held for security review
+              {{ scanStatus === 'INFECTED'
+                ? 'Quarantined: threat detected'
+                : 'Quarantined: suspicious content' }}
             </p>
             <p class="mt-1">
               <template v-if="creatorIsViewing">
@@ -305,6 +315,14 @@ const groupedLabels = computed(() => {
               >
                 {{ reviewRequested ? 'Human review requested' : requestingReview ? 'Requesting review…' : 'Request human review' }}
               </button>
+              <button
+                type="button"
+                class="font-medium underline disabled:no-underline disabled:opacity-70"
+                :disabled="retryingScan"
+                @click="retryScan"
+              >
+                {{ retryingScan ? 'Retrying…' : 'Retry scan' }}
+              </button>
             </div>
             <p v-if="requestReviewError" class="mt-2 font-medium">
               The review request could not be sent. Please try again.
@@ -313,7 +331,7 @@ const groupedLabels = computed(() => {
           <template v-else>
             <p class="font-medium">
               <i class="fa-solid fa-triangle-exclamation mr-1" />
-              Security scan unavailable
+              Quarantined: security check incomplete
             </p>
             <p class="mt-1">
               <template v-if="creatorIsViewing">
@@ -343,6 +361,19 @@ const groupedLabels = computed(() => {
               {{ retryError }}
             </p>
           </template>
+          <p v-if="scanCheckedDisplay" class="mt-2 text-xs opacity-80">
+            Last checked {{ scanCheckedDisplay }}
+          </p>
+          <NuxtLink
+            v-if="scanStatus !== 'CLEAN'"
+            class="mt-2 inline-block font-medium underline"
+            :to="pipelinePath"
+          >
+            View security pipeline
+          </NuxtLink>
+          <p v-if="hasReviewAccess && scanStatus !== 'CLEAN'" class="mt-2 text-xs">
+            Direct download is disabled while this file is quarantined. Review the scanner findings before clearing it.
+          </p>
         </div>
         <dl class="mt-3 grid grid-cols-2 gap-3 text-sm">
           <div>

--- a/components/discussion/list/ChannelDownloadListItem.vue
+++ b/components/discussion/list/ChannelDownloadListItem.vue
@@ -18,6 +18,7 @@ import CheckCircleIcon from '@/components/icons/CheckCircleIcon.vue';
 import CommentIcon from '@/components/icons/CommentIcon.vue';
 import ImageIcon from '@/components/icons/ImageIcon.vue';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
+import DownloadQuarantineBadge from '@/components/download/DownloadQuarantineBadge.vue';
 
 // Define props
 const props = defineProps({
@@ -200,6 +201,10 @@ const filteredQuery = computed(() => {
 
           <!-- Top right buttons container -->
           <div class="absolute right-2 top-2 z-10 flex gap-2">
+            <DownloadQuarantineBadge
+              v-if="discussion.DownloadableFiles?.[0]"
+              :status="discussion.DownloadableFiles[0].scanStatus"
+            />
             <!-- Add to Favorites Button -->
             <div
               v-if="discussion"

--- a/components/discussion/list/SitewideDownloadListItem.vue
+++ b/components/discussion/list/SitewideDownloadListItem.vue
@@ -8,6 +8,7 @@ import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavo
 import ImageIcon from '@/components/icons/ImageIcon.vue';
 import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue';
 import CommentIcon from '@/components/icons/CommentIcon.vue';
+import DownloadQuarantineBadge from '@/components/download/DownloadQuarantineBadge.vue';
 import { relativeTime } from '@/utils';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 import type { DiscussionWithFavorited } from '@/types/Discussion';
@@ -218,6 +219,14 @@ const handleOpenAlbum = () => {
       </div>
 
       <!-- Top right buttons container -->
+      <div
+        v-if="discussion.DownloadableFiles?.[0]"
+        class="absolute left-2 top-2 z-10"
+      >
+        <DownloadQuarantineBadge
+          :status="discussion.DownloadableFiles[0].scanStatus"
+        />
+      </div>
       <div class="absolute right-2 top-2 z-10 flex gap-2">
         <!-- Add to Favorites Button -->
         <div

--- a/components/download/DownloadQuarantineBadge.spec.ts
+++ b/components/download/DownloadQuarantineBadge.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import DownloadQuarantineBadge from './DownloadQuarantineBadge.vue';
+
+describe('DownloadQuarantineBadge', () => {
+  it.each([
+    ['CLEAN', 'Verified'],
+    ['INFECTED', 'Quarantined'],
+    ['SUSPICIOUS', 'Quarantined'],
+    ['FAILED', 'Scan failed'],
+    ['PENDING', 'Scanning'],
+  ] as const)('shows %s as %s', (status, label) => {
+    const wrapper = mount(DownloadQuarantineBadge, { props: { status } });
+
+    expect(wrapper.text()).toBe(label);
+  });
+});

--- a/components/download/DownloadQuarantineBadge.vue
+++ b/components/download/DownloadQuarantineBadge.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+type ScanStatus = 'PENDING' | 'CLEAN' | 'INFECTED' | 'SUSPICIOUS' | 'FAILED';
+
+const props = defineProps<{
+  status?: ScanStatus | null;
+}>();
+
+const badge = computed(() => {
+  switch (props.status) {
+    case 'CLEAN':
+      return { label: 'Verified', classes: 'bg-green-700 text-white' };
+    case 'INFECTED':
+      return { label: 'Quarantined', classes: 'bg-red-700 text-white' };
+    case 'SUSPICIOUS':
+      return { label: 'Quarantined', classes: 'bg-amber-600 text-black' };
+    case 'FAILED':
+      return { label: 'Scan failed', classes: 'bg-sky-700 text-white' };
+    default:
+      return { label: 'Scanning', classes: 'bg-gray-800 text-white' };
+  }
+});
+</script>
+
+<template>
+  <span
+    class="rounded-full px-2 py-1 text-xs font-semibold shadow"
+    :class="badge.classes"
+    data-testid="download-quarantine-badge"
+  >
+    {{ badge.label }}
+  </span>
+</template>

--- a/graphQLData/discussion/queries.js
+++ b/graphQLData/discussion/queries.js
@@ -154,6 +154,10 @@ export const GET_DISCUSSIONS_WITH_DISCUSSION_CHANNEL_DATA = gql`
           Tags {
             text
           }
+          DownloadableFiles(where: { permanentlyRemoved_NOT: true }) {
+            id
+            scanStatus
+          }
         }
       }
     }
@@ -238,6 +242,10 @@ export const GET_SITE_WIDE_DISCUSSION_LIST = gql`
         }
         Tags {
           text
+        }
+        DownloadableFiles(where: { permanentlyRemoved_NOT: true }) {
+          id
+          scanStatus
         }
       }
     }

--- a/utils/pipelineSchema.spec.ts
+++ b/utils/pipelineSchema.spec.ts
@@ -50,6 +50,17 @@ describe('pipelineSchema utilities', () => {
       );
     });
 
+    it('should include downloadableFile.downloaded as server event', () => {
+      const event = PIPELINE_EVENTS.find((e) => e.value === 'downloadableFile.downloaded');
+      expect(event).toEqual(
+        expect.objectContaining({
+          value: 'downloadableFile.downloaded',
+          scope: 'server',
+          label: 'Download Requested',
+        })
+      );
+    });
+
     it('should include comment.created as server event', () => {
       const event = PIPELINE_EVENTS.find((e) => e.value === 'comment.created');
       expect(event).toEqual(
@@ -85,12 +96,14 @@ describe('pipelineSchema utilities', () => {
         allServer: events.every((e) => e.scope === 'server'),
         hasCreated: events.some((e) => e.value === 'downloadableFile.created'),
         hasUpdated: events.some((e) => e.value === 'downloadableFile.updated'),
+        hasDownloaded: events.some((e) => e.value === 'downloadableFile.downloaded'),
         hasComment: events.some((e) => e.value === 'comment.created'),
       }).toEqual({
-        count: 3,
+        count: 4,
         allServer: true,
         hasCreated: true,
         hasUpdated: true,
+        hasDownloaded: true,
         hasComment: true,
       });
     });
@@ -154,12 +167,14 @@ describe('pipelineSchema utilities', () => {
         titleIncludesServer: schema.title.includes('Server'),
         hasCreated: eventEnum?.includes('downloadableFile.created'),
         hasUpdated: eventEnum?.includes('downloadableFile.updated'),
+        hasDownloaded: eventEnum?.includes('downloadableFile.downloaded'),
         hasComment: eventEnum?.includes('comment.created'),
         hasChannel: eventEnum?.includes('discussionChannel.created'),
       }).toEqual({
         titleIncludesServer: true,
         hasCreated: true,
         hasUpdated: true,
+        hasDownloaded: true,
         hasComment: true,
         hasChannel: false,
       });

--- a/utils/pipelineSchema.ts
+++ b/utils/pipelineSchema.ts
@@ -46,6 +46,12 @@ export const PIPELINE_EVENTS = [
     scope: 'server' as PipelineConfigScope,
   },
   {
+    value: 'downloadableFile.downloaded',
+    label: 'Download Requested',
+    description: 'Triggered when a download needs a fresh security check',
+    scope: 'server' as PipelineConfigScope,
+  },
+  {
     value: 'comment.created',
     label: 'Comment Created',
     description: 'Triggered when a comment is created',


### PR DESCRIPTION
## Summary
- show precise quarantine states on download details and list cards
- remove ordinary reviewer download access while a file is quarantined
- add moderator retry, pipeline review, and audited release controls
- expose download-requested events in the server pipeline editor

## Verification
- pnpm exec vitest run
- pnpm run tsc
- ESLint on changed files
- targeted coverage-enabled tests