### PR TITLE
test: fix @/utils mock asymmetry in forum basic settings spec (Vite 8)

### DIFF
--- a/pages/forums/[forumId]/edit/basic.spec.ts
+++ b/pages/forums/[forumId]/edit/basic.spec.ts
@@ -39,6 +39,7 @@ vi.mock('@/utils', async (importOriginal) => {
     ...actual,
     getUploadFileName: vi.fn(() => 'alice-banner.png'),
     uploadAndGetEmbeddedLink: h.uploadAndGetEmbeddedLink,
+    isFileSizeValid: h.isFileSizeValid,
   };
 });
 


### PR DESCRIPTION
## Why

Third and (verified) final prerequisite for the Vite 8 bump (#411), after #438 and #449.

After #449 merged I rebased #411 and its unit-tests check surfaced one more order-dependent failure that my earlier local run hadn't hit (CI's test ordering differs):

```
FAIL pages/forums/[forumId]/edit/basic.spec.ts > rejects an oversized upload before requesting a signed URL
AssertionError: expected "vi.fn()" to be called with arguments: [ 'Too large' ]
```

## Root cause

The same `@/utils` vs `@/utils/index` normalization collision fixed in #449. `basic.vue` imports `isFileSizeValid` from `@/utils/index` but its other helpers from `@/utils`. The spec overrode `isFileSizeValid` only on the `@/utils/index` mock; the `@/utils` mock spread the real module. Under Vite 8 both paths resolve to a single module, so when the `@/utils` registration won, the **real** `isFileSizeValid` ran, judged the tiny test file as valid, and the `alert('Too large')` branch never fired.

## What

Override `isFileSizeValid: h.isFileSizeValid` on the `@/utils` mock too, so both registrations agree regardless of resolution order — matching `useImageUpload.spec.ts` and #449. One line, transformer-agnostic.

## Verification

I reproduced CI faithfully: checked out #411's branch (Vite `^8.2.0` lockfile), applied this fix, `pnpm install --frozen-lockfile`, and ran the full unit suite → **784 files / 7506 tests passing** under vite@8.2.0. This is the last `@/utils` dual-mock asymmetry in the repo (audited every `isFileSizeValid` mock site).

## Follow-up

Once merged, I'll rebase #411 one more time; unit-tests should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)