### PR TITLE
fix: stop DiscussionAlbum from clipping the top-nav search dropdown

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -126,7 +126,15 @@ onMounted(() => {
           />
         </header>
 
-        <div class="relative flex flex-grow flex-col">
+        <!--
+          `isolate` (isolation: isolate) forces this content column to be its own
+          stacking context so page-content z-indexes stay contained below the app
+          chrome. Without it, a positioned descendant with a z-index higher than
+          the top nav's (e.g. DiscussionAlbum's `z-40` in expanded view) escapes
+          this column and paints over the fixed top nav — clipping the nav's
+          search-type dropdown (z-30, trapped inside the nav's own z-20 context).
+        -->
+        <div class="relative isolate flex flex-grow flex-col">
           <!-- Vertical Icon Navigation for Large Screens -->
           <nav aria-label="Main navigation">
             <VerticalIconNav />


### PR DESCRIPTION
## Problem

On pages with an expanded `DiscussionAlbum` (e.g. a download/discussion detail in a forum), opening the top-nav search **Type** dropdown gets clipped — the album's image renders on top of the lower part of the menu.

## Root cause

A stacking-context escape:

- `DiscussionAlbum.vue` gives its root `relative z-40` in expanded view (added deliberately in "Fix discussion album/carousel ui issue").
- The layout's main content column (`layouts/default.vue`) was `relative` with **no** z-index, so it never established a stacking context.
- With no containing context, the album's `z-40` bubbles up to the root and beats the fixed top nav (`<nav>` is `relative z-20`).
- The nav's search dropdown (`TopNavSearch` popover, `z-30`) lives **inside** the nav's own `z-20` stacking context, so it's trapped at level 20 — beneath the album's 40, and gets clipped.

## Fix

Add `isolate` (`isolation: isolate`) to the content column in `layouts/default.vue` so all page-content z-indexes stay contained below the app chrome. The album keeps its `z-40` layering relative to its own siblings; it just can't paint over the nav anymore.

## Why not just raise the nav's z-index / lower the album's?

- Lowering the album's `z-40` risks re-introducing the carousel UI bug it was added to fix.
- **Raising the nav's z-index doesn't actually work here** — verified below.

Other overlays are unaffected: `SiteSidenav` (mobile) has no z-index on its container and already sits below the nav; `RecentForumsDrawer` is contained inside `VerticalIconNav`'s own `fixed z-[18]` context; lightboxes/modals teleport to `<body>` (outside this column).

## Verification

Tested against the live DOM with `document.elementFromPoint` at the overlap of a simulated `z-30` nav dropdown and a `z-40` album:

| scenario | top element at overlap |
| --- | --- |
| before | album (bug reproduced) |
| **content column `isolate`** | **dropdown (fixed)** |
| nav raised to `z-50` | album (does **not** fix) |

`eslint` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)