### PR TITLE
ci(self-hosting): publish official frontend images

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,194 @@
+name: Container image
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+concurrency:
+  group: container-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-publish-smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Sign in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            type=ref,event=pr
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and optionally publish image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
+          sbom: ${{ github.event_name != 'pull_request' }}
+
+      - name: Select image for smoke test
+        id: smoke-image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=${IMAGE_NAME}:pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${IMAGE_NAME}@${DIGEST}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Start mock backend
+        run: |
+          set -euo pipefail
+          docker network create multiforum-frontend-image-smoke
+          docker run --detach \
+            --name multiforum-backend-mock \
+            --network multiforum-frontend-image-smoke \
+            node:26.5.1-alpine \
+            node -e 'require("http").createServer((_request,response)=>{response.writeHead(200,{"content-type":"application/json"});response.end(JSON.stringify({data:{imageSmoke:"ok"}}))}).listen(4000,"0.0.0.0")'
+
+      - name: Start Multiforum frontend image
+        env:
+          SMOKE_IMAGE: ${{ steps.smoke-image.outputs.value }}
+        run: |
+          set -euo pipefail
+          docker run --detach \
+            --name multiforum-frontend-smoke \
+            --network multiforum-frontend-image-smoke \
+            --publish 127.0.0.1:3000:3000 \
+            --env NUXT_PUBLIC_AUTH_PROVIDER=local-dev \
+            --env NUXT_PUBLIC_BASE_URL=http://127.0.0.1:3000 \
+            --env NUXT_PUBLIC_ENVIRONMENT=development \
+            --env NUXT_PUBLIC_SERVER_NAME='Image Smoke Test' \
+            --env NUXT_PUBLIC_SERVER_DISPLAY_NAME='Image Smoke Test' \
+            --env NUXT_BACKEND_GRAPHQL_URL=http://multiforum-backend-mock:4000/graphql \
+            --env NUXT_LOCAL_AUTH_TOKEN_ENDPOINT=http://multiforum-backend-mock:4000/auth/local-dev/token \
+            "$SMOKE_IMAGE"
+
+      - name: Verify frontend runtime behavior
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            status="$(docker inspect --format='{{.State.Health.Status}}' multiforum-frontend-smoke)"
+            if [ "$status" = "healthy" ]; then
+              break
+            fi
+            if [ "$status" = "unhealthy" ]; then
+              docker logs multiforum-frontend-smoke
+              exit 1
+            fi
+            sleep 5
+          done
+
+          test "$(docker inspect --format='{{.State.Health.Status}}' multiforum-frontend-smoke)" = healthy
+          test "$(docker inspect --format='{{.Config.User}}' multiforum-frontend-smoke)" = node
+
+          curl --fail --silent --show-error http://127.0.0.1:3000/login \
+            | grep --fixed-strings 'Image Smoke Test' >/dev/null
+          curl --fail --silent --show-error \
+            --header 'content-type: application/json' \
+            --data '{"query":"query ImageSmoke { imageSmoke }"}' \
+            http://127.0.0.1:3000/api/graphql \
+            | grep --fixed-strings '"imageSmoke":"ok"' >/dev/null
+
+      - name: Verify incomplete Auth0 configuration is rejected
+        env:
+          SMOKE_IMAGE: ${{ steps.smoke-image.outputs.value }}
+        run: |
+          set -euo pipefail
+          docker run --detach \
+            --name multiforum-frontend-auth0-smoke \
+            --env NUXT_PUBLIC_AUTH_PROVIDER=auth0 \
+            "$SMOKE_IMAGE"
+
+          for _ in $(seq 1 30); do
+            running="$(docker inspect --format='{{.State.Running}}' multiforum-frontend-auth0-smoke)"
+            if [ "$running" = "false" ]; then
+              break
+            fi
+            sleep 1
+          done
+
+          test "$(docker inspect --format='{{.State.Running}}' multiforum-frontend-auth0-smoke)" = false
+          test "$(docker inspect --format='{{.State.ExitCode}}' multiforum-frontend-auth0-smoke)" != 0
+          docker logs multiforum-frontend-auth0-smoke 2>&1 \
+            | grep --fixed-strings 'Auth0 runtime configuration is missing' >/dev/null
+
+      - name: Show container logs on failure
+        if: failure()
+        run: |
+          docker logs multiforum-backend-mock || true
+          docker logs multiforum-frontend-smoke || true
+          docker logs multiforum-frontend-auth0-smoke || true
+
+      - name: Clean up smoke containers
+        if: always()
+        run: |
+          docker rm --force multiforum-backend-mock multiforum-frontend-smoke multiforum-frontend-auth0-smoke || true
+          docker network rm multiforum-frontend-image-smoke || true
+
+      # GITHUB_TOKEN can publish repository-linked packages but cannot change
+      # organization package visibility. An organization owner must make the
+      # package public once; every publication then proves anonymous access.
+      - name: Verify the published image is public
+        if: github.event_name != 'pull_request'
+        env:
+          PUBLISHED_IMAGE: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          anonymous_docker_config="$(mktemp -d)"
+          trap 'rm -rf "$anonymous_docker_config"' EXIT
+          DOCKER_CONFIG="$anonymous_docker_config" docker pull "$PUBLISHED_IMAGE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY . .
 # so this image can be promoted between environments without rebuilding.
 ENV NITRO_PRESET=node-server
 
-RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm run build
+RUN NODE_OPTIONS=--max-old-space-size=4096 pnpm run build
 
 FROM node:${NODE_VERSION}-alpine AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM node:26.5.1-alpine AS build
+# Keep build and runtime aligned with .nvmrc and CI. The arguments also make
+# deliberate patch-version updates easy to audit in release PRs.
+ARG NODE_VERSION=26.5.1
+ARG PNPM_VERSION=10.28.2
+
+FROM node:${NODE_VERSION}-alpine AS build
+
+ARG PNPM_VERSION
 
 WORKDIR /app
 
 # Node 26 no longer bundles Corepack, so install the repository-pinned package
 # manager explicitly.
-RUN npm install --global pnpm@10.28.2
+RUN npm install --global "pnpm@${PNPM_VERSION}"
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
@@ -17,7 +24,11 @@ ENV NITRO_PRESET=node-server
 
 RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm run build
 
-FROM node:26.5.1-alpine AS runtime
+FROM node:${NODE_VERSION}-alpine AS runtime
+
+LABEL org.opencontainers.image.title="Multiforum Frontend" \
+  org.opencontainers.image.description="Nuxt web application for Multiforum" \
+  org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
 
@@ -29,5 +40,10 @@ COPY --from=build --chown=node:node /app/.output ./.output
 
 USER node
 EXPOSE 3000
