### PR TITLE
feat(moderation): support image moderation workflows

### DIFF
--- a/components/mod/ArchiveButton.spec.ts
+++ b/components/mod/ArchiveButton.spec.ts
@@ -15,8 +15,12 @@ const issue = { id: 'issue-1', issueNumber: 1 } as unknown as Issue;
 
 const modalStub = (name: string) => ({
   name,
-  props: ['open', 'discussionId', 'eventId', 'commentId'],
-  emits: ['close', 'reported-and-archived-successfully', 'unarchived-successfully'],
+  props: ['open', 'discussionId', 'eventId', 'commentId', 'imageId'],
+  emits: [
+    'close',
+    'reported-and-archived-successfully',
+    'unarchived-successfully',
+  ],
   template: '<div />',
 });
 
@@ -27,7 +31,11 @@ const mountButton = (props: Record<string, unknown> = {}) =>
       stubs: {
         BrokenRulesModal: modalStub('BrokenRulesModal'),
         UnarchiveModal: modalStub('UnarchiveModal'),
-        Notification: { name: 'Notification', props: ['show', 'title'], template: '<div />' },
+        Notification: {
+          name: 'Notification',
+          props: ['show', 'title'],
+          template: '<div />',
+        },
         ArchiveBox: true,
         ArchiveBoxXMark: true,
       },
@@ -38,6 +46,7 @@ const archivedResult = (archived: boolean) => ({
   discussionChannels: [{ id: 'dc1', archived }],
   eventChannels: [{ id: 'ec1', archived }],
   comments: [{ archived }],
+  images: [{ archived }],
 });
 
 beforeEach(() => {
@@ -64,9 +73,22 @@ describe('ArchiveButton label', () => {
     expect(wrapper.text()).toContain('Archive Comment');
   });
 
+  it('shows "Archive Image" for an image', () => {
+    const wrapper = mountButton({ imageId: 'i1' });
+
+    expect(wrapper.text()).toContain('Archive Image');
+  });
+
   it('shows Unarchive when the content is archived', () => {
     h.result = ref(archivedResult(true));
     const wrapper = mountButton({ discussionId: 'd1' });
+
+    expect(wrapper.text()).toContain('Unarchive');
+  });
+
+  it('shows Unarchive when an image is archived', () => {
+    h.result = ref(archivedResult(true));
+    const wrapper = mountButton({ imageId: 'i1' });
 
     expect(wrapper.text()).toContain('Unarchive');
   });
@@ -84,9 +106,9 @@ describe('ArchiveButton disabled state', () => {
 
     await wrapper.get('button').trigger('click');
 
-    expect(wrapper.getComponent({ name: 'BrokenRulesModal' }).props('open')).toBe(
-      false
-    );
+    expect(
+      wrapper.getComponent({ name: 'BrokenRulesModal' }).props('open')
+    ).toBe(false);
   });
 });
 
