### PR TITLE
refactor(downloads): simplify license and metadata UI

### DIFF
--- a/components/channel/DownloadSidebar.spec.ts
+++ b/components/channel/DownloadSidebar.spec.ts
@@ -6,17 +6,21 @@ import { makeDiscussion } from '@/tests/utils/factories';
 
 const authState = ref(false);
 const mockUsernameRef = ref('');
-const trackDownloadMock = vi.hoisted(() => vi.fn(() => Promise.resolve({
-  data: {
-    prepareDownload: {
-      ready: true,
-      url: 'https://signed.example.com/asset.zip',
-      scanStatus: 'CLEAN',
-      reviewAccess: false,
-      message: 'No threats found. Your download is ready.',
-    },
-  },
-})));
+const trackDownloadMock = vi.hoisted(() =>
+  vi.fn(() =>
+    Promise.resolve({
+      data: {
+        prepareDownload: {
+          ready: true,
+          url: 'https://signed.example.com/asset.zip',
+          scanStatus: 'CLEAN',
+          reviewAccess: false,
+          message: 'No threats found. Your download is ready.',
+        },
+      },
+    })
+  )
+);
 
 vi.mock('@/stores/toastStore', () => ({
   useToastStore: () => ({
@@ -180,6 +184,18 @@ describe('DownloadSidebar', () => {
     expect(wrapper.text()).toContain('4');
   });
 
+  it('does not show license details', () => {
+    const wrapper = mount(DownloadSidebar, {
+      props: {
+        discussion: discussionWithFile,
+        discussionId: 'discussion-1',
+        channelUniqueName: 'test-forum',
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('CC BY');
+  });
+
   it('shows the unavailable message without rendering license details when no files exist', () => {
     const wrapper = mount(DownloadSidebar, {
       props: {
@@ -249,10 +265,13 @@ describe('DownloadSidebar', () => {
 
     expect({
       status: wrapper.get('[data-testid="download-scan-status"]').text(),
-      directReviewDownload: wrapper.findAll('button').some((button) =>
-        button.text() === 'Download for review'
-      ),
-      downloadDisabled: wrapper.findAll('button').at(-1)?.attributes('disabled'),
+      directReviewDownload: wrapper
+        .findAll('button')
+        .some((button) => button.text() === 'Download for review'),
+      downloadDisabled: wrapper
+        .findAll('button')
+        .at(-1)
+        ?.attributes('disabled'),
     }).toEqual({
       status: expect.stringContaining(
         'This upload was blocked by the security scan: Known malware signature.'
@@ -302,7 +321,9 @@ describe('DownloadSidebar', () => {
       },
     });
 
-    await wrapper.get('[data-testid="download-scan-status"] button').trigger('click');
+    await wrapper
+      .get('[data-testid="download-scan-status"] button')
+      .trigger('click');
 
     expect(trackDownloadMock).toHaveBeenCalledWith({
       downloadableFileId: 'file-1',
@@ -341,10 +362,9 @@ describe('DownloadSidebar', () => {
     expect({
       title: status.get('p.font-medium').text(),
       message: status.get('p.text-xs').text(),
-      actions: [
-        ...status.findAll('button'),
-        ...status.findAll('a'),
-      ].map((action) => action.text()),
+      actions: [...status.findAll('button'), ...status.findAll('a')].map(
+        (action) => action.text()
+      ),
     }).toEqual({
       title: 'Security check needs another try',
       message: "The scan service had a problem—your file wasn't rejected.",
@@ -370,7 +390,9 @@ describe('DownloadSidebar', () => {
       },
     });
 
-    await wrapper.get('[data-testid="download-scan-status"] button').trigger('click');
+    await wrapper
+      .get('[data-testid="download-scan-status"] button')
+      .trigger('click');
 
     expect(trackDownloadMock).toHaveBeenCalledWith({
       downloadableFileId: 'file-1',

--- a/components/channel/DownloadSidebar.vue
+++ b/components/channel/DownloadSidebar.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import type { Discussion, FilterOption } from '@/__generated__/graphql';
+import type { Discussion } from '@/__generated__/graphql';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import DownloadNowButton from '@/components/channel/DownloadNowButton.vue';
 import FunctionalDownloadNow from '@/components/channel/FunctionalDownloadNow.vue';
 import DownloadSuccessPopover from '@/components/download/DownloadSuccessPopover.vue';
 import DownloadPipelineStatusSummary from '@/components/plugins/DownloadPipelineStatusSummary.vue';
 import { computed, ref } from 'vue';
-import { useMutation, useQuery } from '@vue/apollo-composable';
-import { GET_DOWNLOAD_LABELS } from '@/graphQLData/discussion/queries';
+import { useMutation } from '@vue/apollo-composable';
 import {
   REQUEST_DOWNLOADABLE_FILE_REVIEW,
   RETRY_DOWNLOADABLE_FILE_SCAN,
@@ -16,11 +15,7 @@ import {
 import { useUsername } from '@/composables/useAuthState';
 
 type DownloadScanStatus =
-  | 'PENDING'
-  | 'CLEAN'
-  | 'INFECTED'
-  | 'SUSPICIOUS'
-  | 'FAILED';
+  'PENDING' | 'CLEAN' | 'INFECTED' | 'SUSPICIOUS' | 'FAILED';
 
 type ScannedDownloadableFile = Omit<
   Discussion['DownloadableFiles'][number],
@@ -70,17 +65,18 @@ const showSuccessPopover = ref(false);
 
 // Get the primary downloadable file (first one)
 const primaryFile = computed(() => {
-  return (props.discussion?.DownloadableFiles?.[0] as
-    | ScannedDownloadableFile
-    | undefined) || null;
+  return (
+    (props.discussion?.DownloadableFiles?.[0] as
+      ScannedDownloadableFile | undefined) || null
+  );
 });
 
 const hasDownloadableFile = computed(() => {
   return (props.discussion?.DownloadableFiles?.length || 0) > 0;
 });
 
-const scanStatus = computed<DownloadScanStatus>(
-  () => retryingScan.value ? 'PENDING' : primaryFile.value?.scanStatus || 'PENDING'
+const scanStatus = computed<DownloadScanStatus>(() =>
+  retryingScan.value ? 'PENDING' : primaryFile.value?.scanStatus || 'PENDING'
 );
 
 const retryScan = async () => {
@@ -98,15 +94,19 @@ const retryScan = async () => {
 };
 
 const creatorIsViewing = computed(
-  () => Boolean(username.value) && props.discussion?.Author?.username === username.value
+  () =>
+    Boolean(username.value) &&
+    props.discussion?.Author?.username === username.value
 );
 
-const reviewRequested = computed(
-  () => reviewRequestedLocally.value
-);
+const reviewRequested = computed(() => reviewRequestedLocally.value);
 
 const requestHumanReview = () => {
-  if (!primaryFile.value?.id || requestingReview.value || reviewRequested.value) {
+  if (
+    !primaryFile.value?.id ||
+    requestingReview.value ||
+    reviewRequested.value
+  ) {
     return;
   }
   requestDownloadableFileReview({
@@ -120,49 +120,25 @@ const hasReviewAccess = computed(
 );
 
 const downloadDisabled = computed(
-  () =>
-    !hasDownloadableFile.value ||
-    scanStatus.value !== 'CLEAN'
+  () => !hasDownloadableFile.value || scanStatus.value !== 'CLEAN'
 );
 
 const downloadLabel = 'Download Now';
 
 const replaceFilePath = computed(
-  () => `/forums/${props.channelUniqueName}/downloads/edit/${props.discussionId}`
+  () =>
+    `/forums/${props.channelUniqueName}/downloads/edit/${props.discussionId}`
 );
 
 const pipelinePath = computed(
-  () => `/forums/${props.channelUniqueName}/downloads/${props.discussionId}/pipelines`
+  () =>
+    `/forums/${props.channelUniqueName}/downloads/${props.discussionId}/pipelines`
 );
 
 const scanCheckedDisplay = computed(() => {
   if (!primaryFile.value?.scanCheckedAt) return '';
   const checkedAt = new Date(primaryFile.value.scanCheckedAt);
   return Number.isNaN(checkedAt.getTime()) ? '' : checkedAt.toLocaleString();
-});
-
-// Format price display
-const priceDisplay = computed(() => {
-  if (!primaryFile.value) return { main: '$0', sub: '00', label: null };
-
-  if (primaryFile.value.priceModel === 'FREE') {
-    return { main: '$0', sub: '00', label: null };
-  }
-
-  const cents = primaryFile.value.priceCents || 0;
-  const dollars = Math.floor(cents / 100);
-  const remainingCents = cents % 100;
-
-  return {
-    main: `$${dollars}`,
-    sub: remainingCents.toString().padStart(2, '0'),
-    label: 'Purchase',
-  };
-});
-
-// Get license info
-const licenseInfo = computed(() => {
-  return primaryFile.value?.license?.name || 'No license specified';
 });
 
 const downloadCounts = computed(() => {
@@ -189,52 +165,6 @@ const formatFileSize = (sizeInBytes: number | null | undefined): string => {
   const decimals = unitIndex === 0 ? 0 : size >= 10 ? 1 : 2;
   return `${size.toFixed(decimals)} ${units[unitIndex]}`;
 };
-
-// Query for label options
-const { result: labelQueryResult } = useQuery(
-  GET_DOWNLOAD_LABELS,
-  {
-    discussionId: props.discussionId,
-    channelUniqueName: props.channelUniqueName,
-  },
-  {
-    enabled: !!props.discussionId && !!props.channelUniqueName,
-  }
-);
-
-// Get label options from query result
-const labelOptions = computed(() => {
-  const discussionChannels =
-    labelQueryResult.value?.discussions?.[0]?.DiscussionChannels;
-  const discussionChannel = discussionChannels?.[0];
-  return discussionChannel?.LabelOptions || [];
-});
-
-// Group labels by their group key for display
-const groupedLabels = computed(() => {
-  const groups: Record<
-    string,
-    Array<{ key: string; value: string; displayName: string }>
-  > = {};
-
-  labelOptions.value.forEach((option: FilterOption) => {
-    const groupKey = option.group?.key;
-    const groupDisplayName = option.group?.displayName;
-
-    if (groupKey && groupDisplayName) {
-      if (!groups[groupKey]) {
-        groups[groupKey] = [];
-      }
-      groups[groupKey].push({
-        key: groupDisplayName,
-        value: option.value || '',
-        displayName: option.displayName || option.value || '',
-      });
-    }
-  });
-
-  return groups;
-});
 </script>
 
 <template>
@@ -245,7 +175,7 @@ const groupedLabels = computed(() => {
       <!-- Boxed Info Section -->
       <div
         v-if="primaryFile"
-        class="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700"
+        class="bg-gray-50 mb-4 rounded-lg border border-gray-200 p-4 dark:border-gray-600 dark:bg-gray-700"
       >
         <!-- File Name -->
         <h2
@@ -259,24 +189,18 @@ const groupedLabels = computed(() => {
           {{ formatFileSize(primaryFile.size) }}
         </div>
 
-        <!-- Price Section -->
-        <!-- <div class="text-left mb-3">
-          <div class="text-3xl font-bold text-gray-900 dark:text-white">
-            <sup class="text-lg">{{ priceDisplay.main?.charAt(0) || '$' }}</sup>{{ priceDisplay.main?.slice(1) || '0' }}<sup class="text-lg">.{{ priceDisplay.sub || '00' }}</sup>
-          </div>
-          <div v-if="priceDisplay.label" class="py-1 text-sm text-gray-500 dark:text-gray-400">
-            {{ priceDisplay.label }}
-          </div>
-        </div> -->
-
         <div
           aria-live="polite"
           class="rounded-md p-3 text-sm"
           :class="{
-            'bg-green-50 text-green-800 dark:bg-green-900/30 dark:text-green-200': scanStatus === 'CLEAN',
-            'bg-amber-50 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200': scanStatus === 'PENDING' || scanStatus === 'SUSPICIOUS',
-            'bg-red-50 text-red-900 dark:bg-red-900/30 dark:text-red-200': scanStatus === 'INFECTED',
-            'bg-sky-50 text-sky-900 dark:bg-sky-900/30 dark:text-sky-200': scanStatus === 'FAILED',
+            'bg-green-50 text-green-800 dark:bg-green-900/30 dark:text-green-200':
+              scanStatus === 'CLEAN',
+            'bg-amber-50 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200':
+              scanStatus === 'PENDING' || scanStatus === 'SUSPICIOUS',
+            'bg-red-50 text-red-900 dark:bg-red-900/30 dark:text-red-200':
+              scanStatus === 'INFECTED',
+            'bg-sky-50 text-sky-900 dark:bg-sky-900/30 dark:text-sky-200':
+              scanStatus === 'FAILED',
           }"
           data-testid="download-scan-status"
         >
@@ -288,19 +212,27 @@ const groupedLabels = computed(() => {
             <i class="fa-solid fa-hourglass-half mr-1" />
             Quarantined: security check pending
           </p>
-          <template v-else-if="scanStatus === 'INFECTED' || scanStatus === 'SUSPICIOUS'">
+          <template
+            v-else-if="scanStatus === 'INFECTED' || scanStatus === 'SUSPICIOUS'"
+          >
             <p class="font-medium">
               <i class="fa-solid fa-shield-halved mr-1" />
-              {{ scanStatus === 'INFECTED'
-                ? 'Quarantined: threat detected'
-                : 'Quarantined: suspicious content' }}
+              {{
+                scanStatus === 'INFECTED'
+                  ? 'Quarantined: threat detected'
+                  : 'Quarantined: suspicious content'
+              }}
             </p>
             <p class="mt-1">
               <template v-if="creatorIsViewing">
-                This upload was blocked by the security scan<span v-if="primaryFile.scanReason">: {{ primaryFile.scanReason }}</span>.
+                This upload was blocked by the security scan<span
+                  v-if="primaryFile.scanReason"
+                  >: {{ primaryFile.scanReason }}</span
+                >.
               </template>
               <template v-else>
-                This download is not publicly available while its content is reviewed.
+                This download is not publicly available while its content is
+                reviewed.
               </template>
             </p>
             <div v-if="creatorIsViewing" class="mt-2 flex flex-wrap gap-3">
@@ -313,7 +245,13 @@ const groupedLabels = computed(() => {
                 :disabled="requestingReview || reviewRequested"
                 @click="requestHumanReview"
               >
-                {{ reviewRequested ? 'Human review requested' : requestingReview ? 'Requesting review…' : 'Request human review' }}
+                {{
+                  reviewRequested
+                    ? 'Human review requested'
+                    : requestingReview
+                      ? 'Requesting review…'
+                      : 'Request human review'
+                }}
               </button>
               <button
                 type="button"
@@ -353,10 +291,7 @@ const groupedLabels = computed(() => {
                   >
                     {{ retryingScan ? 'Retrying…' : 'Retry scan' }}
                   </button>
-                  <NuxtLink
-                    class="font-medium underline"
-                    :to="pipelinePath"
-                  >
+                  <NuxtLink class="font-medium underline" :to="pipelinePath">
                     View checks
                   </NuxtLink>
                 </div>
@@ -364,10 +299,7 @@ const groupedLabels = computed(() => {
             </div>
             <p v-if="retryError" class="mt-2 font-medium">
               {{ retryError }}
-              <NuxtLink
-                class="ml-1 underline"
-                to="/server/issues/create"
-              >
+              <NuxtLink class="ml-1 underline" to="/server/issues/create">
                 Open an issue
               </NuxtLink>
             </p>
@@ -386,10 +318,15 @@ const groupedLabels = computed(() => {
             View security pipeline
           </NuxtLink>
           <p
-            v-if="hasReviewAccess && scanStatus !== 'CLEAN' && scanStatus !== 'FAILED'"
+            v-if="
+              hasReviewAccess &&
+              scanStatus !== 'CLEAN' &&
+              scanStatus !== 'FAILED'
+            "
             class="mt-2 text-xs"
           >
-            Direct download is disabled while this file is quarantined. Review the scanner findings before clearing it.
+            Direct download is disabled while this file is quarantined. Review
+            the scanner findings before clearing it.
           </p>
         </div>
         <dl class="mt-3 grid grid-cols-2 gap-3 text-sm">
@@ -411,7 +348,7 @@ const groupedLabels = computed(() => {
       <!-- No File Available -->
       <div
         v-if="!primaryFile"
-        class="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4 text-center text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300"
+        class="bg-gray-50 mb-4 rounded-lg border border-gray-200 p-4 text-center text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300"
       >
         No downloadable files available
       </div>
@@ -441,61 +378,6 @@ const groupedLabels = computed(() => {
         :discussion-id="discussionId"
         :channel-name="channelUniqueName"
       />
-      <div
-        v-if="primaryFile && priceDisplay.label === 'Free Download'"
-        class="mt-2 text-xs text-gray-500 dark:text-gray-400"
-      >
-        By downloading, you agree to the content license
-      </div>
-      <!-- <div v-else class="text-xs mt-2 text-gray-500 dark:text-gray-400">
-        By placing an order, you're purchasing a content license
-      </div> -->
-
-      <!-- License Section -->
-      <div
-        v-if="primaryFile"
-        class="border-t border-gray-200 pt-4 dark:border-gray-700"
-      >
-        <h2 class="mb-2 text-sm font-medium text-gray-900 dark:text-white">
-          License
-        </h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
-          {{ licenseInfo }}
-        </p>
-      </div>
-
-      <!-- Labels Section -->
-      <div
-        v-if="Object.keys(groupedLabels).length > 0"
-        class="border-t border-gray-200 pt-4 dark:border-gray-700"
-      >
-        <h2 class="mb-2 text-sm font-medium text-gray-900 dark:text-white">
-          Labels
-        </h2>
-        <div class="space-y-2">
-          <div
-            v-for="(labels, groupKey) in groupedLabels"
-            :key="groupKey"
-            class="flex flex-wrap gap-2"
-          >
-            <div
-              v-for="label in labels"
-              :key="`${groupKey}-${label.value}`"
-              class="inline-flex items-center gap-2 text-sm"
-            >
-              <span class="font-medium text-gray-700 dark:text-gray-300">
-                {{ label.key }}:
-              </span>
-              <span
-                class="rounded-full bg-gray-100 px-2 py-1 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
-              >
-                {{ label.displayName }}
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-
     </div>
   </div>
 

--- a/components/discussion/detail/DownloadModeLayout.spec.ts
+++ b/components/discussion/detail/DownloadModeLayout.spec.ts
@@ -7,7 +7,9 @@ import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 
 const h = vi.hoisted(() => ({ username: null as unknown }));
 
-vi.mock('@/composables/useAuthState', () => ({ useUsername: () => h.username }));
+vi.mock('@/composables/useAuthState', () => ({
+  useUsername: () => h.username,
+}));
 
 const discussion = (overrides: Record<string, unknown> = {}) =>
   ({
@@ -19,7 +21,11 @@ const discussion = (overrides: Record<string, unknown> = {}) =>
   }) as unknown as Discussion;
 
 const channel = () =>
-  ({ id: 'dc1', channelUniqueName: 'cats', Channel: {} }) as unknown as DiscussionChannel;
+  ({
+    id: 'dc1',
+    channelUniqueName: 'cats',
+    Channel: {},
+  }) as unknown as DiscussionChannel;
 
 const discussionBodyStub = {
   name: 'DiscussionBody',
@@ -39,10 +45,28 @@ const mountLayout = (props: Record<string, unknown> = {}) =>
     global: {
       stubs: {
         DiscussionBody: discussionBodyStub,
-        DiscussionAlbum: { name: 'DiscussionAlbum', props: ['stlFiles'], template: '<div class="album" />' },
-        DiscussionVotes: { name: 'DiscussionVotes', emits: ['handle-click-give-feedback'], template: '<div class="votes" />' },
-        MarkAsAnsweredButton: { name: 'MarkAsAnsweredButton', template: '<div class="answered" />' },
-        DownloadSidebar: { name: 'DownloadSidebar', template: '<div class="sidebar" />' },
+        DiscussionAlbum: {
+          name: 'DiscussionAlbum',
+          props: ['stlFiles'],
+          template: '<div class="album" />',
+        },
+        DiscussionVotes: {
+          name: 'DiscussionVotes',
+          emits: ['handle-click-give-feedback'],
+          template: '<div class="votes" />',
+        },
+        MarkAsAnsweredButton: {
+          name: 'MarkAsAnsweredButton',
+          template: '<div class="answered" />',
+        },
+        DownloadSidebar: {
+          name: 'DownloadSidebar',
+          template: '<div class="sidebar" />',
+        },
+        DownloadMetadata: {
+          name: 'DownloadMetadata',
+          template: '<div class="metadata" />',
+        },
         CrosspostedDiscussionEmbed: true,
         ImageIcon: true,
       },
@@ -58,7 +82,9 @@ describe('DownloadModeLayout album empty state', () => {
   it('offers the author an Add Images button when there is no album', () => {
     const wrapper = mountLayout();
 
-    expect(wrapper.find('[data-testid="add-album-button"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="add-album-button"]').exists()).toBe(
+      true
+    );
   });
 
   it('shows "No images available" to non-authors', () => {
@@ -96,11 +122,34 @@ describe('DownloadModeLayout album present', () => {
     });
     await flushPromises();
 
-    expect(wrapper.getComponent({ name: 'DiscussionAlbum' }).props('stlFiles')).toHaveLength(1);
+    expect(
+      wrapper.getComponent({ name: 'DiscussionAlbum' }).props('stlFiles')
+    ).toHaveLength(1);
   });
 });
 
 describe('DownloadModeLayout sidebar and votes', () => {
+  it('renders metadata below the album in the left column', () => {
+    const wrapper = mountLayout({
+      discussion: discussion({ Album: { Images: [{ id: 'i1' }] } }),
+    });
+
+    expect({
+      followsAlbum: Boolean(
+        wrapper
+          .get('.album')
+          .element.compareDocumentPosition(wrapper.get('.metadata').element) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+      ),
+      precedesSidebar: Boolean(
+        wrapper
+          .get('.metadata')
+          .element.compareDocumentPosition(wrapper.get('.sidebar').element) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+      ),
+    }).toEqual({ followsAlbum: true, precedesSidebar: true });
+  });
+
   it('renders the download sidebar', () => {
     const wrapper = mountLayout();
 
@@ -117,7 +166,9 @@ describe('DownloadModeLayout sidebar and votes', () => {
     h.username = ref('bob');
     const wrapper = mountLayout();
 
-    await wrapper.getComponent({ name: 'DiscussionVotes' }).vm.$emit('handle-click-give-feedback');
+    await wrapper
+      .getComponent({ name: 'DiscussionVotes' })
+      .vm.$emit('handle-click-give-feedback');
 
     expect(wrapper.emitted('handleClickGiveFeedback')).toBeTruthy();
   });

--- a/components/discussion/detail/DownloadModeLayout.vue
+++ b/components/discussion/detail/DownloadModeLayout.vue
@@ -7,6 +7,7 @@ import MarkAsAnsweredButton from '@/components/discussion/detail/MarkAsAnsweredB
 import DownloadSidebar from '@/components/channel/DownloadSidebar.vue';
 import ImageIcon from '@/components/icons/ImageIcon.vue';
 import CrosspostedDiscussionEmbed from '@/components/discussion/detail/CrosspostedDiscussionEmbed.vue';
+import DownloadMetadata from '@/components/download/DownloadMetadata.vue';
 import { useUsername } from '@/composables/useAuthState';
 
 const usernameVar = useUsername();
@@ -113,7 +114,9 @@ const markdownImagesEnabled = computed(
               <div class="flex flex-col items-center space-y-3">
                 <span v-if="!loggedInUserIsAuthor">No images available.</span>
                 <button
-                  v-if="loggedInUserIsAuthor && usernameVar && imageUploadsEnabled"
+                  v-if="
+                    loggedInUserIsAuthor && usernameVar && imageUploadsEnabled
+                  "
                   class="flex items-center space-x-2 rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors duration-200 hover:bg-blue-700"
                   data-testid="add-album-button"
                   @click="emit('handleClickAddAlbum')"
@@ -157,6 +160,11 @@ const markdownImagesEnabled = computed(
           </div>
         </template>
       </DiscussionBody>
+      <DownloadMetadata
+        v-if="activeDiscussionChannel"
+        :discussion-id="discussionId"
+        :channel-unique-name="activeDiscussionChannel.channelUniqueName"
+      />
     </div>
     <div class="flex-shrink-0">
       <DownloadSidebar

--- a/components/discussion/form/DownloadEditForm.spec.ts
+++ b/components/discussion/form/DownloadEditForm.spec.ts
@@ -194,6 +194,18 @@ describe('DownloadEditForm rendering', () => {
     ).toBe(true);
   });
 
+  it('does not render the label picker when license is the only filter group', () => {
+    const wrapper = mountForm({
+      channelData: {
+        FilterGroups: [{ id: 'license-group', key: 'license' }],
+      },
+    });
+
+    expect(
+      wrapper.findComponent({ name: 'DownloadLabelPicker' }).exists()
+    ).toBe(false);
+  });
+
   it('hides support fields by default for files without custom values', async () => {
     const wrapper = mountForm({
       discussion: makeDiscussion({ DownloadableFiles: [fileRecord()] }),

--- a/components/discussion/form/DownloadEditForm.vue
+++ b/components/discussion/form/DownloadEditForm.vue
@@ -159,10 +159,10 @@ const formValues = ref({
 const shouldShowSupportFields = (file: DownloadFormFile) =>
   Boolean(
     file.attributionOverride ||
-      file.supportPatreonUrl ||
-      file.supportBuyMeACoffeeUrl ||
-      file.supportKoFiUrl ||
-      file.supportPayPalMeUrl
+    file.supportPatreonUrl ||
+    file.supportBuyMeACoffeeUrl ||
+    file.supportKoFiUrl ||
+    file.supportPayPalMeUrl
   );
 
 const customSupportFieldsEnabled = ref<boolean[]>([]);
@@ -213,6 +213,12 @@ const downloadsDisabled = computed(() => {
   return props.channelData?.downloadsEnabled === false;
 });
 
+const downloadLabelFilterGroups = computed(() =>
+  (props.channelData?.FilterGroups || []).filter(
+    (group) => group.key !== 'license'
+  )
+);
+
 const currentChannelConnections = computed(() => {
   return props.channelData?.uniqueName ? [props.channelData.uniqueName] : [];
 });
@@ -220,8 +226,9 @@ const currentChannelConnections = computed(() => {
 // Initialize form values after component is mounted
 onMounted(() => {
   formValues.value.downloadableFiles = [...downloadableFiles.value];
-  customSupportFieldsEnabled.value =
-    formValues.value.downloadableFiles.map(shouldShowSupportFields);
+  customSupportFieldsEnabled.value = formValues.value.downloadableFiles.map(
+    shouldShowSupportFields
+  );
 
   // Initialize download labels from props
   formValues.value.downloadLabels = { ...props.existingDownloadLabels };
@@ -317,8 +324,8 @@ const uploadFile = async (file: File): Promise<boolean> => {
 
     // Ask the server for a signed storage URL
     const signedUrlResult = await createSignedStorageUrl(signedStorageURLInput);
-    const signedUpload = signedUrlResult?.data
-      ?.createSignedStorageURL as SignedStorageUrlPayload | undefined;
+    const signedUpload = signedUrlResult?.data?.createSignedStorageURL as
+      SignedStorageUrlPayload | undefined;
     const signedStorageURL = signedUpload?.url;
 
     if (!signedStorageURL) {
@@ -522,7 +529,9 @@ function handleSave() {
       />
 
       <ErrorBanner
-        v-else-if="permanentDeleteFileError || permanentlyDeleteDownloadableFileError"
+        v-else-if="
+          permanentDeleteFileError || permanentlyDeleteDownloadableFileError
+        "
         :text="
           permanentDeleteFileError ||
           permanentlyDeleteDownloadableFileError?.message ||
@@ -543,7 +552,7 @@ function handleSave() {
                 :accept="acceptAttribute"
                 :disabled="uploadingFile || downloadsDisabled"
                 @change="handleFileUpload"
-              >
+              />
               <label
                 for="downloadable-file-input"
                 class="hover:bg-gray-50 focus:ring-indigo-500 inline-flex cursor-pointer items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
@@ -563,7 +572,7 @@ function handleSave() {
                 <span v-else>
                   Maximum file size: {{ MAX_DOWNLOAD_FILE_SIZE_MB }}MB
                 </span>
-                <br >
+                <br />
                 <span v-if="channelData?.allowedFileTypes?.length">
                   Allowed file types:
                   {{ channelData.allowedFileTypes.join(', ') }}
@@ -605,7 +614,7 @@ function handleSave() {
                           readonly
                           class="bg-gray-50 flex-1 cursor-not-allowed rounded border border-gray-200 px-2 py-1 text-sm text-gray-600 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400"
                           type="text"
-                        >
+                        />
                         <button
                           type="button"
                           class="text-sm font-medium text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
@@ -635,14 +644,14 @@ function handleSave() {
                         <input
                           :checked="customSupportFieldsEnabled[index]"
                           type="checkbox"
-                          class="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700"
+                          class="text-indigo-600 focus:ring-indigo-500 mt-1 h-4 w-4 rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700"
                           @change="
                             updateCustomSupportFieldsEnabled(
                               index,
                               ($event.target as HTMLInputElement).checked
                             )
                           "
-                        >
+                        />
                         <span class="text-sm text-gray-700 dark:text-gray-300">
                           Use custom attribution and/or support links
                         </span>
@@ -685,9 +694,7 @@ function handleSave() {
                               {{ supportField.label }}
                             </span>
                             <input
-                              :value="
-                                file[supportField.key] || ''
-                              "
+                              :value="file[supportField.key] || ''"
                               type="url"
                               class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
                               :placeholder="supportField.placeholder"
@@ -698,7 +705,7 @@ function handleSave() {
                                   ($event.target as HTMLInputElement).value
                                 )
                               "
-                            >
+                            />
                           </label>
                         </div>
                       </div>
@@ -716,7 +723,7 @@ function handleSave() {
                   :accept="acceptAttribute"
                   :disabled="uploadingFile || downloadsDisabled"
                   @change="handleFileUpload"
-                >
+                />
                 <label
                   for="additional-file-input"
                   class="hover:bg-gray-50 inline-flex cursor-pointer items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
@@ -737,13 +744,13 @@ function handleSave() {
 
       <!-- Download Labels Section -->
       <FormRow
-        v-if="channelData?.FilterGroups && channelData.FilterGroups.length > 0"
+        v-if="downloadLabelFilterGroups.length > 0"
         section-title="Labels"
         class="mt-6"
       >
         <template #content>
           <DownloadLabelPicker
-            :filter-groups="channelData.FilterGroups || []"
+            :filter-groups="downloadLabelFilterGroups"
             :selected-labels="formValues.downloadLabels"
             @update:selected-labels="
               (newLabels) => {

--- a/components/download/DownloadLabelPicker.spec.ts
+++ b/components/download/DownloadLabelPicker.spec.ts
@@ -51,7 +51,7 @@ const mockFilterGroups: FilterGroup[] = [
 ] as FilterGroup[];
 
 describe('DownloadLabelPicker', () => {
-  it('displays filter group names', () => {
+  it('displays non-license filter group names', () => {
     const wrapper = mount(DownloadLabelPicker, {
       props: {
         filterGroups: mockFilterGroups,
@@ -70,7 +70,26 @@ describe('DownloadLabelPicker', () => {
     });
 
     expect(wrapper.text()).toContain('Category');
-    expect(wrapper.text()).toContain('License Type');
+  });
+
+  it('hides the license filter group', () => {
+    const wrapper = mount(DownloadLabelPicker, {
+      props: {
+        filterGroups: mockFilterGroups,
+        selectedLabels: {},
+      },
+      global: {
+        stubs: {
+          MultiSelect: { template: '<div class="multi-select" />' },
+          CheckBox: {
+            template: '<div class="checkbox"><span>{{ label }}</span></div>',
+            props: ['checked', 'label'],
+          },
+        },
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('License Type');
   });
 
   it('displays all options in small groups as checkboxes', () => {
@@ -90,12 +109,10 @@ describe('DownloadLabelPicker', () => {
       },
     });
 
-    // All options from both groups should be visible
+    // All options from the visible group should be visible
     expect(wrapper.text()).toContain('Tools');
     expect(wrapper.text()).toContain('Models');
     expect(wrapper.text()).toContain('Textures');
-    expect(wrapper.text()).toContain('Free');
-    expect(wrapper.text()).toContain('Commercial');
   });
 
   it('shows selected count when labels are selected', () => {
@@ -118,8 +135,8 @@ describe('DownloadLabelPicker', () => {
       },
     });
 
-    // Should show total count of selected labels
-    expect(wrapper.text()).toContain('3 selected');
+    // License selections are preserved in data but omitted from the user-facing count.
+    expect(wrapper.text()).toContain('2 selected');
   });
 
   it('emits update event when checkbox is toggled', async () => {

--- a/components/download/DownloadLabelPicker.vue
+++ b/components/download/DownloadLabelPicker.vue
@@ -21,6 +21,16 @@ const emit = defineEmits<{
   'update:selectedLabels': [labels: Record<string, string[]>];
 }>();
 
+const visibleFilterGroups = computed(() =>
+  props.filterGroups.filter((group) => group.key !== 'license')
+);
+
+const visibleSelectedLabels = computed<Array<[string, string[]]>>(() =>
+  Object.entries(props.selectedLabels).filter(
+    ([groupKey]) => groupKey !== 'license'
+  )
+);
+
 // Helper function to determine if a group should use dropdown
 const shouldUseDropdown = (group: FilterGroup) => {
   return (group.options?.length || 0) >= 10;
@@ -81,15 +91,13 @@ const handleMultiSelectUpdate = (
 
 // Check if any labels are selected
 const hasSelectedLabels = computed(() => {
-  return Object.values(props.selectedLabels).some(
-    (values) => values.length > 0
-  );
+  return visibleSelectedLabels.value.some(([, values]) => values.length > 0);
 });
 
 // Get total count of selected labels
 const selectedLabelCount = computed(() => {
-  return Object.values(props.selectedLabels).reduce(
-    (total, values) => total + values.length,
+  return visibleSelectedLabels.value.reduce(
+    (total, [, values]) => total + values.length,
     0
   );
 });
@@ -117,7 +125,11 @@ const selectedLabelCount = computed(() => {
 
     <!-- Filter Groups -->
     <div class="space-y-6">
-      <div v-for="group in filterGroups" :key="group.id" class="space-y-3">
+      <div
+        v-for="group in visibleFilterGroups"
+        :key="group.id"
+        class="space-y-3"
+      >
         <h4 class="text-md font-medium text-gray-800 dark:text-gray-200">
           {{ group.displayName }}
         </h4>
@@ -137,10 +149,7 @@ const selectedLabelCount = computed(() => {
 
         <!-- Regular checkboxes for groups with <10 options -->
         <div v-else class="space-y-2">
-          <div
-            v-for="option in group.options"
-            :key="option.id"
-          >
+          <div v-for="option in group.options" :key="option.id">
             <CheckBox
               :checked="
                 selectedLabels[group.key]?.includes(option.value) || false
@@ -155,7 +164,7 @@ const selectedLabelCount = computed(() => {
 
     <!-- Empty state -->
     <div
-      v-if="filterGroups.length === 0"
+      v-if="visibleFilterGroups.length === 0"
       class="py-6 text-center text-gray-500 dark:text-gray-400"
     >
       <p class="text-sm">No label categories configured for this forum.</p>

--- a/components/download/DownloadMetadata.spec.ts
+++ b/components/download/DownloadMetadata.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import DownloadMetadata from './DownloadMetadata.vue';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: () => ({
+    result: ref({
+      discussions: [
+        {
+          DiscussionChannels: [
+            {
+              LabelOptions: [
+                {
+                  value: 'beginner',
+                  displayName: 'Beginner',
+                  group: { key: 'difficulty', displayName: 'Difficulty' },
+                },
+                {
+                  value: 'cc-by',
+                  displayName: 'CC BY',
+                  group: { key: 'license', displayName: 'License' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  }),
+}));
+
+describe('DownloadMetadata', () => {
+  it('shows non-license metadata without exposing license labels', () => {
+    const wrapper = mount(DownloadMetadata, {
+      props: {
+        discussionId: 'discussion-1',
+        channelUniqueName: 'models',
+      },
+    });
+
+    expect(wrapper.text()).toEqual(
+      expect.stringMatching(/Metadata.*Difficulty.*Beginner/s)
+    );
+  });
+
+  it('does not show license metadata', () => {
+    const wrapper = mount(DownloadMetadata, {
+      props: {
+        discussionId: 'discussion-1',
+        channelUniqueName: 'models',
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('CC BY');
+  });
+});

--- a/components/download/DownloadMetadata.vue
+++ b/components/download/DownloadMetadata.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import type { FilterOption } from '@/__generated__/graphql';
+import { GET_DOWNLOAD_LABELS } from '@/graphQLData/discussion/queries';
+
+const props = defineProps({
+  discussionId: {
+    type: String,
+    required: true,
+  },
+  channelUniqueName: {
+    type: String,
+    required: true,
+  },
+});
+
+const { result: labelQueryResult } = useQuery(
+  GET_DOWNLOAD_LABELS,
+  {
+    discussionId: props.discussionId,
+    channelUniqueName: props.channelUniqueName,
+  },
+  {
+    enabled: !!props.discussionId && !!props.channelUniqueName,
+  }
+);
+
+const labelOptions = computed<FilterOption[]>(() => {
+  return (
+    labelQueryResult.value?.discussions?.[0]?.DiscussionChannels?.[0]
+      ?.LabelOptions || []
+  );
+});
+
+const groupedLabels = computed(() => {
+  const groups: Record<
+    string,
+    {
+      displayName: string;
+      labels: Array<{ value: string; displayName: string }>;
+    }
+  > = {};
+
+  labelOptions.value.forEach((option) => {
+    const groupKey = option.group?.key;
+    const groupDisplayName = option.group?.displayName;
+
+    if (!groupKey || !groupDisplayName || groupKey === 'license') return;
+
+    if (!groups[groupKey]) {
+      groups[groupKey] = { displayName: groupDisplayName, labels: [] };
+    }
+    groups[groupKey].labels.push({
+      value: option.value || '',
+      displayName: option.displayName || option.value || '',
+    });
+  });
+
+  return groups;
+});
+</script>
+
+<template>
+  <section
+    v-if="Object.keys(groupedLabels).length > 0"
+    class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+    data-testid="download-metadata"
+  >
+    <h2 class="font-semibold mb-3 text-sm text-gray-900 dark:text-white">
+      Metadata
+    </h2>
+    <dl class="space-y-3">
+      <div
+        v-for="(group, groupKey) in groupedLabels"
+        :key="groupKey"
+        class="flex flex-wrap items-center gap-2 text-sm"
+      >
+        <dt class="font-medium text-gray-700 dark:text-gray-300">
+          {{ group.displayName }}:
+        </dt>
+        <dd class="flex flex-wrap gap-2">
+          <span
+            v-for="label in group.labels"
+            :key="`${groupKey}-${label.value}`"
+            class="rounded-full bg-gray-100 px-2 py-1 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+          >
+            {{ label.displayName }}
+          </span>
+        </dd>
+      </div>
+    </dl>
+  </section>
+</template>


### PR DESCRIPTION
## Summary
- remove user-facing license details from download creation/editing and detail views
- move non-license download metadata from the sidebar into the main column below the album
- add focused coverage for license suppression and metadata placement

## Verification
- `vue-tsc --noEmit`
- ESLint on all changed files
- 80 focused unit tests across download forms, sidebar, metadata, and detail layouts