+
+# Check only that the Node server is listening. Backend and integration health
+# are separate concerns and should not make the frontend container unhealthy.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=12 \
+  CMD node -e "const socket=require('net').connect(process.env.PORT||3000,'127.0.0.1');socket.setTimeout(4000);socket.on('connect',()=>{socket.destroy();process.exit(0)});socket.on('timeout',()=>{socket.destroy();process.exit(1)});socket.on('error',()=>process.exit(1))"
 
 CMD ["node", ".output/server/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ client.
 Start here:
 
 - [Local self-hosting quick-start](./docs/self-hosting-quickstart.md)
+- [Official frontend container image](./docs/frontend-container-image.md)
 - [Development setup](./docs/development-setup.md)
 - [AWS single-VM Terraform example](./deploy/terraform/aws-single-vm/README.md)
 - [Contributing guide](./CONTRIBUTING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Developer documentation for the Multiforum Nuxt frontend. See the
 
 - [Local self-hosting quick-start](./self-hosting-quickstart.md) — start a usable instance with one Docker Compose command
 - [Frontend runtime configuration](./frontend-runtime-configuration.md) — configure one built frontend image at container startup
+- [Frontend container image](./frontend-container-image.md) — official image tags, architectures, and runtime behavior
 - [Development setup](./development-setup.md) — local environment and tooling
 - [AWS single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md) — provision a Docker-ready self-hosting VM without storing app secrets in Terraform state
 - [Frontend architecture and authentication](./architecture-and-auth.md)

--- a/docs/frontend-container-image.md
+++ b/docs/frontend-container-image.md
@@ -1,0 +1,69 @@
+# Frontend container image
+
+The official Multiforum frontend image is published at:
+
+```text
+ghcr.io/gennit-project/multiforum-nuxt
+```
+
+Images support `linux/amd64` and `linux/arm64`. They run as the unprivileged
+`node` user and include an internal health check for the Nuxt server on port 3000.
+
+## Tags
+
+| Tag            | Meaning                                     | Recommended use                          |
+| -------------- | ------------------------------------------- | ---------------------------------------- |
+| `edge`         | Current `main` branch                       | Local evaluation and integration testing |
+| `latest`       | Most recent stable semantic-version release | Convenient stable installs               |
+| `1.2.3`        | Exact semantic-version release              | Repeatable production installs           |
+| `1.2` or `1`   | Moving release series                       | Controlled automatic updates             |
+| `sha-<commit>` | Immutable source revision                   | Maximum deployment reproducibility       |
+
+Production deployments should pin an exact semantic version or immutable SHA
+instead of following `edge` or another moving tag.
+
+## Run the image
+
+The frontend requires a reachable Multiforum backend. This minimal example
+uses local development authentication and assumes the backend is named
+`backend` on the same Docker network:
+
+```bash
+docker run --rm \
+  --network multiforum-network \
+  --publish 127.0.0.1:3000:3000 \
+  --env NUXT_PUBLIC_AUTH_PROVIDER=local-dev \
+  --env NUXT_PUBLIC_BASE_URL=http://localhost:3000 \
+  --env NUXT_PUBLIC_SERVER_NAME='My Multiforum' \
+  --env NUXT_PUBLIC_SERVER_DISPLAY_NAME='My Multiforum' \
+  --env NUXT_BACKEND_GRAPHQL_URL=http://backend:4000/graphql \
+  --env NUXT_LOCAL_AUTH_TOKEN_ENDPOINT=http://backend:4000/auth/local-dev/token \
+  ghcr.io/gennit-project/multiforum-nuxt:edge
+```
+
+The same image supports Auth0 when the corresponding server-only
+`NUXT_AUTH0_*` secrets are supplied. See
+[frontend runtime configuration](./frontend-runtime-configuration.md) for the
+complete variable list and security boundaries.
+
+The local-development provider must not be exposed to the public internet.
+Production deployments require TLS, production authentication, unique secrets,
+backups, and appropriately secured backend and database services.
+
+## Supply-chain metadata
+
+Main-branch and release publications include OCI source and revision labels,
+a software bill of materials, and build provenance. Pulling by digest provides
+an immutable reference independent of the tag policy:
+
+```bash
+docker pull ghcr.io/gennit-project/multiforum-nuxt@sha256:DIGEST
+```
+
+The publishing workflow tests the non-root runtime, health check, runtime
+branding, same-origin GraphQL proxy, local-development mode, and rejection of
+incomplete Auth0 configuration before accepting an image publication.
+
+The GHCR package must be made public once by an organization owner after its
+first publication. Every subsequent publication verifies that its digest can
+be pulled with an anonymous Docker configuration.


### PR DESCRIPTION
## Summary

- publish `linux/amd64` and `linux/arm64` images to `ghcr.io/gennit-project/multiforum-nuxt` from `main` and semantic-version tags
- provide edge, stable, semantic-version, and immutable commit-SHA tags with OCI labels, SBOMs, and build provenance
- harden the runtime image with auditable Node/pnpm versions, OCI metadata, a non-root user, and a dependency-independent health check
- smoke-test runtime branding, the same-origin GraphQL proxy, local-development auth mode, non-root execution, and rejection of incomplete Auth0 configuration
- document image tags, supported architectures, runtime configuration, production pinning, and the one-time GHCR visibility step

## Validation

- `actionlint` passes with no findings
- workflow YAML parses and all changed Markdown/YAML files pass Prettier
- `pnpm run tsc`
- runtime-only image assembled from the verified Nuxt output and exercised through the complete container smoke flow
- `git diff --check`

## Local build note

The available Docker VM is capped at 2 GB. A full image build reached Nuxt client compilation and was killed by that resource ceiling, including with a constrained Node heap. This PR's container-image job performs the full production build on a GitHub-hosted runner before running the smoke tests.

## Owner follow-up after merge

GHCR creates organization packages as private by default, and a repository-scoped `GITHUB_TOKEN` cannot change organization package visibility. After the first main-branch publication, an organization owner must make `multiforum-nuxt` public once. The workflow then verifies anonymous access on every publication.
