### PR TITLE
chore(tooling): add Claude Code skills, commands, hooks, and PR guardrails

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,39 @@
+---
+description: Verify, commit, push, and open a PR with a Conventional-Commit title that passes CI
+argument-hint: "[optional: short description of the change]"
+allowed-tools: Bash(pnpm run tsc:*), Bash(pnpm run test:unit:run:*), Bash(pnpm run lint:a11y:*), Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git checkout:*), Bash(git push:*), Bash(git branch:*), Bash(git rev-parse:*), Bash(gh pr create:*), Bash(gh pr view:*)
+---
+
+Ship the current change. Extra context from the user: $ARGUMENTS
+
+Do these steps in order, stopping to report if any step fails:
+
+1. **Verify.** Run `pnpm run tsc`, `pnpm run test:unit:run`, and `pnpm run lint:a11y`.
+   If any fail, stop and report — do not commit broken code.
+
+2. **Branch.** Run `git rev-parse --abbrev-ref HEAD`. If on `main`, create a feature
+   branch first (never commit directly to `main`). Otherwise stay on the current branch.
+
+3. **Commit.** Stage the relevant changes and commit. End the commit message with:
+   ```
+   Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+   ```
+
+4. **Push** the branch to the remote.
+
+5. **Open a PR** with `gh pr create` against `main`. The **PR title is CI-gated** — the
+   repo squash-merges and validates the title as a Conventional Commit
+   (`.github/workflows/pr-title-lint.yml`). The title MUST:
+   - use one of these types: `feat fix docs style refactor perf test build ci chore revert`
+   - use an optional lower-case/kebab-case scope, e.g. `feat(moderation): ...`
+   - have a subject that does **not** start with an upper-case letter
+     (`fix(markdown): keep table cell words whole`, not `Fix Table`)
+   End the PR body with:
+   ```
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   ```
+
+6. Report the PR URL.
+
+Only commit and push when the user has asked to ship. If the working tree has unrelated
+changes, ask before staging everything.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,16 @@
+---
+description: Run the local quality gate (type check, unit tests, a11y lint) and report results
+allowed-tools: Bash(pnpm run tsc:*), Bash(pnpm run test:unit:run:*), Bash(pnpm run lint:a11y:*), Bash(pnpm run verify:*)
+---
+
+Run the project's quality gate and report a concise pass/fail summary. This mirrors
+what CI enforces so failures are caught before pushing.
+
+Run these (stop and report the first hard failure with its output, otherwise run all three):
+
+1. `pnpm run tsc` — vue-tsc type checking (catches mock-shape / prop-type errors)
+2. `pnpm run test:unit:run` — Vitest unit suite
+3. `pnpm run lint:a11y` — accessibility lint on components
+
+Then report: which passed, which failed, and for any failure the specific file(s) and
+error. Do not attempt fixes unless asked — just surface the state clearly.

