### PR TITLE
feat(auth): add local development sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ VITE_LOGOUT_URL=localhost:3000/logout
 # at the bottom of this file. The old VITE_AUTH0_* client/SPA vars were removed
 # (the SPA SDK is gone).
 
+# Authentication provider. Keep auth0 for production. local-dev enables the
+# bootstrap-password sign-in flow and requires the backend local-dev provider.
+NUXT_PUBLIC_AUTH_PROVIDER=auth0
+# Optional override; otherwise derived from VITE_GRAPHQL_URL.
+NUXT_LOCAL_AUTH_TOKEN_ENDPOINT=
+
 # File Uploads
 VITE_GOOGLE_CLOUD_STORAGE_BUCKET=placeholder
 

--- a/components/auth/RequireAuth.spec.ts
+++ b/components/auth/RequireAuth.spec.ts
@@ -16,6 +16,13 @@ vi.mock('@/composables/useAuthState', () => ({
   useIsAuthenticated: () => mockIsAuthenticated,
 }));
 
+vi.mock('@/composables/useAuthNavigation', () => ({
+  useAuthNavigation: () => ({
+    getLoginUrl: (returnTo: string) =>
+      `/auth/login?returnTo=${encodeURIComponent(returnTo)}`,
+  }),
+}));
+
 const slots = {
   'has-auth': '<div data-testid="auth-content">Auth Content</div>',
   'does-not-have-auth':
@@ -87,9 +94,9 @@ describe('RequireAuth', () => {
       async ({ authenticated, username, props, expected }) => {
         await setAuthState({ authenticated, username });
         const wrapper = mount(RequireAuth, { props, slots });
-        expect(wrapper.find('[data-auth-state]').attributes('data-auth-state')).toBe(
-          expected
-        );
+        expect(
+          wrapper.find('[data-auth-state]').attributes('data-auth-state')
+        ).toBe(expected);
       }
     );
   });

--- a/components/auth/RequireAuth.vue
+++ b/components/auth/RequireAuth.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useIsAuthenticated, useUsername } from '@/composables/useAuthState';
+import { useAuthNavigation } from '@/composables/useAuthNavigation';
 
 const isAuthenticatedVar = useIsAuthenticated();
 const usernameVar = useUsername();
