### PR TITLE
fix: retain pipelines tab on error

### DIFF
--- a/components/discussion/detail/DownloadTabNavigation.spec.ts
+++ b/components/discussion/detail/DownloadTabNavigation.spec.ts
@@ -102,4 +102,13 @@ describe('DownloadTabNavigation', () => {
 
     expect(wrapper.text()).not.toContain('Pipelines');
   });
+
+  it('keeps the Pipelines tab visible on its route when loading fails', async () => {
+    mockHasPipelineContent.value = false;
+    const wrapper = await mountNav(
+      'forums-forumId-downloads-discussionId-pipelines'
+    );
+
+    expect(wrapper.text()).toContain('Pipelines');
+  });
 });

--- a/components/discussion/detail/DownloadTabNavigation.vue
+++ b/components/discussion/detail/DownloadTabNavigation.vue
@@ -127,7 +127,11 @@ const {
           Activity
         </nuxt-link>
         <nuxt-link
-          v-if="hasPipelineContent"
+          v-if="
+            hasPipelineContent ||
+            (typeof $route.name === 'string' &&
+              $route.name.includes('pipelines'))
+          "
           :to="{
             name: 'forums-forumId-downloads-discussionId-pipelines',
             params: {


### PR DESCRIPTION
## Summary
- keep the Pipelines tab visible while the user is already on the pipelines route
- prevent a failed overview request from leaving pipeline content without its tab label
- add regression coverage for the error-state route

## Verification
- focused Vitest suite: 4 tests passed
- `npm run tsc`
- ESLint on changed files