### PR TITLE
ci: gate accessibility lint (lint:a11y) in CI

### DIFF
--- a/.github/workflows/unit-tests-ci.yml
+++ b/.github/workflows/unit-tests-ci.yml
@@ -92,6 +92,57 @@ jobs:
       - name: Run linting
         run: pnpm run lint
 
+  accessibility:
+    runs-on: ubuntu-latest
+    env:
+      GRAPHQL_URL_FOR_TYPES: ${{ secrets.GRAPHQL_URL_FOR_TYPES }}
+      VITE_GRAPHQL_URL: ${{ secrets.VITE_GRAPHQL_URL }}
+      VITE_BASE_URL: ${{ secrets.VITE_BASE_URL }}
+      VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
+      VITE_GOOGLE_MAP_ID: ${{ secrets.VITE_GOOGLE_MAP_ID }}
+      VITE_OPEN_CAGE_API_KEY: ${{ secrets.VITE_OPEN_CAGE_API_KEY }}
+      VITE_AUTH0_DOMAIN: ${{ secrets.VITE_AUTH0_DOMAIN }}
+      VITE_OPEN_GRAPH_API_KEY: ${{ secrets.VITE_OPEN_GRAPH_API_KEY }}
+      VITE_LOGOUT_URL: ${{ secrets.VITE_LOGOUT_URL }}
+      VITE_AUTH0_USERNAME: ${{ secrets.VITE_AUTH0_USERNAME }}
+      VITE_AUTH0_PASSWORD: ${{ secrets.VITE_AUTH0_PASSWORD }}
+      VITE_AUTH0_USERNAME_2: ${{ secrets.VITE_AUTH0_USERNAME_2 }}
+      VITE_AUTH0_PASSWORD_2: ${{ secrets.VITE_AUTH0_PASSWORD_2 }}
+      VITE_AUTH0_URL: ${{ secrets.VITE_AUTH0_URL }}
+      VITE_AUTH0_AUDIENCE: ${{ secrets.VITE_AUTH0_AUDIENCE }}
+      VITE_AUTH0_SCOPE: ${{ secrets.VITE_AUTH0_SCOPE }}
+      VITE_AUTH0_CLIENT_ID: ${{ secrets.VITE_AUTH0_CLIENT_ID }}
+      VITE_AUTH0_CLIENT_SECRET: ${{ secrets.VITE_AUTH0_CLIENT_SECRET }}
+      VITE_AUTH0_CALLBACK_URL: ${{ secrets.VITE_AUTH0_CALLBACK_URL }}
+      VITE_GOOGLE_CLOUD_STORAGE_BUCKET: ${{ secrets.VITE_GOOGLE_CLOUD_STORAGE_BUCKET }}
+      VITE_SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN }}
+      VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+      VITE_LIGHTGALLERY_LICENSE_KEY: ${{ secrets.VITE_LIGHTGALLERY_LICENSE_KEY }}
+      NITRO_PRESET: ${{ secrets.NITRO_PRESET }}
+      VITE_SERVER_NAME: ${{ secrets.VITE_SERVER_NAME }}
+      VITE_ENVIRONMENT: ${{ secrets.VITE_ENVIRONMENT }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run accessibility lint
+        run: pnpm run lint:a11y
+
   typecheck:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Adds an `accessibility` job to the Tests CI workflow (`unit-tests-ci.yml`) that runs `pnpm run lint:a11y` — the eslint `vuejs-accessibility` ruleset over `components/**/*.vue`.

- The `lint:a11y` script already existed but was never gated in CI. It **passes on the current tree**, so this only prevents regressions.
- Mirrors the existing `lint` job's setup (pnpm, `.nvmrc` Node, frozen-lockfile install).
- Complements the AI-tooling PR (#471), which adds the `accessibility` skill as the prevention layer; this is the detection layer.

Separately, `knip` and `prettier:check` are **not** gated here: knip fails only on an intentional `useChannelPermissions` alias, and `prettier:check` currently flags ~1000 never-formatted files — both are separate cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)