### PR TITLE
feat(self-hosting): pull official backend image

### DIFF
--- a/.env.quickstart.example
+++ b/.env.quickstart.example
@@ -14,11 +14,16 @@ MULTIFORUM_BIND_ADDRESS=127.0.0.1
 MULTIFORUM_PUBLIC_FRONTEND_URL=http://localhost:3000
 MULTIFORUM_PUBLIC_BACKEND_URL=http://localhost:4000
 
-# The default builds the merged backend main branch. Pin a release tag or commit
-# for repeatable deployments.
+# The quick-start pulls the official backend image. Pin a full release or
+# immutable sha-* tag instead of edge when you need a repeatable installation.
+MULTIFORUM_BACKEND_IMAGE=ghcr.io/gennit-project/multiforum-backend:edge
+MULTIFORUM_BACKEND_PULL_POLICY=always
+
+# These settings are used only with docker-compose.source.yml when contributors
+# deliberately build the backend from source.
 MULTIFORUM_BACKEND_REPOSITORY=https://github.com/gennit-project/multiforum-backend.git
 MULTIFORUM_BACKEND_REF=main
+MULTIFORUM_SOURCE_BACKEND_IMAGE=multiforum-backend:quickstart
 
-# Optional local image tags.
-MULTIFORUM_BACKEND_IMAGE=multiforum-backend:quickstart
+# Optional local frontend image tag.
 MULTIFORUM_FRONTEND_IMAGE=multiforum-frontend:quickstart

