### PR TITLE
feat(self-hosting): pull official frontend image

### DIFF
--- a/.env.quickstart.example
+++ b/.env.quickstart.example
@@ -1,4 +1,4 @@
-# Optional overrides for `docker compose up --build`.
+# Optional overrides for `docker compose up`.
 # Copy this file to .env.quickstart, edit it, then pass
 # `--env-file .env.quickstart` to Docker Compose.
 
@@ -13,16 +13,16 @@ NEO4J_PASSWORD=multiforum-local-neo4j
 MULTIFORUM_BIND_ADDRESS=127.0.0.1
 MULTIFORUM_PUBLIC_FRONTEND_URL=http://localhost:3000
 
-# The quick-start pulls the official backend image. Pin a full release or
-# immutable sha-* tag instead of edge when you need a repeatable installation.
+# The quick-start pulls the official backend and frontend images. Pin full
+# release or immutable sha-* tags instead of edge for a repeatable installation.
 MULTIFORUM_BACKEND_IMAGE=ghcr.io/gennit-project/multiforum-backend:edge
 MULTIFORUM_BACKEND_PULL_POLICY=always
+MULTIFORUM_FRONTEND_IMAGE=ghcr.io/gennit-project/multiforum-nuxt:edge
+MULTIFORUM_FRONTEND_PULL_POLICY=always
 
 # These settings are used only with docker-compose.source.yml when contributors
-# deliberately build the backend from source.
+# deliberately build the application services from source.
 MULTIFORUM_BACKEND_REPOSITORY=https://github.com/gennit-project/multiforum-backend.git
 MULTIFORUM_BACKEND_REF=main
 MULTIFORUM_SOURCE_BACKEND_IMAGE=multiforum-backend:quickstart
