### PR TITLE
feat(self-hosting): deploy official images with terraform

### DIFF
--- a/deploy/terraform/aws-single-vm/README.md
+++ b/deploy/terraform/aws-single-vm/README.md
@@ -2,19 +2,22 @@
 
 This example creates one Ubuntu 24.04 EC2 instance for Multiforum, installs
 Docker and Docker Compose with cloud-init, clones the frontend repository into
-`/opt/multiforum`, and assigns a stable Elastic IP. It is deliberately a small
-operator-owned starting point, not a managed production platform.
+`/opt/multiforum` for its deployment configuration, pre-pulls the official
+backend and frontend images, and assigns a stable Elastic IP. It is deliberately
+a small operator-owned starting point, not a managed production platform.
 
-Terraform does **not** receive application secrets. Auth0 credentials, the
+Terraform does **not** receive application secrets. The bootstrap credentials,
 Neo4j password, and optional integration keys therefore stay out of Terraform
-plans and state. You add them directly on the host after provisioning.
+plans and state. The selected non-secret image references are stored in state
+and written to `/opt/multiforum/.env.quickstart`; you add secrets directly on
+the host after provisioning.
 
 ## What it creates
 
 - one EC2 instance in the account's default VPC;
 - one encrypted gp3 root volume (40 GiB by default), including Docker volumes;
 - one security group exposing SSH only to `admin_cidr`;
-- port 3000 to `application_cidrs` (public by default); and
+- port 3000 only to the explicitly configured `application_cidrs`; and
 - one Elastic IP for a stable address.
 
 Neo4j's ports (7474 and 7687) and the backend port (4000) are not admitted by
@@ -48,7 +51,9 @@ address. Terraform prints the resulting SSH command and temporary application
 URL.
 
 Cloud-init may continue installing packages for a few minutes after EC2 reports
-the instance as running. Follow its progress with:
+the instance as running. It clones the selected `repository_ref`, writes the
+selected image references, and runs `docker compose pull`. Follow its progress
+with:
 
 ```bash
 ssh ubuntu@PUBLIC_IP
@@ -57,38 +62,49 @@ cloud-init status --wait
 
 ## Configure and start Multiforum
 
-On the host, create `/opt/multiforum/.env` from the repository example and fill
-in strong, real values. The current application stack requires Auth0 for login;
-maps, geocoding, mail, and storage remain optional and degrade when omitted.
+Cloud-init creates `/opt/multiforum/.env.quickstart` from the repository example
+and injects the selected image references. On the host, replace the default
+credentials with strong, unique values before starting. Maps, geocoding, mail,
+and storage remain optional and degrade when omitted.
 
 ```bash
 cd /opt/multiforum
-cp .env.example .env
-$EDITOR .env
-docker compose up -d --build
+$EDITOR .env.quickstart
+docker compose --env-file .env.quickstart up -d
 docker compose ps
 ```
 
-Do not use the placeholder Neo4j password. Keep `NEO4J_AUTH` and
-`NEO4J_PASSWORD` consistent, and configure the Auth0 callback/base URLs for the
-address users will visit.
+Do not use either placeholder password left in `.env.quickstart` by cloud-init.
 
-Port 3000 serves plain HTTP only. Before allowing public users, put a TLS
-reverse proxy or load balancer in front of the instance, configure a domain,
-and remove public port-3000 access. A future module can make that advanced path
-repeatable without coupling the basic example to a specific DNS provider.
+This stack uses Multiforum's local development authentication and is for a
+private evaluation environment only. Restrict `application_cidrs` to trusted
+addresses and do not expose this configuration as a public production forum.
+
+Port 3000 serves plain HTTP only. A public production deployment also needs a
+production identity provider, a TLS reverse proxy or load balancer, a domain,
+and removal of public port-3000 access. Those production-hardening steps remain
+outside this private evaluation example.
 
 ## Updating and destroying
 
-Application updates are explicit so an infrastructure plan cannot silently
-change the running forum:
+The image inputs select the initial installation; Terraform is deliberately not
+an in-place application updater. Update an existing host explicitly:
 
 ```bash
+ssh ubuntu@PUBLIC_IP
 cd /opt/multiforum
 git fetch --tags
 git checkout RELEASE_TAG
