### PR TITLE
feat(self-hosting): configure frontend at runtime

### DIFF
--- a/.env.quickstart.example
+++ b/.env.quickstart.example
@@ -12,7 +12,6 @@ NEO4J_PASSWORD=multiforum-local-neo4j
 # unsupported; use Auth0 or another production-ready identity provider instead.
 MULTIFORUM_BIND_ADDRESS=127.0.0.1
 MULTIFORUM_PUBLIC_FRONTEND_URL=http://localhost:3000
-MULTIFORUM_PUBLIC_BACKEND_URL=http://localhost:4000
 
 # The quick-start pulls the official backend image. Pin a full release or
 # immutable sha-* tag instead of edge when you need a repeatable installation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,21 +11,9 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 
-# Vite values are embedded in the client bundle at build time. Compose passes
-# browser-reachable defaults; other image consumers can override these args.
-ARG NUXT_PUBLIC_AUTH_PROVIDER=auth0
-ARG NUXT_BACKEND_GRAPHQL_URL=
-ARG VITE_BASE_URL=http://localhost:3000
-ARG VITE_ENVIRONMENT=production
-ARG VITE_GRAPHQL_URL=http://localhost:4000
-ARG VITE_SERVER_NAME=Multiforum
-ENV NUXT_PUBLIC_AUTH_PROVIDER=$NUXT_PUBLIC_AUTH_PROVIDER
-ENV NUXT_BACKEND_GRAPHQL_URL=$NUXT_BACKEND_GRAPHQL_URL
+# Deployment-specific configuration is supplied when the built server starts,
+# so this image can be promoted between environments without rebuilding.
 ENV NITRO_PRESET=node-server
-ENV VITE_BASE_URL=$VITE_BASE_URL
-ENV VITE_ENVIRONMENT=$VITE_ENVIRONMENT
-ENV VITE_GRAPHQL_URL=$VITE_GRAPHQL_URL
-ENV VITE_SERVER_NAME=$VITE_SERVER_NAME
 
 RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm run build
 

--- a/app.vue
+++ b/app.vue
@@ -15,6 +15,12 @@ useHead({
     titleChunk && titleChunk !== config.serverDisplayName
       ? `${titleChunk} · ${config.serverDisplayName}`
       : config.serverDisplayName,
+  meta: [
+    {
+      name: 'description',
+      content: () => `Welcome to ${config.serverDisplayName}`,
+    },
+  ],
 });
 
 // Initialize theme class on application load