--- a/docker-compose.source.yml
+++ b/docker-compose.source.yml
@@ -1,0 +1,12 @@
+# Contributor override: build the backend from source instead of pulling the
+# official GHCR image used by the normal self-hosting quick-start.
+services:
+  backend:
+    image: ${MULTIFORUM_SOURCE_BACKEND_IMAGE:-multiforum-backend:quickstart}
+    pull_policy: build
+    build:
+      context: .
+      dockerfile: docker/backend.Dockerfile
+      args:
+        MULTIFORUM_BACKEND_REPOSITORY: ${MULTIFORUM_BACKEND_REPOSITORY:-https://github.com/gennit-project/multiforum-backend.git}
+        MULTIFORUM_BACKEND_REF: ${MULTIFORUM_BACKEND_REF:-main}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,13 +39,8 @@ services:
       - multiforum-network
 
   backend:
-    image: ${MULTIFORUM_BACKEND_IMAGE:-multiforum-backend:quickstart}
-    build:
-      context: .
-      dockerfile: docker/backend.Dockerfile
-      args:
-        MULTIFORUM_BACKEND_REPOSITORY: ${MULTIFORUM_BACKEND_REPOSITORY:-https://github.com/gennit-project/multiforum-backend.git}
-        MULTIFORUM_BACKEND_REF: ${MULTIFORUM_BACKEND_REF:-main}
+    image: ${MULTIFORUM_BACKEND_IMAGE:-ghcr.io/gennit-project/multiforum-backend:edge}
+    pull_policy: ${MULTIFORUM_BACKEND_PULL_POLICY:-always}
     restart: unless-stopped
     ports:
       - '${MULTIFORUM_BIND_ADDRESS:-127.0.0.1}:4000:4000'
@@ -63,7 +58,7 @@ services:
       SUPERADMIN_EMAIL: ${MULTIFORUM_BOOTSTRAP_EMAIL:-admin@multiforum.local}
       SERVER_CONFIG_NAME: ${MULTIFORUM_INSTANCE_NAME:-My Multiforum}
       NEO4J_URI: bolt://database:7687
-      NEO4J_USERNAME: neo4j
+      NEO4J_USER: neo4j
       NEO4J_PASSWORD: ${NEO4J_PASSWORD:-multiforum-local-neo4j}
       AUTH0_DOMAIN: ''
       AUTH0_CLIENT_ID: ''

--- a/docs/self-hosting-quickstart.md
+++ b/docs/self-hosting-quickstart.md
@@ -2,14 +2,14 @@
 
 Try Multiforum locally before configuring Auth0, cloud storage, maps, email, or
 other production integrations. The default Docker Compose stack starts Neo4j,
-builds the backend and frontend, creates the initial server configuration and
-roles, and provisions the first administrator automatically.
+pulls the backend, builds the frontend, creates the initial server configuration
+and roles, and provisions the first administrator automatically.
 
 ## Requirements
 
 - Docker Engine with Docker Compose v2 (Docker Desktop includes it)
 - Git
-- At least 6 GB of memory available to Docker during the initial builds
+- At least 4 GB of memory available to Docker during the initial frontend build
 
 ## Start Multiforum
 
@@ -19,9 +19,10 @@ From this repository's root, run:
 docker compose up --build
 ```
 
-The first run builds both applications and can take several minutes. When all
-three services are healthy, open [http://localhost:3000](http://localhost:3000)
-and choose **Sign in**. The local administrator password is:
+The first run pulls the official backend image, builds the frontend, and can
+take several minutes. When all three services are healthy, open
+[http://localhost:3000](http://localhost:3000) and choose **Sign in**. The local
+administrator password is:
 
 ```text
 multiforum-local-admin
@@ -47,14 +48,27 @@ The bootstrap password must contain at least 12 characters. The bootstrap user
 is created only when its email is not already present, so changing the values
 later does not replace an existing administrator.
 
-The backend build defaults to the public backend repository's `main` branch
-because an official continuously published image is not yet available. For
-repeatable deployments, set `MULTIFORUM_BACKEND_REF` to a release tag or commit,
-for example:
+The default `edge` backend image follows the backend repository's `main` branch.
+For a repeatable installation, pin a full release tag or immutable commit tag:
 
 ```dotenv
-MULTIFORUM_BACKEND_REF=v1.2.3
+MULTIFORUM_BACKEND_IMAGE=ghcr.io/gennit-project/multiforum-backend:1.2.3
+# Or: ghcr.io/gennit-project/multiforum-backend:sha-0123456
 ```
+
+Contributors who need to test an unmerged backend branch can retain the old
+source-build behavior with the provided override:
+
+```bash
+docker compose \
+  --env-file .env.quickstart \
+  -f docker-compose.yml \
+  -f docker-compose.source.yml \
+  up --build
+```
+
+Set `MULTIFORUM_BACKEND_REPOSITORY` and `MULTIFORUM_BACKEND_REF` in
+`.env.quickstart` to choose the source revision for that command.
 
 ## Stop or reset the stack
 
@@ -93,12 +107,9 @@ docker compose ps
 docker compose logs --tail=100 database backend frontend
 ```
 
-If an initial build is killed for lack of memory, increase Docker's memory limit
-or make Compose build one image at a time:
-
-```bash
-COMPOSE_PARALLEL_LIMIT=1 docker compose up --build
-```
+If the initial frontend build is killed for lack of memory, increase Docker's
+memory allocation and run the command again. Docker will reuse completed layers
+and already-downloaded images.
 
 If ports 3000, 4000, 7474, or 7687 are already in use, stop the conflicting
 local services before starting the stack.


### PR DESCRIPTION
## Summary

- make the local quick-start pull `ghcr.io/gennit-project/multiforum-backend:edge` instead of compiling the backend on every host
- retain contributor source builds through the explicit `docker-compose.source.yml` override
- support pinned release or immutable SHA image tags and configurable pull policy
- correct the backend database username variable to `NEO4J_USER`
- lower the documented first-build memory requirement and update troubleshooting guidance

## Dependency

- Backend image publishing landed in gennit-project/multiforum-backend#220. The first main-branch multi-architecture publication is currently running; keep this PR draft until an unauthenticated pull succeeds.

## Validation

- `docker compose config`
- `docker compose --env-file .env.quickstart.example -f docker-compose.yml -f docker-compose.source.yml config`
- `git diff --check`

This is Compose/documentation-only and does not add application code, so unit-test coverage is unchanged.