### PR TITLE
feat(events): guard unavailable location services

### DIFF
--- a/components/event/list/filters/LocationSearchBar.spec.ts
+++ b/components/event/list/filters/LocationSearchBar.spec.ts
@@ -1,24 +1,63 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
+import { ref } from 'vue';
 
 import LocationSearchBar from '@/components/event/list/filters/LocationSearchBar.vue';
 
-const h = vi.hoisted(() => ({ get: vi.fn() }));
+const h = vi.hoisted(() => ({
+  get: vi.fn(),
+  capability: null as unknown as { value: unknown },
+  available: null as unknown as { value: boolean },
+  loading: null as unknown as { value: boolean },
+  error: null as unknown as { value: unknown },
+}));
 
-vi.mock('axios', () => ({ default: { get: (...a: unknown[]) => h.get(...a) } }));
+vi.mock('axios', () => ({
+  default: { get: (...a: unknown[]) => h.get(...a) },
+}));
+vi.mock('@/composables/useInstanceSetupStatus', () => ({
+  useInstanceCapability: () => ({
+    capability: h.capability,
+    available: h.available,
+    loading: h.loading,
+    error: h.error,
+  }),
+}));
 
-const result = { formatted: 'Paris, France', geometry: { lat: 48.8, lng: 2.3 } };
+const result = {
+  formatted: 'Paris, France',
+  geometry: { lat: 48.8, lng: 2.3 },
+};
 
 const mountBar = (props: Record<string, unknown> = {}, slot = '') =>
   mount(LocationSearchBar, {
     props,
     slots: { default: slot },
-    global: { stubs: { ClientOnly: { template: '<div><slot /></div>' }, LocationIcon: true } },
+    global: {
+      stubs: {
+        ClientOnly: { template: '<div><slot /></div>' },
+        LocationIcon: true,
+        NuxtLink: {
+          props: ['to'],
+          template: '<a :href="to"><slot /></a>',
+        },
+      },
+    },
   });
 
 beforeEach(() => {
   vi.clearAllMocks();
   h.get = vi.fn(() => Promise.resolve({ data: { results: [result] } }));
+  h.capability = ref({
+    configured: true,
+    enabled: true,
+    requiredEnvVarsMissing: [],
+    setupUrl: '/admin/setup#geocoding',
+    docsPath: '/roles/admins/map-setup',
+  });
+  h.available = ref(true);
+  h.loading = ref(false);
+  h.error = ref(null);
 });
 
 describe('LocationSearchBar rendering', () => {
@@ -31,13 +70,45 @@ describe('LocationSearchBar rendering', () => {
   it('uses the initial value', () => {
     const wrapper = mountBar({ initialValue: 'Berlin' });
 
-    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('Berlin');
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe(
+      'Berlin'
+    );
   });
 
   it('renders the default slot', () => {
     const wrapper = mountBar({}, '<button class="my-btn" />');
 
     expect(wrapper.find('.my-btn').exists()).toBe(true);
+  });
+
+  it('disables location search when geocoding is not configured', () => {
+    h.available = ref(false);
+    h.capability = ref({
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: ['VITE_OPEN_CAGE_API_KEY'],
+      setupUrl: '/admin/setup#geocoding',
+      docsPath: '/roles/admins/map-setup',
+    });
+
+    const wrapper = mountBar();
+
+    expect(wrapper.get('input').attributes('disabled')).toBeDefined();
+  });
+
+  it('shows a setup link when geocoding is not configured', () => {
+    h.available = ref(false);
+    h.capability = ref({
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: ['VITE_OPEN_CAGE_API_KEY'],
+      setupUrl: '/admin/setup#geocoding',
+      docsPath: '/roles/admins/map-setup',
+    });
+
+    const wrapper = mountBar();
+
+    expect(wrapper.get('a').attributes('href')).toBe('/admin/setup#geocoding');
   });
 });
 
@@ -58,6 +129,16 @@ describe('LocationSearchBar search', () => {
     await wrapper.find('input').setValue('Pa');
     await wrapper.find('input').trigger('input');
     await flushPromises();
+
+    expect(h.get).not.toHaveBeenCalled();
+  });
+
+  it('does not call OpenCage when geocoding is unavailable', async () => {
+    h.available = ref(false);
+    h.capability = ref({ configured: false, enabled: false });
+    const wrapper = mountBar();
+
+    await wrapper.find('input').trigger('input');
 
     expect(h.get).not.toHaveBeenCalled();
   });

--- a/components/event/list/filters/LocationSearchBar.vue
+++ b/components/event/list/filters/LocationSearchBar.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref, useId } from 'vue';
 import axios from 'axios';
 import LocationIcon from '@/components/icons/LocationIcon.vue';
 import { config } from '@/config';
+import { useInstanceCapability } from '@/composables/useInstanceSetupStatus';
 
 // OpenCage API location result type
 interface LocationResult {
@@ -70,8 +71,33 @@ const props = defineProps({
 const searchQuery = ref(props.initialValue);
 const searchResults = ref<LocationResult[]>([]);
 const apiKey = config.openCageApiKey;
+const searchInputId = useId();
+const unavailableMessageId = useId();
+const {
+  capability: geocodingCapability,
+  available: geocodingAvailable,
+  loading: geocodingLoading,
+  error: geocodingError,
+} = useInstanceCapability('geocoding');
+
+const geocodingUnavailable = computed(
+  () =>
+    Boolean(geocodingCapability.value || geocodingError.value) &&
+    !geocodingAvailable.value
+);
+const effectivePlaceholder = computed(() => {
+  if (geocodingLoading.value && !geocodingCapability.value) {
+    return 'Checking location search...';
+  }
+  if (!geocodingAvailable.value) return 'Location search is not configured';
+  return props.searchPlaceholder;
+});
+const setupUrl = computed(
+  () => geocodingCapability.value?.setupUrl || '/admin/setup#geocoding'
+);
 
 const searchLocations = async () => {
+  if (!geocodingAvailable.value) return;
   if (searchQuery.value.length > 2) {
     const response = await axios.get(
       'https://api.opencagedata.com/geocode/v1/json',
@@ -103,7 +129,7 @@ const emit = defineEmits(['updateLocationInput', 'requestUserLocation']);
 
 <template>
   <div class="flex-1 dark:text-white">
-    <label for="search" class="sr-only">Search Location</label>
+    <label :for="searchInputId" class="sr-only">Search Location</label>
     <div class="relative flex items-center">
       <div
         class="pointer-events-none absolute left-0 flex items-center py-2.5 pl-3"
@@ -114,15 +140,20 @@ const emit = defineEmits(['updateLocationInput', 'requestUserLocation']);
         />
       </div>
       <input
+        :id="searchInputId"
         v-model="searchQuery"
         :autofocus="autoFocus"
-        class="h-10 w-full border border-gray-300 bg-white py-3 pl-10 pr-3 text-sm leading-5 placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+        :disabled="!geocodingAvailable"
+        :aria-describedby="
+          geocodingUnavailable ? unavailableMessageId : undefined
+        "
+        class="h-10 w-full border border-gray-300 bg-white py-3 pl-10 pr-3 text-sm leading-5 placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400 dark:disabled:bg-gray-900 dark:disabled:text-gray-400"
         :class="[
           leftSideIsRounded ? 'rounded-l-full' : '',
           rightSideIsRounded ? 'rounded-r-full' : '',
           useMediumRoundedCorners ? 'rounded-md' : '',
         ]"
-        :placeholder="searchPlaceholder"
+        :placeholder="effectivePlaceholder"
         @input="searchLocations"
       >
       <slot />
@@ -153,6 +184,16 @@ const emit = defineEmits(['updateLocationInput', 'requestUserLocation']);
         </template>
       </client-only>
     </div>
+    <p
+      v-if="geocodingUnavailable"
+      :id="unavailableMessageId"
+      class="mt-1 text-xs text-amber-800 dark:text-amber-200"
+    >
+      Location search is unavailable until geocoding is configured.
+      <NuxtLink :to="setupUrl" class="font-medium underline">
+        Open instance setup
+      </NuxtLink>
+    </p>
   </div>
 </template>
 

--- a/components/event/map/MapUnavailable.spec.ts
+++ b/components/event/map/MapUnavailable.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import MapUnavailable from './MapUnavailable.vue';
+
+describe('MapUnavailable', () => {
+  it('links operators to the backend-provided setup location', () => {
+    const wrapper = mountWithDefaults(MapUnavailable, {
+      props: { setupUrl: '/admin/setup#custom-map' },
+    });
+
+    expect(wrapper.get('a').attributes('href')).toBe('/admin/setup#custom-map');
+  });
+
+  it('offers a list view when maps are not configured', () => {
+    const wrapper = mountWithDefaults(MapUnavailable);
+
+    expect(wrapper.text()).toContain('Browse events as a list');
+  });
+
+  it('distinguishes an unavailable status query from missing configuration', () => {
+    const wrapper = mountWithDefaults(MapUnavailable, {
+      props: { statusUnavailable: true },
+    });
+
+    expect(wrapper.text()).toContain('Map availability could not be checked');
+  });
+});

--- a/components/event/map/MapUnavailable.vue
+++ b/components/event/map/MapUnavailable.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+defineProps({
+  setupUrl: {
+    type: String,
+    default: '/admin/setup#maps',
+  },
+  statusUnavailable: {
+    type: Boolean,
+    default: false,
+  },
+});
+</script>
+
+<template>
+  <div
+    class="flex h-full min-h-64 items-center justify-center bg-gray-100 p-6 dark:bg-gray-900"
+    data-testid="map-unavailable"
+  >
+    <div
+      class="max-w-md rounded-lg border border-gray-200 bg-white p-6 text-center shadow-sm dark:border-gray-700 dark:bg-gray-800"
+    >
+      <h2 class="font-semibold text-lg text-gray-900 dark:text-white">
+        {{
+          statusUnavailable
+            ? 'Map availability could not be checked'
+            : 'Map is not configured'
+        }}
+      </h2>
+      <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+        {{
+          statusUnavailable
+            ? 'The event list remains available while the instance setup status is unavailable.'
+            : 'Add the Google Maps configuration to enable the interactive event map.'
+        }}
+      </p>
+      <div class="mt-4 flex flex-wrap justify-center gap-3 text-sm font-medium">
+        <NuxtLink
+          :to="setupUrl"
+          class="text-orange-700 hover:underline dark:text-orange-300"
+        >
+          Open instance setup
+        </NuxtLink>
+        <NuxtLink
+          to="/events/list/search"
+          class="text-gray-700 hover:underline dark:text-gray-200"
+        >
+          Browse events as a list
+        </NuxtLink>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/event/map/MapView.spec.ts
+++ b/components/event/map/MapView.spec.ts
@@ -24,6 +24,10 @@ const h = vi.hoisted(() => ({
     where: { value: unknown };
     resultsOrder: { value: unknown };
   },
+  mapsCapability: null as unknown as { value: unknown },
+  mapsAvailable: null as unknown as { value: boolean },
+  mapsCapabilityLoading: null as unknown as { value: boolean },
+  mapsCapabilityError: null as unknown as { value: unknown },
 }));
 
 vi.mock('@headlessui/vue', async (importOriginal) => ({
@@ -32,6 +36,15 @@ vi.mock('@headlessui/vue', async (importOriginal) => ({
 
 vi.mock('@/composables/useDisplay', () => ({
   useDisplay: () => ({ mdAndUp: h.mdAndUp }),
+}));
+
+vi.mock('@/composables/useInstanceSetupStatus', () => ({
+  useInstanceCapability: () => ({
+    capability: h.mapsCapability,
+    available: h.mapsAvailable,
+    loading: h.mapsCapabilityLoading,
+    error: h.mapsCapabilityError,
+  }),
 }));
 
 vi.mock('nuxt/app', () => ({
@@ -62,6 +75,16 @@ h.result = ref({ events: [] as unknown[], eventsAggregate: { count: 0 } });
 h.loading = ref(false);
 h.error = ref(null);
 h.mdAndUp = ref(true);
+h.mapsCapability = ref({
+  configured: true,
+  enabled: true,
+  requiredEnvVarsMissing: [],
+  setupUrl: '/admin/setup#maps',
+  docsPath: '/roles/admins/map-setup',
+});
+h.mapsAvailable = ref(true);
+h.mapsCapabilityLoading = ref(false);
+h.mapsCapabilityError = ref(null);
 h.route = reactive(h.route);
 
 const EventFilterBar = {
@@ -123,6 +146,11 @@ const EventMap = {
   emits: ['highlight-event', 'open-preview', 'lock-colors', 'set-marker-data'],
   template: '<div class="event-map" />',
 };
+const MapUnavailable = {
+  name: 'MapUnavailable',
+  props: ['setupUrl', 'statusUnavailable'],
+  template: '<div class="map-unavailable" />',
+};
 
 const stubs = {
   EventFilterBar,
@@ -131,6 +159,7 @@ const stubs = {
   ErrorBanner,
   EventList,
   EventMap,
+  MapUnavailable,
   EventPreview,
   PreviewContainer,
   CloseButton,
@@ -193,6 +222,16 @@ beforeEach(() => {
   h.onResultCb = null;
   h.queryVariables = null;
   h.mdAndUp.value = true;
+  h.mapsCapability.value = {
+    configured: true,
+    enabled: true,
+    requiredEnvVarsMissing: [],
+    setupUrl: '/admin/setup#maps',
+    docsPath: '/roles/admins/map-setup',
+  };
+  h.mapsAvailable.value = true;
+  h.mapsCapabilityLoading.value = false;
+  h.mapsCapabilityError.value = null;
   vi.stubGlobal('CSS', { escape: (value: string) => value });
 });
 
@@ -205,6 +244,25 @@ describe('MapView', () => {
   it('shows an error banner when the query errors', () => {
     h.error.value = { message: 'boom' };
     expect(mountView().findComponent(ErrorBanner).text()).toContain('boom');
+  });
+
+  it('renders the setup placeholder instead of the map when maps are unavailable', () => {
+    h.result.value = { events: [event('1')], eventsAggregate: { count: 1 } };
+    h.mapsCapability.value = {
+      configured: false,
+      enabled: false,
+      requiredEnvVarsMissing: ['VITE_GOOGLE_MAPS_API_KEY'],
+      setupUrl: '/admin/setup#maps',
+      docsPath: '/roles/admins/map-setup',
+    };
+    h.mapsAvailable.value = false;
+
+    const wrapper = mountView();
+
+    expect({
+      map: wrapper.findComponent(EventMap).exists(),
+      placeholder: wrapper.findComponent(MapUnavailable).exists(),
+    }).toEqual({ map: false, placeholder: true });
   });
 
   it('routes to the online list from the map search header button', async () => {

--- a/components/event/map/MapView.vue
+++ b/components/event/map/MapView.vue
@@ -29,11 +29,23 @@ import type { Event as EventData } from '@/__generated__/graphql';
 import type { SearchEventValues } from '@/types/Event';
 import type { Ref, PropType } from 'vue';
 import { isEventSearchRoute } from '@/utils/isEventSearchRoute';
+import { useInstanceCapability } from '@/composables/useInstanceSetupStatus';
+import MapUnavailable from './MapUnavailable.vue';
 
 // Map.vue statically imports the Google Maps JS API loader + marker clusterer
 // (~840KB decoded). Load it lazily so that weight is only fetched when the map
 // view actually renders, not prefetched with the event routes.
 const EventMap = defineAsyncComponent(() => import('./Map.vue'));
+
+const {
+  capability: mapsCapability,
+  available: mapsAvailable,
+  loading: mapsCapabilityLoading,
+  error: mapsCapabilityError,
+} = useInstanceCapability('maps');
+const mapsSetupUrl = computed(
+  () => mapsCapability.value?.setupUrl || '/admin/setup#maps'
+);
 
 const props = defineProps({
   selectedTags: {
@@ -503,7 +515,10 @@ const isClientSide = typeof window !== 'undefined';
           />
           <EventMap
             v-else-if="
-              eventResult && eventResult.events && eventResult.events.length > 0
+              mapsAvailable &&
+              eventResult &&
+              eventResult.events &&
+              eventResult.events.length > 0
             "
             :key="eventResult.events.length"
             class="absolute inset-0"
@@ -515,6 +530,17 @@ const isClientSide = typeof window !== 'undefined';
             @open-preview="openPreview"
             @lock-colors="colorLocked = true"
             @set-marker-data="setMarkerData"
+          />
+          <MapUnavailable
+            v-else-if="
+              !mapsAvailable && (mapsCapability || mapsCapabilityError)
+            "
+            :setup-url="mapsSetupUrl"
+            :status-unavailable="Boolean(mapsCapabilityError)"
+          />
+          <LoadingSpinner
+            v-else-if="mapsCapabilityLoading"
+            class="mx-auto my-4"
           />
         </div>
       </div>
@@ -533,7 +559,7 @@ const isClientSide = typeof window !== 'undefined';
         >
           <div class="event-map-container w-full">
             <EventMap
-              v-if="eventResult.events.length > 0"
+              v-if="mapsAvailable && eventResult.events.length > 0"
               :events="eventResult.events"
               :preview-is-open="
                 eventPreviewIsOpen || multipleEventPreviewIsOpen
@@ -544,6 +570,17 @@ const isClientSide = typeof window !== 'undefined';
               @open-preview="openPreview"
               @lock-colors="colorLocked = true"
               @set-marker-data="setMarkerData"
+            />
+            <MapUnavailable
+              v-else-if="
+                !mapsAvailable && (mapsCapability || mapsCapabilityError)
+              "
+              :setup-url="mapsSetupUrl"
+              :status-unavailable="Boolean(mapsCapabilityError)"
+            />
+            <LoadingSpinner
+              v-else-if="mapsCapabilityLoading"
+              class="mx-auto my-4"
             />
           </div>
           <div class="h-1/3 w-full">

--- a/composables/useInstanceSetupStatus.spec.ts
+++ b/composables/useInstanceSetupStatus.spec.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { GET_INSTANCE_SETUP_STATUS } from '@/graphQLData/admin/queries';
-import { useInstanceSetupStatus } from './useInstanceSetupStatus';
+import {
+  useInstanceCapability,
+  useInstanceSetupStatus,
+} from './useInstanceSetupStatus';
 
 vi.mock('@vue/apollo-composable', () => ({
   useQuery: vi.fn(),
@@ -56,5 +59,63 @@ describe('useInstanceSetupStatus', () => {
 
     expect(setup.status.value).toBeNull();
     expect(setup.loading.value).toBe(true);
+  });
+
+  it('exposes a single available capability', () => {
+    mockedUseQuery.mockReturnValue({
+      result: ref({
+        getInstanceSetupStatus: {
+          maps: {
+            configured: true,
+            enabled: true,
+            requiredEnvVarsMissing: [],
+            setupUrl: '/admin/setup#maps',
+            docsPath: '/roles/admins/map-setup',
+          },
+        },
+      }),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    } as never);
+
+    const maps = useInstanceCapability('maps');
+
+    expect({
+      capability: maps.capability.value,
+      available: maps.available.value,
+    }).toEqual({
+      capability: {
+        configured: true,
+        enabled: true,
+        requiredEnvVarsMissing: [],
+        setupUrl: '/admin/setup#maps',
+        docsPath: '/roles/admins/map-setup',
+      },
+      available: true,
+    });
+  });
+
+  it('does not mark a configured but disabled capability as available', () => {
+    mockedUseQuery.mockReturnValue({
+      result: ref({
+        getInstanceSetupStatus: {
+          maps: {
+            configured: true,
+            enabled: false,
+            requiredEnvVarsMissing: [],
+            setupUrl: '/admin/setup#maps',
+            docsPath: '/roles/admins/map-setup',
+          },
+        },
+      }),
+      loading: ref(false),
+      error: ref(null),
+      refetch: vi.fn(),
+    } as never);
+
+    const maps = useInstanceCapability('maps');
+
+    expect(maps.available.value).toBe(false);
   });
 });

--- a/composables/useInstanceSetupStatus.ts
+++ b/composables/useInstanceSetupStatus.ts
@@ -42,3 +42,15 @@ export function useInstanceSetupStatus() {
 
   return { status, loading, error, refetch };
 }
+
+export function useInstanceCapability(key: InstanceCapabilityKey) {
+  const setup = useInstanceSetupStatus();
+  const capability = computed(() => setup.status.value?.[key] ?? null);
+  const available = computed(
+    () =>
+      capability.value?.configured === true &&
+      capability.value?.enabled === true
+  );
+
+  return { ...setup, capability, available };
+}


### PR DESCRIPTION
## Summary

- disable event location search when geocoding is unavailable and surface setup guidance
- replace unavailable maps with a dedicated configuration placeholder
- expose map and geocoding capabilities through the instance setup composable
- add focused component and composable coverage for configured and unconfigured states

## Stack

- Depends on #464
- Base branch: `codex/self-hosting-04-instance-setup`

## Testing

- Existing focused unit specs are included in this commit
- Full CI will run on this draft PR