### PR TITLE
fix: use static pending scan indicator

### DIFF
--- a/components/channel/DownloadSidebar.spec.ts
+++ b/components/channel/DownloadSidebar.spec.ts
@@ -214,13 +214,17 @@ describe('DownloadSidebar', () => {
       },
     });
 
+    const scanStatus = wrapper.get('[data-testid="download-scan-status"]');
     expect({
-      message: wrapper.get('[data-testid="download-scan-status"]').text(),
+      message: scanStatus.text(),
       disabled: wrapper.get('button').attributes('disabled'),
+      icon: scanStatus.get('i').classes(),
     }).toEqual({
       message: expect.stringContaining('Quarantined: security check pending'),
       disabled: '',
+      icon: expect.arrayContaining(['fa-hourglass-half']),
     });
+    expect(scanStatus.get('i').classes()).not.toContain('animate-spin');
   });
 
   it('gives the creator cause-aware quarantine copy without a direct download', () => {

--- a/components/channel/DownloadSidebar.vue
+++ b/components/channel/DownloadSidebar.vue
@@ -285,7 +285,7 @@ const groupedLabels = computed(() => {
             Available to download
           </p>
           <p v-else-if="scanStatus === 'PENDING'" class="font-medium">
-            <i class="fa-solid fa-spinner mr-1 animate-spin" />
+            <i class="fa-solid fa-hourglass-half mr-1" />
             Quarantined: security check pending
           </p>
           <template v-else-if="scanStatus === 'INFECTED' || scanStatus === 'SUSPICIOUS'">


### PR DESCRIPTION
## Summary
- replace the indefinitely spinning pending-scan icon with a static hourglass
- retain the quarantined state and disabled download behavior
- add regression coverage ensuring the pending indicator does not animate

## Verification
- focused Vitest suite: 10 tests passed
- `npm run tsc`
- ESLint on changed files