### PR TITLE
feat(self-hosting): add one-command compose quickstart

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.nuxt
+.output
+.vercel
+coverage
+coverage-e2e
+deploy
+docs
+node_modules
+playwright-report
+test-results
+tests
+*.log
+.env*
+!.env.example
+!.env.quickstart.example

--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,10 @@ VITE_LOGOUT_URL=localhost:3000/logout
 # Authentication provider. Keep auth0 for production. local-dev enables the
 # bootstrap-password sign-in flow and requires the backend local-dev provider.
 NUXT_PUBLIC_AUTH_PROVIDER=auth0
-# Optional override; otherwise derived from VITE_GRAPHQL_URL.
+# Optional server-only GraphQL URL for container/private networks.
+NUXT_BACKEND_GRAPHQL_URL=
+# Optional token override; otherwise derived from the server-side GraphQL URL,
+# then VITE_GRAPHQL_URL.
 NUXT_LOCAL_AUTH_TOKEN_ENDPOINT=
 
 # File Uploads

--- a/.env.quickstart.example
+++ b/.env.quickstart.example
@@ -1,0 +1,24 @@
+# Optional overrides for `docker compose up --build`.
+# Copy this file to .env.quickstart, edit it, then pass
+# `--env-file .env.quickstart` to Docker Compose.
+
+MULTIFORUM_INSTANCE_NAME=My Multiforum
+MULTIFORUM_BOOTSTRAP_EMAIL=admin@multiforum.local
+MULTIFORUM_BOOTSTRAP_USERNAME=admin
+MULTIFORUM_BOOTSTRAP_PASSWORD=multiforum-local-admin
+NEO4J_PASSWORD=multiforum-local-neo4j
+
+# Keep the local development auth mode on loopback. Exposing it publicly is
+# unsupported; use Auth0 or another production-ready identity provider instead.
+MULTIFORUM_BIND_ADDRESS=127.0.0.1
+MULTIFORUM_PUBLIC_FRONTEND_URL=http://localhost:3000
+MULTIFORUM_PUBLIC_BACKEND_URL=http://localhost:4000
+
+# The default builds the merged backend main branch. Pin a release tag or commit
+# for repeatable deployments.
+MULTIFORUM_BACKEND_REPOSITORY=https://github.com/gennit-project/multiforum-backend.git
+MULTIFORUM_BACKEND_REF=main
+
+# Optional local image tags.
+MULTIFORUM_BACKEND_IMAGE=multiforum-backend:quickstart
+MULTIFORUM_FRONTEND_IMAGE=multiforum-frontend:quickstart

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ logs
 .env
 .env.*
 !.env.example
+!.env.quickstart.example
 
 # Cypress env file (contains secrets; must never be committed)
 cypress.env.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,45 @@
-FROM node:26.5.1-alpine
+FROM node:26.5.1-alpine AS build
 
 WORKDIR /app
 
-# Node 26 no longer bundles Corepack, so install the pinned package manager directly.
+# Node 26 no longer bundles Corepack, so install the repository-pinned package
+# manager explicitly.
 RUN npm install --global pnpm@10.28.2
 
 COPY package.json pnpm-lock.yaml ./
-
 RUN pnpm install --frozen-lockfile
 
 COPY . .
 
-# Build the Nuxt application
-RUN pnpm run build
+# Vite values are embedded in the client bundle at build time. Compose passes
+# browser-reachable defaults; other image consumers can override these args.
+ARG NUXT_PUBLIC_AUTH_PROVIDER=auth0
+ARG NUXT_BACKEND_GRAPHQL_URL=
+ARG VITE_BASE_URL=http://localhost:3000
+ARG VITE_ENVIRONMENT=production
+ARG VITE_GRAPHQL_URL=http://localhost:4000
+ARG VITE_SERVER_NAME=Multiforum
+ENV NUXT_PUBLIC_AUTH_PROVIDER=$NUXT_PUBLIC_AUTH_PROVIDER
+ENV NUXT_BACKEND_GRAPHQL_URL=$NUXT_BACKEND_GRAPHQL_URL
+ENV NITRO_PRESET=node-server
+ENV VITE_BASE_URL=$VITE_BASE_URL
+ENV VITE_ENVIRONMENT=$VITE_ENVIRONMENT
+ENV VITE_GRAPHQL_URL=$VITE_GRAPHQL_URL
+ENV VITE_SERVER_NAME=$VITE_SERVER_NAME
 
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm run build
+
+FROM node:26.5.1-alpine AS runtime
+
+WORKDIR /app
+
+ENV HOST=0.0.0.0
+ENV NODE_ENV=production
+ENV PORT=3000
+
+COPY --from=build --chown=node:node /app/.output ./.output
+
+USER node
 EXPOSE 3000
 
