### PR TITLE
feat(self-hosting): add AWS Terraform VM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ client.
 Start here:
 
 - [Development setup](./docs/development-setup.md)
+- [AWS single-VM Terraform example](./deploy/terraform/aws-single-vm/README.md)
 - [Contributing guide](./CONTRIBUTING.md)
 - [Developer workflow and standards](./CLAUDE.md)
 

--- a/deploy/terraform/aws-single-vm/.gitignore
+++ b/deploy/terraform/aws-single-vm/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+terraform.tfvars
+crash.log
+crash.*.log

--- a/deploy/terraform/aws-single-vm/.terraform.lock.hcl
+++ b/deploy/terraform/aws-single-vm/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.57.1"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:WXndu9uKvbnmspexcbki89ZuGLt2SUyAfZ5GgQUm+QU=",
+    "zh:2d29e22480a81c21fb3f2fd52f9bd3ca4a82c37f3bb1b1036e881e42cddc75a1",
+    "zh:33aeb08e9973199b30f8a8e48a58dc67cfb6e32879f7a1c05c521899fe718f53",
+    "zh:37b7f977a7e7d45ad11d42958bc264873fb34573eee925915038ea05607abc9e",
+    "zh:41ebdcf4bcd073a01d58505a5f5118b85668de357d2d9f266926923e817a1842",
+    "zh:43093dfc3559c2c0467c92f48b29ae0221d52e912fce03dd77abd90806fdcc7d",
+    "zh:63b4252933e828d3590c0c64b827ec0f8955aa52df719fe67f45a846111fccc4",
+    "zh:7473b036e9f8167c7a09e4865de95d07922eae6a612b94e819d44c87ba5298de",
+    "zh:783c73e66bf50a74983803e1ec6d6237bae2891f9d4fd4824cfd5350121552ae",
+    "zh:83681e1d8d002048b76d7144cb96c8c8501dc973d1fee41b7579a46ad9eb04c2",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b08b4168d4e2a81badbbe65d95f692ed3292c2b71cd00b9889a3bb7cf54c1188",
+    "zh:b4320ca25f4f67beebcbd6563ece2e490bd9dcb0a7e59b5d7a437ddaf53768ed",
+    "zh:d7f99254d6e05bac3dffae9b437c47cd807b4e66d941e56364be0a28ead418bd",
+    "zh:e433e91689758a341c91840cc7b5d3a3c5089004766d20659d57199b88ad8a5f",
+    "zh:e4c5a9b0f96a5fe2b5ed5592d4c2ac33240cf5308bcb14e52d6f2e0eb183a014",
+    "zh:fc4b554ae98e40e3ab6878ec9501ba2b05213d30668ee357d48b207993ffbe03",
+  ]
+}

--- a/deploy/terraform/aws-single-vm/README.md
+++ b/deploy/terraform/aws-single-vm/README.md
@@ -1,0 +1,101 @@
+# AWS single-VM Terraform example
+
+This example creates one Ubuntu 24.04 EC2 instance for Multiforum, installs
+Docker and Docker Compose with cloud-init, clones the frontend repository into
+`/opt/multiforum`, and assigns a stable Elastic IP. It is deliberately a small
+operator-owned starting point, not a managed production platform.
+
+Terraform does **not** receive application secrets. Auth0 credentials, the
+Neo4j password, and optional integration keys therefore stay out of Terraform
+plans and state. You add them directly on the host after provisioning.
+
+## What it creates
+
+- one EC2 instance in the account's default VPC;
+- one encrypted gp3 root volume (40 GiB by default), including Docker volumes;
+- one security group exposing SSH only to `admin_cidr`;
+- port 3000 to `application_cidrs` (public by default); and
+- one Elastic IP for a stable address.
+
+Neo4j's ports (7474 and 7687) and the backend port (4000) are not admitted by
+the AWS security group. The instance metadata service requires IMDSv2 tokens.
+
+## Prerequisites
+
+- Terraform 1.8 or newer;
+- AWS credentials available to Terraform;
+- an existing EC2 key pair in the selected region; and
+- a default VPC with at least one subnet.
+
+The default `t3.large` is a conservative starting size for Neo4j, the backend,
+and the frontend on one machine. Review current EC2, EBS, and Elastic IP pricing
+before applying. This example creates billable resources.
+
+## Provision the host
+
+```bash
+cd deploy/terraform/aws-single-vm
+cp terraform.tfvars.example terraform.tfvars
+# Replace admin_cidr and ssh_key_name before continuing.
+terraform init
+terraform plan
+terraform apply
+```
+
+Use a `/32` containing only your current public IPv4 address for `admin_cidr`.
+During initial setup, consider restricting `application_cidrs` to that same
+address. Terraform prints the resulting SSH command and temporary application
+URL.
+
+Cloud-init may continue installing packages for a few minutes after EC2 reports
+the instance as running. Follow its progress with:
+
+```bash
+ssh ubuntu@PUBLIC_IP
+cloud-init status --wait
+```
+
+## Configure and start Multiforum
+
+On the host, create `/opt/multiforum/.env` from the repository example and fill
+in strong, real values. The current application stack requires Auth0 for login;
+maps, geocoding, mail, and storage remain optional and degrade when omitted.
+
+```bash
+cd /opt/multiforum
+cp .env.example .env
+$EDITOR .env
+docker compose up -d --build
+docker compose ps
+```
+
+Do not use the placeholder Neo4j password. Keep `NEO4J_AUTH` and
+`NEO4J_PASSWORD` consistent, and configure the Auth0 callback/base URLs for the
+address users will visit.
+
+Port 3000 serves plain HTTP only. Before allowing public users, put a TLS
+reverse proxy or load balancer in front of the instance, configure a domain,
+and remove public port-3000 access. A future module can make that advanced path
+repeatable without coupling the basic example to a specific DNS provider.
+
+## Updating and destroying
+
+Application updates are explicit so an infrastructure plan cannot silently
+change the running forum:
+
+```bash
+cd /opt/multiforum
+git fetch --tags
+git checkout RELEASE_TAG
+docker compose up -d --build
+```
+
+The Canonical SSM parameter selects the current Ubuntu 24.04 image when the
+instance is first created. Later AMI changes are ignored because replacing this
+stateful host as an automatic upgrade would also replace its local data disk.
+Apply operating-system security updates on the host and plan image migrations
+as explicit backup-and-restore operations.
+
+Back up Neo4j data before replacing or destroying the instance. The root volume
+is deleted with the instance by default, so `terraform destroy` removes the
+forum data as well as the infrastructure.

