### PR TITLE
feat(admin): add instance setup checklist

### DIFF
--- a/components/admin/ServerTabs.spec.ts
+++ b/components/admin/ServerTabs.spec.ts
@@ -39,6 +39,7 @@ const mountTabs = (props: Record<string, unknown> = {}) =>
         InfoIcon: true,
         UserIcon: true,
         LayoutDashboard: true,
+        ListChecks: true,
       },
     },
   });
@@ -55,7 +56,7 @@ describe('ServerTabs', () => {
   it('renders all admin tabs', () => {
     const wrapper = mountTabs();
 
-    expect(tabs(wrapper)).toHaveLength(7);
+    expect(tabs(wrapper)).toHaveLength(8);
   });
 
   it('labels the first tab Dashboard', () => {
@@ -70,7 +71,7 @@ describe('ServerTabs', () => {
     expect(tabs(wrapper)[1].props('to')).toBe('/admin/issues');
   });
 
-  it('places Suspensions between Settings and Plugins', () => {
+  it('places Setup before Settings and Suspensions before Plugins', () => {
     const wrapper = mountTabs();
     const labels = tabs(wrapper).map((tab) => tab.props('label'));
 
@@ -78,6 +79,7 @@ describe('ServerTabs', () => {
       'Dashboard',
       'Issues',
       'Channel Reports',
+      'Setup',
       'Settings',
       'Suspensions',
       'Plugins',

--- a/components/admin/ServerTabs.vue
+++ b/components/admin/ServerTabs.vue
@@ -10,7 +10,7 @@ import InfoIcon from '@/components/icons/InfoIcon.vue';
 import UserIcon from '@/components/icons/UserIcon.vue';
 import type { Channel } from '@/__generated__/graphql';
 import { useRoute } from 'nuxt/app';
-import { LayoutDashboard } from 'lucide-vue-next';
+import { LayoutDashboard, ListChecks } from 'lucide-vue-next';
 import { useDisplay } from '@/composables/useDisplay';
 
 const Popper = defineAsyncComponent(() => import('vue3-popper'));
@@ -50,6 +50,7 @@ const tabRoutes = computed(() => {
     dashboard: `/admin/dashboard`,
     issues: `/admin/issues`,
     channelReports: `/admin/channel-reports`,
+    setup: `/admin/setup`,
     settings: `/admin/settings`,
     suspensions: `/admin/suspensions/server-membership`,
     plugins: `/admin/plugins`,
@@ -85,6 +86,13 @@ const tabs = computed((): Tab[] => {
       routeSuffix: 'channel-reports',
       label: 'Channel Reports',
       icon: LockClosedIcon,
+      countProperty: null,
+    },
+    {
+      name: 'setup',
+      routeSuffix: 'setup',
+      label: 'Setup',
+      icon: ListChecks,
       countProperty: null,
     },
     {

--- a/composables/useInstanceSetupStatus.spec.ts
+++ b/composables/useInstanceSetupStatus.spec.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { GET_INSTANCE_SETUP_STATUS } from '@/graphQLData/admin/queries';
+import { useInstanceSetupStatus } from './useInstanceSetupStatus';
+
+vi.mock('@vue/apollo-composable', () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockedUseQuery = vi.mocked(useQuery);
+
+describe('useInstanceSetupStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('queries the public capability endpoint and exposes its status', () => {
+    const capabilityStatus = {
+      auth: {
+        configured: false,
+        enabled: false,
+        requiredEnvVarsMissing: ['AUTH0_DOMAIN'],
+        setupUrl: '/admin/setup#authentication',
+        docsPath: '/authentication',
+      },
+    };
+    const refetch = vi.fn();
+    mockedUseQuery.mockReturnValue({
+      result: ref({ getInstanceSetupStatus: capabilityStatus }),
+      loading: ref(false),
+      error: ref(null),
+      refetch,
+    } as never);
+
+    const setup = useInstanceSetupStatus();
+
+    expect(mockedUseQuery).toHaveBeenCalledWith(
+      GET_INSTANCE_SETUP_STATUS,
+      undefined,
+      { fetchPolicy: 'cache-and-network' }
+    );
+    expect(setup.status.value).toEqual(capabilityStatus);
+    expect(setup.refetch).toBe(refetch);
+  });
+
+  it('returns null before the setup status has loaded', () => {
+    mockedUseQuery.mockReturnValue({
+      result: ref(undefined),
+      loading: ref(true),
+      error: ref(null),
+      refetch: vi.fn(),
+    } as never);
+
+    const setup = useInstanceSetupStatus();
+
+    expect(setup.status.value).toBeNull();
+    expect(setup.loading.value).toBe(true);
+  });
+});

--- a/composables/useInstanceSetupStatus.ts
+++ b/composables/useInstanceSetupStatus.ts
@@ -1,0 +1,44 @@
+import { computed } from 'vue';
+import { useQuery } from '@vue/apollo-composable';
+import { GET_INSTANCE_SETUP_STATUS } from '@/graphQLData/admin/queries';
+
+export const instanceCapabilityKeys = [
+  'auth',
+  'mail',
+  'maps',
+  'geocoding',
+  'uploads',
+  'downloads',
+  'events',
+  'plugins',
+] as const;
+
+export type InstanceCapabilityKey = (typeof instanceCapabilityKeys)[number];
+
+export interface InstanceCapabilityStatus {
+  configured: boolean;
+  enabled: boolean;
+  requiredEnvVarsMissing: string[];
+  setupUrl: string;
+  docsPath: string;
+}
+
+export type InstanceSetupStatus = Record<
+  InstanceCapabilityKey,
+  InstanceCapabilityStatus
+>;
+
+interface InstanceSetupQueryResult {
+  getInstanceSetupStatus: InstanceSetupStatus;
+}
+
+export function useInstanceSetupStatus() {
+  const { result, loading, error, refetch } =
+    useQuery<InstanceSetupQueryResult>(GET_INSTANCE_SETUP_STATUS, undefined, {
+      fetchPolicy: 'cache-and-network',
+    });
+
+  const status = computed(() => result.value?.getInstanceSetupStatus ?? null);
+
+  return { status, loading, error, refetch };
+}

--- a/graphQLData/admin/queries.js
+++ b/graphQLData/admin/queries.js
@@ -1,5 +1,68 @@
 import { gql } from '@apollo/client/core';
 
+export const GET_INSTANCE_SETUP_STATUS = gql`
+  query GetInstanceSetupStatus {
+    getInstanceSetupStatus {
+      auth {
+        configured
+        enabled
+        requiredEnvVarsMissing
+        setupUrl
+        docsPath
+      }
+      mail {
+        configured
+        enabled
+        requiredEnvVarsMissing
+        setupUrl
+        docsPath
+      }
+      maps {
+        configured
+        enabled
+        requiredEnvVarsMissing
+        setupUrl
+        docsPath
+      }
+      geocoding {
+        configured
+        enabled
+        requiredEnvVarsMissing
+        setupUrl
+        docsPath
+      }
+      uploads {
+        configured
+        enabled
+        requiredEnvVarsMissing
+        setupUrl
+        docsPath
+      }
+      downloads {
+        configured
+        enabled
+        requiredEnvVarsMissing
+        setupUrl
+        docsPath
+      }
+      events {
+        configured
+        enabled
+        requiredEnvVarsMissing
+        setupUrl
+        docsPath
+      }
+      plugins {
+        configured
+        enabled
+        requiredEnvVarsMissing
+        setupUrl
+        docsPath
+      }
+    }
+  }
+`;
+
 export const GET_SERVER_CONFIG = gql`
   query getServerConfig($serverName: String!) {
     serverConfigs(where: { serverName: $serverName }) {

--- a/pages/admin/setup.spec.ts
+++ b/pages/admin/setup.spec.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import InstanceSetupPage from './setup.vue';
+
+const harness = vi.hoisted(() => ({
+  status: null as unknown,
+  loading: null as unknown,
+  error: null as unknown,
+  refetch: vi.fn(),
+}));
+
+vi.mock('@/composables/useInstanceSetupStatus', async () => {
+  const actual = await vi.importActual('@/composables/useInstanceSetupStatus');
+  return {
+    ...actual,
+    useInstanceSetupStatus: () => ({
+      status: harness.status,
+      loading: harness.loading,
+      error: harness.error,
+      refetch: harness.refetch,
+    }),
+  };
+});
+
+const capability = (
+  configured: boolean,
+  enabled: boolean,
+  missing: string[] = []
+) => ({
+  configured,
+  enabled,
+  requiredEnvVarsMissing: missing,
+  setupUrl: '/admin/setup#authentication',
+  docsPath: '/authentication',
+});
+
+describe('admin instance setup page', () => {
+  beforeEach(() => {
+    harness.status = ref({
+      auth: capability(false, false, ['AUTH0_DOMAIN']),
+      mail: capability(true, true),
+      maps: capability(true, false),
+      geocoding: capability(true, true),
+      uploads: capability(true, true),
+      downloads: capability(true, true),
+      events: capability(true, true),
+      plugins: capability(true, true),
+    });
+    harness.loading = ref(false);
+    harness.error = ref(null);
+    harness.refetch.mockClear();
+  });
+
+  it('renders all capabilities and their readiness states', () => {
+    const wrapper = mountWithDefaults(InstanceSetupPage);
+
+    expect(wrapper.findAll('section')).toHaveLength(8);
+    expect(wrapper.get('[data-testid="setup-state-auth"]').text()).toBe(
+      'Setup required'
+    );
+    expect(wrapper.get('[data-testid="setup-state-mail"]').text()).toBe(
+      'Ready'
+    );
+    expect(wrapper.get('[data-testid="setup-state-maps"]').text()).toBe(
+      'Configured, disabled'
+    );
+    expect(wrapper.text()).toContain('AUTH0_DOMAIN');
+  });
+
+  it('builds documentation links from backend-provided paths', () => {
+    const wrapper = mountWithDefaults(InstanceSetupPage);
+
+    expect(wrapper.get('section a').attributes('href')).toBe(
+      'https://docs.multiforum.net/authentication'
+    );
+  });
+
+  it('shows a loading state before status is available', () => {
+    harness.status = ref(null);
+    harness.loading = ref(true);
+    const wrapper = mountWithDefaults(InstanceSetupPage);
+
+    expect(wrapper.text()).toContain('Checking instance capabilities...');
+  });
+
+  it('offers to retry when the query fails', async () => {
+    harness.status = ref(null);
+    harness.error = ref(new Error('unsupported query'));
+    const wrapper = mountWithDefaults(InstanceSetupPage);
+
+    expect(wrapper.text()).toContain('Setup status is unavailable');
+    await wrapper.get('button').trigger('click');
+    expect(harness.refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/pages/admin/setup.vue
+++ b/pages/admin/setup.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import RequireAuth from '@/components/auth/RequireAuth.vue';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import {
+  instanceCapabilityKeys,
+  useInstanceSetupStatus,
+  type InstanceCapabilityKey,
+  type InstanceCapabilityStatus,
+} from '@/composables/useInstanceSetupStatus';
+
+const DOCS_BASE_URL = 'https://docs.multiforum.net';
+
+const capabilityCopy: Record<
+  InstanceCapabilityKey,
+  { title: string; description: string }
+> = {
+  auth: {
+    title: 'Authentication',
+    description: 'Controls how people sign in to this instance.',
+  },
+  mail: {
+    title: 'Email',
+    description: 'Sends invitations, notifications, and account messages.',
+  },
+  maps: {
+    title: 'Maps',
+    description: 'Displays maps for events and location-aware features.',
+  },
+  geocoding: {
+    title: 'Geocoding',
+    description: 'Converts event addresses into map coordinates.',
+  },
+  uploads: {
+    title: 'File uploads',
+    description: 'Stores images and other user-uploaded files.',
+  },
+  downloads: {
+    title: 'Downloads',
+    description: 'Enables channels to publish downloadable files.',
+  },
+  events: {
+    title: 'Events',
+    description: 'Enables event publishing across the instance.',
+  },
+  plugins: {
+    title: 'Plugins',
+    description: 'Extends the instance with installed integrations and tools.',
+  },
+};
+
+const { status, loading, error, refetch } = useInstanceSetupStatus();
+
+const capabilities = computed(() =>
+  instanceCapabilityKeys.flatMap((key) => {
+    const capability = status.value?.[key];
+    return capability ? [{ key, ...capabilityCopy[key], ...capability }] : [];
+  })
+);
+
+const sectionId = (setupUrl: string) =>
+  setupUrl.includes('#') ? setupUrl.split('#').pop() : undefined;
+
+const docsUrl = (docsPath: string) =>
+  `${DOCS_BASE_URL}${docsPath.startsWith('/') ? docsPath : `/${docsPath}`}`;
+
+const stateLabel = (capability: InstanceCapabilityStatus) => {
+  if (!capability.configured) return 'Setup required';
+  if (!capability.enabled) return 'Configured, disabled';
+  return 'Ready';
+};
+
+const stateClasses = (capability: InstanceCapabilityStatus) => {
+  if (!capability.configured) {
+    return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200';
+  }
+  if (!capability.enabled) {
+    return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200';
+  }
+  return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200';
+};
+</script>
+
+<template>
+  <ClientOnly>
+    <RequireAuth>
+      <template #has-auth>
+        <main class="mx-auto w-full max-w-6xl px-4 py-6 sm:px-8">
+          <div class="mb-6">
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+              Instance setup
+            </h1>
+            <p class="mt-2 max-w-3xl text-sm text-gray-600 dark:text-gray-300">
+              Review which services are ready before enabling features for your
+              community. Configuration remains environment-based; after making
+              changes, restart the affected services and refresh this page.
+            </p>
+          </div>
+
+          <div
+            v-if="loading && !status"
+            class="flex items-center justify-center rounded-lg border border-gray-200 py-12 text-gray-600 dark:border-gray-700 dark:text-gray-300"
+            aria-live="polite"
+          >
+            <LoadingSpinner class="mr-3 inline-flex" />
+            Checking instance capabilities...
+          </div>
+
+          <div
+            v-else-if="error && !status"
+            class="bg-red-50 dark:bg-red-950/30 rounded-lg border border-red-200 p-5 dark:border-red-900"
+            role="alert"
+          >
+            <h2 class="font-semibold text-red-800 dark:text-red-200">
+              Setup status is unavailable
+            </h2>
+            <p class="mt-1 text-sm text-red-700 dark:text-red-300">
+              Confirm that the backend supports the instance setup status query,
+              then try again.
+            </p>
+            <button
+              type="button"
+              class="mt-4 rounded-md bg-red-700 px-3 py-2 text-sm font-medium text-white hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+              @click="refetch()"
+            >
+              Try again
+            </button>
+          </div>
+
+          <div v-else class="grid gap-4 md:grid-cols-2">
+            <section
+              v-for="capability in capabilities"
+              :id="sectionId(capability.setupUrl)"
+              :key="capability.key"
+              class="scroll-mt-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+            >
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <h2 class="font-semibold text-gray-900 dark:text-white">
+                    {{ capability.title }}
+                  </h2>
+                  <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                    {{ capability.description }}
+                  </p>
+                </div>
+                <span
+                  class="font-semibold shrink-0 rounded-full px-2.5 py-1 text-xs"
+                  :class="stateClasses(capability)"
+                  :data-testid="`setup-state-${capability.key}`"
+                >
+                  {{ stateLabel(capability) }}
+                </span>
+              </div>
+
+              <div
+                v-if="capability.requiredEnvVarsMissing.length"
+                class="mt-4 rounded-md bg-amber-50 p-3 dark:bg-amber-950/30"
+              >
+                <p
+                  class="font-semibold text-xs uppercase tracking-wide text-amber-800 dark:text-amber-200"
+                >
+                  Missing environment variables
+                </p>
+                <div class="mt-2 flex flex-wrap gap-2">
+                  <code
+                    v-for="variable in capability.requiredEnvVarsMissing"
+                    :key="variable"
+                    class="rounded bg-white px-2 py-1 text-xs text-gray-800 ring-1 ring-amber-200 dark:bg-gray-900 dark:text-gray-100 dark:ring-amber-800"
+                    >{{ variable }}</code
+                  >
+                </div>
+              </div>
+
+              <a
+                :href="docsUrl(capability.docsPath)"
+                class="mt-4 inline-flex text-sm font-medium text-orange-700 hover:text-orange-800 hover:underline dark:text-orange-300 dark:hover:text-orange-200"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View setup documentation
+                <span class="sr-only"> for {{ capability.title }}</span>
+              </a>
+            </section>
+          </div>
+        </main>
+      </template>
+      <template #does-not-have-auth>
+        <div class="p-8 text-sm text-gray-700 dark:text-gray-200">
+          You don't have permission to see this page.
+        </div>
+      </template>
+    </RequireAuth>
+  </ClientOnly>
+</template>


### PR DESCRIPTION
## Summary
- add a reusable Apollo capability-status consumer for the backend setup contract
- add a read-only /admin/setup checklist for authentication, email, maps, geocoding, uploads, downloads, events, and plugins
- show ready, configured-but-disabled, and setup-required states with missing environment variable names and documentation links
- add Setup to desktop and mobile admin navigation

## Stack
- frontend base: #462
- runtime dependency: gennit-project/multiforum-backend#203

## Verification
- 16 focused unit tests passed
- vue-tsc --noEmit passed
- focused ESLint passed
- Nuxt production build passed

## Notes
This PR intentionally keeps configuration read-only. Operators continue to set environment variables and restart services; later PRs can add integration-specific controls without duplicating capability detection in individual components.