+const { getLoginUrl } = useAuthNavigation();
 
 /*
 Wrapper around content that requires authentication: renders the `has-auth`
@@ -46,7 +48,7 @@ const showAuthContent = computed(() => {
 const handleLogin = () => {
   if (typeof window === 'undefined') return;
   const returnTo = window.location.pathname + window.location.search;
-  window.location.href = `/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
+  window.location.href = getLoginUrl(returnTo);
 };
 </script>
 

--- a/components/nav/LoginButton.spec.ts
+++ b/components/nav/LoginButton.spec.ts
@@ -6,7 +6,10 @@ import LoginButton from '@/components/nav/LoginButton.vue';
 
 const route = createMockRoute();
 
-vi.mock('nuxt/app', () => ({ useRoute: () => route }));
+vi.mock('nuxt/app', () => ({
+  useRoute: () => route,
+  useRuntimeConfig: () => ({ public: { authProvider: 'auth0' } }),
+}));
 // Logout now goes through useServerLogout -> /auth/logout; no SPA SDK to mock.
 
 // Stub that renders the unauthenticated slot instead of the harness default.

--- a/composables/useAuthNavigation.spec.ts
+++ b/composables/useAuthNavigation.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLoginUrl,
+  buildLogoutUrl,
+  normalizeAuthProvider,
+} from './useAuthNavigation';
+
+describe('auth navigation', () => {
+  it.each([
+    ['local-dev', 'local-dev'],
+    ['auth0', 'auth0'],
+    ['unexpected', 'auth0'],
+    [undefined, 'auth0'],
+  ] as const)('normalizes %s to %s', (value, expected) => {
+    expect(normalizeAuthProvider(value)).toBe(expected);
+  });
+
+  it('builds a local sign-in URL with an encoded return path', () => {
+    expect(
+      buildLoginUrl({ provider: 'local-dev', returnTo: '/forums/cats?tab=new' })
+    ).toBe('/login?returnTo=%2Fforums%2Fcats%3Ftab%3Dnew');
+  });
+
+  it('preserves the Auth0 login route by default', () => {
+    expect(buildLoginUrl({ provider: 'auth0', returnTo: '/' })).toBe(
+      '/auth/login?returnTo=%2F'
+    );
+  });
+
+  it.each([
+    ['local-dev', '/auth/local-dev/logout'],
+    ['auth0', '/auth/logout'],
+  ] as const)('builds the %s logout route', (provider, expected) => {
+    expect(buildLogoutUrl(provider)).toBe(expected);
+  });
+});

--- a/composables/useAuthNavigation.ts
+++ b/composables/useAuthNavigation.ts
@@ -1,0 +1,31 @@
+import { useRuntimeConfig } from 'nuxt/app';
+
+export type AuthProvider = 'auth0' | 'local-dev';
+
+export const normalizeAuthProvider = (provider: unknown): AuthProvider =>
+  provider === 'local-dev' ? 'local-dev' : 'auth0';
+
+export const buildLoginUrl = ({
+  provider,
+  returnTo,
+}: {
+  provider: AuthProvider;
+  returnTo: string;
+}) => {
+  const path = provider === 'local-dev' ? '/login' : '/auth/login';
+  return `${path}?returnTo=${encodeURIComponent(returnTo)}`;
+};
+
+export const buildLogoutUrl = (provider: AuthProvider) =>
+  provider === 'local-dev' ? '/auth/local-dev/logout' : '/auth/logout';
+
+export const useAuthNavigation = () => {
+  const config = useRuntimeConfig();
+  const provider = normalizeAuthProvider(config.public.authProvider);
+
+  return {
+    provider,
+    getLoginUrl: (returnTo: string) => buildLoginUrl({ provider, returnTo }),
+    logoutUrl: buildLogoutUrl(provider),
+  };
+};

--- a/composables/useServerLogout.spec.ts
+++ b/composables/useServerLogout.spec.ts
@@ -14,6 +14,10 @@ vi.mock('@/utils/authUtils', () => ({
   clearPersistedAuth: () => clearPersistedAuth(),
 }));
 
+vi.mock('@/composables/useAuthNavigation', () => ({
+  useAuthNavigation: () => ({ logoutUrl: '/auth/logout' }),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
   window.localStorage.clear();

--- a/composables/useServerLogout.ts
+++ b/composables/useServerLogout.ts
@@ -12,9 +12,11 @@
 // token (plugins/apollo-auth.client.ts) until it is wired directly to the
 // server session. This is the one place that knows about both systems.
 import { setIsAuthenticated, setUsername } from '@/composables/useAuthState';
+import { useAuthNavigation } from '@/composables/useAuthNavigation';
 import { clearPersistedAuth } from '@/utils/authUtils';
 
 export const useServerLogout = () => {
+  const { logoutUrl } = useAuthNavigation();
   const logout = () => {
     if (typeof window === 'undefined') {
       return;
@@ -33,7 +35,7 @@ export const useServerLogout = () => {
     setIsAuthenticated(false);
     setUsername('');
     clearPersistedAuth();
-    window.location.href = '/auth/logout';
+    window.location.href = logoutUrl;
   };
 
   return { logout };

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -78,9 +78,7 @@ export default defineNuxtConfig({
   },
   compatibilityDate: '2024-04-03',
   components: true,
-  css: [
-    '@/assets/css/index.css',
-  ],
+  css: ['@/assets/css/index.css'],
   devtools: { enabled: true },
   imports: {
     autoImport: true,
@@ -380,6 +378,9 @@ export default defineNuxtConfig({
     { src: '@/plugins/test-auth.client', mode: 'client' },
   ],
   runtimeConfig: {
+    // Optional explicit backend token URL for local development auth. When it
+    // is empty, the server derives /auth/local-dev/token from the GraphQL URL.
+    localAuthTokenEndpoint: '',
     // SPIKE (auth0-nuxt server-session migration): server-only Auth0 config.
     // These are overridden by NUXT_AUTH0_* env vars at runtime (see
     // .env.auth0-nuxt.example). clientSecret + sessionSecret mean this is a
@@ -404,6 +405,10 @@ export default defineNuxtConfig({
       },
     },
     public: {
+      authProvider:
+        process.env.NUXT_PUBLIC_AUTH_PROVIDER === 'local-dev'
+          ? 'local-dev'
+          : 'auth0',
       apollo: {
         clients: {
           default: {

--- a/pages/login.spec.ts
+++ b/pages/login.spec.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
+import LoginPage from './login.vue';
+
+const h = vi.hoisted(() => ({
+  provider: 'local-dev',
+  query: { returnTo: '/admin/setup' } as Record<string, unknown>,
+  navigateTo: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('nuxt/app', () => ({
+  navigateTo: h.navigateTo,
+  useHead: vi.fn(),
+  useRoute: () => ({ query: h.query }),
+  useRuntimeConfig: () => ({ public: { authProvider: h.provider } }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.provider = 'local-dev';
+  h.query = { returnTo: '/admin/setup' };
+  h.fetch.mockResolvedValue({ authenticated: true });
+  vi.stubGlobal('$fetch', h.fetch);
+});
+
+describe('local sign-in page', () => {
+  it('labels the flow as local development authentication', () => {
+    const wrapper = mountWithDefaults(LoginPage);
+    expect(wrapper.text()).toContain('Local development authentication');
+  });
+
+  it('submits the bootstrap password to the same-origin session endpoint', async () => {
+    const wrapper = mountWithDefaults(LoginPage);
+    await wrapper.get('input').setValue('local-password');
+    await wrapper.get('form').trigger('submit');
+    expect(h.fetch).toHaveBeenCalledWith('/api/auth/local-dev/login', {
+      method: 'POST',
+      body: { password: 'local-password' },
+    });
+  });
+
+  it('performs a full navigation to the requested page after sign-in', async () => {
+    const wrapper = mountWithDefaults(LoginPage);
+    await wrapper.get('input').setValue('local-password');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+    expect(h.navigateTo).toHaveBeenCalledWith('/admin/setup', {
+      external: true,
+    });
+  });
+
+  it('rejects a protocol-relative return URL', async () => {
+    h.query = { returnTo: '//attacker.example' };
+    const wrapper = mountWithDefaults(LoginPage);
+    await wrapper.get('input').setValue('local-password');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+    expect(h.navigateTo).toHaveBeenCalledWith('/', { external: true });
+  });
+
+  it('shows a credential-specific error for a rejected password', async () => {
+    h.fetch.mockRejectedValue({ response: { status: 401 } });
+    const wrapper = mountWithDefaults(LoginPage);
+    await wrapper.get('input').setValue('wrong-password');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+    expect(wrapper.get('[role="alert"]').text()).toBe(
+      'That password was not accepted.'
+    );
+  });
+
+  it('hands Auth0 deployments back to the existing login route', async () => {
+    h.provider = 'auth0';
+    mountWithDefaults(LoginPage);
+    await flushPromises();
+    expect(h.navigateTo).toHaveBeenCalledWith(
+      '/auth/login?returnTo=%2Fadmin%2Fsetup',
+      {
+        external: true,
+      }
+    );
+  });
+});

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { navigateTo, useHead, useRoute, useRuntimeConfig } from 'nuxt/app';
+import {
+  buildLoginUrl,
+  normalizeAuthProvider,
+} from '@/composables/useAuthNavigation';
+
+useHead({ title: 'Local sign in' });
+
+const config = useRuntimeConfig();
+const route = useRoute();
+const provider = normalizeAuthProvider(config.public.authProvider);
+const password = ref('');
+const submitting = ref(false);
+const errorMessage = ref('');
+
+const returnTo = computed(() => {
+  const requested = Array.isArray(route.query.returnTo)
+    ? route.query.returnTo[0]
+    : route.query.returnTo;
+  return typeof requested === 'string' &&
+    requested.startsWith('/') &&
+    !requested.startsWith('//')
+    ? requested
+    : '/';
+});
+
+onMounted(() => {
+  if (provider !== 'local-dev') {
+    void navigateTo(
+      buildLoginUrl({
+        provider: 'auth0',
+        returnTo: returnTo.value,
+      }),
+      { external: true }
+    );
+  }
+});
+
+const submit = async () => {
+  if (!password.value || submitting.value) return;
+  submitting.value = true;
+  errorMessage.value = '';
+
+  try {
+    await $fetch('/api/auth/local-dev/login', {
+      method: 'POST',
+      body: { password: password.value },
+    });
+    await navigateTo(returnTo.value, { external: true });
+  } catch (error) {
+    const status = (error as { response?: { status?: number } }).response
+      ?.status;
+    errorMessage.value =
+      status === 401
+        ? 'That password was not accepted.'
+        : 'Local sign in is unavailable. Check the instance configuration.';
+  } finally {
+    submitting.value = false;
+  }
+};
+</script>
+
+<template>
+  <NuxtLayout>
+    <div class="mx-auto flex min-h-[70vh] max-w-md items-center px-4 py-12">
+      <section
+        v-if="provider === 'local-dev'"
+        class="w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+        aria-labelledby="local-sign-in-title"
+      >
+        <p class="mb-2 text-sm font-medium text-amber-700 dark:text-amber-300">
+          Local development authentication
+        </p>
+        <h1
+          id="local-sign-in-title"
+          class="font-semibold text-2xl dark:text-white"
+        >
+          Sign in to this instance
+        </h1>
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          Use the bootstrap password configured by the instance administrator.
+          This sign-in mode is intended only for local self-hosting and
+          evaluation.
+        </p>
+
+        <form class="mt-6 space-y-4" @submit.prevent="submit">
+          <div>
+            <label
+              for="local-password"
+              class="block text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              Bootstrap password
+            </label>
+            <input
+              id="local-password"
+              v-model="password"
+              name="password"
+              type="password"
+              autocomplete="current-password"
+              required
+              class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            />
+          </div>
+
+          <p
+            v-if="errorMessage"
+            role="alert"
+            class="text-sm text-red-700 dark:text-red-300"
+          >
+            {{ errorMessage }}
+          </p>
+
+          <button
+            type="submit"
+            :disabled="submitting || !password"
+            class="w-full rounded-md bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {{ submitting ? 'Signing in…' : 'Sign in' }}
+          </button>
+        </form>
+      </section>
+    </div>
+  </NuxtLayout>
+</template>

--- a/server/api/auth/local-dev/login.post.spec.ts
+++ b/server/api/auth/local-dev/login.post.spec.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createError } from 'h3';
+
+const h = vi.hoisted(() => ({
+  body: { password: 'local-password' } as { password?: unknown },
+  config: {
+    localAuthTokenEndpoint: 'http://backend:4000/auth/local-dev/token',
+    public: { authProvider: 'local-dev' },
+  },
+  fetch: vi.fn(),
+  setCookie: vi.fn(),
+  setResponseHeader: vi.fn(),
+}));
+
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler);
+vi.stubGlobal('setResponseHeader', h.setResponseHeader);
+vi.stubGlobal('useRuntimeConfig', () => h.config);
+vi.stubGlobal('readBody', async () => h.body);
+vi.stubGlobal('$fetch', h.fetch);
+vi.stubGlobal('setCookie', h.setCookie);
+vi.stubGlobal('createError', createError);
+
+const { default: handler } = await import('./login.post');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.body = { password: 'local-password' };
+  h.config.localAuthTokenEndpoint = 'http://backend:4000/auth/local-dev/token';
+  h.config.public.authProvider = 'local-dev';
+  h.fetch.mockResolvedValue({
+    accessToken: 'signed-token',
+    expiresIn: 900,
+  });
+});
+
+describe('local development login endpoint', () => {
+  it('forwards only the password to the configured backend endpoint', async () => {
+    await handler({} as never);
+    expect(h.fetch).toHaveBeenCalledWith(
+      'http://backend:4000/auth/local-dev/token',
+      { method: 'POST', body: { password: 'local-password' } }
+    );
+  });
+
+  it('stores the bearer token in an HTTP-only cookie', async () => {
+    await handler({} as never);
+    expect(h.setCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      'multiforum-local-token',
+      'signed-token',
+      expect.objectContaining({ httpOnly: true, maxAge: 900, path: '/' })
+    );
+  });
+
+  it('does not expose the bearer token in its response', async () => {
+    const result = await handler({} as never);
+    expect(result).toEqual({ authenticated: true, expiresIn: 900 });
+  });
+
+  it('is unavailable unless local auth is explicitly enabled', async () => {
+    h.config.public.authProvider = 'auth0';
+    await expect(handler({} as never)).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it('rejects an empty password before contacting the backend', async () => {
+    h.body = { password: '' };
+    await expect(handler({} as never)).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+
+  it('maps backend credential failures without echoing the password', async () => {
+    h.fetch.mockRejectedValue({ response: { status: 401 } });
+    await expect(handler({} as never)).rejects.toMatchObject({
+      statusCode: 401,
+      statusMessage: 'Invalid credentials',
+    });
+  });
+
+  it('fails closed when the backend returns no token', async () => {
+    h.fetch.mockResolvedValue({ expiresIn: 900 });
+    await expect(handler({} as never)).rejects.toMatchObject({
+      statusCode: 502,
+    });
+  });
+});

--- a/server/api/auth/local-dev/login.post.ts
+++ b/server/api/auth/local-dev/login.post.ts
@@ -1,0 +1,71 @@
+import {
+  getLocalAuthTokenEndpoint,
+  isLocalDevAuth,
+  LOCAL_AUTH_COOKIE,
+} from '@/server/utils/local-auth';
+
+type TokenResponse = {
+  accessToken?: string;
+  expiresIn?: number;
+};
+
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, 'Cache-Control', 'no-store');
+
+  const config = useRuntimeConfig(event);
+  if (!isLocalDevAuth(config)) {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' });
+  }
+
+  const body = await readBody<{ password?: unknown }>(event);
+  if (typeof body?.password !== 'string' || !body.password) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Password is required',
+    });
+  }
+
+  const endpoint = getLocalAuthTokenEndpoint(config);
+  if (!endpoint) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'Local authentication is not configured',
+    });
+  }
+
+  let tokenResponse: TokenResponse;
+  try {
+    tokenResponse = await $fetch<TokenResponse>(endpoint, {
+      method: 'POST',
+      body: { password: body.password },
+    });
+  } catch (error) {
+    const status = (error as { response?: { status?: number } }).response
+      ?.status;
+    throw createError({
+      statusCode: status === 401 ? 401 : 502,
+      statusMessage:
+        status === 401
+          ? 'Invalid credentials'
+          : 'Local authentication service is unavailable',
+    });
+  }
+
+  if (!tokenResponse.accessToken) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Local authentication returned no token',
+    });
+  }
+
+  const maxAge = Math.max(1, tokenResponse.expiresIn ?? 15 * 60);
+  setCookie(event, LOCAL_AUTH_COOKIE, tokenResponse.accessToken, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: false,
+    path: '/',
+    maxAge,
+  });
+
+  return { authenticated: true, expiresIn: maxAge };
+});

--- a/server/api/session/token.get.spec.ts
+++ b/server/api/session/token.get.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  provider: 'local-dev',
+  cookie: 'signed-token' as string | undefined,
+  getAccessToken: vi.fn(),
+}));
+
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler);
+vi.stubGlobal('setResponseHeader', vi.fn());
+vi.stubGlobal('useRuntimeConfig', () => ({
+  public: { authProvider: h.provider },
+}));
+vi.stubGlobal('getCookie', () => h.cookie);
+vi.stubGlobal('useAuth0', () => ({ getAccessToken: h.getAccessToken }));
+
+const { default: handler } = await import('./token.get');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.provider = 'local-dev';
+  h.cookie = 'signed-token';
+  h.getAccessToken.mockResolvedValue({ accessToken: 'auth0-token' });
+});
+
+describe('session token endpoint', () => {
+  it('returns the local cookie token for Apollo synchronization', async () => {
+    await expect(handler({} as never)).resolves.toEqual({
+      accessToken: 'signed-token',
+    });
+  });
+
+  it('returns null when the local session has expired', async () => {
+    h.cookie = undefined;
+    await expect(handler({} as never)).resolves.toEqual({ accessToken: null });
+  });
+
+  it('preserves the existing Auth0 token path', async () => {
+    h.provider = 'auth0';
+    await expect(handler({} as never)).resolves.toEqual({
+      accessToken: 'auth0-token',
+    });
+  });
+});

--- a/server/api/session/token.get.ts
+++ b/server/api/session/token.get.ts
@@ -3,9 +3,14 @@
 // Alias for the session access token endpoint. Some embedded browsers are more
 // aggressive about blocking `/api/auth/*` paths, so the browser fallback uses
 // this neutral path instead.
+import { isLocalDevAuth, LOCAL_AUTH_COOKIE } from '@/server/utils/local-auth';
 
 export default defineEventHandler(async (event) => {
   setResponseHeader(event, 'Cache-Control', 'no-store');
+
+  if (isLocalDevAuth(useRuntimeConfig(event))) {
+    return { accessToken: getCookie(event, LOCAL_AUTH_COOKIE) ?? null };
+  }
 
   try {
     const tokenSet = await useAuth0(event).getAccessToken();

--- a/server/middleware/2.auth-session.ts
+++ b/server/middleware/2.auth-session.ts
@@ -31,6 +31,27 @@
 //
 // Numeric filename prefix controls middleware order (runs after
 // 1.cache-control.ts), matching the existing convention in this directory.
+import type * as H3 from 'h3';
+import type { Storage, StorageValue } from 'unstorage';
+import { isLocalDevAuth, LOCAL_AUTH_COOKIE } from '@/server/utils/local-auth';
+
+// Nitro injects these server auto-imports at build time. Declare their narrow
+// shapes here as well so this middleware remains type-checkable when a unit
+// test imports it through the client-side vue-tsc project.
+declare const defineEventHandler: typeof H3.defineEventHandler;
+declare const getCookie: typeof H3.getCookie;
+declare const deleteCookie: typeof H3.deleteCookie;
+declare const useRuntimeConfig: (event?: H3.H3Event) => {
+  public?: {
+    authProvider?: string;
+    apollo?: { clients?: { default?: { httpEndpoint?: string } } };
+  };
+};
+declare const useStorage: <T extends StorageValue>(base?: string) => Storage<T>;
+declare const useAuth0: (event: H3.H3Event) => {
+  getSession: () => Promise<{ user?: Record<string, unknown> } | null>;
+  getAccessToken: () => Promise<{ accessToken?: string } | null>;
+};
 
 type AuthSessionContext = {
   isAuthenticated: boolean;
@@ -59,6 +80,7 @@ declare module 'h3' {
 const GET_OWN_EMAIL = /* GraphQL */ `
   query getOwnEmail {
     getOwnEmail {
+      address
       username
       profilePicURL
       modProfileName
@@ -70,6 +92,7 @@ const GET_OWN_EMAIL = /* GraphQL */ `
 type OwnEmailResponse = {
   data?: {
     getOwnEmail?: {
+      address?: string | null;
       username?: string | null;
       profilePicURL?: string | null;
       modProfileName?: string | null;
@@ -146,6 +169,44 @@ export default defineEventHandler(async (event) => {
     return;
   }
 
+  const runtimeConfig = useRuntimeConfig(event);
+  if (isLocalDevAuth(runtimeConfig)) {
+    const accessToken = getCookie(event, LOCAL_AUTH_COOKIE);
+    const graphqlUrl =
+      runtimeConfig.public?.apollo?.clients?.default?.httpEndpoint;
+    if (!accessToken || !graphqlUrl) return;
+
+    try {
+      const response = await $fetch<OwnEmailResponse>(graphqlUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: { query: GET_OWN_EMAIL },
+      });
+      const profile = response?.data?.getOwnEmail;
+      if (!profile?.address) {
+        deleteCookie(event, LOCAL_AUTH_COOKIE, { path: '/' });
+        return;
+      }
+
+      event.context.accessToken = accessToken;
+      event.context.authSession = {
+        isAuthenticated: true,
+        username: profile.username || '',
+        email: profile.address,
+        modProfileName: profile.modProfileName || '',
+        notificationCount: profile.unreadNotificationCount || 0,
+        profilePicURL: profile.profilePicURL || '',
+      };
+    } catch {
+      // An expired or invalid local token restores the anonymous state.
+      deleteCookie(event, LOCAL_AUTH_COOKIE, { path: '/' });
+    }
+    return;
+  }
+
   try {
     // useAuth0 is auto-imported by @auth0/auth0-nuxt in the Nitro context.
     const auth0 = useAuth0(event);
@@ -186,8 +247,7 @@ export default defineEventHandler(async (event) => {
           event.context.accessToken = accessToken;
         }
         const graphqlUrl =
-          useRuntimeConfig(event).public?.apollo?.clients?.default
-            ?.httpEndpoint;
+          runtimeConfig.public?.apollo?.clients?.default?.httpEndpoint;
 
         if (accessToken && graphqlUrl) {
           const queryBackend = <T>(query: string) =>
@@ -209,10 +269,9 @@ export default defineEventHandler(async (event) => {
             username = cached.username;
             modProfileName = cached.modProfileName;
             profilePicURL = cached.profilePicURL;
-            const countRes =
-              await queryBackend<NotificationCountResponse>(
-                GET_NOTIFICATION_COUNT
-              );
+            const countRes = await queryBackend<NotificationCountResponse>(
+              GET_NOTIFICATION_COUNT
+            );
             notificationCount =
               countRes?.data?.getOwnEmail?.unreadNotificationCount || 0;
           } else {

--- a/server/routes/auth/local-dev/logout.get.ts
+++ b/server/routes/auth/local-dev/logout.get.ts
@@ -1,0 +1,6 @@
+import { LOCAL_AUTH_COOKIE } from '@/server/utils/local-auth';
+
+export default defineEventHandler((event) => {
+  deleteCookie(event, LOCAL_AUTH_COOKIE, { path: '/' });
+  return sendRedirect(event, '/', 302);
+});

--- a/server/utils/local-auth.spec.ts
+++ b/server/utils/local-auth.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { getLocalAuthTokenEndpoint, isLocalDevAuth } from './local-auth';
+
+describe('local auth server configuration', () => {
+  it('recognizes only the explicit local development provider', () => {
+    expect(isLocalDevAuth({ public: { authProvider: 'local-dev' } })).toBe(
+      true
+    );
+  });
+
+  it('uses an explicit token endpoint when configured', () => {
+    expect(
+      getLocalAuthTokenEndpoint({
+        localAuthTokenEndpoint: ' http://backend:4000/custom-token ',
+      })
+    ).toBe('http://backend:4000/custom-token');
+  });
+
+  it('derives the token endpoint from the GraphQL origin', () => {
+    expect(
+      getLocalAuthTokenEndpoint({
+        public: {
+          apollo: {
+            clients: {
+              default: { httpEndpoint: 'http://backend:4000/graphql' },
+            },
+          },
+        },
+      })
+    ).toBe('http://backend:4000/auth/local-dev/token');
+  });
+
+  it.each([undefined, '', 'not a url'])(
+    'rejects an unusable GraphQL URL',
+    (url) => {
+      expect(
+        getLocalAuthTokenEndpoint({
+          public: { apollo: { clients: { default: { httpEndpoint: url } } } },
+        })
+      ).toBe('');
+    }
+  );
+});

--- a/server/utils/local-auth.ts
+++ b/server/utils/local-auth.ts
@@ -1,0 +1,36 @@
+export const LOCAL_AUTH_PROVIDER = 'local-dev';
+export const LOCAL_AUTH_COOKIE = 'multiforum-local-token';
+
+type LocalAuthRuntimeConfig = {
+  localAuthTokenEndpoint?: string;
+  public?: {
+    authProvider?: string;
+    apollo?: {
+      clients?: {
+        default?: {
+          httpEndpoint?: string;
+        };
+      };
+    };
+  };
+};
+
+export const isLocalDevAuth = (config: LocalAuthRuntimeConfig) =>
+  config.public?.authProvider === LOCAL_AUTH_PROVIDER;
+
+export const getLocalAuthTokenEndpoint = (
+  config: LocalAuthRuntimeConfig
+): string => {
+  const configured = config.localAuthTokenEndpoint?.trim();
+  if (configured) return configured;
+
+  const graphqlUrl =
+    config.public?.apollo?.clients?.default?.httpEndpoint?.trim();
+  if (!graphqlUrl) return '';
+
+  try {
+    return new URL('/auth/local-dev/token', graphqlUrl).toString();
+  } catch {
+    return '';
+  }
+};

--- a/tests/unit/server/local-auth-session.spec.ts
+++ b/tests/unit/server/local-auth-session.spec.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  cookie: 'signed-token' as string | undefined,
+  fetch: vi.fn(),
+  deleteCookie: vi.fn(),
+  useAuth0: vi.fn(),
+}));
+
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler);
+vi.stubGlobal('getCookie', () => h.cookie);
+vi.stubGlobal('deleteCookie', h.deleteCookie);
+vi.stubGlobal('$fetch', h.fetch);
+vi.stubGlobal('useAuth0', h.useAuth0);
+vi.stubGlobal('useRuntimeConfig', () => ({
+  public: {
+    authProvider: 'local-dev',
+    apollo: {
+      clients: { default: { httpEndpoint: 'http://backend:4000/graphql' } },
+    },
+  },
+}));
+
+const { default: handler } = await import('@/server/middleware/2.auth-session');
+
+const createEvent = () => ({ context: {} });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.cookie = 'signed-token';
+  process.env.VITE_E2E_MOCK_MODE = 'false';
+  h.fetch.mockResolvedValue({
+    data: {
+      getOwnEmail: {
+        address: 'admin@example.test',
+        username: 'admin',
+        profilePicURL: null,
+        modProfileName: 'bootstrap-admin',
+        unreadNotificationCount: 2,
+      },
+    },
+  });
+});
+
+describe('local auth session middleware', () => {
+  it('validates the cookie against the self-scoped backend profile query', async () => {
+    const event = createEvent();
+    await handler(event as never);
+    expect(h.fetch).toHaveBeenCalledWith(
+      'http://backend:4000/graphql',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer signed-token',
+        }),
+      })
+    );
+  });
+
+  it('seeds the same request-scoped profile shape used by Auth0', async () => {
+    const event = createEvent();
+    await handler(event as never);
+    expect(event.context).toEqual({
+      accessToken: 'signed-token',
+      authSession: {
+        isAuthenticated: true,
+        username: 'admin',
+        email: 'admin@example.test',
+        modProfileName: 'bootstrap-admin',
+        notificationCount: 2,
+        profilePicURL: '',
+      },
+    });
+  });
+
+  it('does not invoke Auth0 while the local provider is active', async () => {
+    await handler(createEvent() as never);
+    expect(h.useAuth0).not.toHaveBeenCalled();
+  });
+
+  it('stays anonymous when no local cookie exists', async () => {
+    h.cookie = undefined;
+    const event = createEvent();
+    await handler(event as never);
+    expect(event.context).toEqual({});
+  });
+
+  it('clears a token rejected by the backend', async () => {
+    h.fetch.mockRejectedValue(new Error('expired'));
+    await handler(createEvent() as never);
+    expect(h.deleteCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      'multiforum-local-token',
+      { path: '/' }
+    );
+  });
+
+  it('clears a token that resolves no authenticated profile', async () => {
+    h.fetch.mockResolvedValue({ data: { getOwnEmail: null } });
+    await handler(createEvent() as never);
+    expect(h.deleteCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      'multiforum-local-token',
+      { path: '/' }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a provider-aware local sign-in page for the bootstrap password flow introduced by backend PR #205
- proxy credentials server-side and store the short-lived bearer token in an HTTP-only cookie instead of returning it to page code
- validate local sessions through the backend self-scoped `getOwnEmail` query, then seed the same SSR auth state and Apollo token path used by Auth0
- preserve Auth0 as the default login, logout, middleware, and token behavior
- document the frontend provider and optional token-endpoint environment variables

## Safety boundaries

- local login routes return 404 unless `NUXT_PUBLIC_AUTH_PROVIDER=local-dev`
- invalid/expired tokens are cleared and restore anonymous state
- return paths accept only same-origin absolute paths
- local mode is labeled as development/evaluation-only in the UI

## Verification

- `pnpm run tsc`
- focused ESLint on changed TypeScript/Vue files
- 50 focused tests across provider routing, login UI, password proxy, cookie session, middleware, Apollo handoff, and Auth0 compatibility
- `pnpm run test:unit:run` — 7,578 passing
- `pnpm run build`