--- a/deploy/terraform/aws-single-vm/cloud-init.tftpl
+++ b/deploy/terraform/aws-single-vm/cloud-init.tftpl
@@ -1,0 +1,16 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - docker.io
+  - docker-compose-v2
+  - git
+
+runcmd:
+  - systemctl enable --now docker
+  - usermod -aG docker ubuntu
+  - git clone --branch '${repository_ref}' --depth 1 https://github.com/gennit-project/multiforum-nuxt.git /opt/multiforum
+  - chown -R ubuntu:ubuntu /opt/multiforum
+
+final_message: "Multiforum host prerequisites are ready. Application secrets have not been installed."

--- a/deploy/terraform/aws-single-vm/main.tf
+++ b/deploy/terraform/aws-single-vm/main.tf
@@ -1,0 +1,96 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_ssm_parameter" "ubuntu_ami" {
+  name            = "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id"
+  with_decryption = false
+}
+
+resource "aws_security_group" "multiforum" {
+  name_prefix = "${var.name}-"
+  description = "Network access for the Multiforum single-VM example"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "SSH administration"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.admin_cidr]
+  }
+
+  ingress {
+    description = "Multiforum HTTP (replace with TLS before production use)"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = var.application_cidrs
+  }
+
+  egress {
+    description = "Package, image, and application outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "${var.name}-host"
+  }
+}
+
+resource "aws_instance" "multiforum" {
+  ami                         = nonsensitive(data.aws_ssm_parameter.ubuntu_ami.value)
+  instance_type               = var.instance_type
+  key_name                    = var.ssh_key_name
+  subnet_id                   = sort(data.aws_subnets.default.ids)[0]
+  associate_public_ip_address = true
+  vpc_security_group_ids      = [aws_security_group.multiforum.id]
+
+  user_data = templatefile("${path.module}/cloud-init.tftpl", {
+    repository_ref = var.repository_ref
+  })
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  root_block_device {
+    encrypted   = true
+    volume_size = var.root_volume_size_gib
+    volume_type = "gp3"
+  }
+
+  lifecycle {
+    # The public Canonical SSM parameter advances over time. Do not replace a
+    # stateful, single-node forum merely because a newer image was published.
+    ignore_changes = [ami]
+  }
+
+  tags = {
+    Name = "${var.name}-host"
+  }
+}
+
+resource "aws_eip" "multiforum" {
+  domain   = "vpc"
+  instance = aws_instance.multiforum.id
+
+  tags = {
+    Name = "${var.name}-public-ip"
+  }
+}