-
-# Optional local frontend image tag.
-MULTIFORUM_FRONTEND_IMAGE=multiforum-frontend:quickstart
+MULTIFORUM_SOURCE_FRONTEND_IMAGE=multiforum-frontend:quickstart

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,194 @@
+name: Container image
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+concurrency:
+  group: container-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-publish-smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Sign in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            type=ref,event=pr
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and optionally publish image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
+          sbom: ${{ github.event_name != 'pull_request' }}
+
+      - name: Select image for smoke test
+        id: smoke-image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=${IMAGE_NAME}:pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${IMAGE_NAME}@${DIGEST}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Start mock backend
+        run: |
+          set -euo pipefail
+          docker network create multiforum-frontend-image-smoke
+          docker run --detach \
+            --name multiforum-backend-mock \
+            --network multiforum-frontend-image-smoke \
+            node:26.5.1-alpine \
+            node -e 'require("http").createServer((_request,response)=>{response.writeHead(200,{"content-type":"application/json"});response.end(JSON.stringify({data:{imageSmoke:"ok"}}))}).listen(4000,"0.0.0.0")'
+
+      - name: Start Multiforum frontend image
+        env:
+          SMOKE_IMAGE: ${{ steps.smoke-image.outputs.value }}
+        run: |
+          set -euo pipefail
+          docker run --detach \
+            --name multiforum-frontend-smoke \
+            --network multiforum-frontend-image-smoke \
+            --publish 127.0.0.1:3000:3000 \
+            --env NUXT_PUBLIC_AUTH_PROVIDER=local-dev \
+            --env NUXT_PUBLIC_BASE_URL=http://127.0.0.1:3000 \
+            --env NUXT_PUBLIC_ENVIRONMENT=development \
+            --env NUXT_PUBLIC_SERVER_NAME='Image Smoke Test' \
+            --env NUXT_PUBLIC_SERVER_DISPLAY_NAME='Image Smoke Test' \
+            --env NUXT_BACKEND_GRAPHQL_URL=http://multiforum-backend-mock:4000/graphql \
+            --env NUXT_LOCAL_AUTH_TOKEN_ENDPOINT=http://multiforum-backend-mock:4000/auth/local-dev/token \
+            "$SMOKE_IMAGE"
+
+      - name: Verify frontend runtime behavior
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            status="$(docker inspect --format='{{.State.Health.Status}}' multiforum-frontend-smoke)"
+            if [ "$status" = "healthy" ]; then
+              break
+            fi
+            if [ "$status" = "unhealthy" ]; then
+              docker logs multiforum-frontend-smoke
+              exit 1
+            fi
+            sleep 5
+          done
+
+          test "$(docker inspect --format='{{.State.Health.Status}}' multiforum-frontend-smoke)" = healthy
+          test "$(docker inspect --format='{{.Config.User}}' multiforum-frontend-smoke)" = node
+
+          curl --fail --silent --show-error http://127.0.0.1:3000/login \
+            | grep --fixed-strings 'Image Smoke Test' >/dev/null
+          curl --fail --silent --show-error \
+            --header 'content-type: application/json' \
+            --data '{"query":"query ImageSmoke { imageSmoke }"}' \
+            http://127.0.0.1:3000/api/graphql \
+            | grep --fixed-strings '"imageSmoke":"ok"' >/dev/null
+
+      - name: Verify incomplete Auth0 configuration is rejected
+        env:
+          SMOKE_IMAGE: ${{ steps.smoke-image.outputs.value }}
+        run: |
+          set -euo pipefail
+          docker run --detach \
+            --name multiforum-frontend-auth0-smoke \
+            --env NUXT_PUBLIC_AUTH_PROVIDER=auth0 \
+            "$SMOKE_IMAGE"
+
+          for _ in $(seq 1 30); do
+            running="$(docker inspect --format='{{.State.Running}}' multiforum-frontend-auth0-smoke)"
+            if [ "$running" = "false" ]; then
+              break
+            fi
+            sleep 1
+          done
+
+          test "$(docker inspect --format='{{.State.Running}}' multiforum-frontend-auth0-smoke)" = false
+          test "$(docker inspect --format='{{.State.ExitCode}}' multiforum-frontend-auth0-smoke)" != 0
+          docker logs multiforum-frontend-auth0-smoke 2>&1 \
+            | grep --fixed-strings 'Auth0 runtime configuration is missing' >/dev/null
+
+      - name: Show container logs on failure
+        if: failure()
+        run: |
+          docker logs multiforum-backend-mock || true
+          docker logs multiforum-frontend-smoke || true
+          docker logs multiforum-frontend-auth0-smoke || true
+
+      - name: Clean up smoke containers
+        if: always()
+        run: |
+          docker rm --force multiforum-backend-mock multiforum-frontend-smoke multiforum-frontend-auth0-smoke || true
+          docker network rm multiforum-frontend-image-smoke || true
+
+      # GITHUB_TOKEN can publish repository-linked packages but cannot change
+      # organization package visibility. An organization owner must make the
+      # package public once; every publication then proves anonymous access.
+      - name: Verify the published image is public
+        if: github.event_name != 'pull_request'
+        env:
+          PUBLISHED_IMAGE: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          anonymous_docker_config="$(mktemp -d)"
+          trap 'rm -rf "$anonymous_docker_config"' EXIT
+          DOCKER_CONFIG="$anonymous_docker_config" docker pull "$PUBLISHED_IMAGE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM node:26.5.1-alpine AS build
+# Keep build and runtime aligned with .nvmrc and CI. The arguments also make
+# deliberate patch-version updates easy to audit in release PRs.
+ARG NODE_VERSION=26.5.1
+ARG PNPM_VERSION=10.28.2
+
+FROM node:${NODE_VERSION}-alpine AS build
+
+ARG PNPM_VERSION
 
 WORKDIR /app
 
 # Node 26 no longer bundles Corepack, so install the repository-pinned package
 # manager explicitly.
