### PR TITLE
Improve mobile channel navigation performance

### DIFF
--- a/components/channel/ChannelTabs.spec.ts
+++ b/components/channel/ChannelTabs.spec.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => ({
   mdAndUp: null as unknown,
   route: null as unknown,
   closePopper: vi.fn(),
+  preloadRouteComponents: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('@/composables/useAuthState', () => ({
@@ -27,6 +28,7 @@ vi.mock('@vue/apollo-composable', () => ({
 vi.mock('nuxt/app', () => ({
   useRoute: () => h.route,
   useRouter: () => ({ push: vi.fn() }),
+  preloadRouteComponents: h.preloadRouteComponents,
 }));
 
 const makeChannel = (overrides: Partial<Channel> = {}) =>
@@ -80,6 +82,7 @@ beforeEach(() => {
     path: '/forums/cats/discussions',
   });
   h.closePopper.mockReset();
+  h.preloadRouteComponents.mockClear();
 });
 
 describe('ChannelTabs base tabs', () => {
@@ -211,5 +214,27 @@ describe('ChannelTabs mobile layout', () => {
     await wrapper.get('[data-testid="mobile-dropdown-about"]').trigger('click');
 
     expect(h.closePopper).toHaveBeenCalledOnce();
+  });
+
+  it('preloads sibling channel routes that are hidden inside the dropdown', async () => {
+    (h.mdAndUp as { value: boolean }).value = false;
+    mountTabs({
+      channel: makeChannel({ downloadsEnabled: true, eventsEnabled: true }),
+    });
+    await nextTick();
+
+    expect(h.preloadRouteComponents.mock.calls.map(([path]) => path)).toEqual([
+      '/forums/cats/downloads',
+      '/forums/cats/events',
+      '/forums/cats/contributors',
+      '/forums/cats/about',
+    ]);
+  });
+
+  it('does not preload hidden channel routes on desktop', async () => {
+    mountTabs();
+    await nextTick();
+
+    expect(h.preloadRouteComponents).not.toHaveBeenCalled();
   });
 });

--- a/components/channel/ChannelTabs.vue
+++ b/components/channel/ChannelTabs.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref, watch, type Component } from 'vue';
+import { computed, onMounted, ref, watch, type Component } from 'vue';
 import TabButton from '@/components/channel/TabButton.vue';
 import CalendarIcon from '@/components/icons/CalendarIcon.vue';
 import DiscussionIcon from '@/components/icons/DiscussionIcon.vue';
@@ -15,7 +15,7 @@ import {
   useUsername,
   useIsAuthenticated,
 } from '@/composables/useAuthState';
-import { useRoute } from 'nuxt/app';
+import { preloadRouteComponents, useRoute } from 'nuxt/app';
 import { useDisplay } from '@/composables/useDisplay';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_SERVER_CONFIG } from '@/graphQLData/admin/queries';
@@ -123,6 +123,8 @@ const iconSize = computed(() =>
 );
 
 const { mdAndUp } = useDisplay();
+const hasMounted = ref(false);
+const preloadedTabRoutes = new Set<string>();
 
 // Check if a tab should be active based on route
 const isTabActive = (tab: Tab) => {
@@ -256,6 +258,35 @@ const tabs = computed((): Tab[] => {
 
   return filteredResult;
 });
+
+const preloadMobileTabRoutes = () => {
+  if (!hasMounted.value || mdAndUp.value) {
+    return;
+  }
+
+  for (const tab of tabs.value) {
+    const tabRoute = tabRoutes.value[tab.name];
+    if (
+      !tabRoute ||
+      tabRoute === route.path ||
+      preloadedTabRoutes.has(tabRoute)
+    ) {
+      continue;
+    }
+
+    preloadedTabRoutes.add(tabRoute);
+    void preloadRouteComponents(tabRoute).catch(() => {
+      preloadedTabRoutes.delete(tabRoute);
+    });
+  }
+};
+
+onMounted(() => {
+  hasMounted.value = true;
+  preloadMobileTabRoutes();
+});
+
+watch([mdAndUp, tabs, tabRoutes], preloadMobileTabRoutes);
 </script>
 
 <template>

--- a/pages/forums/[forumId].spec.ts
+++ b/pages/forums/[forumId].spec.ts
@@ -17,6 +17,7 @@ const mockState = vi.hoisted(() => ({
   useHead: vi.fn(),
   queryResultCallback: null as null | ((result: unknown) => void),
   refetchChannel: vi.fn(),
+  mdAndUp: null as unknown,
 }));
 
 vi.mock('nuxt/app', () => ({
@@ -29,6 +30,10 @@ vi.mock('@vue/apollo-composable', () => ({ useQuery: vi.fn() }));
 
 vi.mock('@/composables/useAuthState', () => ({
   useUsername: () => ref('viewer'),
+}));
+
+vi.mock('@/composables/useDisplay', () => ({
+  useDisplay: () => ({ mdAndUp: mockState.mdAndUp }),
 }));
 
 vi.mock('@/config', () => ({
@@ -208,6 +213,7 @@ describe('forum shell page', () => {
     mockState.route.name = 'forums-forumId';
     mockState.route.query = {};
     mockState.queryResultCallback = null;
+    mockState.mdAndUp = ref(true);
   });
 
   it('shows the not-found page when the channel does not exist', async () => {
@@ -368,6 +374,16 @@ describe('forum shell page', () => {
     wrapper.findComponent(ChannelSidebarStub).vm.$emit('refetch-channel-data');
 
     expect(mockState.refetchChannel).toHaveBeenCalledOnce();
+  });
+
+  it('does not mount the detail sidebar on mobile', async () => {
+    mockState.route.name = 'forums-forumId-events-eventId';
+    (mockState.mdAndUp as { value: boolean }).value = false;
+    const wrapper = await mountWith([
+      { uniqueName: 'cats', displayName: 'Cats' },
+    ]);
+
+    expect(wrapper.findComponent(ChannelSidebarStub).exists()).toBe(false);
   });
 
   it('builds SEO metadata from the loaded channel', async () => {

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -32,11 +32,13 @@ import {
 import { getForumShellVisibility } from '@/utils/forumShellVisibility';
 import type { ForumItem } from '@/types/forum';
 import { useUsername } from '@/composables/useAuthState';
+import { useDisplay } from '@/composables/useDisplay';
 
 const route = useRoute();
 const router = useRouter();
 const loggedInUsername = useUsername();
 const uiStore = useUIStore();
+const { mdAndUp } = useDisplay();
 const {
   selectedChannelDiscussionTitle,
   selectedChannelEventId,
@@ -541,7 +543,7 @@ definePageMeta({
                 </div>
               </div>
               <div
-                v-if="showChannelSidebarOnIssueDetail"
+                v-if="showChannelSidebarOnIssueDetail && mdAndUp"
                 class="hidden md:flex md:w-1/3 md:flex-col md:overflow-y-auto"
                 tabindex="0"
                 role="region"
@@ -555,7 +557,7 @@ definePageMeta({
                 />
               </div>
               <div
-                v-if="showChannelSidebarOnDetail"
+                v-if="showChannelSidebarOnDetail && mdAndUp"
                 class="hidden md:flex md:w-1/3 md:flex-col md:overflow-y-auto"
                 tabindex="0"
                 role="region"

--- a/pages/forums/[forumId]/downloads/index.spec.ts
+++ b/pages/forums/[forumId]/downloads/index.spec.ts
@@ -101,6 +101,11 @@ describe('downloads index page', () => {
     expect(wrapper.text()).not.toContain('Downloads Not Available');
   });
 
+  it('mounts one download list for both mobile and desktop layouts', async () => {
+    const wrapper = await mountWith({});
+    expect(wrapper.findAllComponents(DownloadListStub)).toHaveLength(1);
+  });
+
   it('removes stale download filter params after channel filters load', async () => {
     h.route.query = { filter_old: 'x', filter_type: 'pdf' };
     await mountWith({});

--- a/pages/forums/[forumId]/downloads/index.vue
+++ b/pages/forums/[forumId]/downloads/index.vue
@@ -182,10 +182,13 @@ watch(
     <div v-show="shouldShowDownloads">
       <DownloadFilterBar :filter-groups="filterGroups" />
 
-      <!-- Desktop Layout with Sidebar -->
-      <div class="hidden lg:flex">
+      <!-- Responsive layout with a desktop-only filter sidebar -->
+      <div class="lg:flex">
         <!-- Left Sidebar for Filters -->
-        <div v-if="filterGroups.length > 0" class="w-64 flex-shrink-0 pr-6">
+        <div
+          v-if="filterGroups.length > 0"
+          class="hidden w-64 flex-shrink-0 pr-6 lg:block"
+        >
           <div class="sticky top-4">
             <DownloadFilters :filter-groups="filterGroups" :is-sidebar="true" />
           </div>
@@ -195,11 +198,6 @@ watch(
         <div class="min-w-0 flex-1">
           <DownloadList :filter-groups="filterGroups" />
         </div>
-      </div>
-
-      <!-- Mobile Layout (no sidebar) -->
-      <div class="lg:hidden">
-        <DownloadList :filter-groups="filterGroups" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- preload sibling channel route components on mobile, where dropdown links are otherwise hidden from automatic prefetching
- render one channel download list across responsive layouts instead of mounting duplicate mobile and desktop query trees
- avoid mounting detail sidebars and their queries below the desktop breakpoint

## Verification

- 40 focused Vitest tests passed
- ESLint passed for all changed files
- vue-tsc --noEmit passed
- Nuxt production build passed

## Follow-up

This is the first low-risk frontend slice from the broader channel-list and detail-page performance investigation. Query centralization and forum-shell waterfall reduction can follow in separate PRs.