--- a/deploy/terraform/aws-single-vm/outputs.tf
+++ b/deploy/terraform/aws-single-vm/outputs.tf
@@ -1,0 +1,14 @@
+output "public_ip" {
+  description = "Stable public IPv4 address of the Multiforum host."
+  value       = aws_eip.multiforum.public_ip
+}
+
+output "application_url" {
+  description = "Temporary HTTP URL. Configure a domain and TLS before production use."
+  value       = "http://${aws_eip.multiforum.public_ip}:3000"
+}
+
+output "ssh_command" {
+  description = "SSH command for completing application configuration."
+  value       = "ssh ubuntu@${aws_eip.multiforum.public_ip}"
+}

--- a/deploy/terraform/aws-single-vm/terraform.tfvars.example
+++ b/deploy/terraform/aws-single-vm/terraform.tfvars.example
@@ -1,0 +1,9 @@
+aws_region   = "us-east-1"
+admin_cidr   = "203.0.113.10/32"
+ssh_key_name = "my-existing-ec2-key"
+
+# Pin a release tag for a repeatable production deployment.
+repository_ref = "main"
+
+# Start narrower during setup if the instance should not yet be public.
+application_cidrs = ["203.0.113.10/32"]

--- a/deploy/terraform/aws-single-vm/variables.tf
+++ b/deploy/terraform/aws-single-vm/variables.tf
@@ -1,0 +1,70 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region in which to create the Multiforum host."
+  default     = "us-east-1"
+}
+
+variable "name" {
+  type        = string
+  description = "Name prefix applied to the instance and security group."
+  default     = "multiforum"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]{1,32}$", var.name))
+    error_message = "name must contain 1-32 letters, numbers, or hyphens."
+  }
+}
+
+variable "admin_cidr" {
+  type        = string
+  description = "Single trusted IPv4 CIDR allowed to SSH to the host, for example 203.0.113.10/32."
+
+  validation {
+    condition     = can(cidrnetmask(var.admin_cidr))
+    error_message = "admin_cidr must be a valid IPv4 CIDR. Prefer a single-address /32."
+  }
+}
+
+variable "ssh_key_name" {
+  type        = string
+  description = "Name of an existing EC2 key pair used to access the Ubuntu host."
+}
+
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance type. t3.large is the conservative starting point for Neo4j plus both app services."
+  default     = "t3.large"
+}
+
+variable "root_volume_size_gib" {
+  type        = number
+  description = "Size of the encrypted gp3 root volume, which also stores Neo4j Docker volumes."
+  default     = 40
+
+  validation {
+    condition     = var.root_volume_size_gib >= 30
+    error_message = "root_volume_size_gib must be at least 30 GiB."
+  }
+}
+
+variable "application_cidrs" {
+  type        = list(string)
+  description = "IPv4 CIDRs allowed to reach the temporary HTTP application port (3000)."
+  default     = ["0.0.0.0/0"]
+
+  validation {
+    condition     = length(var.application_cidrs) > 0 && alltrue([for cidr in var.application_cidrs : can(cidrnetmask(cidr))])
+    error_message = "application_cidrs must contain at least one valid IPv4 CIDR."
+  }
+}
+
+variable "repository_ref" {
+  type        = string
+  description = "Git branch or tag checked out by cloud-init. Pin a release tag for repeatable production installs."
+  default     = "main"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._/-]{1,100}$", var.repository_ref))
+    error_message = "repository_ref contains unsupported characters."
+  }
+}

--- a/deploy/terraform/aws-single-vm/versions.tf
+++ b/deploy/terraform/aws-single-vm/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Application = "multiforum"
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Developer documentation for the Multiforum Nuxt frontend. See the
 ## Getting started & architecture
 
 - [Development setup](./development-setup.md) — local environment and tooling
+- [AWS single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md) — provision a Docker-ready self-hosting VM without storing app secrets in Terraform state
 - [Frontend architecture and authentication](./architecture-and-auth.md)
 - [Moderation architecture](./moderation-architecture.md) — canonical reference for permissions and suspensions
 - [Performance](./performance.md) — code splitting, caching, image optimization


### PR DESCRIPTION
## Summary
- add a Terraform root configuration for a Docker-ready Ubuntu 24.04 EC2 host
- keep application credentials out of Terraform state and document the SSH handoff
- restrict SSH by CIDR, require IMDSv2, encrypt the root volume, and avoid automatic stateful AMI replacement
- document cost, TLS, backup, update, and destroy boundaries

## Validation
- `terraform fmt -check -diff` (Terraform 1.13.5 container)
- `terraform init -backend=false`
- `terraform validate` against locked AWS provider 6.57.1
- `git diff --check`

## Roadmap context
This is the small infrastructure-as-code example discussed for self-hosting. It intentionally provisions infrastructure only; it does not store Auth0, Neo4j, or integration secrets in Terraform state. The current Compose stack still requires Auth0 for login, which is called out explicitly in the handoff docs.