-RUN npm install --global pnpm@10.28.2
+RUN npm install --global "pnpm@${PNPM_VERSION}"
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
@@ -17,7 +24,11 @@ ENV NITRO_PRESET=node-server
 
 RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm run build
 
-FROM node:26.5.1-alpine AS runtime
+FROM node:${NODE_VERSION}-alpine AS runtime
+
+LABEL org.opencontainers.image.title="Multiforum Frontend" \
+  org.opencontainers.image.description="Nuxt web application for Multiforum" \
+  org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
 
@@ -29,5 +40,10 @@ COPY --from=build --chown=node:node /app/.output ./.output
 
 USER node
 EXPOSE 3000
+
+# Check only that the Node server is listening. Backend and integration health
+# are separate concerns and should not make the frontend container unhealthy.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=12 \
+  CMD node -e "const socket=require('net').connect(process.env.PORT||3000,'127.0.0.1');socket.setTimeout(4000);socket.on('connect',()=>{socket.destroy();process.exit(0)});socket.on('timeout',()=>{socket.destroy();process.exit(1)});socket.on('error',()=>process.exit(1))"
 
 CMD ["node", ".output/server/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ client.
 Start here:
 
 - [Local self-hosting quick-start](./docs/self-hosting-quickstart.md)
+- [Official frontend container image](./docs/frontend-container-image.md)
 - [Development setup](./docs/development-setup.md)
 - [AWS single-VM Terraform example](./deploy/terraform/aws-single-vm/README.md)
 - [Contributing guide](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start a usable local instance, including Neo4j, the backend, the frontend, and
 an automatically provisioned administrator:
 
 ```bash
-docker compose up --build
+docker compose up
 ```
 
 Then open [http://localhost:3000](http://localhost:3000) and sign in with the

--- a/docker-compose.source.yml
+++ b/docker-compose.source.yml
@@ -1,5 +1,5 @@
-# Contributor override: build the backend from source instead of pulling the
-# official GHCR image used by the normal self-hosting quick-start.
+# Contributor override: build the application services from source instead of
+# pulling the official GHCR images used by the normal self-hosting quick-start.
 services:
   backend:
     image: ${MULTIFORUM_SOURCE_BACKEND_IMAGE:-multiforum-backend:quickstart}
@@ -10,3 +10,10 @@ services:
       args:
         MULTIFORUM_BACKEND_REPOSITORY: ${MULTIFORUM_BACKEND_REPOSITORY:-https://github.com/gennit-project/multiforum-backend.git}
         MULTIFORUM_BACKEND_REF: ${MULTIFORUM_BACKEND_REF:-main}
+
+  frontend:
+    image: ${MULTIFORUM_SOURCE_FRONTEND_IMAGE:-multiforum-frontend:quickstart}
+    pull_policy: build
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,10 +82,8 @@ services:
       - multiforum-network
 
   frontend:
-    image: ${MULTIFORUM_FRONTEND_IMAGE:-multiforum-frontend:quickstart}
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ${MULTIFORUM_FRONTEND_IMAGE:-ghcr.io/gennit-project/multiforum-nuxt:edge}
+    pull_policy: ${MULTIFORUM_FRONTEND_PULL_POLICY:-always}
     restart: unless-stopped
     ports:
       - '${MULTIFORUM_BIND_ADDRESS:-127.0.0.1}:3000:3000'

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Developer documentation for the Multiforum Nuxt frontend. See the
 
 - [Local self-hosting quick-start](./self-hosting-quickstart.md) — start a usable instance with one Docker Compose command
 - [Frontend runtime configuration](./frontend-runtime-configuration.md) — configure one built frontend image at container startup
+- [Frontend container image](./frontend-container-image.md) — official image tags, architectures, and runtime behavior
 - [Development setup](./development-setup.md) — local environment and tooling
 - [AWS single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md) — provision a Docker-ready self-hosting VM without storing app secrets in Terraform state
 - [Frontend architecture and authentication](./architecture-and-auth.md)

--- a/docs/frontend-container-image.md
+++ b/docs/frontend-container-image.md
@@ -1,0 +1,69 @@
+# Frontend container image
+
+The official Multiforum frontend image is published at:
+
+```text
+ghcr.io/gennit-project/multiforum-nuxt
+```
+
+Images support `linux/amd64` and `linux/arm64`. They run as the unprivileged
+`node` user and include an internal health check for the Nuxt server on port 3000.
+
+## Tags
+
+| Tag            | Meaning                                     | Recommended use                          |
+| -------------- | ------------------------------------------- | ---------------------------------------- |
+| `edge`         | Current `main` branch                       | Local evaluation and integration testing |
+| `latest`       | Most recent stable semantic-version release | Convenient stable installs               |
+| `1.2.3`        | Exact semantic-version release              | Repeatable production installs           |
+| `1.2` or `1`   | Moving release series                       | Controlled automatic updates             |
+| `sha-<commit>` | Immutable source revision                   | Maximum deployment reproducibility       |
+
+Production deployments should pin an exact semantic version or immutable SHA
+instead of following `edge` or another moving tag.
+
+## Run the image
+
+The frontend requires a reachable Multiforum backend. This minimal example
+uses local development authentication and assumes the backend is named
+`backend` on the same Docker network:
+
+```bash
+docker run --rm \
+  --network multiforum-network \
+  --publish 127.0.0.1:3000:3000 \
+  --env NUXT_PUBLIC_AUTH_PROVIDER=local-dev \
+  --env NUXT_PUBLIC_BASE_URL=http://localhost:3000 \
+  --env NUXT_PUBLIC_SERVER_NAME='My Multiforum' \
+  --env NUXT_PUBLIC_SERVER_DISPLAY_NAME='My Multiforum' \
+  --env NUXT_BACKEND_GRAPHQL_URL=http://backend:4000/graphql \
+  --env NUXT_LOCAL_AUTH_TOKEN_ENDPOINT=http://backend:4000/auth/local-dev/token \
+  ghcr.io/gennit-project/multiforum-nuxt:edge
+```
+
+The same image supports Auth0 when the corresponding server-only
+`NUXT_AUTH0_*` secrets are supplied. See
+[frontend runtime configuration](./frontend-runtime-configuration.md) for the
+complete variable list and security boundaries.
+
+The local-development provider must not be exposed to the public internet.
+Production deployments require TLS, production authentication, unique secrets,
+backups, and appropriately secured backend and database services.
+
+## Supply-chain metadata
+
+Main-branch and release publications include OCI source and revision labels,
+a software bill of materials, and build provenance. Pulling by digest provides
+an immutable reference independent of the tag policy:
+
+```bash
+docker pull ghcr.io/gennit-project/multiforum-nuxt@sha256:DIGEST
+```
+
+The publishing workflow tests the non-root runtime, health check, runtime
+branding, same-origin GraphQL proxy, local-development mode, and rejection of
+incomplete Auth0 configuration before accepting an image publication.
+
+The GHCR package must be made public once by an organization owner after its
+first publication. Every subsequent publication verifies that its digest can
+be pulled with an anonymous Docker configuration.

--- a/docs/self-hosting-quickstart.md
+++ b/docs/self-hosting-quickstart.md
@@ -2,25 +2,25 @@
 
 Try Multiforum locally before configuring Auth0, cloud storage, maps, email, or
 other production integrations. The default Docker Compose stack starts Neo4j,
-pulls the backend, builds the frontend, creates the initial server configuration
-and roles, and provisions the first administrator automatically.
+pulls the official backend and frontend images, creates the initial server
+configuration and roles, and provisions the first administrator automatically.
 
 ## Requirements
 
 - Docker Engine with Docker Compose v2 (Docker Desktop includes it)
 - Git
-- At least 4 GB of memory available to Docker during the initial frontend build
+- At least 2 GB of memory available to Docker (4 GB recommended)
 
 ## Start Multiforum
 
 From this repository's root, run:
 
 ```bash
-docker compose up --build
+docker compose up
 ```
 
-The first run pulls the official backend image, builds the frontend, and can
-take several minutes. When all three services are healthy, open
+The first run pulls the official backend and frontend images and can take a few
+minutes. When all three services are healthy, open
 [http://localhost:3000](http://localhost:3000) and choose **Sign in**. The local
 administrator password is:
 
@@ -41,23 +41,25 @@ Copy the provided template, change both passwords, and start Compose with it:
 
 ```bash
 cp .env.quickstart.example .env.quickstart
-docker compose --env-file .env.quickstart up --build
+docker compose --env-file .env.quickstart up
 ```
 
 The bootstrap password must contain at least 12 characters. The bootstrap user
 is created only when its email is not already present, so changing the values
 later does not replace an existing administrator.
 
-The default `edge` backend image follows the backend repository's `main` branch.
-For a repeatable installation, pin a full release tag or immutable commit tag:
+The default `edge` images follow each repository's `main` branch. For a
+repeatable installation, pin both images to full release tags or immutable
+commit tags:
 
 ```dotenv
 MULTIFORUM_BACKEND_IMAGE=ghcr.io/gennit-project/multiforum-backend:1.2.3
-# Or: ghcr.io/gennit-project/multiforum-backend:sha-0123456
+MULTIFORUM_FRONTEND_IMAGE=ghcr.io/gennit-project/multiforum-nuxt:1.2.3
+# Or use each image's sha-0123456 tag.
 ```
 
-Contributors who need to test an unmerged backend branch can retain the old
-source-build behavior with the provided override:
+Contributors who need to test the current frontend checkout or an unmerged
+backend branch can build both application services with the provided override:
 
 ```bash
 docker compose \
@@ -68,11 +70,11 @@ docker compose \
 ```
 
 Set `MULTIFORUM_BACKEND_REPOSITORY` and `MULTIFORUM_BACKEND_REF` in
-`.env.quickstart` to choose the source revision for that command.
+`.env.quickstart` to choose the backend source revision for that command. The
+frontend is built from the current checkout.
 
-The frontend currently builds locally, but its deployment-specific settings
-are runtime configurable so the same artifact can be reused by the upcoming
-official frontend image. See
+See [frontend container image](./frontend-container-image.md) for tag and
+platform details, and
 [frontend runtime configuration](./frontend-runtime-configuration.md) for the
 supported `NUXT_*` variables.
 
@@ -113,9 +115,9 @@ docker compose ps
 docker compose logs --tail=100 database backend frontend
 ```
 
-If the initial frontend build is killed for lack of memory, increase Docker's
-memory allocation and run the command again. Docker will reuse completed layers
-and already-downloaded images.
+If a contributor source build is killed for lack of memory, increase Docker's
+memory allocation and run the override command again. Docker will reuse
+completed layers and already-downloaded images.
 
 If ports 3000, 4000, 7474, or 7687 are already in use, stop the conflicting
 local services before starting the stack.


### PR DESCRIPTION
## Summary

- make the default Docker Compose quick-start pull the official frontend and backend images
- preserve opt-in source builds for both application services through `docker-compose.source.yml`
- document frontend image pinning and remove the initial frontend build requirement from the quick-start

## Stack

- Depends on #476
- Base: `codex/self-hosting-14-frontend-image`

## Validation

- `docker compose config --quiet`
- `docker compose --env-file .env.quickstart.example config --quiet`
- `docker compose --env-file .env.quickstart.example -f docker-compose.yml -f docker-compose.source.yml config --quiet`
- assertions against resolved default images, absent default build blocks, and source override build targets
- `pnpm exec prettier --check README.md docker-compose.yml docker-compose.source.yml docs/self-hosting-quickstart.md`
- `git diff --check`

## Coverage

This change only updates Compose configuration and documentation; it adds no executable frontend application code, so code coverage is unchanged.