-# Add debug environment variables
-ENV NODE_ENV=development
-ENV DEBUG=*
-ENV NITRO_DEBUG=1
-
-# Start with verbose debugging
-CMD ["sh", "-c", "echo 'Debug: Current directory:' && pwd && \
-echo 'Debug: Directory contents:' && ls -la && \
-echo 'Debug: Output directory contents:' && ls -la .output/server/ && \
-echo 'Debug: Starting server with full logging...' && \
-NITRO_DEBUG=1 node --trace-warnings .output/server/index.mjs 2>&1"]
+CMD ["node", ".output/server/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 
 > Multiforum is under active development; test coverage is being expanded as core features stabilize.
 
+## Try it locally
+
+Start a usable local instance, including Neo4j, the backend, the frontend, and
+an automatically provisioned administrator:
+
+```bash
+docker compose up --build
+```
+
+Then open [http://localhost:3000](http://localhost:3000) and sign in with the
+default local password `multiforum-local-admin`. No Auth0, cloud storage, maps,
+email provider, or manual Cypher bootstrap is required. See the
+[local self-hosting quick-start](./docs/self-hosting-quickstart.md) before
+customizing credentials or exposing any service beyond your machine.
+
 ## About
 
 Multiforum is a community platform that lets people create and manage topic-based forums with multiple content types:
@@ -39,7 +54,7 @@ The frontend talks to the backend exclusively through GraphQL.
 
 ## Technology choices — and why
 
-These are the main technologies and, more importantly, *why* they fit a
+These are the main technologies and, more importantly, _why_ they fit a
 cross-posting, deeply-interconnected community platform. If you have never used
 them, the short version of each explains what problem it solves here.
 
@@ -73,14 +88,14 @@ every forum this download appears in" or "walk this comment thread" turns into a
 pile of join tables and recursive queries.
 
 [Neo4j](https://neo4j.com/) stores data as nodes and relationships directly, so
-those traversals — *follow the edges between connected things* — are natural and
+those traversals — _follow the edges between connected things_ — are natural and
 efficient. The shape of the database mirrors the shape of the product.
 
 ### GraphQL + Apollo Client
 
 Because the data is a graph, the API is too. [GraphQL](https://graphql.org/)
 lets the frontend ask for exactly the connected data a screen needs — a
-discussion *with* its channels, author, and comment counts — in a single
+discussion _with_ its channels, author, and comment counts — in a single
 request shaped like the result. [Apollo Client](https://www.apollographql.com/docs/react/)
 adds a normalized cache so repeated views of the same entity stay consistent and
 fast without manual bookkeeping.
@@ -107,6 +122,7 @@ client.
 
 Start here:
 
+- [Local self-hosting quick-start](./docs/self-hosting-quickstart.md)
 - [Development setup](./docs/development-setup.md)
 - [AWS single-VM Terraform example](./deploy/terraform/aws-single-vm/README.md)
 - [Contributing guide](./CONTRIBUTING.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,20 @@
-version: '3.8'
-
 services:
   database:
     image: neo4j:5.1.0
-    container_name: database
+    restart: unless-stopped
     ports:
-      - '7474:7474'
-      - '7687:7687'
+      - '${MULTIFORUM_BIND_ADDRESS:-127.0.0.1}:7474:7474'
+      - '${MULTIFORUM_BIND_ADDRESS:-127.0.0.1}:7687:7687'
     environment:
-      - NEO4J_AUTH=${NEO4J_AUTH:-neo4j/playwright-ci-password}
-      - NEO4J_PLUGINS=["apoc"]
-      - NEO4J_dbms_security_procedures_unrestricted=apoc.*
-      - NEO4J_dbms_default__database=neo4j
-      - NEO4J_dbms_logs_debug_level=INFO
-      - NEO4J_dbms_logs_query_enabled=OFF
-      - NEO4J_dbms_memory_pagecache_size=512M
-      - NEO4J_dbms_memory_heap_initial__size=512M
-      - NEO4J_dbms_memory_heap_max__size=1G
+      NEO4J_AUTH: 'neo4j/${NEO4J_PASSWORD:-multiforum-local-neo4j}'
+      NEO4J_PLUGINS: '["apoc"]'
+      NEO4J_dbms_security_procedures_unrestricted: 'apoc.*'
+      NEO4J_dbms_default__database: neo4j
+      NEO4J_dbms_logs_debug_level: INFO
+      NEO4J_dbms_logs_query_enabled: 'OFF'
+      NEO4J_dbms_memory_pagecache_size: 256M
+      NEO4J_dbms_memory_heap_initial__size: 256M
+      NEO4J_dbms_memory_heap_max__size: 512M
     volumes:
       - neo4j-data:/data
       - neo4j-logs:/logs
@@ -30,83 +28,102 @@ services:
           '-u',
           'neo4j',
           '-p',
-          '${NEO4J_PASSWORD:-playwright-ci-password}',
+          '${NEO4J_PASSWORD:-multiforum-local-neo4j}',
           'RETURN 1',
         ]
-      interval: 15s
+      interval: 10s
       timeout: 10s
-      retries: 10
+      retries: 20
+      start_period: 30s
     networks:
       - multiforum-network
 
   backend:
-    image: cluse/multiforum-backend:latest
-    container_name: multiforum-backend
+    image: ${MULTIFORUM_BACKEND_IMAGE:-multiforum-backend:quickstart}
+    build:
+      context: .
+      dockerfile: docker/backend.Dockerfile
+      args:
+        MULTIFORUM_BACKEND_REPOSITORY: ${MULTIFORUM_BACKEND_REPOSITORY:-https://github.com/gennit-project/multiforum-backend.git}
+        MULTIFORUM_BACKEND_REF: ${MULTIFORUM_BACKEND_REF:-main}
+    restart: unless-stopped
     ports:
-      - '4000:4000'
+      - '${MULTIFORUM_BIND_ADDRESS:-127.0.0.1}:4000:4000'
     depends_on:
       database:
         condition: service_healthy
     environment:
-      - AUTH0_CLIENT_ID=${AUTH0_CLIENT_ID}
-      - AUTH0_DOMAIN=${AUTH0_DOMAIN}
-      - ENVIRONMENT=local
-      - GCS_BUCKET_NAME=${GCS_BUCKET_NAME}
-      - GOOGLE_CREDENTIALS_BASE64=${GOOGLE_CREDENTIALS_BASE64}
-      - NEO4J_PASSWORD=${NEO4J_PASSWORD:-playwright-ci-password}
-      - NEO4J_URI=bolt://database:7687
-      - NEO4J_USERNAME=${NEO4J_USERNAME:-neo4j}
-      - SERVER_CONFIG_NAME=${VITE_SERVER_NAME:-Gennit}
-      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
+      NODE_ENV: development
+      ENVIRONMENT: local
+      MULTIFORUM_AUTH_PROVIDER: local-dev
+      MULTIFORUM_AUTO_PROVISION: 'true'
+      MULTIFORUM_BOOTSTRAP_EMAIL: ${MULTIFORUM_BOOTSTRAP_EMAIL:-admin@multiforum.local}
+      MULTIFORUM_BOOTSTRAP_USERNAME: ${MULTIFORUM_BOOTSTRAP_USERNAME:-admin}
+      MULTIFORUM_BOOTSTRAP_PASSWORD: ${MULTIFORUM_BOOTSTRAP_PASSWORD:-multiforum-local-admin}
+      SUPERADMIN_EMAIL: ${MULTIFORUM_BOOTSTRAP_EMAIL:-admin@multiforum.local}
+      SERVER_CONFIG_NAME: ${MULTIFORUM_INSTANCE_NAME:-My Multiforum}
+      NEO4J_URI: bolt://database:7687
+      NEO4J_USERNAME: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-multiforum-local-neo4j}
+      AUTH0_DOMAIN: ''
+      AUTH0_CLIENT_ID: ''
+      GCS_BUCKET_NAME: ''
+      GOOGLE_APPLICATION_CREDENTIALS: ''
+      GOOGLE_CREDENTIALS_BASE64: ''
+      SLACK_WEBHOOK_URL: ''
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:4000']
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "require('net').connect(4000, '127.0.0.1').on('connect', () => process.exit(0)).on('error', () => process.exit(1))",
+        ]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 30
+      start_period: 60s
     networks:
       - multiforum-network
 
   frontend:
+    image: ${MULTIFORUM_FRONTEND_IMAGE:-multiforum-frontend:quickstart}
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: multiforum-frontend
+      args:
+        NUXT_PUBLIC_AUTH_PROVIDER: local-dev
+        NUXT_BACKEND_GRAPHQL_URL: http://backend:4000
+        VITE_BASE_URL: ${MULTIFORUM_PUBLIC_FRONTEND_URL:-http://localhost:3000}
+        VITE_ENVIRONMENT: development
+        VITE_GRAPHQL_URL: ${MULTIFORUM_PUBLIC_BACKEND_URL:-http://localhost:4000}
+        VITE_SERVER_NAME: ${MULTIFORUM_INSTANCE_NAME:-My Multiforum}
+    restart: unless-stopped
     ports:
-      - '3000:3000'
+      - '${MULTIFORUM_BIND_ADDRESS:-127.0.0.1}:3000:3000'
     depends_on:
       backend:
         condition: service_healthy
     environment:
-      - GRAPHQL_URL_FOR_TYPES=${GRAPHQL_URL_FOR_TYPES:-http://localhost:4000}
-      - VITE_AUTH0_AUDIENCE=${VITE_AUTH0_AUDIENCE}
-      - VITE_AUTH0_CALLBACK_URL=${VITE_AUTH0_CALLBACK_URL:-http://localhost:3000}
-      - VITE_AUTH0_CLIENT_ID=${VITE_AUTH0_CLIENT_ID}
-      - VITE_AUTH0_CLIENT_SECRET=${VITE_AUTH0_CLIENT_SECRET}
-      - VITE_AUTH0_DOMAIN=${VITE_AUTH0_DOMAIN}
-      - VITE_AUTH0_PASSWORD=${VITE_AUTH0_PASSWORD}
-      - VITE_AUTH0_PASSWORD_2=${VITE_AUTH0_PASSWORD_2}
-      - VITE_AUTH0_SCOPE=${VITE_AUTH0_SCOPE}
-      - VITE_AUTH0_URL=${VITE_AUTH0_URL}
-      - VITE_AUTH0_USERNAME=${VITE_AUTH0_USERNAME}
-      - VITE_AUTH0_USERNAME_2=${VITE_AUTH0_USERNAME_2}
-      - VITE_BASE_URL=${VITE_BASE_URL:-http://localhost:3000}
-      - VITE_ENVIRONMENT=${VITE_ENVIRONMENT:-development}
-      - VITE_GOOGLE_CLOUD_STORAGE_BUCKET=${VITE_GOOGLE_CLOUD_STORAGE_BUCKET}
-      - VITE_GOOGLE_MAPS_API_KEY=${VITE_GOOGLE_MAPS_API_KEY}
-      - VITE_GRAPHQL_URL=${VITE_GRAPHQL_URL:-http://localhost:4000}
-      - VITE_LOGOUT_URL=${VITE_LOGOUT_URL:-http://localhost:3000}
-      - VITE_OPEN_CAGE_API_KEY=${VITE_OPEN_CAGE_API_KEY}
-      - VITE_OPEN_GRAPH_API_KEY=${VITE_OPEN_GRAPH_API_KEY}
-      - VITE_SERVER_NAME=${VITE_SERVER_NAME:-Gennit}
+      NUXT_PUBLIC_AUTH_PROVIDER: local-dev
+      NUXT_BACKEND_GRAPHQL_URL: http://backend:4000
+      NUXT_LOCAL_AUTH_TOKEN_ENDPOINT: http://backend:4000/auth/local-dev/token
     healthcheck:
-      test: ['CMD', 'wget', '--spider', '-q', 'http://localhost:3000']
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://127.0.0.1:3000').then(response => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
       interval: 10s
       timeout: 5s
-      retries: 3
+      retries: 12
+      start_period: 30s
     logging:
-      driver: 'json-file'
+      driver: json-file
       options:
-        max-size: '10m'
+        max-size: 10m
         max-file: '3'
     networks:
       - multiforum-network

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -1,0 +1,23 @@
+FROM node:26.5.1-alpine
+
+ARG MULTIFORUM_BACKEND_REPOSITORY=https://github.com/gennit-project/multiforum-backend.git
+ARG MULTIFORUM_BACKEND_REF=main
+
+WORKDIR /app
+
+RUN apk add --no-cache git \
+  && npm install --global pnpm@10.28.2
+
+# Fetch exactly the selected branch, tag, or commit without requiring a second
+# repository checkout beside this frontend repository.
+RUN git init \
+  && git remote add origin "$MULTIFORUM_BACKEND_REPOSITORY" \
+  && git fetch --depth 1 origin "$MULTIFORUM_BACKEND_REF" \
+  && git checkout --detach FETCH_HEAD \
+  && rm -rf .git
+
+RUN pnpm install --frozen-lockfile
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm run build
+
+EXPOSE 4000
+CMD ["pnpm", "run", "start"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Developer documentation for the Multiforum Nuxt frontend. See the
 
 ## Getting started & architecture
 
+- [Local self-hosting quick-start](./self-hosting-quickstart.md) — start a usable instance with one Docker Compose command
 - [Development setup](./development-setup.md) — local environment and tooling
 - [AWS single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md) — provision a Docker-ready self-hosting VM without storing app secrets in Terraform state
 - [Frontend architecture and authentication](./architecture-and-auth.md)

--- a/docs/self-hosting-quickstart.md
+++ b/docs/self-hosting-quickstart.md
@@ -1,0 +1,104 @@
+# Local self-hosting quick-start
+
+Try Multiforum locally before configuring Auth0, cloud storage, maps, email, or
+other production integrations. The default Docker Compose stack starts Neo4j,
+builds the backend and frontend, creates the initial server configuration and
+roles, and provisions the first administrator automatically.
+
+## Requirements
+
+- Docker Engine with Docker Compose v2 (Docker Desktop includes it)
+- Git
+- At least 6 GB of memory available to Docker during the initial builds
+
+## Start Multiforum
+
+From this repository's root, run:
+
+```bash
+docker compose up --build
+```
+
+The first run builds both applications and can take several minutes. When all
+three services are healthy, open [http://localhost:3000](http://localhost:3000)
+and choose **Sign in**. The local administrator password is:
+
+```text
+multiforum-local-admin
+```
+
+The default administrator is `admin` (`admin@multiforum.local`). No manual
+Cypher commands or third-party accounts are required. Neo4j Browser is
+available at [http://localhost:7474](http://localhost:7474) for local debugging.
+
+The database, API, and frontend ports bind to `127.0.0.1` by default, and data
+persists in named Docker volumes between restarts.
+
+## Choose your own local credentials
+
+Copy the provided template, change both passwords, and start Compose with it:
+
+```bash
+cp .env.quickstart.example .env.quickstart
+docker compose --env-file .env.quickstart up --build
+```
+
+The bootstrap password must contain at least 12 characters. The bootstrap user
+is created only when its email is not already present, so changing the values
+later does not replace an existing administrator.
+
+The backend build defaults to the public backend repository's `main` branch
+because an official continuously published image is not yet available. For
+repeatable deployments, set `MULTIFORUM_BACKEND_REF` to a release tag or commit,
+for example:
+
+```dotenv
+MULTIFORUM_BACKEND_REF=v1.2.3
+```
+
+## Stop or reset the stack
+
+Stop the containers without deleting data:
+
+```bash
+docker compose down
+```
+
+To intentionally delete all local Multiforum data and start over:
+
+```bash
+docker compose down --volumes
+```
+
+## What is deliberately disabled
+
+Uploads, maps, geocoding, outbound email, and Auth0 are not required by this
+local stack. The frontend uses the instance capability status to hide or
+explain unavailable controls instead of failing. Configure those integrations
+only when you need them.
+
+Local development authentication is intentionally restricted by the backend to
+`NODE_ENV=development`. Its shared bootstrap password is not a production
+identity system. Do not expose this Compose configuration to the public
+internet; use the production self-hosting path with Auth0 (or a future supported
+OIDC provider), TLS, unique secrets, backups, and an appropriately secured
+Neo4j deployment.
+
+## Troubleshooting
+
+Inspect service health and recent logs with:
+
+```bash
+docker compose ps
+docker compose logs --tail=100 database backend frontend
+```
+
+If an initial build is killed for lack of memory, increase Docker's memory limit
+or make Compose build one image at a time:
+
+```bash
+COMPOSE_PARALLEL_LIMIT=1 docker compose up --build
+```
+
+If ports 3000, 4000, 7474, or 7687 are already in use, stop the conflicting
+local services before starting the stack.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,10 @@ import path from 'path';
 import { inMemoryCacheOptions } from './cache';
 
 const isMockedE2E = process.env.VITE_E2E_MOCK_MODE === 'true';
+const isLocalDevAuthBuild =
+  process.env.NUXT_PUBLIC_AUTH_PROVIDER === 'local-dev';
+const serverGraphqlUrl =
+  process.env.NUXT_BACKEND_GRAPHQL_URL || config?.graphqlUrl || '';
 const ignoredDevWatchPatterns = [
   '**/.claude/**',
   '**/.agents/**',
@@ -88,23 +92,32 @@ export default defineNuxtConfig({
     // Server-session auth: registers /auth/login, /auth/logout,
     // /auth/callback, /auth/backchannel-logout. Config is read from the private
     // `runtimeConfig.auth0` block below (NUXT_AUTH0_* envs).
-    [
-      '@auth0/auth0-nuxt',
-      {
-        mountRoutes: true,
-        // SPIKE Phase 2: use a server-side session store (small cookie holds
-        // only a session id). The default stateless cookie store overflows the
-        // ~4KB browser limit once a refresh token is in the session. See the
-        // factory for the dev (in-memory) vs prod (persistent) note.
-        sessionStoreFactoryPath: '~/server/utils/session-store-factory.ts',
-      },
-    ],
+    ...(isLocalDevAuthBuild
+      ? []
+      : [
+          [
+            '@auth0/auth0-nuxt',
+            {
+              mountRoutes: true,
+              // SPIKE Phase 2: use a server-side session store (small cookie
+              // holds only a session id). The default stateless cookie store
+              // overflows the ~4KB browser limit once a refresh token is in
+              // the session. See the factory for the dev (in-memory) vs prod
+              // (persistent) note.
+              sessionStoreFactoryPath:
+                '~/server/utils/session-store-factory.ts',
+            },
+          ] as [string, Record<string, unknown>],
+        ]),
     [
       '@nuxtjs/apollo',
       {
         clients: {
           default: {
-            httpEndpoint: config?.graphqlUrl || '',
+            // SSR uses the private container URL while browser requests keep
+            // using the public origin compiled into VITE_GRAPHQL_URL.
+            httpEndpoint: serverGraphqlUrl,
+            browserHttpEndpoint: config?.graphqlUrl || serverGraphqlUrl,
             // @nuxtjs/apollo attaches localStorage['token'] as the Bearer
             // (tokenStorage: 'localStorage'). plugins/apollo-auth.client.ts keeps
             // that key in sync with the server-session access token. (The old
@@ -263,7 +276,7 @@ export default defineNuxtConfig({
     authToken: process.env.VITE_SENTRY_AUTH_TOKEN,
   },
   nitro: {
-    preset: 'vercel',
+    preset: process.env.NITRO_PRESET || 'vercel',
     // `sanitize-html` (used by composables/useMarkdownRenderer.ts) is CommonJS
     // and does `require('htmlparser2')`. When Nitro externalizes it, the Vercel
     // serverless function performs that require at runtime — which crashes with
@@ -378,8 +391,13 @@ export default defineNuxtConfig({
     { src: '@/plugins/test-auth.client', mode: 'client' },
   ],
   runtimeConfig: {
+    // Optional server-only GraphQL URL. Docker deployments use this to reach
+    // the backend over the Compose network while the browser keeps using the
+    // public URL below (usually http://localhost:4000 for local quick-starts).
+    backendGraphqlUrl: '',
     // Optional explicit backend token URL for local development auth. When it
-    // is empty, the server derives /auth/local-dev/token from the GraphQL URL.
+    // is empty, the server derives /auth/local-dev/token from the server-side
+    // GraphQL URL above, then falls back to the public browser URL.
     localAuthTokenEndpoint: '',
     // SPIKE (auth0-nuxt server-session migration): server-only Auth0 config.
     // These are overridden by NUXT_AUTH0_* env vars at runtime (see

--- a/server/api/auth/profile.get.ts
+++ b/server/api/auth/profile.get.ts
@@ -3,6 +3,7 @@
 // Returns the current session-backed auth profile for the browser. This is a
 // same-origin fallback for embedded browsers where localStorage-backed token
 // sync is unreliable or unavailable.
+import { getServerGraphqlUrl } from '@/server/utils/local-auth';
 
 type OwnEmailResponse = {
   data?: {
@@ -48,8 +49,7 @@ export default defineEventHandler(async (event) => {
   try {
     const tokenSet = await useAuth0(event).getAccessToken();
     const accessToken = tokenSet?.accessToken;
-    const graphqlUrl =
-      useRuntimeConfig(event).public?.apollo?.clients?.default?.httpEndpoint;
+    const graphqlUrl = getServerGraphqlUrl(useRuntimeConfig(event));
 
     if (!accessToken || !graphqlUrl) {
       return session;

--- a/server/api/session/profile.get.ts
+++ b/server/api/session/profile.get.ts
@@ -2,6 +2,7 @@
 //
 // Same-origin session-backed profile fallback for embedded browsers where
 // localStorage-backed token flows are unreliable or unavailable.
+import { getServerGraphqlUrl } from '@/server/utils/local-auth';
 
 type OwnEmailResponse = {
   data?: {
@@ -47,8 +48,7 @@ export default defineEventHandler(async (event) => {
   try {
     const tokenSet = await useAuth0(event).getAccessToken();
     const accessToken = tokenSet?.accessToken;
-    const graphqlUrl =
-      useRuntimeConfig(event).public?.apollo?.clients?.default?.httpEndpoint;
+    const graphqlUrl = getServerGraphqlUrl(useRuntimeConfig(event));
 
     if (!accessToken || !graphqlUrl) {
       return session;

--- a/server/middleware/2.auth-session.ts
+++ b/server/middleware/2.auth-session.ts
@@ -33,7 +33,11 @@
 // 1.cache-control.ts), matching the existing convention in this directory.
 import type * as H3 from 'h3';
 import type { Storage, StorageValue } from 'unstorage';
-import { isLocalDevAuth, LOCAL_AUTH_COOKIE } from '@/server/utils/local-auth';
+import {
+  getServerGraphqlUrl,
+  isLocalDevAuth,
+  LOCAL_AUTH_COOKIE,
+} from '@/server/utils/local-auth';
 
 // Nitro injects these server auto-imports at build time. Declare their narrow
 // shapes here as well so this middleware remains type-checkable when a unit
@@ -42,6 +46,7 @@ declare const defineEventHandler: typeof H3.defineEventHandler;
 declare const getCookie: typeof H3.getCookie;
 declare const deleteCookie: typeof H3.deleteCookie;
 declare const useRuntimeConfig: (event?: H3.H3Event) => {
+  backendGraphqlUrl?: string;
   public?: {
     authProvider?: string;
     apollo?: { clients?: { default?: { httpEndpoint?: string } } };
@@ -172,8 +177,7 @@ export default defineEventHandler(async (event) => {
   const runtimeConfig = useRuntimeConfig(event);
   if (isLocalDevAuth(runtimeConfig)) {
     const accessToken = getCookie(event, LOCAL_AUTH_COOKIE);
-    const graphqlUrl =
-      runtimeConfig.public?.apollo?.clients?.default?.httpEndpoint;
+    const graphqlUrl = getServerGraphqlUrl(runtimeConfig);
     if (!accessToken || !graphqlUrl) return;
 
     try {
@@ -246,8 +250,7 @@ export default defineEventHandler(async (event) => {
         if (accessToken) {
           event.context.accessToken = accessToken;
         }
-        const graphqlUrl =
-          runtimeConfig.public?.apollo?.clients?.default?.httpEndpoint;
+        const graphqlUrl = getServerGraphqlUrl(runtimeConfig);
 
         if (accessToken && graphqlUrl) {
           const queryBackend = <T>(query: string) =>

--- a/server/utils/local-auth.spec.ts
+++ b/server/utils/local-auth.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getLocalAuthTokenEndpoint, isLocalDevAuth } from './local-auth';
+import {
+  getLocalAuthTokenEndpoint,
+  getServerGraphqlUrl,
+  isLocalDevAuth,
+} from './local-auth';
 
 describe('local auth server configuration', () => {
   it('recognizes only the explicit local development provider', () => {
@@ -14,6 +18,50 @@ describe('local auth server configuration', () => {
         localAuthTokenEndpoint: ' http://backend:4000/custom-token ',
       })
     ).toBe('http://backend:4000/custom-token');
+  });
+
+  it('uses the private backend URL for server-side GraphQL requests', () => {
+    expect(
+      getServerGraphqlUrl({
+        backendGraphqlUrl: ' http://backend:4000 ',
+        public: {
+          apollo: {
+            clients: {
+              default: { httpEndpoint: 'http://localhost:4000' },
+            },
+          },
+        },
+      })
+    ).toBe('http://backend:4000');
+  });
+
+  it('falls back to the public GraphQL URL outside container networks', () => {
+    expect(
+      getServerGraphqlUrl({
+        public: {
+          apollo: {
+            clients: {
+              default: { httpEndpoint: ' http://localhost:4000 ' },
+            },
+          },
+        },
+      })
+    ).toBe('http://localhost:4000');
+  });
+
+  it('derives local auth from the private backend URL when available', () => {
+    expect(
+      getLocalAuthTokenEndpoint({
+        backendGraphqlUrl: 'http://backend:4000/graphql',
+        public: {
+          apollo: {
+            clients: {
+              default: { httpEndpoint: 'http://localhost:4000/graphql' },
+            },
+          },
+        },
+      })
+    ).toBe('http://backend:4000/auth/local-dev/token');
   });
 
   it('derives the token endpoint from the GraphQL origin', () => {

--- a/server/utils/local-auth.ts
+++ b/server/utils/local-auth.ts
@@ -2,6 +2,7 @@ export const LOCAL_AUTH_PROVIDER = 'local-dev';
 export const LOCAL_AUTH_COOKIE = 'multiforum-local-token';
 
 type LocalAuthRuntimeConfig = {
+  backendGraphqlUrl?: string;
   localAuthTokenEndpoint?: string;
   public?: {
     authProvider?: string;
@@ -18,14 +19,18 @@ type LocalAuthRuntimeConfig = {
 export const isLocalDevAuth = (config: LocalAuthRuntimeConfig) =>
   config.public?.authProvider === LOCAL_AUTH_PROVIDER;
 
+export const getServerGraphqlUrl = (config: LocalAuthRuntimeConfig): string =>
+  config.backendGraphqlUrl?.trim() ||
+  config.public?.apollo?.clients?.default?.httpEndpoint?.trim() ||
+  '';
+
 export const getLocalAuthTokenEndpoint = (
   config: LocalAuthRuntimeConfig
 ): string => {
   const configured = config.localAuthTokenEndpoint?.trim();
   if (configured) return configured;
 
-  const graphqlUrl =
-    config.public?.apollo?.clients?.default?.httpEndpoint?.trim();
+  const graphqlUrl = getServerGraphqlUrl(config);
   if (!graphqlUrl) return '';
 
   try {

--- a/tests/unit/server/local-auth-session.spec.ts
+++ b/tests/unit/server/local-auth-session.spec.ts
@@ -13,10 +13,11 @@ vi.stubGlobal('deleteCookie', h.deleteCookie);
 vi.stubGlobal('$fetch', h.fetch);
 vi.stubGlobal('useAuth0', h.useAuth0);
 vi.stubGlobal('useRuntimeConfig', () => ({
+  backendGraphqlUrl: 'http://backend:4000/graphql',
   public: {
     authProvider: 'local-dev',
     apollo: {
-      clients: { default: { httpEndpoint: 'http://backend:4000/graphql' } },
+      clients: { default: { httpEndpoint: 'http://localhost:4000/graphql' } },
     },
   },
 }));


### PR DESCRIPTION
## Summary

- replace the integration-heavy Compose defaults with a loopback-only local-dev stack that auto-provisions the server, roles, and first SuperAdmin
- build the merged backend source and a production-style Nuxt node-server image without requiring Auth0, GCS, maps, mail, or manual Cypher
- split internal SSR GraphQL traffic from the browser-visible backend URL and omit Auth0 module initialization in local-dev builds
- add configurable quick-start env defaults, health checks, lower Neo4j runtime memory, and a complete local self-hosting guide

## Verification

- `docker compose config --quiet`
- `npx vitest run server/utils/local-auth.spec.ts tests/unit/server/local-auth-session.spec.ts server/api/auth/local-dev/login.post.spec.ts` (22 tests)
- `npm run tsc`
- focused ESLint and Prettier checks
- production Vercel build and local-dev `node-server` build
- backend container image build from merged backend `main`
- fresh isolated Compose database: provisioned 7 roles, ServerConfig, bootstrap `admin`, and SuperAdmin membership
- backend token/profile smoke test: 200/200
- frontend end-to-end smoke test: homepage 200, local login 200, HTTP-only cookie issued, authenticated SSR profile returned

## Resource note

The available Docker daemon is capped at 2 GB, below the documented 6 GB initial-build requirement, so parallel image compilation was killed by the daemon. The backend image and frontend node-server output were built and exercised separately; the guide includes `COMPOSE_PARALLEL_LIMIT=1` as the constrained-memory fallback.