@@ -96,9 +118,9 @@ describe('ArchiveButton modal flow', () => {
 
     await wrapper.get('button').trigger('click');
 
-    expect(wrapper.getComponent({ name: 'BrokenRulesModal' }).props('open')).toBe(
-      true
-    );
+    expect(
+      wrapper.getComponent({ name: 'BrokenRulesModal' }).props('open')
+    ).toBe(true);
   });
 
   it('opens the unarchive modal on click when archived', async () => {

--- a/components/mod/ArchiveButton.vue
+++ b/components/mod/ArchiveButton.vue
@@ -13,6 +13,7 @@ import {
   GET_EVENT_CHANNEL,
 } from '@/graphQLData/mod/queries';
 import { GET_COMMENT_ARCHIVED } from '@/graphQLData/comment/queries';
+import { GET_IMAGE_DETAILS } from '@/graphQLData/image/queries';
 
 const props = defineProps({
   issue: {
@@ -30,6 +31,11 @@ const props = defineProps({
     default: '',
   },
   commentId: {
+    type: String,
+    required: false,
+    default: '',
+  },
+  imageId: {
     type: String,
     required: false,
     default: '',
@@ -55,17 +61,30 @@ const { result: getDiscussionChannelResult } = useQuery(
   {
     discussionId: props.discussionId,
     channelUniqueName: props.channelUniqueName,
-  }
+  },
+  { enabled: !!props.discussionId }
 );
 
-const { result: getEventChannelResult } = useQuery(GET_EVENT_CHANNEL, {
-  eventId: props.eventId,
-  channelUniqueName: props.channelUniqueName,
-});
+const { result: getEventChannelResult } = useQuery(
+  GET_EVENT_CHANNEL,
+  {
+    eventId: props.eventId,
+    channelUniqueName: props.channelUniqueName,
+  },
+  { enabled: !!props.eventId }
+);
 
-const { result: isCommentArchivedResult } = useQuery(GET_COMMENT_ARCHIVED, {
-  commentId: props.commentId,
-});
+const { result: isCommentArchivedResult } = useQuery(
+  GET_COMMENT_ARCHIVED,
+  { commentId: props.commentId },
+  { enabled: !!props.commentId }
+);
+
+const { result: imageResult } = useQuery(
+  GET_IMAGE_DETAILS,
+  { imageId: props.imageId },
+  { enabled: !!props.imageId }
+);
 
 const isArchived = computed(() => {
   if (props.discussionId) {
@@ -74,6 +93,8 @@ const isArchived = computed(() => {
     return getEventChannelResult.value?.eventChannels?.[0]?.archived;
   } else if (props.commentId) {
     return isCommentArchivedResult.value?.comments?.[0]?.archived;
+  } else if (props.imageId) {
+    return imageResult.value?.images?.[0]?.archived;
   }
   return false;
 });
@@ -122,6 +143,8 @@ const archivedContentType = computed(() => {
     return 'Event';
   } else if (props.commentId) {
     return 'Comment';
+  } else if (props.imageId) {
+    return 'Image';
   }
   return 'Content';
 });
@@ -162,6 +185,7 @@ const archivedContentType = computed(() => {
     :discussion-id="discussionId"
     :event-id="eventId"
     :comment-id="commentId"
+    :image-id="imageId"
     :archive-after-reporting="true"
     :discussion-channel-id="discussionChannelId"
     :event-channel-id="eventChannelId"
@@ -177,7 +201,8 @@ const archivedContentType = computed(() => {
     v-if="
       (discussionChannelId && discussionId) ||
       (eventChannelId && eventId) ||
-      commentId
+      commentId ||
+      imageId
     "
     :open="showUnarchiveModal"
     :discussion-channel-id="discussionChannelId"
@@ -185,6 +210,7 @@ const archivedContentType = computed(() => {
     :discussion-id="discussionId"
     :event-id="eventId"
     :comment-id="commentId"
+    :image-id="imageId"
     @close="closeUnarchiveModal"
     @unarchived-successfully="
       () => {

--- a/components/mod/IssueDetail.vue
+++ b/components/mod/IssueDetail.vue
@@ -348,7 +348,8 @@ const extractChannelUniqueNames = (
 
 const issueContextChannels = computed<string[]>(() => {
   const discussionChannels = extractChannelUniqueNames(
-    relatedDiscussion.value?.DiscussionChannels as DiscussionChannel[] | null | undefined
+    relatedDiscussion.value?.DiscussionChannels as
+      DiscussionChannel[] | null | undefined
   );
   if (discussionChannels.length > 0) {
     return [...new Set(discussionChannels)];
@@ -448,7 +449,9 @@ const handleLockReasonUpdate = (value: string) => {
 
     <!-- Related Channel (for server-scoped channel reports) -->
     <div v-if="relatedChannelUniqueName" class="px-4 pt-2">
-      <IssueRelatedChannel :related-channel-unique-name="relatedChannelUniqueName" />
+      <IssueRelatedChannel
+        :related-channel-unique-name="relatedChannelUniqueName"
+      />
     </div>
 
     <div v-if="activeIssue" class="mt-2 flex flex-col gap-2 px-4">
@@ -475,7 +478,9 @@ const handleLockReasonUpdate = (value: string) => {
         :report-count-label="reportCountLabel"
         :channel-id="channelId"
         :is-author-mod="authorType === 'mod'"
-        :suspend-mod-disabled="isSuspendedMod || !issueActionVisibility.modActionsEnabled"
+        :suspend-mod-disabled="
+          isSuspendedMod || !issueActionVisibility.modActionsEnabled
+        "
         :can-permanently-remove-image="
           modPermissions.canPermanentlyRemoveImage &&
           !isSuspendedMod &&
@@ -510,7 +515,7 @@ const handleLockReasonUpdate = (value: string) => {
       <div
         v-else-if="shouldShowIssueDetailsSection"
         id="original-post-container"
-        class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-600 dark:bg-gray-800"
+        class="bg-gray-50 rounded-lg border border-gray-200 px-4 py-2 dark:border-gray-600 dark:bg-gray-800"
       >
         <IssueBodyEditor
           v-if="activeIssue?.body || isIssueAuthor"
@@ -580,7 +585,7 @@ const handleLockReasonUpdate = (value: string) => {
           <ErrorBanner v-if="deleteReasonError" :text="deleteReasonError" />
           <div
             v-if="isSuspendedMod"
-            class="mb-6 rounded-lg border border-orange-200 bg-orange-50 p-4 text-sm text-gray-700 dark:border-orange-500/40 dark:bg-orange-500/10 dark:text-gray-200"
+            class="bg-orange-50 mb-6 rounded-lg border border-orange-200 p-4 text-sm text-gray-700 dark:border-orange-500/40 dark:bg-orange-500/10 dark:text-gray-200"
           >
             Your moderator account is suspended. You can still use your user
             account where normal user permissions allow it, but moderation
@@ -593,6 +598,7 @@ const handleLockReasonUpdate = (value: string) => {
             :discussion-id="activeIssue?.relatedDiscussionId || ''"
             :event-id="activeIssue?.relatedEventId || ''"
             :comment-id="activeIssue?.relatedCommentId || ''"
+            :image-id="activeIssue?.relatedImageId || ''"
             :channel-unique-name="channelId"
             :close-issue-loading="closeIssueLoading"
             :is-current-user-original-poster="
@@ -626,9 +632,15 @@ const handleLockReasonUpdate = (value: string) => {
             :actions-disabled="!issueActionVisibility.opActionsEnabled"
             :is-locked="isLocked"
             :is-closed="!activeIssue?.isOpen"
-            @delete-discussion="(id: string) => handleDeleteRelatedContent('discussion', id)"
-            @delete-event="(id: string) => handleDeleteRelatedContent('event', id)"
-            @delete-comment="(id: string) => handleDeleteRelatedContent('comment', id)"
+            @delete-discussion="
+              (id: string) => handleDeleteRelatedContent('discussion', id)
+            "
+            @delete-event="
+              (id: string) => handleDeleteRelatedContent('event', id)
+            "
+            @delete-comment="
+              (id: string) => handleDeleteRelatedContent('comment', id)
+            "
           />
 
           <IssueCommentForm

--- a/components/mod/ModerationWizard.spec.ts
+++ b/components/mod/ModerationWizard.spec.ts
@@ -20,6 +20,7 @@ const { mockQueryState } = vi.hoisted(() => ({
       discussionChannels: [{ archived: false }],
       eventChannels: [{ archived: false }],
       comments: [{ archived: false }],
+      images: [{ archived: false }],
       isOriginalPosterSuspended: false,
       discussions: [{ hasDownload: false }],
     } as Record<string, unknown>,
@@ -61,6 +62,7 @@ describe('ModerationWizard', () => {
       discussionChannels: [{ archived: false }],
       eventChannels: [{ archived: false }],
       comments: [{ archived: false }],
+      images: [{ archived: false }],
       isOriginalPosterSuspended: false,
       discussions: [{ hasDownload: false }],
     };
@@ -289,6 +291,7 @@ describe('ModerationWizard', () => {
       { commentId: undefined, eventId: 'e1' },
       { eventChannels: [{ archived: true }] },
     ],
+    [{ commentId: undefined, imageId: 'i1' }, { images: [{ archived: true }] }],
   ])('resolves archived state for related content', (props, queryState) => {
     setQueryState(queryState);
     const wrapper = mountWrapper({ ...props, isSuspendedMod: false });

--- a/components/mod/ModerationWizard.vue
+++ b/components/mod/ModerationWizard.vue
@@ -19,6 +19,7 @@ import {
   IS_ORIGINAL_POSTER_SUSPENDED,
 } from '@/graphQLData/mod/queries';
 import { GET_COMMENT_ARCHIVED } from '@/graphQLData/comment/queries';
+import { GET_IMAGE_DETAILS } from '@/graphQLData/image/queries';
 
 const modProfileNameVar = useModProfileName();
 
@@ -38,6 +39,11 @@ const props = defineProps({
     default: '',
   },
   commentId: {
+    type: String,
+    required: false,
+    default: '',
+  },
+  imageId: {
     type: String,
     required: false,
     default: '',
@@ -115,7 +121,9 @@ defineEmits([
 // Compute whether actions should be disabled
 const actionsDisabled = computed(() => {
   return (
-    !props.issue.isOpen || props.isCurrentUserOriginalPoster || props.isSuspendedMod
+    !props.issue.isOpen ||
+    props.isCurrentUserOriginalPoster ||
+    props.isSuspendedMod
   );
 });
 
@@ -185,6 +193,15 @@ const { result: isCommentArchivedResult } = useQuery(
   })
 );
 
+const { result: imageResult } = useQuery(
+  GET_IMAGE_DETAILS,
+  () => ({ imageId: props.imageId }),
+  () => ({
+    enabled: !!props.imageId,
+    fetchPolicy: 'cache-first',
+  })
+);
+
 const isArchived = computed(() => {
   if (props.discussionId) {
     return getDiscussionChannelResult.value?.discussionChannels?.[0]?.archived;
@@ -192,6 +209,8 @@ const isArchived = computed(() => {
     return getEventChannelResult.value?.eventChannels?.[0]?.archived;
   } else if (props.commentId) {
     return isCommentArchivedResult.value?.comments?.[0]?.archived;
+  } else if (props.imageId) {
+    return imageResult.value?.images?.[0]?.archived;
   }
   return false;
 });
@@ -251,8 +270,12 @@ const editActions = computed(() => {
 const editModalOpen = ref(false);
 
 const shouldShowEditActions = computed(() => {
-  const isReported = typeof props.reportCount === 'number' && props.reportCount > 0;
-  return isReported && ['comment', 'discussion'].includes(relatedContentType.value || '');
+  const isReported =
+    typeof props.reportCount === 'number' && props.reportCount > 0;
+  return (
+    isReported &&
+    ['comment', 'discussion'].includes(relatedContentType.value || '')
+  );
 });
 
 const hasEditPermission = computed(() => {
@@ -394,6 +417,7 @@ const editModalTargetType = computed(() => {
                         :discussion-id="discussionId"
                         :event-id="eventId"
                         :comment-id="commentId"
+                        :image-id="imageId"
                         :context-text="contextText"
                         :channel-unique-name="channelUniqueName"
                         :issue="issue"
@@ -495,7 +519,7 @@ const editModalTargetType = computed(() => {
                     </div>
 
                     <div
-                      class="border-amber-300 bg-amber-50 dark:border-amber-500/50 dark:bg-amber-500/10 -mx-4 -mb-4 space-y-3 rounded-b-lg p-4"
+                      class="-mx-4 -mb-4 space-y-3 rounded-b-lg border-amber-300 bg-amber-50 p-4 dark:border-amber-500/50 dark:bg-amber-500/10"
                     >
                       <p
                         class="font-semibold text-xs uppercase tracking-wide text-gray-700 dark:text-gray-300"
@@ -519,6 +543,7 @@ const editModalTargetType = computed(() => {
                             :discussion-id="discussionId"
                             :event-id="eventId"
                             :comment-id="commentId"
+                            :image-id="imageId"
                             :context-text="contextText"
                             :channel-unique-name="channelUniqueName"
                             :issue="issue"

--- a/components/mod/UnarchiveModal.spec.ts
+++ b/components/mod/UnarchiveModal.spec.ts
@@ -15,6 +15,7 @@ const h = vi.hoisted(() => ({
   disc: {} as Slot,
   evt: {} as Slot,
   comment: {} as Slot,
+  image: {} as Slot,
   callIndex: { n: 0 },
 }));
 
@@ -22,7 +23,14 @@ vi.mock('@vue/apollo-composable', () => ({
   useApolloClient: () => ({ client: h.client }),
   useMutation: (_doc: unknown, options?: { update?: (c: unknown) => void }) => {
     h.callIndex.n++;
-    const slot = h.callIndex.n === 1 ? h.disc : h.callIndex.n === 2 ? h.evt : h.comment;
+    const slot =
+      h.callIndex.n === 1
+        ? h.disc
+        : h.callIndex.n === 2
+          ? h.evt
+          : h.callIndex.n === 3
+            ? h.comment
+            : h.image;
     slot.update = options?.update;
     return {
       mutate: slot.mutate,
@@ -34,12 +42,21 @@ vi.mock('@vue/apollo-composable', () => ({
     };
   },
 }));
-vi.mock('nuxt/app', () => ({ useRoute: () => ({ params: { forumId: 'cats' } }) }));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => ({ params: { forumId: 'cats' } }),
+}));
 
 const stubs = {
   GenericModal: {
     name: 'GenericModal',
-    props: ['title', 'body', 'open', 'loading', 'primaryButtonDisabled', 'error'],
+    props: [
+      'title',
+      'body',
+      'open',
+      'loading',
+      'primaryButtonDisabled',
+      'error',
+    ],
     emits: ['primary-button-click', 'close'],
     template: '<div><slot name="content" /></div>',
   },
@@ -63,6 +80,7 @@ beforeEach(() => {
   h.disc = { mutate: vi.fn() };
   h.evt = { mutate: vi.fn() };
   h.comment = { mutate: vi.fn() };
+  h.image = { mutate: vi.fn() };
   h.client = { refetchQueries: vi.fn() };
 });
 
@@ -83,6 +101,12 @@ describe('UnarchiveModal labels', () => {
     const wrapper = mountModal({ eventId: 'e1' });
 
     expect(modal(wrapper).props('title')).toBe('Unarchive Event');
+  });
+
+  it('titles the modal for an image', () => {
+    const wrapper = mountModal({ imageId: 'i1' });
+
+    expect(modal(wrapper).props('title')).toBe('Unarchive Image');
   });
 
   it('describes the content type in the body', () => {
@@ -131,6 +155,18 @@ describe('UnarchiveModal submit', () => {
 
     expect(h.evt.mutate).toHaveBeenCalledWith({
       eventId: 'e1',
+      explanation: 'No violation',
+      channelUniqueName: 'cats',
+    });
+  });
+
+  it('unarchives an image with the channel name', async () => {
+    const wrapper = mountModal({ imageId: 'i1' });
+
+    await modal(wrapper).vm.$emit('primary-button-click');
+
+    expect(h.image.mutate).toHaveBeenCalledWith({
+      imageId: 'i1',
       explanation: 'No violation',
       channelUniqueName: 'cats',
     });
@@ -199,6 +235,15 @@ describe('UnarchiveModal cache updates', () => {
     const cache = makeCache();
 
     h.comment.update?.(cache);
+
+    expect(cache.modify).toHaveBeenCalled();
+  });
+
+  it('flips archived to false for an image', () => {
+    mountModal({ imageId: 'i1' });
+    const cache = makeCache();
+
+    h.image.update?.(cache);
 
     expect(cache.modify).toHaveBeenCalled();
   });

--- a/components/mod/UnarchiveModal.vue
+++ b/components/mod/UnarchiveModal.vue
@@ -9,6 +9,7 @@ import {
   UNARCHIVE_DISCUSSION,
   UNARCHIVE_EVENT,
   UNARCHIVE_COMMENT,
+  UNARCHIVE_IMAGE,
 } from '@/graphQLData/issue/mutations';
 import { GET_ISSUE } from '@/graphQLData/issue/queries';
 
@@ -38,6 +39,11 @@ const props = defineProps({
     default: '',
   },
   eventId: {
+    type: String,
+    required: false,
+    default: '',
+  },
+  imageId: {
     type: String,
     required: false,
     default: '',
@@ -142,6 +148,27 @@ const {
   },
 });
 
+const {
+  mutate: unarchiveImage,
+  loading: unarchiveImageLoading,
+  error: unarchiveImageError,
+  onDone: unarchiveImageDone,
+} = useMutation(UNARCHIVE_IMAGE, {
+  update: (cache) => {
+    cache.modify({
+      id: cache.identify({
+        __typename: 'Image',
+        id: props.imageId,
+      }),
+      fields: {
+        archived() {
+          return false;
+        },
+      },
+    });
+  },
+});
+
 unarchiveDiscussionDone(() => {
   client.refetchQueries({
     include: [GET_ISSUE],
@@ -163,6 +190,13 @@ unarchiveCommentDone(() => {
   emit('unarchivedSuccessfully');
 });
 
+unarchiveImageDone(() => {
+  client.refetchQueries({
+    include: [GET_ISSUE],
+  });
+  emit('unarchivedSuccessfully');
+});
+
 const modalTitle = computed(() => {
   if (props.commentId) {
     return 'Unarchive Comment';
@@ -170,6 +204,8 @@ const modalTitle = computed(() => {
     return 'Unarchive Discussion';
   } else if (props.eventId) {
     return 'Unarchive Event';
+  } else if (props.imageId) {
+    return 'Unarchive Image';
   }
 
   return 'Unarchive Content';
@@ -181,6 +217,8 @@ const modalBody = computed(() => {
     contentType = 'comment';
   } else if (props.eventId) {
     contentType = 'event';
+  } else if (props.imageId) {
+    contentType = 'image';
   }
   return `(Optional) Please add any more information or context about why this ${contentType} should be unarchived.`;
 });
@@ -191,13 +229,20 @@ const modalPlaceholder = computed(() => {
     contentType = 'comment';
   } else if (props.eventId) {
     contentType = 'event';
+  } else if (props.imageId) {
+    contentType = 'image';
   }
   return `Explain why this ${contentType} should be unarchived`;
 });
 
 const submit = async () => {
-  if (!props.discussionId && !props.eventId && !props.commentId) {
-    console.error('No discussion, event, or comment ID provided.');
+  if (
+    !props.discussionId &&
+    !props.eventId &&
+    !props.commentId &&
+    !props.imageId
+  ) {
+    console.error('No discussion, event, comment, or image ID provided.');
     return;
   }
 
@@ -205,6 +250,15 @@ const submit = async () => {
     unarchiveComment({
       commentId: props.commentId,
       explanation: explanation.value,
+    });
+    return;
+  }
+
+  if (props.imageId) {
+    unarchiveImage({
+      imageId: props.imageId,
+      explanation: explanation.value,
+      channelUniqueName: channelId.value || null,
     });
     return;
   }
@@ -241,7 +295,8 @@ const close = () => {
     :loading="
       unarchiveDiscussionLoading ||
       unarchiveEventLoading ||
-      unarchiveCommentLoading
+      unarchiveCommentLoading ||
+      unarchiveImageLoading
     "
     :primary-button-disabled="explanation.length === 0"
     :primary-button-text="'Unarchive'"
@@ -249,7 +304,8 @@ const close = () => {
     :error="
       unarchiveDiscussionError?.message ||
       unarchiveEventError?.message ||
-      unarchiveCommentError?.message
+      unarchiveCommentError?.message ||
+      unarchiveImageError?.message
     "
     @primary-button-click="submit"
     @close="close"

--- a/graphQLData/image/queries.js
+++ b/graphQLData/image/queries.js
@@ -4,6 +4,7 @@ export const GET_IMAGE_DETAILS = gql`
   query GetImageDetails($imageId: ID!) {
     images(where: { id: $imageId }) {
       id
+      archived
       url
       alt
       caption
@@ -162,7 +163,9 @@ export const GET_USER_ALBUMS = gql`
           username
         }
       }
-      ImagesAggregate(where: { archived_NOT: true, permanentlyRemoved_NOT: true }) {
+      ImagesAggregate(
+        where: { archived_NOT: true, permanentlyRemoved_NOT: true }
+      ) {
         count
       }
       Discussions(options: { sort: { createdAt: DESC } }) {

--- a/tests/playwright/mocked/channels/channelServerModeration.spec.ts
+++ b/tests/playwright/mocked/channels/channelServerModeration.spec.ts
@@ -160,6 +160,70 @@ test.describe('Forum About page – server moderation', () => {
     }
   });
 
+  for (const imageType of ['ICON', 'BANNER'] as const) {
+    test(`reporting the forum ${imageType.toLowerCase()} submits its image type`, async ({
+      context,
+      page,
+    }, testInfo) => {
+      await installMockAuth(context, page);
+      const diagnostics = await installGraphqlMocks(page, {
+        ...createBaseHandlers({
+          channelId: CHANNEL,
+          channelOverrides: {
+            channelIconURL: '/favicon.ico',
+            channelBannerURL: '/favicon.ico',
+          },
+          serverConfigOverrides: { DefaultModRole: SERVER_MOD_ROLE },
+        }),
+        getServerRules: serverRulesHandler,
+        reportChannelImage: () => ({
+          data: {
+            reportChannelImage: {
+              id: `issue-${imageType.toLowerCase()}`,
+              issueNumber: imageType === 'ICON' ? 2 : 3,
+              relatedChannelUniqueName: CHANNEL,
+            },
+          },
+        }),
+      });
+
+      try {
+        await page.goto(ABOUT_URL);
+        await page
+          .getByRole('button', {
+            name: imageType === 'ICON' ? 'Report Icon' : 'Report Banner',
+          })
+          .click();
+
+        await page.getByLabel('Select rule: Be kind').check();
+        await page
+          .getByTestId('report-channel-image-modal-primary-button')
+          .click();
+
+        await waitForGraphqlOperation(
+          diagnostics.completedOperations,
+          'reportChannelImage'
+        );
+        const operation = diagnostics.completedOperations.find(
+          (item) => item.operationName === 'reportChannelImage'
+        );
+
+        expect(operation?.variables).toMatchObject({
+          channelUniqueName: CHANNEL,
+          imageType,
+          selectedServerRules: ['Be kind'],
+        });
+      } finally {
+        await testInfo.attach('graphql-operations.json', {
+          body: Buffer.from(
+            JSON.stringify(diagnostics.seenOperations, null, 2)
+          ),
+          contentType: 'application/json',
+        });
+      }
+    });
+  }
+
   test('locking the forum from the About page fires lockChannel with a reason', async ({
     context,
     page,
@@ -171,7 +235,9 @@ test.describe('Forum About page – server moderation', () => {
         serverConfigOverrides: { DefaultModRole: SERVER_MOD_ROLE },
       }),
       getServerRules: serverRulesHandler,
-      lockChannel: () => ({ data: { lockChannel: lockedChannelResponse(true) } }),
+      lockChannel: () => ({
+        data: { lockChannel: lockedChannelResponse(true) },
+      }),
     });
 
     try {

--- a/tests/playwright/mocked/discussions/imageLightboxReport.spec.ts
+++ b/tests/playwright/mocked/discussions/imageLightboxReport.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test } from '../../helpers/testFixture';
+import {
+  installGraphqlMocks,
+  waitForGraphqlOperation,
+} from '../../helpers/mockGraphql';
+import { installMockAuth } from '../../helpers/mockAuth';
+import {
+  buildDiscussion,
+  buildDiscussionChannel,
+} from '../../helpers/graphqlFixtures';
+import { createBaseHandlers } from '../../helpers/baseHandlers';
+import type { Album } from '@/__generated__/graphql';
+
+const CHANNEL = 'cats';
+const DISCUSSION_ID = 'discussion-with-reported-image';
+const DISCUSSION_CHANNEL_ID = 'discussion-channel-with-reported-image';
+const IMAGE_ID = 'image-to-report';
+
+const image = {
+  __typename: 'Image' as const,
+  id: IMAGE_ID,
+  url: '/favicon.ico',
+  alt: 'Image that violates a rule',
+  caption: 'Reported from the lightbox',
+  copyright: '',
+  Uploader: { username: 'bob', displayName: 'Bob' },
+};
+
+test('reports an album image from the lightbox with the selected rules', async ({
+  context,
+  page,
+}, testInfo) => {
+  await installMockAuth(context, page, {
+    username: 'alice',
+    email: 'alice@example.com',
+  });
+
+  const diagnostics = await installGraphqlMocks(page, {
+    ...createBaseHandlers({
+      username: 'alice',
+      channelId: CHANNEL,
+      discussionId: DISCUSSION_ID,
+      discussionChannelId: DISCUSSION_CHANNEL_ID,
+      discussionsCount: 1,
+    }),
+    getDiscussion: () => ({
+      data: {
+        discussions: [
+          buildDiscussion({
+            id: DISCUSSION_ID,
+            discussionChannelId: DISCUSSION_CHANNEL_ID,
+            channelUniqueName: CHANNEL,
+            body: 'Lightbox report test.',
+            overrides: {
+              Album: {
+                __typename: 'Album',
+                id: 'album-1',
+                imageOrder: [IMAGE_ID],
+                Images: [image],
+              } as unknown as Album,
+            },
+          }),
+        ],
+      },
+    }),
+    getCommentSection: () => ({
+      data: {
+        getCommentSection: {
+          DiscussionChannel: buildDiscussionChannel({
+            id: DISCUSSION_CHANNEL_ID,
+            discussionId: DISCUSSION_ID,
+            channelUniqueName: CHANNEL,
+          }),
+          Comments: [],
+        },
+      },
+    }),
+    getDiscussionChannelRootCommentAggregate: () => ({
+      data: {
+        discussionChannels: [
+          {
+            id: DISCUSSION_CHANNEL_ID,
+            discussionId: DISCUSSION_ID,
+            channelUniqueName: CHANNEL,
+            archived: false,
+            answered: false,
+            locked: false,
+            CommentsAggregate: { count: 0 },
+          },
+        ],
+      },
+    }),
+    getDiscussionCommentIssue: () => ({
+      data: {
+        discussionChannels: [{ id: DISCUSSION_CHANNEL_ID, Comments: [] }],
+      },
+    }),
+    isDiscussionAnswered: () => ({
+      data: {
+        discussionChannels: [
+          {
+            id: DISCUSSION_CHANNEL_ID,
+            discussionId: DISCUSSION_ID,
+            channelUniqueName: CHANNEL,
+            weightedVotesCount: 1,
+            archived: false,
+            answered: false,
+            locked: false,
+            Channel: { uniqueName: CHANNEL },
+          },
+        ],
+      },
+    }),
+    getUserFavoriteImage: () => ({
+      data: { users: [{ username: 'alice', FavoriteImages: [] }] },
+    }),
+    getServerRules: () => ({
+      data: {
+        serverConfigs: [
+          {
+            serverName: 'Listical',
+            rules: JSON.stringify([
+              { summary: 'Be kind', detail: 'Be civil.' },
+            ]),
+          },
+        ],
+      },
+    }),
+    getChannelRules: () => ({
+      data: {
+        channels: [
+          {
+            uniqueName: CHANNEL,
+            rules: JSON.stringify([{ summary: 'No spam', detail: 'No spam.' }]),
+          },
+        ],
+      },
+    }),
+    reportImage: () => ({
+      data: { reportImage: { id: 'image-issue-1', issueNumber: 7 } },
+    }),
+  });
+
+  try {
+    await page.goto(`/forums/${CHANNEL}/discussions/${DISCUSSION_ID}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await expect(page.getByTestId('discussion-album-carousel')).toBeVisible();
+    await page.getByTestId('discussion-album-carousel').click();
+    await page.getByRole('button', { name: 'Report image' }).click();
+    await page.locator('input[value="Be kind"]').check();
+    await page.getByTestId('report-image-modal-primary-button').click();
+
+    await waitForGraphqlOperation(
+      diagnostics.completedOperations,
+      'reportImage'
+    );
+    const operation = diagnostics.completedOperations.find(
+      (item) => item.operationName === 'reportImage'
+    );
+
+    expect(operation?.variables).toEqual({
+      imageId: IMAGE_ID,
+      reportText: '',
+      selectedForumRules: [],
+      selectedServerRules: ['Be kind'],
+      channelUniqueName: CHANNEL,
+    });
+  } finally {
+    await testInfo.attach('graphql-operations.json', {
+      body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+      contentType: 'application/json',
+    });
+  }
+});

--- a/tests/playwright/mocked/mod/issueDetail.spec.ts
+++ b/tests/playwright/mocked/mod/issueDetail.spec.ts
@@ -176,7 +176,10 @@ test.describe('Moderation issue detail', () => {
       await expect(page.getByText(/the issue was closed by/i)).toBeVisible();
       await expect(page.getByText(/the user was suspended by/i)).toBeVisible();
 
-      await waitForGraphqlOperation(diagnostics.completedOperations, 'getIssue');
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'getIssue'
+      );
     } finally {
       await testInfo.attach('graphql-operations.json', {
         body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
@@ -276,6 +279,117 @@ test.describe('Moderation issue detail', () => {
       const ruleCheckbox = page.locator('input[value="Be kind"]');
       await ruleCheckbox.check();
       await expect(ruleCheckbox).toBeChecked();
+    } finally {
+      await testInfo.attach('graphql-operations.json', {
+        body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),
+        contentType: 'application/json',
+      });
+    }
+  });
+
+  test('archives and unarchives an image from its moderation issue', async ({
+    context,
+    page,
+  }, testInfo) => {
+    await installMockAuth(context, page, {
+      username: TEST_USER,
+      email: 'alice@example.com',
+    });
+
+    const imageId = 'reported-image-1';
+    const issue = buildIssue({
+      issueNumber: ISSUE_NUMBER,
+      channelUniqueName: TEST_CHANNEL,
+      title: 'Reported album image',
+      isOpen: true,
+      overrides: { relatedImageId: imageId },
+    });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      ...getBaseMocks(TEST_USER),
+      getIssue: () => ({ data: { issues: [issue] } }),
+      GetImageDetails: () => ({
+        data: {
+          images: [
+            {
+              __typename: 'Image',
+              id: imageId,
+              archived: false,
+              url: '/favicon.ico',
+              alt: 'Reported image',
+              caption: '',
+              copyright: '',
+              longDescription: '',
+              hasSensitiveContent: false,
+              hasSpoiler: false,
+              createdAt: '2024-01-01T00:00:00.000Z',
+              scanCheckedAt: '2024-01-01T00:00:00.000Z',
+              Uploader: {
+                username: 'bob',
+                displayName: 'Bob',
+                profilePicURL: '',
+              },
+              Albums: [],
+            },
+          ],
+        },
+      }),
+      archiveImage: () => ({
+        data: { archiveImage: { id: issue.id, issueNumber: ISSUE_NUMBER } },
+      }),
+      unarchiveImage: () => ({
+        data: { unarchiveImage: { id: issue.id, issueNumber: ISSUE_NUMBER } },
+      }),
+    });
+
+    try {
+      await page.goto(`/forums/${TEST_CHANNEL}/issues/${ISSUE_NUMBER}`);
+
+      const archiveButton = page
+        .getByRole('button', { name: 'Archive Image' })
+        .first();
+      await expect(archiveButton).toBeVisible();
+      await archiveButton.click();
+      await page.getByLabel('Select rule: Be kind').first().check();
+      await page.getByTestId('report-image-modal-primary-button').click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'archiveImage'
+      );
+      await expect(archiveButton).toHaveCount(0);
+      await expect(
+        page.getByRole('button', { name: 'Unarchive' }).first()
+      ).toBeVisible();
+
+      await page.getByRole('button', { name: 'Unarchive' }).first().click();
+      await page.getByTestId('unarchive-modal-primary-button').click();
+
+      await waitForGraphqlOperation(
+        diagnostics.completedOperations,
+        'unarchiveImage'
+      );
+      await expect(
+        page.getByRole('button', { name: 'Archive Image' }).first()
+      ).toBeVisible();
+
+      const operations = diagnostics.completedOperations.filter((item) =>
+        ['archiveImage', 'unarchiveImage'].includes(item.operationName)
+      );
+      expect(operations.map((item) => item.variables)).toEqual([
+        {
+          imageId,
+          reportText: '',
+          selectedForumRules: [],
+          selectedServerRules: ['Be kind'],
+          channelUniqueName: TEST_CHANNEL,
+        },
+        {
+          imageId,
+          explanation: 'No violation',
+          channelUniqueName: TEST_CHANNEL,
+        },
+      ]);
     } finally {
       await testInfo.attach('graphql-operations.json', {
         body: Buffer.from(JSON.stringify(diagnostics.seenOperations, null, 2)),

--- a/utils/issueDetailDisplay.spec.ts
+++ b/utils/issueDetailDisplay.spec.ts
@@ -48,6 +48,7 @@ describe('hasRelatedContent', () => {
     ['relatedDiscussionId', { relatedDiscussionId: 'd1' }],
     ['relatedEventId', { relatedEventId: 'e1' }],
     ['relatedCommentId', { relatedCommentId: 'c1' }],
+    ['relatedImageId', { relatedImageId: 'i1' }],
     ['relatedWikiPageId', { relatedWikiPageId: 'w1' }],
     ['relatedWikiRevisionId', { relatedWikiRevisionId: 'r1' }],
   ])('is true when %s is set', (_label, issue) => {

--- a/utils/issueDetailDisplay.ts
+++ b/utils/issueDetailDisplay.ts
@@ -4,24 +4,34 @@
  * data-derivation rules can be unit-tested in isolation.
  */
 
-type IssueReportSource = {
-  ActivityFeedAggregate?: { count?: number | null } | null;
-} | null | undefined;
+type IssueReportSource =
+  | {
+      ActivityFeedAggregate?: { count?: number | null } | null;
+    }
+  | null
+  | undefined;
 
-type IssueRelatedContent = {
-  relatedDiscussionId?: string | null;
-  relatedEventId?: string | null;
-  relatedCommentId?: string | null;
-  relatedWikiPageId?: string | null;
-  relatedWikiRevisionId?: string | null;
-} | null | undefined;
+type IssueRelatedContent =
+  | {
+      relatedDiscussionId?: string | null;
+      relatedEventId?: string | null;
+      relatedCommentId?: string | null;
+      relatedImageId?: string | null;
+      relatedWikiPageId?: string | null;
+      relatedWikiRevisionId?: string | null;
+    }
+  | null
+  | undefined;
 
-type RelatedCommentLike = {
-  CommentAuthor?: {
-    __typename?: string;
-    isBot?: boolean | null;
-  } | null;
-} | null | undefined;
+type RelatedCommentLike =
+  | {
+      CommentAuthor?: {
+        __typename?: string;
+        isBot?: boolean | null;
+      } | null;
+    }
+  | null
+  | undefined;
 
 /**
  * Number of items in the issue's activity feed, or null when the count is
@@ -48,10 +58,11 @@ export function formatReportCountLabel(count: number | null): string {
 export function hasRelatedContent(issue: IssueRelatedContent): boolean {
   return Boolean(
     issue?.relatedDiscussionId ||
-      issue?.relatedEventId ||
-      issue?.relatedCommentId ||
-      issue?.relatedWikiPageId ||
-      issue?.relatedWikiRevisionId
+    issue?.relatedEventId ||
+    issue?.relatedCommentId ||
+    issue?.relatedImageId ||
+    issue?.relatedWikiPageId ||
+    issue?.relatedWikiRevisionId
   );
 }
 


### PR DESCRIPTION
## Summary
- add click-through Playwright coverage for reporting album images from the lightbox
- cover channel icon and banner reporting with mutation-variable assertions
- support and test archive/unarchive actions for image moderation issues

## Verification
- vue-tsc --noEmit
- 82 focused Vitest tests
- 4 focused mocked Playwright scenarios
- git diff --check

Closes #200