--- a/config.ts
+++ b/config.ts
@@ -1,17 +1,10 @@
-type ConfigType = {
-  baseUrl: string;
-  environment: string;
-  googleCloudStorageBucket: string;
-  googleMapsApiKey: string;
-  googleMapId: string;
-  graphqlUrl: string;
-  logoutUrl: string;
-  openCageApiKey: string;
-  openGraphApiKey: string;
-  serverName: string;
-  serverDisplayName: string;
-  enableLanguagePicker: boolean;
-};
+import {
+  resolveRuntimeInstanceConfig,
+  type InstanceConfigValues,
+  type RuntimeInstanceConfig,
+} from './utils/runtimeInstanceConfig';
+
+type ConfigType = InstanceConfigValues;
 const config: ConfigType = {
   baseUrl: import.meta.env.VITE_BASE_URL,
   environment: import.meta.env.VITE_ENVIRONMENT,
@@ -33,4 +26,12 @@ const config: ConfigType = {
     'Untitled',
   enableLanguagePicker: import.meta.env.VITE_ENABLE_LANGUAGE_PICKER === 'true',
 };
-export { config };
+
+const applyRuntimeInstanceConfig = (runtime: RuntimeInstanceConfig): void => {
+  Object.assign(
+    config,
+    resolveRuntimeInstanceConfig({ runtime, fallback: config })
+  );
+};
+
+export { applyRuntimeInstanceConfig, config };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,13 +86,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        NUXT_PUBLIC_AUTH_PROVIDER: local-dev
-        NUXT_BACKEND_GRAPHQL_URL: http://backend:4000
-        VITE_BASE_URL: ${MULTIFORUM_PUBLIC_FRONTEND_URL:-http://localhost:3000}
-        VITE_ENVIRONMENT: development
-        VITE_GRAPHQL_URL: ${MULTIFORUM_PUBLIC_BACKEND_URL:-http://localhost:4000}
-        VITE_SERVER_NAME: ${MULTIFORUM_INSTANCE_NAME:-My Multiforum}
     restart: unless-stopped
     ports:
       - '${MULTIFORUM_BIND_ADDRESS:-127.0.0.1}:3000:3000'
@@ -101,6 +94,10 @@ services:
         condition: service_healthy
     environment:
       NUXT_PUBLIC_AUTH_PROVIDER: local-dev
+      NUXT_PUBLIC_BASE_URL: ${MULTIFORUM_PUBLIC_FRONTEND_URL:-http://localhost:3000}
+      NUXT_PUBLIC_ENVIRONMENT: development
+      NUXT_PUBLIC_SERVER_NAME: ${MULTIFORUM_INSTANCE_NAME:-My Multiforum}
+      NUXT_PUBLIC_SERVER_DISPLAY_NAME: ${MULTIFORUM_INSTANCE_NAME:-My Multiforum}
       NUXT_BACKEND_GRAPHQL_URL: http://backend:4000
       NUXT_LOCAL_AUTH_TOKEN_ENDPOINT: http://backend:4000/auth/local-dev/token
     healthcheck:

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Developer documentation for the Multiforum Nuxt frontend. See the
 ## Getting started & architecture
 
 - [Local self-hosting quick-start](./self-hosting-quickstart.md) — start a usable instance with one Docker Compose command
+- [Frontend runtime configuration](./frontend-runtime-configuration.md) — configure one built frontend image at container startup
 - [Development setup](./development-setup.md) — local environment and tooling
 - [AWS single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md) — provision a Docker-ready self-hosting VM without storing app secrets in Terraform state
 - [Frontend architecture and authentication](./architecture-and-auth.md)

--- a/docs/frontend-runtime-configuration.md
+++ b/docs/frontend-runtime-configuration.md
@@ -1,0 +1,46 @@
+# Frontend runtime configuration
+
+Multiforum's frontend accepts deployment-specific settings when its Node
+server starts. A single built image can therefore be promoted between
+environments without rebuilding browser assets for each hostname, instance
+name, authentication provider, or optional integration.
+
+`VITE_*` variables remain supported as build-time defaults for existing local
+and Vercel workflows. Container deployments should prefer the runtime
+variables below.
+
+| Runtime variable | Purpose |
+| --- | --- |
+| `NUXT_PUBLIC_BASE_URL` | Public frontend origin used in links and metadata |
+| `NUXT_PUBLIC_ENVIRONMENT` | Deployment label such as `development`, `staging`, or `production` |
+| `NUXT_PUBLIC_SERVER_NAME` | Backend `ServerConfig` identifier |
+| `NUXT_PUBLIC_SERVER_DISPLAY_NAME` | Human-facing instance name |
+| `NUXT_PUBLIC_AUTH_PROVIDER` | `local-dev` or `auth0` |
+| `NUXT_BACKEND_GRAPHQL_URL` | Server-side GraphQL endpoint on the private container network |
+| `NUXT_PUBLIC_GOOGLE_MAPS_API_KEY` | Optional Google Maps browser key |
+| `NUXT_PUBLIC_GOOGLE_MAP_ID` | Optional Google Maps map ID |
+| `NUXT_PUBLIC_OPEN_CAGE_API_KEY` | Optional OpenCage geocoding key |
+| `NUXT_PUBLIC_GOOGLE_CLOUD_STORAGE_BUCKET` | Optional public storage bucket name |
+| `NUXT_PUBLIC_OPEN_GRAPH_API_KEY` | Optional link-preview API key |
+| `NUXT_PUBLIC_LOGOUT_URL` | Optional post-logout destination |
+| `NUXT_PUBLIC_ENABLE_LANGUAGE_PICKER` | Set to `true` to show language selection |
+
+Nuxt exposes every `NUXT_PUBLIC_*` value to the browser. Do not put secrets in
+these variables. Auth0 client secrets and session secrets belong in the
+server-only `NUXT_AUTH0_*` variables described by
+[`.env.auth0-nuxt.example`](../.env.auth0-nuxt.example).
+
+The image contains inert Auth0 placeholders solely because the Auth0 module
+validates its shape even in `local-dev` mode. Selecting `auth0` without real
+`NUXT_AUTH0_DOMAIN`, `NUXT_AUTH0_CLIENT_ID`, `NUXT_AUTH0_CLIENT_SECRET`, and
+`NUXT_AUTH0_SESSION_SECRET` values stops the server with a clear configuration
+error; the placeholders can never enable an Auth0 session.
+
+Runtime configuration is read before application components and integration
+plugins initialize. Setting an optional integration value to an empty string
+explicitly disables its build-time fallback.
+
+Browser GraphQL requests use the frontend's same-origin `/api/graphql` route.
+The Node server proxies that route to `NUXT_BACKEND_GRAPHQL_URL`, so changing a
+backend hostname or container network does not require rebuilding browser
+assets and does not require exposing the backend directly to browsers.

--- a/docs/self-hosting-quickstart.md
+++ b/docs/self-hosting-quickstart.md
@@ -70,6 +70,12 @@ docker compose \
 Set `MULTIFORUM_BACKEND_REPOSITORY` and `MULTIFORUM_BACKEND_REF` in
 `.env.quickstart` to choose the source revision for that command.
 
+The frontend currently builds locally, but its deployment-specific settings
+are runtime configurable so the same artifact can be reused by the upcoming
+official frontend image. See
+[frontend runtime configuration](./frontend-runtime-configuration.md) for the
+supported `NUXT_*` variables.
+
 ## Stop or reset the stack
 
 Stop the containers without deleting data:

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,7 +18,7 @@ const runtimeGraphqlFetch: typeof globalThis.fetch = (input, init) => {
   const target =
     typeof window === 'undefined'
       ? runtimeBackendUrl || input
-      : frontendGraphqlProxyUrl;
+      : input;
   return globalThis.fetch(target, init);
 };
 const ignoredDevWatchPatterns = [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,12 +3,24 @@ import tailwindcss from '@tailwindcss/vite';
 import { config } from './config';
 import path from 'path';
 import { inMemoryCacheOptions } from './cache';
+import { DORMANT_AUTH0_CONFIG } from './utils/auth0RuntimeConfig';
 
 const isMockedE2E = process.env.VITE_E2E_MOCK_MODE === 'true';
-const isLocalDevAuthBuild =
-  process.env.NUXT_PUBLIC_AUTH_PROVIDER === 'local-dev';
+const browserGraphqlUrl = config?.graphqlUrl || 'http://localhost:4000';
 const serverGraphqlUrl =
-  process.env.NUXT_BACKEND_GRAPHQL_URL || config?.graphqlUrl || '';
+  process.env.NUXT_BACKEND_GRAPHQL_URL || browserGraphqlUrl;
+const frontendGraphqlProxyUrl = '/api/graphql';
+const runtimeGraphqlFetch: typeof globalThis.fetch = (input, init) => {
+  const runtimeBackendUrl =
+    typeof window === 'undefined'
+      ? process.env.NUXT_BACKEND_GRAPHQL_URL?.trim()
+      : '';
+  const target =
+    typeof window === 'undefined'
+      ? runtimeBackendUrl || input
+      : frontendGraphqlProxyUrl;
+  return globalThis.fetch(target, init);
+};
 const ignoredDevWatchPatterns = [
   '**/.claude/**',
   '**/.agents/**',
@@ -93,32 +105,30 @@ export default defineNuxtConfig({
     // Server-session auth: registers /auth/login, /auth/logout,
     // /auth/callback, /auth/backchannel-logout. Config is read from the private
     // `runtimeConfig.auth0` block below (NUXT_AUTH0_* envs).
-    ...(isLocalDevAuthBuild
-      ? []
-      : [
-          [
-            '@auth0/auth0-nuxt',
-            {
-              mountRoutes: true,
-              // SPIKE Phase 2: use a server-side session store (small cookie
-              // holds only a session id). The default stateless cookie store
-              // overflows the ~4KB browser limit once a refresh token is in
-              // the session. See the factory for the dev (in-memory) vs prod
-              // (persistent) note.
-              sessionStoreFactoryPath:
-                '~/server/utils/session-store-factory.ts',
-            },
-          ] as [string, Record<string, unknown>],
-        ]),
+    [
+      '@auth0/auth0-nuxt',
+      {
+        mountRoutes: true,
+        // SPIKE Phase 2: use a server-side session store (small cookie holds
+        // only a session id). Keeping the module in every build lets one
+        // container select Auth0 or local-dev auth through runtime config.
+        sessionStoreFactoryPath: '~/server/utils/session-store-factory.ts',
+      },
+    ],
     [
       '@nuxtjs/apollo',
       {
         clients: {
           default: {
-            // SSR uses the private container URL while browser requests keep
-            // using the public origin compiled into VITE_GRAPHQL_URL.
+            // The custom fetch keeps this module's generated Apollo client
+            // reusable: SSR reads NUXT_BACKEND_GRAPHQL_URL at process startup,
+            // while browser requests use the same-origin proxy below. The
+            // endpoint value is only a backward-compatible build fallback.
             httpEndpoint: serverGraphqlUrl,
-            browserHttpEndpoint: config?.graphqlUrl || serverGraphqlUrl,
+            browserHttpEndpoint: frontendGraphqlProxyUrl,
+            httpLinkOptions: {
+              fetch: runtimeGraphqlFetch,
+            },
             // @nuxtjs/apollo attaches localStorage['token'] as the Bearer
             // (tokenStorage: 'localStorage'). plugins/apollo-auth.client.ts keeps
             // that key in sync with the server-session access token. (The old
@@ -353,6 +363,9 @@ export default defineNuxtConfig({
       // disables caching for the auth routes only.
       '/api/auth/**': { cache: false },
       '/api/session/**': { cache: false },
+      // GraphQL POST responses can be user-specific and proxyRequest returns a
+      // streaming response that Nitro's route cache cannot serialize.
+      '/api/graphql': { cache: false },
       // Cache other API routes
       '/api/**': {
         cache: {
@@ -375,6 +388,7 @@ export default defineNuxtConfig({
     },
   },
   plugins: [
+    { src: '@/plugins/00.runtime-instance-config', mode: 'all' },
     { src: '@/plugins/pinia', mode: 'all' },
     { src: '@/plugins/google-maps', mode: 'client' },
     { src: '@/plugins/performance.client', mode: 'client' },
@@ -383,10 +397,10 @@ export default defineNuxtConfig({
     { src: '@/plugins/test-auth.client', mode: 'client' },
   ],
   runtimeConfig: {
-    // Optional server-only GraphQL URL. Docker deployments use this to reach
-    // the backend over the Compose network while the browser keeps using the
-    // public URL below (usually http://localhost:4000 for local quick-starts).
-    backendGraphqlUrl: '',
+    // Server-only GraphQL URL. Docker deployments override it at runtime to
+    // reach the backend over the private Compose network; browsers use the
+    // same-origin /api/graphql proxy instead.
+    backendGraphqlUrl: serverGraphqlUrl,
     // Optional explicit backend token URL for local development auth. When it
     // is empty, the server derives /auth/local-dev/token from the server-side
     // GraphQL URL above, then falls back to the public browser URL.
@@ -395,13 +409,16 @@ export default defineNuxtConfig({
     // These are overridden by NUXT_AUTH0_* env vars at runtime (see
     // .env.auth0-nuxt.example). clientSecret + sessionSecret mean this is a
     // CONFIDENTIAL "Regular Web Application" in Auth0 — a different app type
-    // than the current SPA. Empty defaults are intentional: the module only
-    // needs them when an /auth/* route is hit, so dev still boots without them.
+    // than the current SPA.
     auth0: {
-      domain: '',
-      clientId: '',
-      clientSecret: '',
-      sessionSecret: '',
+      // The Auth0 module validates these fields even when local-dev auth is
+      // selected. Inert defaults let one image boot in either mode; the Nitro
+      // startup validator rejects them whenever authProvider is actually
+      // `auth0`, so production still requires real NUXT_AUTH0_* secrets.
+      domain: DORMANT_AUTH0_CONFIG.domain,
+      clientId: DORMANT_AUTH0_CONFIG.clientId,
+      clientSecret: DORMANT_AUTH0_CONFIG.clientSecret,
+      sessionSecret: DORMANT_AUTH0_CONFIG.sessionSecret,
       appBaseUrl: 'http://localhost:3000',
       audience: '',
       // Spread by the SDK into the session store's cookie options. The session
@@ -415,6 +432,21 @@ export default defineNuxtConfig({
       },
     },
     public: {
+      // Deployment-specific values use matching NUXT_PUBLIC_* environment
+      // variables at container startup. VITE_* remains the build-time fallback
+      // for existing development and Vercel deployments.
+      baseUrl: config.baseUrl,
+      environment: config.environment,
+      googleCloudStorageBucket: config.googleCloudStorageBucket,
+      googleMapsApiKey: config.googleMapsApiKey,
+      googleMapId: config.googleMapId,
+      graphqlUrl: frontendGraphqlProxyUrl,
+      logoutUrl: config.logoutUrl,
+      openCageApiKey: config.openCageApiKey,
+      openGraphApiKey: config.openGraphApiKey,
+      serverName: config.serverName,
+      serverDisplayName: config.serverDisplayName,
+      enableLanguagePicker: config.enableLanguagePicker,
       authProvider:
         process.env.NUXT_PUBLIC_AUTH_PROVIDER === 'local-dev'
           ? 'local-dev'
@@ -422,7 +454,7 @@ export default defineNuxtConfig({
       apollo: {
         clients: {
           default: {
-            httpEndpoint: config?.graphqlUrl || '',
+            httpEndpoint: frontendGraphqlProxyUrl,
           },
         },
       },

--- a/plugins/00.runtime-instance-config.spec.ts
+++ b/plugins/00.runtime-instance-config.spec.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import plugin from '@/plugins/00.runtime-instance-config';
+
+const h = vi.hoisted(() => ({
+  applyRuntimeInstanceConfig: vi.fn(),
+  publicConfig: {} as Record<string, unknown>,
+}));
+
+vi.mock('nuxt/app', () => ({
+  defineNuxtPlugin: (fn: unknown) => fn,
+  useRuntimeConfig: () => ({ public: h.publicConfig }),
+}));
+
+vi.mock('@/config', () => ({
+  applyRuntimeInstanceConfig: h.applyRuntimeInstanceConfig,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.publicConfig = {
+    baseUrl: 'https://runtime.example',
+    serverDisplayName: 'Runtime Forum',
+  };
+});
+
+describe('runtime instance config plugin', () => {
+  it('applies the public runtime values before the application initializes', () => {
+    (plugin as () => void)();
+    expect(h.applyRuntimeInstanceConfig).toHaveBeenCalledWith(h.publicConfig);
+  });
+});

--- a/plugins/00.runtime-instance-config.ts
+++ b/plugins/00.runtime-instance-config.ts
@@ -1,0 +1,8 @@
+import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app';
+import { applyRuntimeInstanceConfig } from '@/config';
+import type { RuntimeInstanceConfig } from '@/utils/runtimeInstanceConfig';
+
+export default defineNuxtPlugin(() => {
+  const runtimeConfig = useRuntimeConfig();
+  applyRuntimeInstanceConfig(runtimeConfig.public as RuntimeInstanceConfig);
+});

--- a/server/api/graphql.spec.ts
+++ b/server/api/graphql.spec.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import handler from '@/server/api/graphql';
+
+const h = vi.hoisted(() => ({
+  proxyRequest: vi.fn(),
+  backendGraphqlUrl: 'http://backend:4000/graphql',
+}));
+
+vi.mock('h3', () => ({
+  createError: (input: { statusCode: number; statusMessage: string }) =>
+    Object.assign(new Error(input.statusMessage), input),
+  defineEventHandler: (handler: unknown) => handler,
+  proxyRequest: h.proxyRequest,
+}));
+
+vi.stubGlobal('useRuntimeConfig', () => ({
+  backendGraphqlUrl: h.backendGraphqlUrl,
+}));
+
+const event = { method: 'POST' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.backendGraphqlUrl = 'http://backend:4000/graphql';
+});
+
+describe('runtime GraphQL proxy', () => {
+  it('forwards the request to the runtime-configured backend', async () => {
+    h.proxyRequest.mockResolvedValue({ data: {} });
+    await (handler as (event: unknown) => Promise<unknown>)(event);
+    expect(h.proxyRequest).toHaveBeenCalledWith(
+      event,
+      'http://backend:4000/graphql'
+    );
+  });
+
+  it('trims the configured backend URL', async () => {
+    h.backendGraphqlUrl = '  http://backend:4000/graphql  ';
+    await (handler as (event: unknown) => Promise<unknown>)(event);
+    expect(h.proxyRequest).toHaveBeenCalledWith(
+      event,
+      'http://backend:4000/graphql'
+    );
+  });
+
+  it('returns a service-unavailable error when no backend is configured', () => {
+    h.backendGraphqlUrl = ' ';
+    expect(() =>
+      (handler as (event: unknown) => Promise<unknown>)(event)
+    ).toThrowError('Backend GraphQL URL is not configured');
+  });
+});

--- a/server/api/graphql.ts
+++ b/server/api/graphql.ts
@@ -1,0 +1,14 @@
+import { createError, defineEventHandler, proxyRequest } from 'h3';
+
+export default defineEventHandler((event) => {
+  const target = useRuntimeConfig(event).backendGraphqlUrl?.trim();
+
+  if (!target) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'Backend GraphQL URL is not configured',
+    });
+  }
+
+  return proxyRequest(event, target);
+});

--- a/server/plugins/validate-auth-runtime-config.ts
+++ b/server/plugins/validate-auth-runtime-config.ts
@@ -1,0 +1,15 @@
+import { getMissingAuth0RuntimeFields } from '@/utils/auth0RuntimeConfig';
+
+export default defineNitroPlugin(() => {
+  const config = useRuntimeConfig();
+  const missing = getMissingAuth0RuntimeFields({
+    authProvider: config.public.authProvider,
+    auth0: config.auth0,
+  });
+
+  if (missing.length) {
+    throw new Error(
+      `Auth0 runtime configuration is missing: ${missing.join(', ')}`
+    );
+  }
+});

--- a/utils/auth0RuntimeConfig.spec.ts
+++ b/utils/auth0RuntimeConfig.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DORMANT_AUTH0_CONFIG,
+  getMissingAuth0RuntimeFields,
+} from '@/utils/auth0RuntimeConfig';
+
+describe('getMissingAuth0RuntimeFields', () => {
+  it('does not require Auth0 credentials in local development mode', () => {
+    expect(
+      getMissingAuth0RuntimeFields({
+        authProvider: 'local-dev',
+        auth0: DORMANT_AUTH0_CONFIG,
+      })
+    ).toEqual([]);
+  });
+
+  it('accepts a fully configured Auth0 deployment', () => {
+    expect(
+      getMissingAuth0RuntimeFields({
+        authProvider: 'auth0',
+        auth0: {
+          domain: 'tenant.auth0.com',
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+          sessionSecret: 'a-unique-session-secret-with-enough-entropy',
+        },
+      })
+    ).toEqual([]);
+  });
+
+  it('reports dormant placeholder values in Auth0 mode', () => {
+    expect(
+      getMissingAuth0RuntimeFields({
+        authProvider: 'auth0',
+        auth0: DORMANT_AUTH0_CONFIG,
+      })
+    ).toEqual(['domain', 'clientId', 'clientSecret', 'sessionSecret']);
+  });
+
+  it('reports empty and non-string Auth0 values', () => {
+    expect(
+      getMissingAuth0RuntimeFields({
+        authProvider: 'auth0',
+        auth0: {
+          domain: ' ',
+          clientId: null,
+          clientSecret: 'client-secret',
+          sessionSecret: 'session-secret',
+        },
+      })
+    ).toEqual(['domain', 'clientId']);
+  });
+});

--- a/utils/auth0RuntimeConfig.ts
+++ b/utils/auth0RuntimeConfig.ts
@@ -1,0 +1,39 @@
+export const DORMANT_AUTH0_CONFIG = {
+  domain: 'multiforum-auth-disabled.invalid',
+  clientId: 'not-configured',
+  clientSecret: 'not-configured',
+  sessionSecret: 'not-configured-not-configured-not-configured',
+} as const;
+
+type Auth0RuntimeConfig = {
+  domain?: unknown;
+  clientId?: unknown;
+  clientSecret?: unknown;
+  sessionSecret?: unknown;
+};
+
+const requiredAuth0Fields = [
+  'domain',
+  'clientId',
+  'clientSecret',
+  'sessionSecret',
+] as const;
+
+export const getMissingAuth0RuntimeFields = ({
+  authProvider,
+  auth0,
+}: {
+  authProvider: unknown;
+  auth0: Auth0RuntimeConfig;
+}): string[] => {
+  if (authProvider !== 'auth0') return [];
+
+  return requiredAuth0Fields.filter((field) => {
+    const value = auth0[field];
+    return (
+      typeof value !== 'string' ||
+      !value.trim() ||
+      value === DORMANT_AUTH0_CONFIG[field]
+    );
+  });
+};

--- a/utils/runtimeInstanceConfig.spec.ts
+++ b/utils/runtimeInstanceConfig.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveRuntimeInstanceConfig,
+  type InstanceConfigValues,
+} from '@/utils/runtimeInstanceConfig';
+
+const fallback: InstanceConfigValues = {
+  baseUrl: 'https://build.example',
+  environment: 'production',
+  googleCloudStorageBucket: 'build-bucket',
+  googleMapsApiKey: 'build-maps-key',
+  googleMapId: 'build-map-id',
+  graphqlUrl: 'https://build.example/graphql',
+  logoutUrl: 'https://build.example/logout',
+  openCageApiKey: 'build-geocoding-key',
+  openGraphApiKey: 'build-link-preview-key',
+  serverName: 'build-server',
+  serverDisplayName: 'Build Forum',
+  enableLanguagePicker: false,
+};
+
+describe('resolveRuntimeInstanceConfig', () => {
+  it('uses every runtime string supplied by the container', () => {
+    expect(
+      resolveRuntimeInstanceConfig({
+        fallback,
+        runtime: {
+          baseUrl: 'https://runtime.example',
+          environment: 'staging',
+          googleCloudStorageBucket: 'runtime-bucket',
+          googleMapsApiKey: 'runtime-maps-key',
+          googleMapId: 'runtime-map-id',
+          graphqlUrl: 'https://runtime.example/graphql',
+          logoutUrl: 'https://runtime.example/logout',
+          openCageApiKey: 'runtime-geocoding-key',
+          openGraphApiKey: 'runtime-link-preview-key',
+          serverName: 'runtime-server',
+          serverDisplayName: 'Runtime Forum',
+          enableLanguagePicker: true,
+        },
+      })
+    ).toEqual({
+      baseUrl: 'https://runtime.example',
+      environment: 'staging',
+      googleCloudStorageBucket: 'runtime-bucket',
+      googleMapsApiKey: 'runtime-maps-key',
+      googleMapId: 'runtime-map-id',
+      graphqlUrl: 'https://runtime.example/graphql',
+      logoutUrl: 'https://runtime.example/logout',
+      openCageApiKey: 'runtime-geocoding-key',
+      openGraphApiKey: 'runtime-link-preview-key',
+      serverName: 'runtime-server',
+      serverDisplayName: 'Runtime Forum',
+      enableLanguagePicker: true,
+    });
+  });
+
+  it('preserves build fallbacks for missing or invalid runtime values', () => {
+    expect(
+      resolveRuntimeInstanceConfig({
+        fallback,
+        runtime: {
+          baseUrl: 42,
+          environment: null,
+          enableLanguagePicker: 'not-a-boolean',
+        },
+      })
+    ).toEqual(fallback);
+  });
+
+  it.each([
+    ['true', true],
+    ['TRUE', true],
+    ['false', false],
+    ['FALSE', false],
+  ])('normalizes the runtime language-picker value %s', (value, expected) => {
+    expect(
+      resolveRuntimeInstanceConfig({
+        fallback,
+        runtime: { enableLanguagePicker: value },
+      }).enableLanguagePicker
+    ).toBe(expected);
+  });
+
+  it('uses an explicitly overridden server name as the display-name fallback', () => {
+    expect(
+      resolveRuntimeInstanceConfig({
+        fallback,
+        runtime: { serverName: 'runtime-server', serverDisplayName: '' },
+      }).serverDisplayName
+    ).toBe('runtime-server');
+  });
+
+  it('preserves the build display name when no runtime branding is supplied', () => {
+    expect(
+      resolveRuntimeInstanceConfig({ fallback, runtime: {} }).serverDisplayName
+    ).toBe('Build Forum');
+  });
+
+  it('falls back to Untitled when all display-name sources are empty', () => {
+    expect(
+      resolveRuntimeInstanceConfig({
+        fallback: { ...fallback, serverDisplayName: '' },
+        runtime: {},
+      }).serverDisplayName
+    ).toBe('Untitled');
+  });
+
+  it('allows optional integration strings to be cleared at runtime', () => {
+    expect(
+      resolveRuntimeInstanceConfig({
+        fallback,
+        runtime: { googleMapsApiKey: '' },
+      }).googleMapsApiKey
+    ).toBe('');
+  });
+});

--- a/utils/runtimeInstanceConfig.ts
+++ b/utils/runtimeInstanceConfig.ts
@@ -1,0 +1,79 @@
+export type InstanceConfigValues = {
+  baseUrl: string;
+  environment: string;
+  googleCloudStorageBucket: string;
+  googleMapsApiKey: string;
+  googleMapId: string;
+  graphqlUrl: string;
+  logoutUrl: string;
+  openCageApiKey: string;
+  openGraphApiKey: string;
+  serverName: string;
+  serverDisplayName: string;
+  enableLanguagePicker: boolean;
+};
+
+export type RuntimeInstanceConfig = Partial<
+  Record<Exclude<keyof InstanceConfigValues, 'enableLanguagePicker'>, unknown>
+> & {
+  enableLanguagePicker?: unknown;
+};
+
+const runtimeString = (value: unknown, fallback: string): string =>
+  typeof value === 'string' ? value : fallback;
+
+const runtimeDisplayName = (value: unknown, fallback: string): string =>
+  typeof value === 'string' && value.trim() ? value : fallback;
+
+const runtimeBoolean = (value: unknown, fallback: boolean): boolean => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    if (value.toLowerCase() === 'true') return true;
+    if (value.toLowerCase() === 'false') return false;
+  }
+  return fallback;
+};
+
+export const resolveRuntimeInstanceConfig = ({
+  runtime,
+  fallback,
+}: {
+  runtime: RuntimeInstanceConfig;
+  fallback: InstanceConfigValues;
+}): InstanceConfigValues => {
+  const explicitRuntimeServerName = runtimeDisplayName(runtime.serverName, '');
+  const serverName = runtimeString(runtime.serverName, fallback.serverName);
+
+  return {
+    baseUrl: runtimeString(runtime.baseUrl, fallback.baseUrl),
+    environment: runtimeString(runtime.environment, fallback.environment),
+    googleCloudStorageBucket: runtimeString(
+      runtime.googleCloudStorageBucket,
+      fallback.googleCloudStorageBucket
+    ),
+    googleMapsApiKey: runtimeString(
+      runtime.googleMapsApiKey,
+      fallback.googleMapsApiKey
+    ),
+    googleMapId: runtimeString(runtime.googleMapId, fallback.googleMapId),
+    graphqlUrl: runtimeString(runtime.graphqlUrl, fallback.graphqlUrl),
+    logoutUrl: runtimeString(runtime.logoutUrl, fallback.logoutUrl),
+    openCageApiKey: runtimeString(
+      runtime.openCageApiKey,
+      fallback.openCageApiKey
+    ),
+    openGraphApiKey: runtimeString(
+      runtime.openGraphApiKey,
+      fallback.openGraphApiKey
+    ),
+    serverName,
+    serverDisplayName: runtimeDisplayName(
+      runtime.serverDisplayName,
+      explicitRuntimeServerName || fallback.serverDisplayName || 'Untitled'
+    ),
+    enableLanguagePicker: runtimeBoolean(
+      runtime.enableLanguagePicker,
+      fallback.enableLanguagePicker
+    ),
+  };
+};


### PR DESCRIPTION
## Summary
- synchronize deployment-specific frontend settings from Nuxt runtime configuration before app plugins and components initialize
- keep one build compatible with local-dev and Auth0, with explicit Auth0 runtime validation
- route browser GraphQL traffic through an uncached same-origin proxy while SSR reads the runtime backend URL
- remove deployment-specific Docker build arguments and pass quick-start values at container startup
- document supported runtime variables and security boundaries

## Verification
- `pnpm exec vitest run` — 798 files, 7,600 tests passed
- targeted new configuration coverage — 100% statements, branches, functions, and lines
- `pnpm run tsc`
- ESLint on all changed TypeScript and Vue files
- `docker compose config --quiet`
- `NITRO_PRESET=node-server NODE_OPTIONS=--max-old-space-size=4096 NUXT_PUBLIC_AUTH_PROVIDER=local-dev pnpm run build`
- launched the built artifact with runtime-only branding/auth/backend overrides; rendered title was `Local sign in · Runtime Container Forum`
- verified `POST /api/graphql` forwarded to the runtime-selected backend
- verified Auth0 mode without real credentials exits with the explicit missing-configuration error