### PR TITLE
fix: admin dashboard light mode white-on-light text

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -2,6 +2,25 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Pin the document's UA color-scheme to the app's own theme (toggled via the
+ * `.dark` class) rather than the OS. The <meta name="color-scheme"> hint lists
+ * both schemes, so a user whose OS is dark but who runs the app in light mode
+ * would otherwise get the browser's dark UA defaults — most visibly a white
+ * default text color — while our Tailwind backgrounds stay light, producing
+ * white-on-light text anywhere an element inherits its color (e.g. issue titles
+ * and tags on the admin dashboard, textarea contents). Tying color-scheme to
+ * the app theme keeps native defaults (text, form controls, scrollbars) in sync
+ * with the theme the user actually selected.
+ */
+:root {
+  color-scheme: light;
+}
+
+:root.dark {
+  color-scheme: dark;
+}
+
 .vue-map {
   height: 500px;
 }

--- a/components/mod/ModIssueListItem.vue
+++ b/components/mod/ModIssueListItem.vue
@@ -150,7 +150,7 @@ const relatedChannelNames = computed(() =>
         >
           <nuxt-link
             v-if="issue.issueNumber"
-            class="hover:underline dark:text-gray-200 lg:hidden"
+            class="text-gray-900 hover:underline dark:text-gray-200 lg:hidden"
             :to="{
               name: 'forums-forumId-issues-issueNumber',
               params: {
@@ -165,7 +165,7 @@ const relatedChannelNames = computed(() =>
           <button
             v-if="issue.issueNumber"
             type="button"
-            class="hidden text-left hover:underline dark:text-gray-200 lg:inline-block"
+            class="hidden text-left text-gray-900 hover:underline dark:text-gray-200 lg:inline-block"
             @click="handleSelect"
           >
             <span
@@ -178,7 +178,7 @@ const relatedChannelNames = computed(() =>
               {{ issue.title }}
             </span>
           </button>
-          <span v-else class="dark:text-gray-200">{{ issue.title }}</span>
+          <span v-else class="text-gray-900 dark:text-gray-200">{{ issue.title }}</span>
           <span
             v-if="issue.locked"
             class="inline-flex items-center gap-1 rounded-full bg-yellow-200 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/70 dark:text-yellow-100"
@@ -200,7 +200,7 @@ const relatedChannelNames = computed(() =>
           </span>
           <span
             v-if="issue.flaggedServerRuleViolation"
-            class="rounded-lg bg-gray-200 px-2 py-1 text-xs dark:bg-gray-700 dark:text-white"
+            class="rounded-lg bg-gray-200 px-2 py-1 text-xs text-gray-800 dark:bg-gray-700 dark:text-white"
             >Server Rule Violation</span
           >
           <span
@@ -223,7 +223,7 @@ const relatedChannelNames = computed(() =>
             Wiki Edit
           </span>
         </span>
-        <div v-else class="dark:text-gray-200">{{ issue.title }}</div>
+        <div v-else class="text-gray-900 dark:text-gray-200">{{ issue.title }}</div>
         <div
           v-if="relatedChannelNames.length"
           class="mt-2 flex flex-wrap gap-1"


### PR DESCRIPTION
## Problem

In light mode, admin dashboard content rendered white-on-light: issue titles and the "Server Rule Violation" tag on `/admin/issues`, and the text-input contents on `/admin/settings/basic`.

## Root cause

The pages set `<meta name="color-scheme" content="dark light">`. When a user's **OS is in dark mode** but they run the app in its **light theme**, the browser applies its *dark* UA defaults — notably a **white default text color** — while our Tailwind backgrounds stay light. Any element that only declares a `dark:text-*` color and otherwise inherits its color then renders white-on-light. It was never admin-specific; it just surfaced there.

Reproduced live with OS=dark + app=light: titles went invisible and the tag text went white.

## Fix

**Primary (systemic)** — [`assets/css/index.css`](https://github.com/gennit-project/multiforum-nuxt/blob/claude/admin-dashboard-light-mode-c77dd6/assets/css/index.css): pin the document `color-scheme` to the app's own theme (the `.dark` class) instead of the OS:

```css
:root { color-scheme: light; }
:root.dark { color-scheme: dark; }
```

This keeps native defaults (text, form controls, scrollbars) in sync with the selected theme and resolves the whole class of bug in light mode across **every** admin page and the rest of the app. It mirrors the intent of the existing per-input `[color-scheme:light]` hacks already used in a few components.

**Supplementary (hygiene)** — `components/mod/ModIssueListItem.vue`: added explicit light-mode text colors (`text-gray-900` on titles, `text-gray-800` on the server-rule-violation tag) so the component is correct on its own rather than relying on inherited color.

## Audit

Swept `components/admin`, `pages/admin`, and `components/mod` for light-text-without-`dark:` and ambient-inheritance cases. The only other light-text spot (`PluginManifestSection.vue`) sits on an always-dark background and is fine; remaining `text-white` usages are on colored buttons/badges. The systemic `color-scheme` fix covers the rest.

## Verification

- Reproduced the bug and confirmed the exact CSS rule fixes it, live against the deployed site (screenshot before/after).
- `eslint` passes on the changed component; `ModIssueListItem` unit test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)