### PR TITLE
fix: compact failed download scan status

### DIFF
--- a/components/channel/DownloadSidebar.spec.ts
+++ b/components/channel/DownloadSidebar.spec.ts
@@ -327,17 +327,28 @@ describe('DownloadSidebar', () => {
         discussionId: 'discussion-1',
         channelUniqueName: 'test-forum',
       },
+      global: {
+        stubs: {
+          NuxtLink: {
+            props: ['to'],
+            template: '<a><slot /></a>',
+          },
+        },
+      },
     });
 
+    const status = wrapper.get('[data-testid="download-scan-status"]');
     expect({
-      text: wrapper.get('[data-testid="download-scan-status"]').text(),
-      links: wrapper
-        .get('[data-testid="download-scan-status"]')
-        .findAll('a')
-        .map((link) => link.text()),
+      title: status.get('p.font-medium').text(),
+      message: status.get('p.text-xs').text(),
+      actions: [
+        ...status.findAll('button'),
+        ...status.findAll('a'),
+      ].map((action) => action.text()),
     }).toEqual({
-      text: "Security check needs another try The scan service had a problem—your file wasn't rejected. Retry scan View checks",
-      links: ['View checks'],
+      title: 'Security check needs another try',
+      message: "The scan service had a problem—your file wasn't rejected.",
+      actions: ['Retry scan', 'View checks'],
     });
   });
 

--- a/components/channel/DownloadSidebar.spec.ts
+++ b/components/channel/DownloadSidebar.spec.ts
@@ -310,7 +310,7 @@ describe('DownloadSidebar', () => {
     });
   });
 
-  it('identifies a failed scan as a server-side problem for the creator', () => {
+  it('shows a compact failed-scan message with recovery actions', () => {
     mockUsernameRef.value = 'author';
     const wrapper = mount(DownloadSidebar, {
       props: {
@@ -329,9 +329,16 @@ describe('DownloadSidebar', () => {
       },
     });
 
-    expect(wrapper.get('[data-testid="download-scan-status"]').text()).toContain(
-      "a problem on our end, not your file"
-    );
+    expect({
+      text: wrapper.get('[data-testid="download-scan-status"]').text(),
+      links: wrapper
+        .get('[data-testid="download-scan-status"]')
+        .findAll('a')
+        .map((link) => link.text()),
+    }).toEqual({
+      text: "Security check needs another try The scan service had a problem—your file wasn't rejected. Retry scan View checks",
+      links: ['View checks'],
+    });
   });
 
   it('lets the creator retry a failed scan', async () => {

--- a/components/channel/DownloadSidebar.vue
+++ b/components/channel/DownloadSidebar.vue
@@ -93,7 +93,7 @@ const retryScan = async () => {
     });
   } catch {
     retryingScan.value = false;
-    retryError.value = 'The retry could not be started. Please open an issue.';
+    retryError.value = 'The retry could not be started.';
   }
 };
 
@@ -245,7 +245,7 @@ const groupedLabels = computed(() => {
       <!-- Boxed Info Section -->
       <div
         v-if="primaryFile"
-        class="bg-gray-50 mb-4 rounded-lg border border-orange-400 p-4 dark:border-orange-500 dark:bg-gray-700"
+        class="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700"
       >
         <!-- File Name -->
         <h2
@@ -329,49 +329,66 @@ const groupedLabels = computed(() => {
             </p>
           </template>
           <template v-else>
-            <p class="font-medium">
-              <i class="fa-solid fa-triangle-exclamation mr-1" />
-              Quarantined: security check incomplete
-            </p>
-            <p class="mt-1">
-              <template v-if="creatorIsViewing">
-                We couldn't complete the security scan—a problem on our end, not your file. Try again shortly, or open an issue.
-              </template>
-              <template v-else>
-                This download is temporarily unavailable because its security scan could not complete.
-              </template>
-            </p>
-            <div v-if="creatorIsViewing" class="mt-2 flex flex-wrap gap-3">
-              <button
-                type="button"
-                class="font-medium underline"
-                :disabled="retryingScan"
-                @click="retryScan"
-              >
-                Retry scan
-              </button>
+            <div class="flex items-start gap-2">
+              <i
+                class="fa-solid fa-circle-exclamation mt-0.5"
+                aria-hidden="true"
+              />
+              <div class="min-w-0 flex-1">
+                <p class="font-medium">Security check needs another try</p>
+                <p class="mt-0.5 text-xs leading-5">
+                  {{
+                    creatorIsViewing
+                      ? "The scan service had a problem—your file wasn't rejected."
+                      : 'This download is temporarily unavailable.'
+                  }}
+                </p>
+                <div class="mt-1.5 flex flex-wrap gap-3">
+                  <button
+                    v-if="creatorIsViewing"
+                    type="button"
+                    class="font-medium underline disabled:no-underline disabled:opacity-70"
+                    :disabled="retryingScan"
+                    @click="retryScan"
+                  >
+                    {{ retryingScan ? 'Retrying…' : 'Retry scan' }}
+                  </button>
+                  <NuxtLink
+                    class="font-medium underline"
+                    :to="pipelinePath"
+                  >
+                    View checks
+                  </NuxtLink>
+                </div>
+              </div>
+            </div>
+            <p v-if="retryError" class="mt-2 font-medium">
+              {{ retryError }}
               <NuxtLink
-                class="font-medium underline"
+                class="ml-1 underline"
                 to="/server/issues/create"
               >
                 Open an issue
               </NuxtLink>
-            </div>
-            <p v-if="retryError" class="mt-2 font-medium">
-              {{ retryError }}
             </p>
           </template>
-          <p v-if="scanCheckedDisplay" class="mt-2 text-xs opacity-80">
+          <p
+            v-if="scanCheckedDisplay && scanStatus !== 'FAILED'"
+            class="mt-2 text-xs opacity-80"
+          >
             Last checked {{ scanCheckedDisplay }}
           </p>
           <NuxtLink
-            v-if="scanStatus !== 'CLEAN'"
+            v-if="scanStatus !== 'CLEAN' && scanStatus !== 'FAILED'"
             class="mt-2 inline-block font-medium underline"
             :to="pipelinePath"
           >
             View security pipeline
           </NuxtLink>
-          <p v-if="hasReviewAccess && scanStatus !== 'CLEAN'" class="mt-2 text-xs">
+          <p
+            v-if="hasReviewAccess && scanStatus !== 'CLEAN' && scanStatus !== 'FAILED'"
+            class="mt-2 text-xs"
+          >
             Direct download is disabled while this file is quarantined. Review the scanner findings before clearing it.
           </p>
         </div>


### PR DESCRIPTION
## Summary
- replace the tall failed-scan explanation with a compact, reassuring status
- keep Retry scan and View checks as the immediate recovery actions
- show Open an issue only after a retry fails
- avoid repeating timestamp, quarantine guidance, and pipeline links in the failed state
- use a neutral border for the file summary card

## Testing
- `git diff --check` passes
- local unit tests and lint-staged could not run because this checkout's `node_modules` symlinks reference a removed worktree; remote CI should verify in a clean dependency environment