### PR TITLE
Share download pipeline overview queries

### DIFF
--- a/components/discussion/detail/DiscussionLayoutManager.spec.ts
+++ b/components/discussion/detail/DiscussionLayoutManager.spec.ts
@@ -1,8 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 
 import DiscussionLayoutManager from '@/components/discussion/detail/DiscussionLayoutManager.vue';
 import type { Discussion } from '@/__generated__/graphql';
+
+const mockProvideDownloadPipelineOverview = vi.hoisted(() => vi.fn());
+
+vi.mock('@/composables/useDownloadPipelineOverview', () => ({
+  provideDownloadPipelineOverview: mockProvideDownloadPipelineOverview,
+}));
 
 const ALL_EVENTS = [
   'discussion-refetch',
@@ -48,6 +54,18 @@ const mountManager = (props: Record<string, unknown> = {}) =>
   });
 
 describe('DiscussionLayoutManager', () => {
+  it('provides one pipeline overview for the download detail subtree', () => {
+    mountManager({
+      downloadMode: true,
+      discussion: {
+        id: 'd1',
+        DownloadableFiles: [{ id: 'file-1' }],
+      } as unknown as Discussion,
+    });
+
+    expect(mockProvideDownloadPipelineOverview).toHaveBeenCalledOnce();
+  });
+
   it('renders the regular layout by default', () => {
     const wrapper = mountManager();
 

--- a/components/discussion/detail/DiscussionLayoutManager.vue
+++ b/components/discussion/detail/DiscussionLayoutManager.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+import { computed, toRef } from 'vue';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 import DownloadModeLayout from './DownloadModeLayout.vue';
 import RegularDiscussionLayout from './RegularDiscussionLayout.vue';
 import DownloadTabNavigation from './DownloadTabNavigation.vue';
+import { provideDownloadPipelineOverview } from '@/composables/useDownloadPipelineOverview';
 
-defineProps({
+const props = defineProps({
   discussion: {
     type: Object as () => Discussion,
     required: true,
@@ -34,6 +36,19 @@ defineProps({
     default: false,
   },
 });
+
+const downloadableFileId = computed(
+  () =>
+    (props.downloadMode && props.discussion.DownloadableFiles?.[0]?.id) || ''
+);
+
+// The navigation, sidebar, activity tab, and pipelines tab all consume this
+// overview. Providing it here keeps them on one query, cache, and polling loop.
+provideDownloadPipelineOverview(
+  downloadableFileId,
+  toRef(props, 'discussionId'),
+  toRef(props, 'channelId')
+);
 
 const emit = defineEmits<{
   discussionRefetch: [];

--- a/components/discussion/detail/DownloadTabNavigation.spec.ts
+++ b/components/discussion/detail/DownloadTabNavigation.spec.ts
@@ -21,7 +21,7 @@ vi.mock('@/composables/useAuthState', () => ({
 }));
 
 vi.mock('@/composables/useDownloadPipelineOverview', () => ({
-  useDownloadPipelineOverview: () => ({
+  useSharedDownloadPipelineOverview: () => ({
     hasPipelineContent: mockHasPipelineContent,
   }),
 }));

--- a/components/discussion/detail/DownloadTabNavigation.vue
+++ b/components/discussion/detail/DownloadTabNavigation.vue
@@ -8,7 +8,7 @@ import { useQuery } from '@vue/apollo-composable';
 import { GET_PUBLIC_COLLECTIONS_FOR_DOWNLOAD } from '@/graphQLData/collection/queries';
 import PublicCollectionListItem from '@/components/collection/PublicCollectionListItem.vue';
 import { useUsername } from '@/composables/useAuthState';
-import { useDownloadPipelineOverview } from '@/composables/useDownloadPipelineOverview';
+import { useSharedDownloadPipelineOverview } from '@/composables/useDownloadPipelineOverview';
 
 const usernameVar = useUsername();
 
@@ -60,7 +60,7 @@ const primaryFileId = computed(
 );
 const {
   hasPipelineContent,
-} = useDownloadPipelineOverview(
+} = useSharedDownloadPipelineOverview(
   primaryFileId,
   computed(() => props.discussionId),
   computed(() => props.channelId),

--- a/components/plugins/DownloadPipelineStatusSummary.spec.ts
+++ b/components/plugins/DownloadPipelineStatusSummary.spec.ts
@@ -18,7 +18,7 @@ vi.mock('@/composables/useDownloadPipelineOverview', async () => {
   const { ref } = await import('vue');
   return {
     ...actual,
-    useDownloadPipelineOverview: () => ({
+    useSharedDownloadPipelineOverview: () => ({
       applicablePipelines: ref(mockOverview.applicablePipelines),
       attempts: ref(mockOverview.attempts),
       hasPipelineContent: ref(mockOverview.hasPipelineContent),

--- a/components/plugins/DownloadPipelineStatusSummary.vue
+++ b/components/plugins/DownloadPipelineStatusSummary.vue
@@ -2,7 +2,7 @@
 import { computed, toRef } from 'vue';
 import {
   getApplicablePipelineStatus,
-  useDownloadPipelineOverview,
+  useSharedDownloadPipelineOverview,
   type PublicPipelineDisplayStatus,
 } from '@/composables/useDownloadPipelineOverview';
 
@@ -18,7 +18,7 @@ const {
   hasPipelineContent,
   hasActiveAttempt,
   loading,
-} = useDownloadPipelineOverview(
+} = useSharedDownloadPipelineOverview(
   toRef(props, 'fileId'),
   toRef(props, 'discussionId'),
   toRef(props, 'channelName'),

--- a/components/plugins/PublicDownloadPipelines.spec.ts
+++ b/components/plugins/PublicDownloadPipelines.spec.ts
@@ -74,7 +74,7 @@ vi.mock('@/composables/useDownloadPipelineOverview', async () => {
   const { ref } = await import('vue');
   return {
     ...actual,
-    useDownloadPipelineOverview: () => ({
+    useSharedDownloadPipelineOverview: () => ({
       applicablePipelines: ref(mockOverview.applicablePipelines),
       attempts: ref(mockOverview.attempts),
       hasPipelineContent: ref(mockOverview.hasPipelineContent),

--- a/components/plugins/PublicDownloadPipelines.vue
+++ b/components/plugins/PublicDownloadPipelines.vue
@@ -3,7 +3,7 @@ import { computed, nextTick, ref, toRef, watch } from 'vue';
 import { useMutation } from '@vue/apollo-composable';
 import {
   getApplicablePipelineStatus,
-  useDownloadPipelineOverview,
+  useSharedDownloadPipelineOverview,
   type ApplicablePublicPipeline,
   type PublicPipelineAttempt,
   type PublicPipelineDisplayStatus,
@@ -32,7 +32,7 @@ const {
   loading,
   error,
   refetch,
-} = useDownloadPipelineOverview(
+} = useSharedDownloadPipelineOverview(
   toRef(props, 'fileId'),
   toRef(props, 'discussionId'),
   toRef(props, 'channelName')

--- a/composables/useDownloadPipelineOverview.spec.ts
+++ b/composables/useDownloadPipelineOverview.spec.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ref } from 'vue';
+import { defineComponent, h, ref } from 'vue';
+import { mount } from '@vue/test-utils';
 import {
   getApplicablePipelineStatus,
+  provideDownloadPipelineOverview,
+  useSharedDownloadPipelineOverview,
   useDownloadPipelineOverview,
   type ApplicablePublicPipeline,
   type PublicPipelineAttempt,
@@ -58,6 +61,7 @@ describe('useDownloadPipelineOverview', () => {
     vi.useFakeTimers();
     mockQueryResult.value = {};
     mockRefetch.mockReset();
+    mockUseQuery.mockClear();
     mockUseQuery.mockReturnValue({
       result: mockQueryResult,
       loading: ref(false),
@@ -162,6 +166,38 @@ describe('useDownloadPipelineOverview', () => {
     );
 
     expect(overview.hasPipelineContent.value).toBe(false);
+  });
+
+  it('shares one query across descendant pipeline consumers', () => {
+    const Consumer = defineComponent({
+      setup() {
+        useSharedDownloadPipelineOverview(
+          ref('file-1'),
+          ref('discussion-1'),
+          ref('cats')
+        );
+        useSharedDownloadPipelineOverview(
+          ref('file-1'),
+          ref('discussion-1'),
+          ref('cats')
+        );
+        return () => null;
+      },
+    });
+    const Provider = defineComponent({
+      setup() {
+        provideDownloadPipelineOverview(
+          ref('file-1'),
+          ref('discussion-1'),
+          ref('cats')
+        );
+        return () => h(Consumer);
+      },
+    });
+
+    mount(Provider);
+
+    expect(mockUseQuery).toHaveBeenCalledOnce();
   });
 });
 

--- a/composables/useDownloadPipelineOverview.ts
+++ b/composables/useDownloadPipelineOverview.ts
@@ -1,9 +1,12 @@
 import {
   computed,
   getCurrentInstance,
+  inject,
   onUnmounted,
+  provide,
   ref,
   watch,
+  type InjectionKey,
   type Ref,
 } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
@@ -244,4 +247,45 @@ export function useDownloadPipelineOverview(
     error,
     refetch,
   };
+}
+
+export type DownloadPipelineOverview = ReturnType<
+  typeof useDownloadPipelineOverview
+>;
+
+const downloadPipelineOverviewKey: InjectionKey<DownloadPipelineOverview> =
+  Symbol('download-pipeline-overview');
+
+export function provideDownloadPipelineOverview(
+  downloadableFileId: Ref<string | null | undefined>,
+  discussionId: Ref<string | null | undefined>,
+  channelUniqueName: Ref<string | null | undefined>
+) {
+  const overview = useDownloadPipelineOverview(
+    downloadableFileId,
+    discussionId,
+    channelUniqueName
+  );
+  provide(downloadPipelineOverviewKey, overview);
+  return overview;
+}
+
+export function useSharedDownloadPipelineOverview(
+  downloadableFileId: Ref<string | null | undefined>,
+  discussionId: Ref<string | null | undefined>,
+  channelUniqueName: Ref<string | null | undefined>,
+  options: {
+    pollInterval?: number;
+    pollWhileActive?: boolean;
+  } = {}
+) {
+  return (
+    inject(downloadPipelineOverviewKey, null) ??
+    useDownloadPipelineOverview(
+      downloadableFileId,
+      discussionId,
+      channelUniqueName,
+      options
+    )
+  );
 }

--- a/pages/forums/[forumId]/downloads/[discussionId]/activity.spec.ts
+++ b/pages/forums/[forumId]/downloads/[discussionId]/activity.spec.ts
@@ -19,7 +19,7 @@ vi.mock('@/composables/useAuthState', () => ({
 }));
 
 vi.mock('@/composables/useDownloadPipelineOverview', () => ({
-  useDownloadPipelineOverview: () => ({
+  useSharedDownloadPipelineOverview: () => ({
     attempts: ref([
       {
         pipelineId: 'pipeline-1',

--- a/pages/forums/[forumId]/downloads/[discussionId]/activity.vue
+++ b/pages/forums/[forumId]/downloads/[discussionId]/activity.vue
@@ -7,7 +7,7 @@ import { useModProfileName } from '@/composables/useAuthState';
 import DiscussionTitleVersions from '@/components/discussion/detail/activityFeed/DiscussionTitleVersions.vue';
 import LabelChangeHistory from '@/components/discussion/detail/activityFeed/LabelChangeHistory.vue';
 import type { Discussion } from '@/__generated__/graphql';
-import { useDownloadPipelineOverview } from '@/composables/useDownloadPipelineOverview';
+import { useSharedDownloadPipelineOverview } from '@/composables/useDownloadPipelineOverview';
 
 const modProfileNameVar = useModProfileName();
 
@@ -49,7 +49,7 @@ const discussion = computed<Discussion | null>(() => {
 const downloadableFileId = computed(
   () => discussion.value?.DownloadableFiles?.[0]?.id || ''
 );
-const { attempts: pipelineAttempts } = useDownloadPipelineOverview(
+const { attempts: pipelineAttempts } = useSharedDownloadPipelineOverview(
   downloadableFileId,
   discussionId,
   channelId,


### PR DESCRIPTION
## Summary

- create one download pipeline overview query at the download detail layout
- share its reactive results, polling loop, errors, and refetch function with the navigation, sidebar status, activity tab, and pipelines tab
- retain standalone fallbacks for consumers rendered outside the normal detail tree

This replaces the observed 2–3 identical GetDownloadPipelineOverview requests on download detail pages with one request owner and one polling loop.

## Verification

- 43 focused Vitest tests passed across 6 affected test files
- regression coverage verifies multiple descendants create exactly one Apollo query
- ESLint passed for all changed files
- vue-tsc --noEmit passed
- Nuxt production build passed