### PR TITLE
Complete complex event schedule coverage

### DIFF
--- a/components/event/form/TimePicker.spec.ts
+++ b/components/event/form/TimePicker.spec.ts
@@ -28,6 +28,18 @@ describe('TimePicker', () => {
     expect(option(wrapper, '12:15 AM')).toBeTruthy();
   });
 
+  it('stays open when the opening click bubbles to the document', async () => {
+    const wrapper = mount(TimePicker, {
+      props: { value: '09:00' },
+      attachTo: document.body,
+    });
+
+    await trigger(wrapper).trigger('click');
+
+    expect(option(wrapper, '12:15 AM')).toBeTruthy();
+    wrapper.unmount();
+  });
+
   it('emits the 24-hour value when a time is selected', async () => {
     const wrapper = mountPicker();
     await trigger(wrapper).trigger('click');

--- a/components/event/form/TimePicker.vue
+++ b/components/event/form/TimePicker.vue
@@ -25,7 +25,7 @@ const props = defineProps({
 const emit = defineEmits(['update']);
 
 const isDropdownOpen = ref(false);
-const dropdownRef = ref<HTMLElement | null>(null);
+const pickerRef = ref<HTMLElement | null>(null);
 
 // Format the display time in 12-hour clock format with error handling
 const formattedTime = computed(() => {
@@ -88,7 +88,7 @@ const closeDropdown = () => {
 
 // Handle clicks outside the dropdown to close it
 const handleClickOutside = (event: MouseEvent) => {
-  if (dropdownRef.value && !dropdownRef.value.contains(event.target as Node)) {
+  if (pickerRef.value && !pickerRef.value.contains(event.target as Node)) {
     closeDropdown();
   }
 };
@@ -104,7 +104,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="relative">
+  <div ref="pickerRef" class="relative">
     <!-- Custom input field instead of native time input -->
     <div
       :data-testid="testId"
@@ -129,7 +129,6 @@ onUnmounted(() => {
     <!-- Custom dropdown for time selection -->
     <div
       v-if="isDropdownOpen"
-      ref="dropdownRef"
       class="touch-scroll-y absolute left-0 top-full z-10 max-h-60 w-full overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:text-white"
       style="-webkit-overflow-scrolling: touch; scrollbar-width: thin"
     >

--- a/tests/playwright/mocked/events/createSeriesEvent.spec.ts
+++ b/tests/playwright/mocked/events/createSeriesEvent.spec.ts
@@ -10,6 +10,17 @@ import { installGraphqlMocks } from '../../helpers/mockGraphql';
 const TEST_CHANNEL = 'cats';
 const TEST_USERNAME = 'testuser';
 
+type CreateEventSeriesVariables = {
+  input?: {
+    title?: string;
+    channelConnections?: string[];
+    occurrences?: Array<{
+      startTime: string;
+      endTime: string;
+    }>;
+  };
+};
+
 const getCommonMocks = (username: string) => ({
   getBasicUserInfo: () => ({
     data: {
@@ -114,7 +125,10 @@ const getCommonMocks = (username: string) => ({
 });
 
 test.describe('Create Series Event', () => {
-  test('can create event with multiple manual dates', async ({ context, page }) => {
+  test('can create event with multiple manual dates', async ({
+    context,
+    page,
+  }) => {
     await installMockAuth(context, page, {
       username: TEST_USERNAME,
       email: 'test@example.com',
@@ -145,6 +159,100 @@ test.describe('Create Series Event', () => {
     await expect(page.getByTestId('occurrence-1-start-date')).toBeVisible();
   });
 
+  test('creates an expo-hours series from multiple date ranges', async ({
+    context,
+    page,
+  }) => {
+    let createVariables: CreateEventSeriesVariables | null = null;
+
+    await installMockAuth(context, page, {
+      username: TEST_USERNAME,
+      email: 'test@example.com',
+    });
+
+    await installGraphqlMocks(page, {
+      ...getCommonMocks(TEST_USERNAME),
+      createEventSeries: ({ body }) => {
+        createVariables = body.variables as CreateEventSeriesVariables;
+        return {
+          data: {
+            createEventSeriesWithChannelConnections: {
+              id: 'series-1',
+              Occurrences: [{ id: 'event-1' }],
+            },
+          },
+        };
+      },
+    });
+
+    await page.goto(`/forums/${TEST_CHANNEL}/events/create`);
+    await expect(page.getByTestId('event-form')).toBeVisible();
+    await page.getByTestId('title-input').fill('Annual Expo');
+    await page.getByTestId('date-mode-dateRange').click();
+
+    // Wednesday: noon–7:30pm.
+    await page.getByTestId('group-0-start-date').fill('2030-03-06');
+    await page.getByTestId('group-0-end-date').fill('2030-03-06');
+    await page.getByTestId('group-0-start-time').click();
+    await page
+      .locator('.touch-scroll-y:visible')
+      .getByText('12:00 PM', { exact: true })
+      .click();
+    await page.getByTestId('group-0-end-time').click();
+    await page
+      .locator('.touch-scroll-y:visible')
+      .getByText('7:30 PM', { exact: true })
+      .click();
+
+    // Thursday–Saturday: 9am–5pm (the defaults).
+    await page.getByTestId('add-date-range-button').click();
+    await page.getByTestId('group-1-start-date').fill('2030-03-07');
+    await page.getByTestId('group-1-end-date').fill('2030-03-09');
+
+    // Sunday: 9am–noon.
+    await page.getByTestId('add-date-range-button').click();
+    await page.getByTestId('group-2-start-date').fill('2030-03-10');
+    await page.getByTestId('group-2-end-date').fill('2030-03-10');
+    await page.getByTestId('group-2-end-time').click();
+    await page
+      .locator('.touch-scroll-y:visible')
+      .getByText('12:00 PM', { exact: true })
+      .click();
+
+    await expect(page.getByTestId('date-range-occurrence-count')).toHaveText(
+      'Creates 5 events.'
+    );
+
+    await page
+      .getByTestId('event-form')
+      .getByRole('button', { name: 'Save' })
+      .first()
+      .click();
+    await expect.poll(() => createVariables).not.toBeNull();
+
+    const input = createVariables!.input;
+    const occurrenceTimes = input?.occurrences?.map((occurrence) => ({
+      start: occurrence.startTime.slice(0, 16),
+      end: occurrence.endTime.slice(0, 16),
+    }));
+
+    expect({
+      title: input?.title,
+      channels: input?.channelConnections,
+      occurrenceTimes,
+    }).toEqual({
+      title: 'Annual Expo',
+      channels: [TEST_CHANNEL],
+      occurrenceTimes: [
+        { start: '2030-03-06T12:00', end: '2030-03-06T19:30' },
+        { start: '2030-03-07T09:00', end: '2030-03-07T17:00' },
+        { start: '2030-03-08T09:00', end: '2030-03-08T17:00' },
+        { start: '2030-03-09T09:00', end: '2030-03-09T17:00' },
+        { start: '2030-03-10T09:00', end: '2030-03-10T12:00' },
+      ],
+    });
+  });
+
   test('can create event with recurring pattern', async ({ context, page }) => {
     await installMockAuth(context, page, {
       username: TEST_USERNAME,
@@ -172,8 +280,12 @@ test.describe('Create Series Event', () => {
     await page.getByTestId('day-of-week-3').click();
 
     // Verify days are selected (have orange background)
-    await expect(page.getByTestId('day-of-week-1')).toHaveClass(/bg-orange-500/);
-    await expect(page.getByTestId('day-of-week-3')).toHaveClass(/bg-orange-500/);
+    await expect(page.getByTestId('day-of-week-1')).toHaveClass(
+      /bg-orange-500/
+    );
+    await expect(page.getByTestId('day-of-week-3')).toHaveClass(
+      /bg-orange-500/
+    );
 
     // Set end count
     await page.getByTestId('end-type-after_count').click();
@@ -181,7 +293,10 @@ test.describe('Create Series Event', () => {
     await expect(endCountInput).toBeVisible();
   });
 
-  test('shows occurrence preview when configuring recurring pattern', async ({ context, page }) => {
+  test('shows occurrence preview when configuring recurring pattern', async ({
+    context,
+    page,
+  }) => {
     await installMockAuth(context, page, {
       username: TEST_USERNAME,
       email: 'test@example.com',


### PR DESCRIPTION
## Summary
- add the remaining end-to-end coverage for complex multi-range / expo-hours event creation
- verify three schedule ranges expand into five correctly timed series occurrences in the GraphQL payload
- fix the time picker outside-click boundary that caused the dropdown to close immediately when users tried to change range hours
- add a focused regression test for the time picker interaction

Closes #225

## Testing
- `vitest run components/event/form/TimePicker.spec.ts` — 7 passed
- focused Playwright expo-hours flow — passed
- ESLint on changed files — passed
- `vue-tsc --noEmit` — passed
- `git diff --check` — passed

The local pre-commit wrapper could not start lint-staged because it launches pnpm without this desktop environment's bundled Node path; the equivalent checks above were run directly.