### PR TITLE
test: fix @/utils mock asymmetry that breaks under Vite 8 (album upload spec)

### DIFF
--- a/tests/unit/composables/useAlbumImageUpload.spec.ts
+++ b/tests/unit/composables/useAlbumImageUpload.spec.ts
@@ -40,6 +40,7 @@ vi.mock('@/composables/useAuthState', () => ({
 vi.mock('@/utils', () => ({
   getUploadFileName: vi.fn(() => 'test-file-123.jpg'),
   uploadAndGetEmbeddedLink: mockUploadAndGetEmbeddedLink,
+  isFileSizeValid: mockIsFileSizeValid,
 }));
 
 vi.mock('@/utils/index', () => ({


### PR DESCRIPTION
## Why

Second and final prerequisite for the Vite 8 bump (#411), following #438. After #438 landed I re-ran the **full** unit suite on latest `main` under Vite 8.1.5 and found one more file failing that wasn't in #411's original run (it was added to `main` after the PR was opened):

```
FAIL tests/unit/composables/useAlbumImageUpload.spec.ts (6 tests)
Error: [vitest] No "isFileSizeValid" export is defined on the "@/utils" mock.
```

## Root cause

Vite 8's oxc-based resolver normalizes `@/utils` and `@/utils/index` to the **same module**, so the two `vi.mock` registrations for those paths collide — a single mock shape has to satisfy both. `useAlbumImageUpload.ts` imports `isFileSizeValid` from `@/utils/index` but its other helpers from `@/utils`. The spec declared `isFileSizeValid` **only** on the `@/utils/index` mock, so in the full suite the `@/utils` mock (which lacked it) could win and throw.

The file passes in isolation but fails in the full run — classic order/composition-dependent mock leakage, which is exactly the `@/utils` vs `@/utils/index` gotcha documented in CLAUDE.md.

## What

Add `isFileSizeValid: mockIsFileSizeValid` to the `@/utils` mock so both paths expose the same exports — mirroring the already-correct `useImageUpload.spec.ts`. One line, transformer-agnostic (passes under Vite 7 and 8).

## Verification

With this change, the full unit suite under **Vite 8.1.5** on latest `main` is green: **784 files / 7506 tests passing**.

## Follow-up

Once this merges, dependabot PR #411 (the Vite 8 bump) will be rebased onto `main` and its unit-tests check should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)