### PR TITLE
feat(self-hosting): guard unavailable image uploads

### DIFF
--- a/components/AddImage.spec.ts
+++ b/components/AddImage.spec.ts
@@ -1,12 +1,52 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
 
 import AddImage from '@/components/AddImage.vue';
 
+const h = vi.hoisted(() => ({
+  available: null as unknown as { value: boolean },
+  capability: null as unknown as { value: Record<string, unknown> },
+  error: null as unknown as { value: Error | null },
+  loading: null as unknown as { value: boolean },
+}));
+
+vi.mock('@/composables/useInstanceSetupStatus', () => ({
+  useInstanceCapability: () => ({
+    capability: h.capability,
+    available: h.available,
+    loading: h.loading,
+    error: h.error,
+  }),
+}));
+
 const mountAdd = (props: Record<string, unknown> = {}) =>
-  mount(AddImage, { props });
+  mount(AddImage, {
+    props,
+    global: {
+      stubs: {
+        NuxtLink: {
+          props: ['to'],
+          template: '<a :href="to"><slot /></a>',
+        },
+      },
+    },
+  });
 
 describe('AddImage', () => {
+  beforeEach(() => {
+    h.available = ref(true);
+    h.capability = ref({
+      configured: true,
+      enabled: true,
+      requiredEnvVarsMissing: [],
+      setupUrl: '/admin/setup#uploads',
+      docsPath: '/self-hosting/uploads',
+    });
+    h.error = ref(null);
+    h.loading = ref(false);
+  });
+
   it('renders the default label', () => {
     const wrapper = mountAdd();
 
@@ -40,6 +80,39 @@ describe('AddImage', () => {
   it('disables the input when disabled', () => {
     const wrapper = mountAdd({ disabled: true });
 
-    expect(wrapper.find('input[type="file"]').attributes('disabled')).toBeDefined();
+    expect(
+      wrapper.find('input[type="file"]').attributes('disabled')
+    ).toBeDefined();
+  });
+
+  it('disables the input when uploads are unavailable', () => {
+    h.available = ref(false);
+    h.capability = ref({
+      ...h.capability.value,
+      configured: false,
+      enabled: false,
+    });
+
+    const wrapper = mountAdd();
+
+    expect(
+      wrapper.find('input[type="file"]').attributes('disabled')
+    ).toBeDefined();
+  });
+
+  it('links to instance setup when uploads are unavailable', () => {
+    h.available = ref(false);
+    h.capability = ref({
+      ...h.capability.value,
+      configured: false,
+      enabled: false,
+      setupUrl: '/admin/setup#custom-uploads',
+    });
+
+    const wrapper = mountAdd();
+
+    expect(wrapper.get('a').attributes('href')).toBe(
+      '/admin/setup#custom-uploads'
+    );
   });
 });

--- a/components/AddImage.vue
+++ b/components/AddImage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref, useId } from 'vue';
 import ImageIcon from '@/components/icons/ImageIcon.vue';
+import { useInstanceCapability } from '@/composables/useInstanceSetupStatus';
 
 const props = defineProps({
   fieldName: {
@@ -23,6 +24,24 @@ const props = defineProps({
 const emit = defineEmits(['file-change']);
 
 const fileInput = ref<HTMLInputElement | null>(null);
+const unavailableMessageId = useId();
+const {
+  capability: uploadsCapability,
+  available: uploadsAvailable,
+  loading: uploadsLoading,
+  error: uploadsError,
+} = useInstanceCapability('uploads');
+const uploadsUnavailable = computed(
+  () =>
+    Boolean(uploadsCapability.value || uploadsError.value) &&
+    !uploadsAvailable.value
+);
+const effectiveDisabled = computed(
+  () => props.disabled || !uploadsAvailable.value
+);
+const setupUrl = computed(
+  () => uploadsCapability.value?.setupUrl || '/admin/setup#uploads'
+);
 
 // Force iOS to properly recognize this as an image upload input
 const clearFileInput = () => {
@@ -33,7 +52,7 @@ const clearFileInput = () => {
 
 // For mobile browsers that might not properly cleanup
 const onFileSelected = (event: Event) => {
-  if (props.disabled) return;
+  if (effectiveDisabled.value) return;
 
   emit('file-change', {
     event,
@@ -51,11 +70,12 @@ const onFileSelected = (event: Event) => {
     <label
       :class="[
         'my-1 inline-flex items-center rounded-md border border-orange-400 px-3 py-1 py-1.5 text-sm transition-colors dark:border-orange-800 dark:text-white',
-        !disabled
+        !effectiveDisabled
           ? 'cursor-pointer bg-orange-100 text-orange-700 hover:bg-orange-100 dark:bg-orange-900 dark:text-orange-200 dark:hover:bg-orange-800'
           : 'cursor-not-allowed bg-gray-100 text-gray-500 opacity-60 dark:bg-gray-700 dark:text-gray-400',
       ]"
       :for="`file-input-${props.fieldName}`"
+      :aria-describedby="uploadsUnavailable ? unavailableMessageId : undefined"
     >
       <ImageIcon class="mr-2 h-4 w-4" aria-hidden="true" /> {{ props.label }}
       <input
@@ -64,10 +84,26 @@ const onFileSelected = (event: Event) => {
         type="file"
         accept="image/*"
         style="display: none"
-        :disabled="disabled"
+        :disabled="effectiveDisabled"
         @change="onFileSelected"
         @click="clearFileInput"
       >
     </label>
+    <p
+      v-if="uploadsUnavailable"
+      :id="unavailableMessageId"
+      class="mt-1 text-xs text-amber-800 dark:text-amber-200"
+    >
+      Image uploads are unavailable until file storage is configured.
+      <NuxtLink :to="setupUrl" class="font-medium underline">
+        Open instance setup
+      </NuxtLink>
+    </p>
+    <p
+      v-else-if="uploadsLoading && !uploadsCapability"
+      class="mt-1 text-xs text-gray-500 dark:text-gray-400"
+    >
+      Checking upload availability...
+    </p>
   </div>
 </template>

--- a/components/discussion/form/AlbumDropZone.spec.ts
+++ b/components/discussion/form/AlbumDropZone.spec.ts
@@ -6,6 +6,14 @@ import AlbumDropZone from '@/components/discussion/form/AlbumDropZone.vue';
 const mountZone = (props: Record<string, unknown> = {}) =>
   mount(AlbumDropZone, {
     props: { isLimitReached: false, maxImages: 5, ...props },
+    global: {
+      stubs: {
+        NuxtLink: {
+          props: ['to'],
+          template: '<a :href="to"><slot /></a>',
+        },
+      },
+    },
   });
 
 const buttonByText = (w: ReturnType<typeof mount>, text: string) =>
@@ -33,6 +41,35 @@ describe('AlbumDropZone rendering', () => {
     const wrapper = mountZone({ isLimitReached: true });
 
     expect(buttonByText(wrapper, 'Choose Files')).toBeUndefined();
+  });
+
+  it('keeps link and reuse actions available when file storage is unavailable', () => {
+    const wrapper = mountZone({
+      fileUploadAvailable: false,
+      fileUploadUnavailableMessage: 'File storage is not configured.',
+      setupUrl: '/admin/setup#uploads',
+    });
+
+    expect(
+      wrapper.findAll('button').map((button) => ({
+        text: button.text(),
+        disabled: button.attributes('disabled') !== undefined,
+      }))
+    ).toEqual([
+      { text: 'Choose Files', disabled: true },
+      { text: 'Link to Image', disabled: false },
+      { text: 'Reuse an Image', disabled: false },
+    ]);
+  });
+
+  it('links operators to upload setup when provided', () => {
+    const wrapper = mountZone({
+      fileUploadAvailable: false,
+      fileUploadUnavailableMessage: 'File storage is not configured.',
+      setupUrl: '/admin/setup#uploads',
+    });
+
+    expect(wrapper.get('a').attributes('href')).toBe('/admin/setup#uploads');
   });
 });
 
@@ -92,6 +129,14 @@ describe('AlbumDropZone actions', () => {
     await wrapper.find('.border-dotted').trigger('drop');
 
     expect(wrapper.emitted('drop')).toBeTruthy();
+  });
+
+  it('ignores dropped files when file uploads are unavailable', async () => {
+    const wrapper = mountZone({ fileUploadAvailable: false });
+
+    await wrapper.find('.border-dotted').trigger('drop');
+
+    expect(wrapper.emitted('drop')).toBeUndefined();
   });
 
   it('handles dragover without emitting', async () => {

--- a/components/discussion/form/AlbumDropZone.vue
+++ b/components/discussion/form/AlbumDropZone.vue
@@ -1,10 +1,20 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
 
-const props = defineProps<{
-  isLimitReached: boolean;
-  maxImages: number;
-}>();
+const props = withDefaults(
+  defineProps<{
+    isLimitReached: boolean;
+    maxImages: number;
+    fileUploadAvailable?: boolean;
+    fileUploadUnavailableMessage?: string;
+    setupUrl?: string;
+  }>(),
+  {
+    fileUploadAvailable: true,
+    fileUploadUnavailableMessage: '',
+    setupUrl: '',
+  }
+);
 
 const emit = defineEmits<{
   (e: 'files-selected', files: FileList): void;
@@ -20,6 +30,8 @@ const selectFiles = (event?: Event) => {
     event.stopPropagation();
   }
 
+  if (!props.fileUploadAvailable) return;
+
   if (props.isLimitReached) {
     alert(`You've reached the maximum limit of ${props.maxImages} images.`);
     return;
@@ -31,6 +43,8 @@ const selectFiles = (event?: Event) => {
 };
 
 const handleFileInputChange = (event: Event) => {
+  if (!props.fileUploadAvailable) return;
+
   const input = event.target as HTMLInputElement;
   if (!input?.files?.length) return;
 
@@ -42,6 +56,7 @@ const handleFileInputChange = (event: Event) => {
 
 const handleDrop = (event: DragEvent) => {
   event.preventDefault();
+  if (!props.fileUploadAvailable) return;
   emit('drop', event);
 };
 
@@ -73,22 +88,41 @@ const handleShowExistingPicker = (event?: Event) => {
 <template>
   <div
     v-if="!isLimitReached"
-    class="my-3 cursor-pointer rounded-md border-2 border-dotted border-gray-400 p-4 text-center"
+    class="my-3 rounded-md border-2 border-dotted border-gray-400 p-4 text-center"
+    :class="fileUploadAvailable ? 'cursor-pointer' : ''"
     @drop="handleDrop"
     @dragover="handleDragOver"
   >
     <label
       for="album-file-input"
-      class="flex h-full w-full cursor-pointer flex-col items-center justify-center"
+      class="flex h-full w-full flex-col items-center justify-center"
+      :class="fileUploadAvailable ? 'cursor-pointer' : ''"
     >
       <p class="mb-3 text-sm text-gray-500 dark:text-gray-300">
-        Drag and drop, tap to add files, paste a link, or reuse an image you
-        already have
+        {{
+          fileUploadAvailable
+            ? 'Drag and drop, tap to add files, paste a link, or reuse an image you already have'
+            : 'Paste a link or reuse an image you already have'
+        }}
+      </p>
+      <p
+        v-if="fileUploadUnavailableMessage"
+        class="mb-3 text-xs text-amber-800 dark:text-amber-200"
+      >
+        {{ fileUploadUnavailableMessage }}
+        <NuxtLink
+          v-if="setupUrl"
+          :to="setupUrl"
+          class="font-medium underline"
+        >
+          Open instance setup
+        </NuxtLink>
       </p>
       <div class="flex flex-wrap items-center justify-center gap-4 text-black">
         <button
           type="button"
-          class="rounded bg-orange-500 px-4 py-2 transition-colors hover:bg-orange-600"
+          class="rounded bg-orange-500 px-4 py-2 transition-colors hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-600 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+          :disabled="!fileUploadAvailable"
           @click="selectFiles"
         >
           Choose Files
@@ -118,6 +152,7 @@ const handleShowExistingPicker = (event?: Event) => {
       multiple
       accept="image/*"
       style="display: none"
+      :disabled="!fileUploadAvailable"
       @change="handleFileInputChange"
     >
   </div>

--- a/components/discussion/form/AlbumEditor.spec.ts
+++ b/components/discussion/form/AlbumEditor.spec.ts
@@ -7,11 +7,31 @@ import AlbumEditor from '@/components/discussion/form/AlbumEditor.vue';
 
 // Hoisted, controllable test seams: username (for the no-username branch) and
 // the URL-image creation spy (for the submit success/failure branches).
-const { usernameRef, createImageFromUrl, permanentlyDeleteImage } = vi.hoisted(
+const {
+  usernameRef,
+  createImageFromUrl,
+  permanentlyDeleteImage,
+  uploadsAvailable,
+  uploadsCapability,
+  uploadsLoading,
+  uploadsError,
+} = vi.hoisted(
   () => ({
     usernameRef: { value: 'alice' as string },
     createImageFromUrl: vi.fn(),
     permanentlyDeleteImage: vi.fn(),
+    uploadsAvailable: { value: true },
+    uploadsCapability: {
+      value: {
+        configured: true,
+        enabled: true,
+        requiredEnvVarsMissing: [],
+        setupUrl: '/admin/setup#uploads',
+        docsPath: '/self-hosting/uploads',
+      },
+    },
+    uploadsLoading: { value: false },
+    uploadsError: { value: null as Error | null },
   })
 );
 
@@ -44,6 +64,14 @@ vi.mock('@/composables/useAlbumAutoSave', () => ({
     debouncedAutoSave: vi.fn(),
   }),
 }));
+vi.mock('@/composables/useInstanceSetupStatus', () => ({
+  useInstanceCapability: () => ({
+    capability: uploadsCapability,
+    available: uploadsAvailable,
+    loading: uploadsLoading,
+    error: uploadsError,
+  }),
+}));
 
 const AlbumImageItemStub = {
   name: 'AlbumImageItem',
@@ -54,6 +82,11 @@ const AlbumImageItemStub = {
 
 const AlbumDropZoneStub = {
   name: 'AlbumDropZone',
+  props: [
+    'fileUploadAvailable',
+    'fileUploadUnavailableMessage',
+    'setupUrl',
+  ],
   emits: ['files-selected', 'drop', 'show-url-input', 'show-existing-picker'],
   template: '<div class="drop-zone-stub" />',
 };
@@ -134,11 +167,32 @@ describe('AlbumEditor', () => {
     permanentlyDeleteImage.mockResolvedValue({
       data: { permanentlyDeleteImage: { id: 'a' } },
     });
+    uploadsAvailable.value = true;
+    uploadsCapability.value.configured = true;
+    uploadsCapability.value.enabled = true;
+    uploadsCapability.value.setupUrl = '/admin/setup#uploads';
+    uploadsLoading.value = false;
+    uploadsError.value = null;
   });
 
   it('renders one image item per ordered image', () => {
     const wrapper = mountEditor();
     expect(wrapper.findAllComponents(AlbumImageItemStub)).toHaveLength(3);
+  });
+
+  it('disables direct file uploads but preserves album editing when storage is unavailable', () => {
+    uploadsAvailable.value = false;
+    uploadsCapability.value.configured = false;
+    uploadsCapability.value.enabled = false;
+
+    const wrapper = mountEditor();
+
+    expect(wrapper.getComponent(AlbumDropZoneStub).props()).toMatchObject({
+      fileUploadAvailable: false,
+      fileUploadUnavailableMessage:
+        'File uploads are unavailable until file storage is configured.',
+      setupUrl: '/admin/setup#uploads',
+    });
   });
 
   it('emits the album without the deleted image', async () => {

--- a/components/discussion/form/AlbumEditor.vue
+++ b/components/discussion/form/AlbumEditor.vue
@@ -19,6 +19,7 @@ import {
   moveImageOrderDown,
 } from '@/utils/albumImageOrder';
 import type { Album } from '@/__generated__/graphql';
+import { useInstanceCapability } from '@/composables/useInstanceSetupStatus';
 
 const usernameVar = useUsername();
 
@@ -43,19 +44,57 @@ type ExistingImageInput = Omit<Partial<ImageInput>, 'alt' | 'caption' | 'copyrig
   copyright?: string | null;
 };
 
-const props = defineProps<{
-  formValues: {
-    album: {
-      images: ImageInput[];
-      imageOrder: string[];
+const props = withDefaults(
+  defineProps<{
+    formValues: {
+      album: {
+        images: ImageInput[];
+        imageOrder: string[];
+      };
     };
-  };
-  allowImageUpload?: boolean;
-  discussionId?: string;
-  existingAlbum?: Album | null | undefined;
-}>();
+    allowImageUpload?: boolean;
+    discussionId?: string;
+    existingAlbum?: Album | null | undefined;
+  }>(),
+  {
+    allowImageUpload: true,
+    discussionId: undefined,
+    existingAlbum: undefined,
+  }
+);
 
 const emit = defineEmits(['updateFormValues']);
+const {
+  capability: uploadsCapability,
+  available: uploadsAvailable,
+  loading: uploadsLoading,
+  error: uploadsError,
+} = useInstanceCapability('uploads');
+const uploadsUnavailable = computed(
+  () =>
+    Boolean(uploadsCapability.value || uploadsError.value) &&
+    !uploadsAvailable.value
+);
+const fileUploadAvailable = computed(
+  () => props.allowImageUpload !== false && uploadsAvailable.value
+);
+const fileUploadUnavailableMessage = computed(() => {
+  if (props.allowImageUpload === false) {
+    return 'File uploads are disabled for this channel.';
+  }
+  if (uploadsLoading.value && !uploadsCapability.value) {
+    return 'Checking file upload availability...';
+  }
+  if (uploadsUnavailable.value) {
+    return 'File uploads are unavailable until file storage is configured.';
+  }
+  return '';
+});
+const uploadSetupUrl = computed(() =>
+  uploadsUnavailable.value
+    ? uploadsCapability.value?.setupUrl || '/admin/setup#uploads'
+    : ''
+);
 
 // Track if we've reached the image limit
 const isImageLimitReached = computed(() => {
@@ -306,13 +345,13 @@ const moveImageDown = (index: number) => {
 
 // Handle files selected from drop zone
 const handleFilesSelected = (files: FileList) => {
-  if (props.allowImageUpload === false) return;
+  if (!fileUploadAvailable.value) return;
   handleMultipleFiles(files);
 };
 
 // Handle drop event from drop zone
 const handleDropEvent = (event: DragEvent) => {
-  if (props.allowImageUpload === false) return;
+  if (!fileUploadAvailable.value) return;
   handleDrop(event, true, isImageLimitReached.value);
 };
 
@@ -432,6 +471,9 @@ const handleUrlCancel = () => {
     <AlbumDropZone
       :is-limit-reached="isImageLimitReached"
       :max-images="MAX_IMAGES"
+      :file-upload-available="fileUploadAvailable"
+      :file-upload-unavailable-message="fileUploadUnavailableMessage"
+      :setup-url="uploadSetupUrl"
       @files-selected="handleFilesSelected"
       @drop="handleDropEvent"
       @show-url-input="handleShowUrlInput"


### PR DESCRIPTION
## Summary

- disable single-image upload controls when instance file storage is unavailable
- show operators a direct Instance Setup link instead of allowing signed-URL failures
- disable album file selection and drag-and-drop while preserving external URL and reusable-image workflows
- distinguish instance storage configuration from channel-level upload settings

## Testing

- `vitest run components/AddImage.spec.ts components/discussion/form/AlbumDropZone.spec.ts components/discussion/form/AlbumEditor.spec.ts` — 42 passed
- targeted ESLint — passed
- `vue-tsc --noEmit` — passed
- the pre-rebase full unit suite passed 7,543 tests; fresh CI will verify the rebased commit