--- a/.claude/hooks/verify-tsc.sh
+++ b/.claude/hooks/verify-tsc.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Stop hook: background type-check. Runs vue-tsc only when .ts/.vue files changed
+# this session. On failure it exits 2 (asyncRewake) so Claude is re-engaged with the
+# errors instead of the user discovering them later. Silent on success / no changes.
+#
+# Personal opt-in — wired from .claude/settings.local.json. Delete that hook entry
+# (or this file) to turn it off.
+
+INPUT=$(cat)
+
+# Avoid Stop-hook loops: if this run was itself triggered by a Stop hook, bail.
+if printf '%s' "$INPUT" | jq -e '.stop_hook_active == true' >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Only bother when TypeScript/Vue source actually changed vs HEAD.
+CHANGED=$(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null | grep -E '\.(ts|vue)$')
+if [ -z "$CHANGED" ]; then
+  exit 0
+fi
+
+OUT=$(pnpm run tsc 2>&1)
+if [ $? -eq 0 ]; then
+  exit 0
+fi
+
+echo "vue-tsc found type errors (fix before finishing):"
+printf '%s\n' "$OUT" | grep -E 'error TS' | head -40
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "statusMessage": "eslint --fix on edited file",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; case \"$f\" in *.ts|*.vue) pnpm exec eslint --fix --cache --cache-location node_modules/.cache/eslint/ \"$f\" ;; esac; } 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/accessibility/SKILL.md
+++ b/.claude/skills/accessibility/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: accessibility
+description: Build accessible Vue/Nuxt UI to WCAG 2.2 AA. Use when creating or editing any component, page, form, modal, menu, tab, toast, tooltip, or interactive control — especially anything with @click, custom widgets, dynamic content, or images. The prevention layer that keeps a11y defects from being written; lint:a11y (eslint) and axe (Playwright) are the detection layers that catch what slips through.
+---
+
+# Accessible Vue/Nuxt (WCAG 2.2 AA)
+
+Prevent accessibility defects at authoring time. This repo already *detects* violations
+via `pnpm run lint:a11y` (eslint on components) and axe-core in Playwright
+(`tests/playwright/helpers/axe.ts`) — this skill stops them being written in the first
+place. Target profile: **WCAG 2.2 AA** (the project's stated standard).
+
+> Adapted for Vue/Nuxt from **A11Y.md** by Felipe A. Carriço — MIT license —
+> https://github.com/fecarrico/A11Y.md. Its examples are React/TSX; the rules below are
+> transposed to Vue single-file components with semantics preserved.
+
+## Behavior contract (apply proactively while generating; audit while reviewing)
+
+1. **No inference.** Don't claim something is accessible without evidence in the code/spec.
+2. **Reference the APG.** For any custom widget, follow the WAI-ARIA Authoring Practices
+   Guide pattern (roles, states, keyboard interaction) — don't improvise ARIA.
+3. **Interrogate non-semantic interactivity.** Before putting `@click` on a `<div>` /
+   `<span>`, replace it with a native element (`<button>`, `<a>`/`<NuxtLink>`) or a full
+   APG ARIA pattern. A clickable non-button is the #1 defect this repo's eslint rule flags.
+4. **Reuse before creating.** Check `components/` for an existing button/modal/menu/form
+   control and extend it rather than spawning a parallel, differently-accessible pattern.
+5. **Explain trade-offs** when a change touches accessibility, and **audit in review mode**:
+   identify violations, classify severity, suggest targeted fixes — don't rewrite whole
+   components unless the structure is critically broken.
+
+## AA thresholds (house defaults for this repo)
+- **Contrast:** 4.5:1 for normal text, 3:1 for large text / UI components / meaningful
+  graphics (SC 1.4.3, 1.4.11). Keep dark-mode (`dark:`) variants in contrast too.
+- **Target size:** aim for 44×44px; 24×24px is the hard AA floor (SC 2.5.8).
+- **Accessible names** on every input and interactive control — a real `<label>` (or
+  `aria-label` / `aria-labelledby` when no visible label exists).
+
+## Vue patterns (the high-frequency ones)
+
+**Interactive elements — use native semantics:**
+```vue
+<!-- ❌ not focusable, no role, no keyboard, no :disabled semantics -->
+<div class="btn" @click="save">Save</div>
+<!-- ✅ -->
+<button type="button" @click="save">Save</button>
+<!-- navigation → a link, not a click handler -->
+<NuxtLink :to="href">Open discussion</NuxtLink>
+```
+
+**Forms — associate label and control, announce errors:**
+```vue
+<label :for="id">Title</label>
+<input :id="id" v-model="title" :aria-invalid="!!error" :aria-describedby="error ? errId : undefined" />
+<p v-if="error" :id="errId" role="alert">{{ error }}</p>
+```
+
+**Icon-only controls need a name:**
+```vue
+<button type="button" :aria-label="expanded ? 'Collapse' : 'Expand'" @click="toggle">
+  <Icon name="chevron" aria-hidden="true" />
+</button>
+```
+
+**Dynamic / async content must be announced.** Wrap client-only, auth-, or query-driven
+regions per this repo's SSR rules (see CLAUDE.md “SSR and Hydration”), and expose status
+politely so screen readers hear updates:
+```vue
+<p aria-live="polite">{{ resultCount }} results</p>   <!-- CharCounter.vue already does this -->
+```
+
+**Modals / menus / tabs / tooltips (composite widgets):** follow the matching APG pattern —
+focus trap + `Esc` to close + return focus for dialogs; roving `tabindex` + arrow keys for
+menus/tabs. Prefer extending the existing components over hand-rolling ARIA.
+
+**Images:** meaningful images need `alt`; decorative images use `alt=""` (or `aria-hidden`).
+
+## Upstream reference guides (consult on demand, transpose to Vue)
+A11Y.md ships 21 APG-aligned guides — pull the relevant one when building that widget:
+`buttons, forms, modals, navigation, tabs-accordion, tooltips-popovers,
+toasts-notifications, tables, images, carousels-sliders, drag-drop, autocomplete,
+infinite-scroll, loading-skeleton, content-interaction, responsive-mobile,
+visual-perception`, plus compliance/governance guides. Source:
+https://github.com/fecarrico/A11Y.md/tree/main/docs/en/references
+
+## Before finishing
+Run `pnpm run lint:a11y`; for user-facing flows, exercise the axe helper in a mocked
+Playwright test (see [write-mocked-playwright-test](../write-mocked-playwright-test/SKILL.md)).

--- a/.claude/skills/apollo-data/SKILL.md
+++ b/.claude/skills/apollo-data/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: apollo-data
+description: Wire GraphQL data with Apollo in Vue components/composables. Use whenever adding or editing a useQuery or useMutation call, handling loading/error/onDone/onResult, typing query variables or mutation inputs, or shaping response types. Enforces using the hook's built-in state (no hand-written shadow refs) and the generated GraphQL types for every input and response.
+---
+
+# Apollo data in Vue/Nuxt (this repo)
+
+Two rules, both of which AI-generated PRs here have violated in the past:
+
+1. **Use the hook's built-in state — never hand-roll it.**
+2. **Type every input and response from `@/__generated__/graphql` — never `any`.**
+
+`no-explicit-any` is an **error** in application source (relaxed only in `*.spec.ts`),
+so untyped GraphQL data will fail lint.
+
+## Rule 1 — use `useQuery` / `useMutation` state directly
+
+`useQuery` returns `result`, `loading`, `error`, `onResult`, `onError`.
+`useMutation` returns `mutate`, `loading`, `error`, `onDone`, `onError`.
+Bind the UI to these refs. Do **not** create parallel `const loading = ref(false)` /
+`const errorMessage = ref('')` and drive them by hand — that's the messy antipattern.
+
+```vue
+<script setup lang="ts">
+import { useQuery, useMutation } from '@vue/apollo-composable';
+
+// ✅ query: consume result/loading/error; react via onResult, not a watcher+ref
+const { result: tagsResult, loading: tagsLoading, error: tagsError, onResult } = useQuery(GET_TAGS, variables);
+const tags = computed(() => tagsResult.value?.tags ?? []);
+onResult(({ data }) => { /* side effects only when needed */ });
+
+// ✅ mutation: consume loading/error; run side effects in onDone/onError
+const { mutate: createTag, loading: createLoading, error: createError, onDone, onError } = useMutation(CREATE_TAG);
+onDone(({ data }) => { /* e.g. close modal, emit */ });
+</script>
+
+<template>
+  <!-- bind straight to the hook's refs -->
+  <BaseButton :loading="tagsLoading || createLoading" :disabled="createLoading" />
+  <ErrorBanner v-if="tagsError" :error="tagsError" />
+</template>
+```
+
+```vue
+<!-- ❌ don't do this -->
+const loading = ref(false);
+const errorMessage = ref('');
+async function load() {
+  loading.value = true;
+  try { /* ... */ } catch (e) { errorMessage.value = String(e); }
+  finally { loading.value = false; }
+}
+```
+
+Existing good references: `components/TagPicker.vue`, `components/mod/IssueDetail.vue`,
+`composables/useCommentPermissions.ts` (query `result`/`loading`), and the
+`onDone`-driven mutations in `composables/useCommentCrudMutations.ts`.
+
+## Rule 2 — generated types for inputs AND responses
+
+The generated schema in `@/__generated__/graphql` has a type for essentially everything:
+`XxxQueryVariables`, `XxxMutationVariables`, entity types (`Discussion`, `Comment`,
+`Event`, `User`, …), and `…Input` / `…Where` / `…CreateInput` shapes.
+
+- **Variables / inputs:** type them with the generated `…QueryVariables` /
+  `…MutationVariables` / `…Input` type — not an inline `{ id: string }` and never `any`.
+- **Responses:** rely on the generated result type (`useQuery`'s `result` is already typed
+  from the document); when you pass data around, annotate with the generated entity type.
+- **Subsets:** when a function/prop needs only part of an entity, use `Pick` (or `Omit`)
+  on the generated type rather than redefining a partial interface or widening to `any`:
+
+```ts
+import type {
+  Discussion,
+  GetDiscussionQueryVariables,
+  UpdateDiscussionMutationVariables,
+} from '@/__generated__/graphql';
+
+// subset instead of a hand-written interface or `any`
+type DiscussionCardData = Pick<Discussion, 'id' | 'title' | 'createdAt'>;
+
+const variables: GetDiscussionQueryVariables = { id };
+const { result } = useQuery(GET_DISCUSSION, variables);
+```
+
+- Only reach for `any` as a genuine last resort for **untyped third-party interop**
+  (e.g. Three.js in `StlViewer.vue`), and then with a targeted
+  `// eslint-disable-next-line @typescript-eslint/no-explicit-any` + a reason — never for
+  GraphQL data, which is always typed.
+- For the known GraphQL-error `as any` cast used in some templates, see CLAUDE.md
+  (Error Type Handling) — prefer the generated/`ApolloError` type where possible.
+
+## Before finishing
+`pnpm run lint` (no-explicit-any is now an error) and `pnpm run tsc` must pass. Test
+components that use Apollo by mocking it at the module level — see
+[write-unit-test](../write-unit-test/SKILL.md).

--- a/.claude/skills/moderation-permission-check/SKILL.md
+++ b/.claude/skills/moderation-permission-check/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: moderation-permission-check
+description: Implement, review, or test moderation permission and suspension logic. Use whenever gating UI on moderator permissions, adding a Give Feedback / Report / Archive action, checking channel vs server scope, working with SuspendedRole / DefaultSuspendedRole, or writing tests that verify unprivileged/suspended users cannot see or use mod actions.
+---
+
+# Moderation & permission checks (Multiforum)
+
+**Single source of truth:** [docs/moderation-architecture.md](../../../docs/moderation-architecture.md).
+Read it for permission precedence/fallback order, suspension lifecycle, issue-linked
+workflow, and the server-scope vs channel-scope model. Do not re-derive these rules.
+
+## Where the logic lives
+- `utils/permissionUtils.ts` — `checkPermission()`, `getAllPermissions()`, the
+  `CORE_PERMISSION_KEYS` / `ADDITIONAL_PERMISSION_KEYS` / `ROLE_STATE_KEYS` flag sets,
+  and `PermissionFlags` / `Role` / `PermissionData` types. **Check specific permission
+  flags** — never infer capability from "is a moderator" alone.
+- `utils/headerPermissionUtils.ts` — `canPerformModActions()`,
+  `buildModerationSection()`, `getDiscussionHeaderMenuItems()`,
+  `getEventHeaderMenuItems()`, `getCommentMenuItems()`. Header menus should surface
+  "Give Feedback" and "Report" whenever resolved permissions allow them.
+- Each has a colocated `*.spec.ts` — extend those when you change behavior.
+
+## Rules to preserve
+- **Gate on specific flags**, not moderator status. The "Moderation Actions" section
+  should appear for any actor with **at least one** moderation permission.
+- **Two scopes**: channel-level suspensions use `SuspendedRole` (very restricted);
+  any active suspension makes server actions (e.g. creating a forum) use
+  `DefaultSuspendedRole`.
+- **Suspension is active** if `suspendedIndefinitely` is true OR `suspendedUntil` is in
+  the future; expired suspensions are cleaned up (disconnected from the channel).
+- **Blocked suspended users get an in-app notification** naming the channel, the blocked
+  action, and the related moderation issue.
+
+## Tests must verify
+- Unprivileged users do **not** see moderation actions.
+- Suspended moderators **cannot** use moderation features.
+- The correct permission level resolves for the actor + scope.
+
+Prefer extracting new permission logic into `utils/` and unit-testing it directly
+(see [write-unit-test](../write-unit-test/SKILL.md)); cover the UI-gating flow with a
+mocked Playwright test (see [write-mocked-playwright-test](../write-mocked-playwright-test/SKILL.md)),
+using the content-type-specific report-modal test IDs.

--- a/.claude/skills/write-mocked-playwright-test/SKILL.md
+++ b/.claude/skills/write-mocked-playwright-test/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: write-mocked-playwright-test
+description: Write or debug a mocked Playwright E2E test in tests/playwright/mocked. Use whenever adding or editing a *.spec.ts under tests/playwright/mocked, mocking GraphQL for an E2E flow, setting up auth for a browser test, or fixing a flaky mocked Playwright test. No backend/Neo4j required — every GraphQL call is intercepted per page.
+---
+
+# Writing a mocked Playwright test (Multiforum)
+
+The mocked suite runs the app as a client-only SPA with every GraphQL call
+intercepted per-page. **No backend, no Neo4j.** This is the default E2E suite.
+
+## Run
+- All mocked: `pnpm run test:playwright:mocked`
+- One file: `pnpm run test:playwright:mocked -- tests/playwright/mocked/discussions/createEditDeleteDiscussions.spec.ts`
+- Fast parallel (prebuilt): `pnpm run build:playwright:mocked` once, then
+  `pnpm run test:playwright:mocked:build`.
+
+## Skeleton (match the existing suite)
+Import from `../../helpers/*`; do not hand-roll auth or fetch mocking.
+```typescript
+import { expect, test } from '../../helpers/testFixture';
+import { buildBasicUser, buildServerConfig } from '../../helpers/graphqlFixtures';
+import { installMockAuth } from '../../helpers/mockAuth';
+import { installGraphqlMocks } from '../../helpers/mockGraphql';
+
+test.describe('Feature', () => {
+  test('does the thing', async ({ context, page }, testInfo) => {
+    await installMockAuth(context, page, { username: 'alice', email: 'alice@example.com' });
+
+    const diagnostics = await installGraphqlMocks(page, {
+      // key each mock by GraphQL operation name; return { data: {...} }
+      getBasicUserInfo: () => ({ data: { users: [buildBasicUser({ username: 'alice' })] } }),
+      getServerConfig: () => ({ data: { serverConfigs: [buildServerConfig({ enableEvents: true })] } }),
+    });
+
+    try {
+      await page.goto('/some-route');
+      // ... interactions + assertions
+    } finally {
+      // diagnostics surface unmatched GraphQL ops — check them when a test is flaky
+    }
+  });
+});
+```
+
+## Rules
+- **Use the helpers**: `installMockAuth()` for auth (never UI login), `installGraphqlMocks()`
+  for GraphQL, fixture builders in `helpers/graphqlFixtures.ts` /
+  `helpers/moderationFixtures.ts` / `helpers/issueDetailMocks.ts`. Reuse fixtures; extend
+  them rather than duplicating inline shapes.
+- **Every mocked GraphQL entity needs `__typename`** or Apollo normalization hands the
+  component only its key field. This is the #1 cause of "data isn't showing up" flakiness.
+- **Wait on requests/UI state, never arbitrary sleeps.** Prefer
+  `await page.waitForResponse((r) => r.url().includes('/graphql'))` and role/testid
+  locators over `waitForTimeout`.
+- **Prefer explicit route helpers / URLs** over hard-coded relative navigation.
+- **Report-modal test IDs are content-type specific** (BrokenRulesModal etc.):
+  - comment → `report-comment-input`
+  - discussion → `report-discussion-input`
+  - event → `report-event-input`
+  Use the one matching the content being moderated.
+- **`diagnostics`** returned by `installGraphqlMocks` reports unmatched operations —
+  inspect it first when a test can't find expected data (usually a missing/mis-keyed mock).
+
+## Moderation flows
+See [docs/moderation-architecture.md](../../../docs/moderation-architecture.md) for
+permission levels and suspension behavior, and `helpers/moderationFixtures.ts` /
+`helpers/issueDetailMocks.ts` for ready-made mod fixtures.
+
+Full patterns: [CLAUDE.md](../../../CLAUDE.md) (Playwright Testing) and
+[CONTRIBUTING.md](../../../CONTRIBUTING.md#frontend-testing-patterns).

--- a/.claude/skills/write-unit-test/SKILL.md
+++ b/.claude/skills/write-unit-test/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: write-unit-test
+description: Write or fix a Vitest unit test for this repo (components/*.spec.ts, foo.ts→foo.spec.ts, tests/unit). Use whenever adding, editing, or debugging a Vitest spec, mounting a Vue component under test, mocking Apollo/GraphQL, or resolving a vue-tsc failure in a spec. Encodes the project's hard-won testing gotchas.
+---
+
+# Writing a Vitest unit test (Multiforum)
+
+Follow these project rules. They are enforced in review and several exist because a
+real spec was rewritten after breaking them.
+
+## Run
+- All: `pnpm run test:unit`
+- One file: `pnpm run test:unit -- --run tests/unit/path/to/test.spec.ts`
+- Type check (CI gate that catches mock-shape bugs local runs miss): `pnpm run tsc`
+
+## Structure
+- **Colocate**: `Foo.vue` → `Foo.spec.ts`, `foo.ts` → `foo.spec.ts`. `tests/unit/**` is also picked up.
+- **One `expect` per `it`.** Split into multiple `it` blocks, or combine into one
+  structured `expect`. Use `it.each(...)` tables to stay DRY.
+
+## The non-negotiable rules (each has burned someone)
+
+1. **Mount the REAL component — never a hand-written stand-in.** A spec that defines
+   `const FooTest = { template: '...' }` and mounts *that* adds **zero** coverage to
+   `Foo.vue` and silently drifts. If a component is hard to mount, mock its
+   dependencies (rule 3) — do not reimplement it. `CommentSection.spec.ts` was
+   rewritten for exactly this.
+
+2. **Test real logic, not reimplementations.** When a component holds non-trivial
+   formatting/validation/derivation, extract it to a `utils/` function and unit-test
+   that function directly (this is how `CreateEditEventFields`, `IssueDetail`,
+   `CommentSection`, `Comment` are tested).
+
+3. **Mock Apollo at the MODULE top level.** `mountWithDefaults` does not wire Apollo.
+   Keep `vi.mock` at file top (Vitest hoists it — calling it inside `beforeEach`/
+   `describe` is deprecated). To exercise a mutation's `onDone`, make `mutate()`
+   synchronously fire the registered `onDone` callbacks; return an empty `useQuery`:
+   ```typescript
+   vi.mock('@vue/apollo-composable', async () => {
+     const { ref } = await import('vue');
+     return {
+       useMutation: () => {
+         const done: Array<(p: unknown) => void> = [];
+         return {
+           mutate: vi.fn(() => { done.forEach((cb) => cb({ data: {} })); }),
+           onDone: (cb: (p: unknown) => void) => done.push(cb),
+           onError: vi.fn(), loading: ref(false), error: ref(null),
+         };
+       },
+       useQuery: () => ({ result: ref(null), loading: ref(false), error: ref(null), onResult: vi.fn(), onError: vi.fn() }),
+     };
+   });
+   ```
+
+4. **Seed hoisted `vi.fn` mocks with the FULL return shape.** `vi.fn(() => ({ valid: true }))`
+   narrows the type, so a later `mockReturnValue({ valid: false, message })` fails CI's
+   `vue-tsc` (TS2353) even when the test passes locally. Seed `{ valid: true, message: '' }`.
+   If the mock factory references a local variable, prefix its name with `mock`.
+
+5. **`@/utils` and `@/utils/index` are the same module.** If you `vi.mock` one, mock
+   both, with every export the code under test imports — otherwise the second mock
+   silently drops exports.
+
+6. **Teleported UI renders into `document.body`.** `<Teleport to="body">` tooltips/
+   modals are outside the wrapper subtree — assert with `document.body.querySelector(...)`.
+
+7. **Mocked GraphQL entities need `__typename`.** Apollo normalizes by `__typename` +
+   key field; without it the component receives only the key field (e.g. a channel
+   arrives with just `uniqueName`).
+
+## Thin page wrappers
+Most pages are thin. Test via `shallowMount` + `findComponent(Child).props(...)`:
+```typescript
+const search = shallowMount(DiscussionsIndexPage, {
+  global: { stubs: { NuxtLayout: SlotRenderingStub } },
+}).findComponent(SearchDiscussions);
+expect(search.props('isForumScoped')).toBe(false);
+```
+- Stub slot wrappers (`NuxtLayout`, `FormRow`) with a component that renders the slot.
+- For pages calling `definePageMeta`, add `vi.stubGlobal('definePageMeta', vi.fn())`.
+
+## Types
+Import real GraphQL types from `@/__generated__/graphql` (`User`, `Comment`,
+`Discussion`, `Event`, `TextVersion`, …). Avoid `any`. Fill all required nested
+connection fields when building type-complete fixtures.
+
+## Before finishing
+Run the specific spec, then `pnpm run tsc`. Both must pass.
+See [CONTRIBUTING.md](../../../CONTRIBUTING.md#frontend-testing-patterns) for the source of these rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,9 +201,11 @@ Hard-won pitfalls (full detail + code in [CONTRIBUTING.md](./CONTRIBUTING.md#fro
 - **Imports**: Group imports by type (Vue, libraries, local components, utils)
 - **Testing**: Each feature should have Playwright coverage, with shared seed data and cleanup helpers
 - **CSS**: Use Tailwind utility classes, dark mode compatible with `dark:` prefix
-- **Accessibility**:
-  - Ensure color contrast meets minimum thresholds (WCAG AA 4.5:1 for normal text).
-  - Provide accessible names for inputs and interactive controls (use explicit `<label>` or `aria-label`/`aria-labelledby` as appropriate).
+- **Accessibility**: build to WCAG 2.2 AA. The `accessibility` skill carries the full
+  contract, AA thresholds, and Vue patterns (invoke it for any UI/component work);
+  `pnpm run lint:a11y` and the axe Playwright helper are the detection layers. Baseline:
+  4.5:1 contrast for normal text; accessible names (`<label>` / `aria-label` /
+  `aria-labelledby`) on every input and interactive control.
 - **Composables**: Extract reusable logic into composables under `composables/` directory
 - **Reactivity and Watchers**:
   - Avoid unnecessary watchers. Use Vue's built-in reactivity system (props, computed, refs) whenever possible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,9 @@ Hard-won pitfalls (full detail + code in [CONTRIBUTING.md](./CONTRIBUTING.md#fro
 ## Code Style Guidelines
 
 - **TypeScript**: Use strict typing whenever possible, proper interfaces in `types/` directory
-  - **Import GraphQL Types**: When fixing TypeScript errors, prefer importing proper types from `@/__generated__/graphql` over using `any`
+  - **Import GraphQL Types**: Use the generated types in `@/__generated__/graphql` for **every** GraphQL input and response — query variables and mutation inputs (`…QueryVariables` / `…MutationVariables` / `…Input`) as well as responses. Use `Pick`/`Omit` on a generated entity type for subsets rather than hand-writing a partial interface.
   - **Examples**: Use `User`, `Comment`, `Discussion`, `Event`, `Revision`, `TextVersion` etc. from the generated GraphQL schema
-  - **Avoid `any`**: Only use `any` as a last resort when proper types are not available
+  - **Avoid `any`**: `@typescript-eslint/no-explicit-any` is an **error** in application source (relaxed only in `*.spec.ts`). Only use `any` for genuinely untyped third-party interop, with a targeted `// eslint-disable-next-line` + reason — never for GraphQL data. See the `apollo-data` skill.
   - **Type Checking**: Use `pnpm run tsc` (which runs `vue-tsc --noEmit`) for proper Vue component type checking
 
 ### Common TypeScript Patterns and Fixes
@@ -196,7 +196,7 @@ Hard-won pitfalls (full detail + code in [CONTRIBUTING.md](./CONTRIBUTING.md#fro
 - **RequireAuth slot pattern**: For auth-gated controls that should look identical in both auth states, extract a shared presentational child component.
   Use a thin functional wrapper for the authenticated slot when the real behavior needs to be attached, and render the shared child directly in the unauthenticated slot unless a placebo wrapper is genuinely useful.
 - **Error Handling**: Use try/catch with specific error types, validate GraphQL responses
-- **Apollo useMutation**: Always leverage `useMutation`’s built-in `loading`, `error`, and `onDone` hooks instead of recreating that state yourself. Bind UI disabled/loading states directly to the mutation’s `loading` ref and surface errors via the `error` ref.
+- **Apollo state (useQuery & useMutation)**: Always leverage the hook's built-in refs — `useMutation`'s `loading` / `error` / `onDone` and `useQuery`'s `result` / `loading` / `error` / `onResult` — instead of recreating that state in hand-written `ref`s. Bind UI disabled/loading/error states directly to the hook's refs, and put side effects in `onDone` / `onResult` / `onError`. Do not hand-roll `mutate()`/`refetch()` in try/catch to mirror state the hook already exposes. See the `apollo-data` skill and [docs/code-review-checklist.md](./docs/code-review-checklist.md).
 - **Naming**: camelCase for variables/functions, PascalCase for components/interfaces
 - **Imports**: Group imports by type (Vue, libraries, local components, utils)
 - **Testing**: Each feature should have Playwright coverage, with shared seed data and cleanup helpers

--- a/components/download/StlViewer.vue
+++ b/components/download/StlViewer.vue
@@ -77,13 +77,14 @@ const isHovered = ref(false);
 const actualWidth = ref(400);
 const actualHeight = ref(400);
 
-// THREE.js objects - using any due to missing type declarations
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// THREE.js objects lack type declarations here, so these are intentionally `any`.
+/* eslint-disable @typescript-eslint/no-explicit-any */
 let scene: any,
   camera: any,
   renderer: any,
-  controls: any,
-  animationId: number | undefined;
+  controls: any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+let animationId: number | undefined;
 
 function updateDimensions() {
   if (!container.value) return;

--- a/docs/code-review-checklist.md
+++ b/docs/code-review-checklist.md
@@ -1,0 +1,44 @@
+# Code Review Checklist
+
+A focused checklist for reviewing pull requests, with emphasis on defects that
+AI-generated PRs in this repo have repeatedly introduced. Use it during human review
+and when running `/code-review`. It complements — does not replace — CI (lint, tsc,
+unit, Playwright, a11y).
+
+## Apollo / GraphQL data
+
+- [ ] **Hook state, not shadow refs.** Components use `useQuery`/`useMutation`'s own
+  `loading`, `error`, `result`, `onResult`, `onDone`, `onError`. Reject hand-written
+  `const loading = ref(false)` / `const errorMessage = ref('')` that duplicate what the
+  hook already provides. (See the `apollo-data` skill.)
+- [ ] **Side effects live in `onDone` / `onResult` / `onError`,** not in ad-hoc `.then()`
+  chains or manually-awaited `mutate()` wrapped in try/catch that re-implements error state.
+- [ ] **UI binds directly to the hook's `loading`/`error`** (disabled/spinner/error banner),
+  rather than a mirrored local variable that can drift out of sync.
+
+## Types
+
+- [ ] **No `any` in application source.** It's an eslint error now; any new `any` should be
+  a genuine untyped third-party interop case with a targeted
+  `// eslint-disable-next-line @typescript-eslint/no-explicit-any` + reason. GraphQL data
+  is never a valid reason.
+- [ ] **Generated types for inputs and responses.** Query variables and mutation inputs are
+  typed with the generated `…QueryVariables` / `…MutationVariables` / `…Input` types from
+  `@/__generated__/graphql`; response data uses the generated entity types.
+- [ ] **Subsets use `Pick`/`Omit` on generated types,** not hand-written partial interfaces
+  or widening to `any`.
+
+## Tests (established repo pitfalls)
+
+- [ ] **Real component mounted, not a hand-written stand-in.** No
+  `const FooTest = { template: '...' }` masquerading as coverage. (See `write-unit-test`.)
+- [ ] **Apollo mocked at module level**; mutation `onDone` exercised via a synchronous
+  `mutate()`; `useQuery` mock returns the full shape.
+- [ ] **Mocked GraphQL entities include `__typename`** (unit mocks and Playwright fixtures).
+- [ ] **One `expect` per `it`.**
+
+## Accessibility
+
+- [ ] Interactive elements are native (`<button>`/`<NuxtLink>`), not clickable `<div>`s;
+  inputs have accessible names; dynamic regions announce. (See the `accessibility` skill;
+  `lint:a11y` + axe are the automated backstops.)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -147,4 +147,12 @@ export default createConfigForNuxt({
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
   },
+}).append({
+  // Stylistic Vue rules we intentionally do not enforce. The Nuxt Vue preset
+  // re-enables vue/html-self-closing after the top-level override, so this final
+  // append is what actually silences it (and vue/first-attribute-linebreak).
+  rules: {
+    'vue/html-self-closing': 'off',
+    'vue/first-attribute-linebreak': 'off',
+  },
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,7 @@ export default createConfigForNuxt({
       },
     ],
     'vue/v-on-event-hyphenation': 'off',
-    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/ban-ts-comment': 'off',
     'no-unused-vars': [
       'error',
@@ -103,7 +103,7 @@ export default createConfigForNuxt({
 }).override('nuxt/typescript/rules', {
   rules: {
     'vue/html-self-closing': 0,
-    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/ban-ts-comment': 'off',
     // Add the same rules here to ensure they're not overridden
     '@typescript-eslint/no-unused-vars': [
@@ -138,4 +138,13 @@ export default createConfigForNuxt({
   // not part of the app's lint surface. The Nuxt flat config otherwise picks it
   // up via .gitignore, so ignore it explicitly here.
   ignores: ['cloud_functions/**'],
+}).append({
+  // Test specs cast Apollo/mocks with `as any` by design (e.g.
+  // `(useMutation as any).mock`). Keep no-explicit-any relaxed in specs while it
+  // is enforced as an error in application source. Genuine external-lib interop
+  // in source (e.g. Three.js in StlViewer.vue) uses targeted inline disables.
+  files: ['**/*.spec.ts', '**/*.test.ts'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
 });


### PR DESCRIPTION
Adds a set of AI-workflow enhancements for this repo. No application runtime behavior changes.

## Skills (on-demand, `.claude/skills/`)
- **write-unit-test** — the Vitest gotchas (real-component mounting, module-level Apollo mocks, full mock-shape seeding, `__typename`, teleport).
- **write-mocked-playwright-test** — `installMockAuth`/`installGraphqlMocks` skeleton, `__typename` flakiness, content-specific report test IDs.
- **moderation-permission-check** — points at `docs/moderation-architecture.md` and the real `permissionUtils`/`headerPermissionUtils`.
- **accessibility** — WCAG 2.2 AA behavior contract + Vue/Nuxt patterns, adapted from [A11Y.md](https://github.com/fecarrico/A11Y.md) (MIT, attributed).
- **apollo-data** — use `useQuery`/`useMutation` built-in state (no hand-written shadow refs); generated input/response types; `Pick` for subsets.

## Slash commands (`.claude/commands/`)
- **/verify** — tsc + unit + a11y.
- **/ship** — verify → branch-if-on-main → commit → push → PR with a Conventional-Commit title that passes `pr-title-lint`.

## Hooks
- **PostToolUse** (`.claude/settings.json`, team) — `eslint --fix` on edited `.ts`/`.vue`, mirroring lint-staged.
- **Stop** (`.claude/settings.local.json`, personal) — background `vue-tsc` that re-engages on type errors.

## Lint enforcement + review guardrails
- `@typescript-eslint/no-explicit-any` → **error** in application source (relaxed only in `*.spec.ts`, which cast Apollo mocks by design). `pnpm run lint` stays green.
- `docs/code-review-checklist.md` — checklist targeting AI-generated PRs (Apollo state, generated types, test pitfalls, a11y).
- CLAUDE.md tightened: `useQuery` state, generated input/response types + `Pick`, and pointers to the new skills.

The accessibility **CI job** (`lint:a11y`) is intentionally split into a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)