### PR TITLE
Load forum child pages in parallel

### DIFF
--- a/pages/forums/[forumId].spec.ts
+++ b/pages/forums/[forumId].spec.ts
@@ -121,6 +121,16 @@ const ChannelTabsStub = defineComponent({
   template: '<div class="channel-tabs-stub" />',
 });
 
+const NuxtPageStub = defineComponent({
+  name: 'NuxtPage',
+  template: '<div class="nuxt-page-stub" />',
+});
+
+const NuxtLayoutStub = defineComponent({
+  name: 'NuxtLayout',
+  template: '<div><slot /></div>',
+});
+
 vi.mock('@/components/PageNotFound.vue', () => ({
   default: PageNotFoundStub,
 }));
@@ -202,7 +212,14 @@ const mountWith = async (
       }),
     });
   const Page = (await import('./[forumId].vue')).default;
-  return shallowMount(Page);
+  return shallowMount(Page, {
+    global: {
+      stubs: {
+        NuxtLayout: NuxtLayoutStub,
+        NuxtPage: NuxtPageStub,
+      },
+    },
+  });
 };
 
 describe('forum shell page', () => {
@@ -218,7 +235,29 @@ describe('forum shell page', () => {
 
   it('shows the not-found page when the channel does not exist', async () => {
     const wrapper = await mountWith([]);
-    expect(wrapper.findComponent(PageNotFoundStub).exists()).toBe(true);
+    expect({
+      notFound: wrapper.findComponent(PageNotFoundStub).exists(),
+      childPage: wrapper.findComponent(NuxtPageStub).exists(),
+    }).toEqual({ notFound: true, childPage: false });
+  });
+
+  it('mounts the child page while the channel query is still loading', async () => {
+    const wrapper = await mountWith([], { loading: true });
+
+    expect({
+      childPage: wrapper.findComponent(NuxtPageStub).exists(),
+      channelTabs: wrapper.findComponent(ChannelTabsStub).exists(),
+      notFound: wrapper.findComponent(PageNotFoundStub).exists(),
+    }).toEqual({ childPage: true, channelTabs: false, notFound: false });
+  });
+
+  it('mounts detail title queries while the channel query is still loading', async () => {
+    mockState.route.name = 'forums-forumId-downloads-discussionId';
+    const wrapper = await mountWith([], { loading: true });
+
+    expect(wrapper.findComponent(DiscussionTitleEditFormStub).exists()).toBe(
+      true
+    );
   });
 
   it('renders the channel tabs on the plain forum route', async () => {

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -293,12 +293,15 @@ definePageMeta({
 <template>
   <NuxtLayout>
     <PageNotFound v-if="showNotFound" />
+    <!-- Keep route content mounted while channel chrome loads so the parent and
+         child GraphQL queries run in parallel instead of in separate waves. -->
     <div
-      v-else-if="channel"
+      v-else
       class="flex flex-col bg-white dark:bg-black dark:text-white sm:px-0 md:min-h-screen"
     >
       <ChannelHeaderMobile
         v-if="
+          channel &&
           !showDiscussionTitle &&
           !showDownloadTitle &&
           !showEventTitle &&
@@ -310,6 +313,7 @@ definePageMeta({
       />
       <ChannelHeaderDesktop
         v-if="
+          channel &&
           channel.channelBannerURL &&
           !showDiscussionTitle &&
           !showDownloadTitle &&
@@ -324,7 +328,7 @@ definePageMeta({
         :show-create-button="true"
       />
       <ChannelLockedBanner
-        v-if="channel.locked"
+        v-if="channel && channel.locked"
         :locked-at="channel.lockedAt"
         :lock-reason="channel.lockReason"
         :locked-by-display-name="channel.LockedBy?.displayName"
@@ -402,7 +406,7 @@ definePageMeta({
               >
                 <div class="flex items-center justify-between">
                   <ChannelTabs
-                    v-if="showChannelTabs"
+                    v-if="showChannelTabs && channel"
                     :admin-list="adminList"
                     :channel="channel"
                     :download-count="downloadCount"


### PR DESCRIPTION
## Summary

- mount nested forum list and detail pages while the parent channel query is still loading
- keep channel-dependent headers, tabs, lock banner, and sidebar content gated on the channel result
- preserve the completed-query 404 behavior for missing channels

This removes the parent-to-child GraphQL waterfall: child page and detail-title queries can now start in the same render wave as the forum shell channel query instead of waiting for it to finish.

## Verification

- 18 focused forum-shell Vitest tests passed
- ESLint passed for both changed files
- vue-tsc --noEmit passed
- Nuxt production build passed