### PR TITLE
ci: reduce test workflow overhead

### DIFF
--- a/.github/workflows/unit-tests-ci.yml
+++ b/.github/workflows/unit-tests-ci.yml
@@ -164,61 +164,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run unit tests
+        if: github.event_name == 'pull_request'
         run: pnpm run test:unit:run
 
-  unit-coverage:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    env:
-      GRAPHQL_URL_FOR_TYPES: ${{ secrets.GRAPHQL_URL_FOR_TYPES }}
-      VITE_GRAPHQL_URL: ${{ secrets.VITE_GRAPHQL_URL }}
-      VITE_BASE_URL: ${{ secrets.VITE_BASE_URL }}
-      VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
-      VITE_GOOGLE_MAP_ID: ${{ secrets.VITE_GOOGLE_MAP_ID }}
-      VITE_OPEN_CAGE_API_KEY: ${{ secrets.VITE_OPEN_CAGE_API_KEY }}
-      VITE_AUTH0_DOMAIN: ${{ secrets.VITE_AUTH0_DOMAIN }}
-      VITE_OPEN_GRAPH_API_KEY: ${{ secrets.VITE_OPEN_GRAPH_API_KEY }}
-      VITE_LOGOUT_URL: ${{ secrets.VITE_LOGOUT_URL }}
-      VITE_AUTH0_USERNAME: ${{ secrets.VITE_AUTH0_USERNAME }}
-      VITE_AUTH0_PASSWORD: ${{ secrets.VITE_AUTH0_PASSWORD }}
-      VITE_AUTH0_USERNAME_2: ${{ secrets.VITE_AUTH0_USERNAME_2 }}
-      VITE_AUTH0_PASSWORD_2: ${{ secrets.VITE_AUTH0_PASSWORD_2 }}
-      VITE_AUTH0_URL: ${{ secrets.VITE_AUTH0_URL }}
-      VITE_AUTH0_AUDIENCE: ${{ secrets.VITE_AUTH0_AUDIENCE }}
-      VITE_AUTH0_SCOPE: ${{ secrets.VITE_AUTH0_SCOPE }}
-      VITE_AUTH0_CLIENT_ID: ${{ secrets.VITE_AUTH0_CLIENT_ID }}
-      VITE_AUTH0_CLIENT_SECRET: ${{ secrets.VITE_AUTH0_CLIENT_SECRET }}
-      VITE_AUTH0_CALLBACK_URL: ${{ secrets.VITE_AUTH0_CALLBACK_URL }}
-      VITE_GOOGLE_CLOUD_STORAGE_BUCKET: ${{ secrets.VITE_GOOGLE_CLOUD_STORAGE_BUCKET }}
-      VITE_SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN }}
-      VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-      VITE_LIGHTGALLERY_LICENSE_KEY: ${{ secrets.VITE_LIGHTGALLERY_LICENSE_KEY }}
-      NITRO_PRESET: ${{ secrets.NITRO_PRESET }}
-      VITE_SERVER_NAME: ${{ secrets.VITE_SERVER_NAME }}
-      VITE_ENVIRONMENT: ${{ secrets.VITE_ENVIRONMENT }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.28.2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Run unit tests with coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: pnpm run coverage
 
       - name: Upload coverage to Codecov
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/playwright.build.config.ts
+++ b/playwright.build.config.ts
@@ -47,9 +47,12 @@ export default defineConfig({
   reporter: [['list'], ['html', { open: 'never' }]],
   use: {
     baseURL,
-    trace: 'retain-on-failure',
+    // CI retries once, so collect the expensive trace/video diagnostics only
+    // for the retry instead of recording every successful first attempt and
+    // deleting the artifacts afterward.
+    trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    video: 'on-first-retry',
     headless: true,
   },
   webServer: skipWebServer

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -54,7 +54,12 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
+      // CI uploads only lcov. Avoid spending time and disk space generating
+      // the JSON and HTML reports there, while preserving the richer local
+      // coverage output for developers.
+      reporter: process.env.CI
+        ? ['text', 'lcovonly']
+        : ['text', 'json', 'html', 'lcov'],
       reportsDirectory: './coverage',
       exclude: [
         'node_modules/',


### PR DESCRIPTION
## Summary
- record Playwright traces and videos only on the first retry
- reuse the existing unit-tests job for main-branch coverage instead of running the full suite twice
- generate only text and LCOV coverage output in CI while preserving rich local reports

## Why
Recent green PR runs spend about 4½ minutes in Playwright, and successful first attempts currently record trace and video data that is discarded. Main pushes also run the 7,500-test Vitest suite twice in parallel, consuming roughly 4½ extra runner-minutes per merge.

## Validation
- `pnpm run tsc`
- `pnpm run test:unit:run` — 784 files / 7,507 tests passed
- `pnpm exec playwright test --config playwright.build.config.ts --list` — 170 tests discovered
- `CI=true pnpm exec vitest run tests/unit/utils/usernameValidation.spec.ts --coverage` — only `coverage/lcov.info` generated
- Prettier, workflow YAML parse, and pre-commit lint checks