-docker compose up -d --build
+# Set the new backend and frontend image references.
+$EDITOR .env.quickstart
+docker compose --env-file .env.quickstart pull
+docker compose --env-file .env.quickstart up -d
 ```
+
+Cloud-init runs only when the instance is first created. Before provisioning a
+replacement host, update `repository_ref`, `backend_image`, and `frontend_image`
+in `terraform.tfvars` to match the revisions you tested. Automated in-place
+application upgrades are deliberately outside this example's current scope.
 
 The Canonical SSM parameter selects the current Ubuntu 24.04 image when the
 instance is first created. Later AMI changes are ignored because replacing this

--- a/deploy/terraform/aws-single-vm/cloud-init.tftpl
+++ b/deploy/terraform/aws-single-vm/cloud-init.tftpl
@@ -11,6 +11,11 @@ runcmd:
   - systemctl enable --now docker
   - usermod -aG docker ubuntu
   - git clone --branch '${repository_ref}' --depth 1 https://github.com/gennit-project/multiforum-nuxt.git /opt/multiforum
+  - cp /opt/multiforum/.env.quickstart.example /opt/multiforum/.env.quickstart
+  - sed -i 's|^MULTIFORUM_BACKEND_IMAGE=.*|MULTIFORUM_BACKEND_IMAGE=${backend_image}|' /opt/multiforum/.env.quickstart
+  - sed -i 's|^MULTIFORUM_FRONTEND_IMAGE=.*|MULTIFORUM_FRONTEND_IMAGE=${frontend_image}|' /opt/multiforum/.env.quickstart
+  - chmod 0600 /opt/multiforum/.env.quickstart
   - chown -R ubuntu:ubuntu /opt/multiforum
+  - docker compose --env-file /opt/multiforum/.env.quickstart --project-directory /opt/multiforum pull
 
-final_message: "Multiforum host prerequisites are ready. Application secrets have not been installed."
+final_message: "Multiforum configuration and container images are ready. Replace the placeholder credentials before starting the stack."

--- a/deploy/terraform/aws-single-vm/main.tf
+++ b/deploy/terraform/aws-single-vm/main.tf
@@ -61,6 +61,8 @@ resource "aws_instance" "multiforum" {
   vpc_security_group_ids      = [aws_security_group.multiforum.id]
 
   user_data = templatefile("${path.module}/cloud-init.tftpl", {
+    backend_image  = var.backend_image
+    frontend_image = var.frontend_image
     repository_ref = var.repository_ref
   })
 

--- a/deploy/terraform/aws-single-vm/terraform.tfvars.example
+++ b/deploy/terraform/aws-single-vm/terraform.tfvars.example
@@ -2,8 +2,10 @@ aws_region   = "us-east-1"
 admin_cidr   = "203.0.113.10/32"
 ssh_key_name = "my-existing-ec2-key"
 
-# Pin a release tag for a repeatable production deployment.
+# Pin the deployment configuration and both images for a repeatable install.
 repository_ref = "main"
+backend_image  = "ghcr.io/gennit-project/multiforum-backend:edge"
+frontend_image = "ghcr.io/gennit-project/multiforum-nuxt:edge"
 
-# Start narrower during setup if the instance should not yet be public.
+# Keep the local-auth quick-start restricted to trusted addresses.
 application_cidrs = ["203.0.113.10/32"]

--- a/deploy/terraform/aws-single-vm/variables.tf
+++ b/deploy/terraform/aws-single-vm/variables.tf
@@ -49,8 +49,7 @@ variable "root_volume_size_gib" {
 
 variable "application_cidrs" {
   type        = list(string)
-  description = "IPv4 CIDRs allowed to reach the temporary HTTP application port (3000)."
-  default     = ["0.0.0.0/0"]
+  description = "Trusted IPv4 CIDRs allowed to reach the temporary HTTP application port (3000)."
 
   validation {
     condition     = length(var.application_cidrs) > 0 && alltrue([for cidr in var.application_cidrs : can(cidrnetmask(cidr))])
@@ -60,11 +59,33 @@ variable "application_cidrs" {
 
 variable "repository_ref" {
   type        = string
-  description = "Git branch or tag checked out by cloud-init. Pin a release tag for repeatable production installs."
+  description = "Git branch or tag containing the deployment configuration. Pin a release tag for repeatable installs."
   default     = "main"
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9._/-]{1,100}$", var.repository_ref))
     error_message = "repository_ref contains unsupported characters."
+  }
+}
+
+variable "backend_image" {
+  type        = string
+  description = "Backend OCI image pulled during cloud-init. Pin a release or digest for repeatable installs."
+  default     = "ghcr.io/gennit-project/multiforum-backend:edge"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.backend_image))
+    error_message = "backend_image must be a valid OCI image reference without whitespace."
+  }
+}
+
+variable "frontend_image" {
+  type        = string
+  description = "Frontend OCI image pulled during cloud-init. Pin a release or digest for repeatable installs."
+  default     = "ghcr.io/gennit-project/multiforum-nuxt:edge"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.frontend_image))
+    error_message = "frontend_image must be a valid OCI image reference without whitespace."
   }
 }


### PR DESCRIPTION
## Summary

- add validated Terraform inputs for the official backend and frontend OCI images
- have cloud-init create a protected quick-start environment file and pre-pull the image-only stack
- require explicit trusted application CIDRs instead of defaulting port 3000 to the public internet
- update the operator guide for private evaluation, image pinning, first start, and explicit upgrades

## Stack

- Depends on #477
- Transitively depends on #476
- Base: `codex/self-hosting-15-pull-frontend-image`

## Validation

- Terraform 1.8.5 `fmt -check -recursive`
- Terraform 1.8.5 `validate` with the locked AWS provider
- rendered cloud-init YAML parse with release-tag and digest image examples
- assertions for repository revision, image injection, environment-file permissions, and image pull command
- `pnpm exec prettier --check deploy/terraform/aws-single-vm/README.md`
- `git diff --check`

## Coverage

This change only updates Terraform, cloud-init, and documentation. It adds no executable frontend application code, so frontend coverage is unchanged.