### PR TITLE
feat(self-hosting): add production compose foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,10 +73,9 @@ NUXT_AUTH0_APP_BASE_URL=http://localhost:3000
 # getAccessToken() returns a JWT the backend accepts.
 NUXT_AUTH0_AUDIENCE=https://api.placeholder.app
 
-# --- Session store (production only) ---
-# Sessions are stored in Upstash Redis in production (nitro.storage in
-# nuxt.config.ts). Provision an Upstash Redis database via the Vercel
-# Marketplace and set these in the Vercel project. Local dev uses a filesystem
-# store instead (nitro.devStorage), so these can be left unset locally.
+# --- Serverless production session store ---
+# Vercel deployments store sessions in Upstash Redis. Provision a database via
+# the Vercel Marketplace and set these in the Vercel project. Local development
+# and the official single-node container use filesystem storage instead.
 UPSTASH_REDIS_REST_URL=https://placeholder.upstash.io
 UPSTASH_REDIS_REST_TOKEN=placeholder

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,36 @@
+# Copy to .env.production, set restrictive permissions, and replace every empty
+# required value before running the production Compose overlay.
+
+MULTIFORUM_DOMAIN=forum.example.com
+MULTIFORUM_INSTANCE_NAME=My Multiforum
+MULTIFORUM_BIND_ADDRESS=127.0.0.1
+CADDY_ACME_EMAIL=admin@example.com
+
+# Pin releases or immutable sha-* tags for repeatable deployments.
+MULTIFORUM_BACKEND_IMAGE=ghcr.io/gennit-project/multiforum-backend:edge
+MULTIFORUM_BACKEND_PULL_POLICY=always
+MULTIFORUM_FRONTEND_IMAGE=ghcr.io/gennit-project/multiforum-nuxt:edge
+MULTIFORUM_FRONTEND_PULL_POLICY=always
+
+# Required secrets and identity configuration.
+NEO4J_PASSWORD=
+MULTIFORUM_SUPERADMIN_EMAIL=
+PLUGIN_SECRET_ENCRYPTION_KEY=
+AUTH0_DOMAIN=
+AUTH0_CLIENT_ID=
+AUTH0_AUDIENCE=
+NUXT_AUTH0_CLIENT_SECRET=
+NUXT_AUTH0_SESSION_SECRET=
+
+# Optional uploads and email. Leave blank to keep each capability disabled.
+GCS_BUCKET_NAME=
+GCS_PRIVATE_DOWNLOAD_BUCKET_NAME=
+GOOGLE_CREDENTIALS_BASE64=
+GOOGLE_MAPS_API_KEY=
+GOOGLE_MAP_ID=
+OPEN_CAGE_API_KEY=
+EMAIL_PROVIDER=
+EMAIL_FROM=
+RESEND_API_KEY=
+SENDGRID_API_KEY=
+SENDGRID_FROM_EMAIL=

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ logs
 .env.*
 !.env.example
 !.env.quickstart.example
+!.env.production.example
 
 # Cypress env file (contains secrets; must never be committed)
 cypress.env.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY . .
 # Deployment-specific configuration is supplied when the built server starts,
 # so this image can be promoted between environments without rebuilding.
 ENV NITRO_PRESET=node-server
+ENV MULTIFORUM_DATA_DIR=/app/data
 
 RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm run build
 
@@ -37,6 +38,10 @@ ENV NODE_ENV=production
 ENV PORT=3000
 
 COPY --from=build --chown=node:node /app/.output ./.output
+
+# The node-server build persists Auth0 sessions here. Creating the mount point
+# in the image gives new named volumes the non-root runtime user's ownership.
+RUN mkdir -p /app/data && chown node:node /app/data
 
 USER node
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ client.
 Start here:
 
 - [Local self-hosting quick-start](./docs/self-hosting-quickstart.md)
+- [Production Compose foundation](./docs/self-hosting-production.md)
 - [Official frontend container image](./docs/frontend-container-image.md)
 - [Development setup](./docs/development-setup.md)
 - [AWS single-VM Terraform example](./deploy/terraform/aws-single-vm/README.md)

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -1,0 +1,15 @@
+{
+	email {$CADDY_ACME_EMAIL}
+}
+
+{$MULTIFORUM_DOMAIN} {
+	encode zstd gzip
+	reverse_proxy frontend:3000
+
+	header {
+		Strict-Transport-Security "max-age=31536000"
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		-Server
+	}
+}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,73 @@
+# Production overlay for the image-based stack. Supply every required value in
+# .env.production and combine this file with docker-compose.yml.
+services:
+  database:
+    environment:
+      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:?Set NEO4J_PASSWORD}
+
+  backend:
+    environment:
+      NODE_ENV: production
+      ENVIRONMENT: production
+      MULTIFORUM_AUTH_PROVIDER: auth0
+      MULTIFORUM_AUTO_PROVISION: 'true'
+      SUPERADMIN_EMAIL: ${MULTIFORUM_SUPERADMIN_EMAIL:?Set MULTIFORUM_SUPERADMIN_EMAIL}
+      AUTH0_DOMAIN: ${AUTH0_DOMAIN:?Set AUTH0_DOMAIN}
+      AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID:?Set AUTH0_CLIENT_ID}
+      AUTH0_AUDIENCE: ${AUTH0_AUDIENCE:?Set AUTH0_AUDIENCE}
+      FRONTEND_URL: https://${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:?Set NEO4J_PASSWORD}
+      PLUGIN_SECRET_ENCRYPTION_KEY: ${PLUGIN_SECRET_ENCRYPTION_KEY:?Set PLUGIN_SECRET_ENCRYPTION_KEY}
+      GCS_BUCKET_NAME: ${GCS_BUCKET_NAME:-}
+      GCS_PRIVATE_DOWNLOAD_BUCKET_NAME: ${GCS_PRIVATE_DOWNLOAD_BUCKET_NAME:-}
+      GOOGLE_CREDENTIALS_BASE64: ${GOOGLE_CREDENTIALS_BASE64:-}
+      EMAIL_PROVIDER: ${EMAIL_PROVIDER:-}
+      EMAIL_FROM: ${EMAIL_FROM:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      SENDGRID_API_KEY: ${SENDGRID_API_KEY:-}
+      SENDGRID_FROM_EMAIL: ${SENDGRID_FROM_EMAIL:-}
+
+  frontend:
+    environment:
+      NODE_ENV: production
+      NUXT_PUBLIC_AUTH_PROVIDER: auth0
+      NUXT_PUBLIC_BASE_URL: https://${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}
+      NUXT_PUBLIC_ENVIRONMENT: production
+      NUXT_PUBLIC_LOGOUT_URL: https://${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}/auth/logout
+      NUXT_AUTH0_DOMAIN: ${AUTH0_DOMAIN:?Set AUTH0_DOMAIN}
+      NUXT_AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID:?Set AUTH0_CLIENT_ID}
+      NUXT_AUTH0_CLIENT_SECRET: ${NUXT_AUTH0_CLIENT_SECRET:?Set NUXT_AUTH0_CLIENT_SECRET}
+      NUXT_AUTH0_SESSION_SECRET: ${NUXT_AUTH0_SESSION_SECRET:?Set NUXT_AUTH0_SESSION_SECRET}
+      NUXT_AUTH0_APP_BASE_URL: https://${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}
+      NUXT_AUTH0_AUDIENCE: ${AUTH0_AUDIENCE:?Set AUTH0_AUDIENCE}
+      NUXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY:-}
+      NUXT_PUBLIC_GOOGLE_MAP_ID: ${GOOGLE_MAP_ID:-}
+      NUXT_PUBLIC_OPEN_CAGE_API_KEY: ${OPEN_CAGE_API_KEY:-}
+      NUXT_PUBLIC_GOOGLE_CLOUD_STORAGE_BUCKET: ${GCS_BUCKET_NAME:-}
+    volumes:
+      - frontend-data:/app/data
+
+  caddy:
+    image: caddy:2.11.4-alpine
+    restart: unless-stopped
+    depends_on:
+      frontend:
+        condition: service_healthy
+    environment:
+      CADDY_ACME_EMAIL: ${CADDY_ACME_EMAIL:?Set CADDY_ACME_EMAIL}
+      MULTIFORUM_DOMAIN: ${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+    volumes:
+      - ./deploy/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    networks:
+      - multiforum-network
+
+volumes:
+  frontend-data:
+  caddy-data:
+  caddy-config:

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Developer documentation for the Multiforum Nuxt frontend. See the
 ## Getting started & architecture
 
 - [Local self-hosting quick-start](./self-hosting-quickstart.md) — start a usable instance with one Docker Compose command
+- [Production Compose foundation](./self-hosting-production.md) — run the official images with Auth0, persistent sessions, and automatic TLS
 - [Frontend runtime configuration](./frontend-runtime-configuration.md) — configure one built frontend image at container startup
 - [Frontend container image](./frontend-container-image.md) — official image tags, architectures, and runtime behavior
 - [Development setup](./development-setup.md) — local environment and tooling

--- a/docs/architecture-and-auth.md
+++ b/docs/architecture-and-auth.md
@@ -82,9 +82,10 @@ small backend-for-frontend under [`server/`](../server):
   session access token and profile to the client (used by the embedded-browser
   token fallback).
 - **Caching** is configured in [`nuxt.config.ts`](../nuxt.config.ts) via Nitro
-  `routeRules` and storage mounts (Upstash Redis in production, filesystem in
-  dev). Auth-personalized forum detail pages are deliberately **not** route
-  cached — a shared cache would leak one user's personalized render to others.
+  `routeRules` and storage mounts (Upstash Redis on serverless deployments,
+  persistent filesystem storage for development and the single-node image).
+  Auth-personalized forum detail pages are deliberately **not** route cached —
+  a shared cache would leak one user's personalized render to others.
 
 ### Rendering — Nuxt SSR + hydration
 

--- a/docs/frontend-container-image.md
+++ b/docs/frontend-container-image.md
@@ -46,6 +46,12 @@ The same image supports Auth0 when the corresponding server-only
 [frontend runtime configuration](./frontend-runtime-configuration.md) for the
 complete variable list and security boundaries.
 
+The `node-server` image stores Auth0 sessions below `/app/data`. Mount persistent
+storage there for production use. This filesystem store supports one frontend
+replica; horizontally scaled deployments require a shared session store. The
+[production Compose foundation](./self-hosting-production.md) configures the
+volume and TLS proxy.
+
 The local-development provider must not be exposed to the public internet.
 Production deployments require TLS, production authentication, unique secrets,
 backups, and appropriately secured backend and database services.

--- a/docs/frontend-runtime-configuration.md
+++ b/docs/frontend-runtime-configuration.md
@@ -27,8 +27,8 @@ variables below.
 
 Nuxt exposes every `NUXT_PUBLIC_*` value to the browser. Do not put secrets in
 these variables. Auth0 client secrets and session secrets belong in the
-server-only `NUXT_AUTH0_*` variables described by
-[`.env.auth0-nuxt.example`](../.env.auth0-nuxt.example).
+server-only `NUXT_AUTH0_*` variables demonstrated by
+[`.env.production.example`](../.env.production.example).
 
 The image contains inert Auth0 placeholders solely because the Auth0 module
 validates its shape even in `local-dev` mode. Selecting `auth0` without real

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -1,0 +1,157 @@
+# Production Compose foundation
+
+This deployment path runs the official Multiforum images behind Caddy with
+automatic HTTPS and Auth0 authentication. It is intended for one host and one
+frontend replica. It is a practical production foundation, not a high-
+availability platform: the host and its local Neo4j volume remain single points
+of failure.
+
+Start with the [local quick-start](./self-hosting-quickstart.md) before using
+this configuration. Do not reuse its credentials or local authentication mode.
+
+## Requirements
+
+- a Linux host with Docker Engine and Docker Compose v2;
+- a domain with its `A` and, when applicable, `AAAA` records pointing to the
+  host;
+- inbound TCP ports 80 and 443 plus UDP port 443 allowed by the host and cloud
+  firewalls;
+- an Auth0 Regular Web Application and Auth0 API; and
+- an off-host backup destination for the Neo4j data.
+
+Caddy obtains and renews certificates automatically. Port 80 must remain
+reachable for HTTP-to-HTTPS redirects and ACME validation unless you configure
+another supported Caddy challenge method.
+
+## Configure Auth0
+
+Create a Regular Web Application for the Nuxt server and a dedicated Auth0 API
+for the GraphQL backend. In the application settings for `forum.example.com`,
+configure:
+
+- Allowed Callback URL: `https://forum.example.com/auth/callback`
+- Allowed Logout URL: `https://forum.example.com`
+
+Use the API identifier as `AUTH0_AUDIENCE`. The same domain, client ID, and API
+audience are supplied to the frontend and backend so the access tokens issued
+by the server-side Auth0 session are accepted by GraphQL.
+
+Set `MULTIFORUM_SUPERADMIN_EMAIL` to a tightly controlled, verified Auth0
+account. It is the backend's break-glass root identity and bypasses normal role
+checks.
+
+## Prepare the environment
+
+Copy the production template and restrict it before adding secrets:
+
+```bash
+cp .env.production.example .env.production
+chmod 600 .env.production
+```
+
+Generate independent secrets rather than reusing passwords:
+
+```bash
+openssl rand -hex 32 # Neo4j password
+openssl rand -hex 16 # 32-character plugin encryption key
+openssl rand -hex 64 # Auth0 session encryption secret
+```
+
+Fill every required empty value in `.env.production`. Pin the backend and
+frontend to tested semantic-version or immutable `sha-*` tags rather than
+`edge`. Optional mail, maps, geocoding, and storage settings can remain empty;
+the instance capability status will keep those features disabled.
+
+Validate the merged Compose model before starting anything:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  config --quiet
+```
+
+Compose fails immediately when a required Auth0 or encryption value is empty.
+The environment file contains secrets: do not commit it, copy it into images,
+or make it world-readable.
+
+## Start and verify
+
+Start the stack and follow Caddy while it obtains the certificate:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  up -d
+
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  logs --tail=100 caddy frontend backend
+```
+
+Verify the HTTPS origin, sign-in redirect, and container health:
+
+```bash
+curl --fail --show-error --head https://forum.example.com
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  ps
+```
+
+Only Caddy publishes public ports. The frontend, backend, and Neo4j ports retain
+loopback-only bindings for host diagnostics. Caddy adds HSTS, MIME-sniffing, and
+referrer-policy headers and proxies traffic to the frontend over the private
+Compose network.
+
+## Persistent state and backups
+
+The deployment has two important persistent data sets:
+
+- `neo4j-data` contains the forum database; and
+- `frontend-data` contains encrypted Auth0 sessions for this single frontend
+  replica.
+
+Losing `frontend-data` signs users out but does not remove forum content.
+Losing `neo4j-data` loses the forum.
+
+Configure automated, encrypted, off-host backups before inviting users. For a
+simple cold snapshot, stop the write path and database, snapshot or copy the
+Neo4j volume with your infrastructure provider's tooling, and then restart:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  stop frontend backend database
+
+# Create and export an off-host snapshot of the neo4j-data volume here.
+
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  up -d
+```
+
+Use Neo4j's backup or dump tooling when your selected edition and operational
+requirements support it. Whichever method you choose, document retention,
+encrypt backups, monitor failures, and test restoring onto a separate host.
+
+## Updates and limitations
+
+Update one component at a time by changing its pinned image tag, pulling, and
+recreating the stack. Back up Neo4j first and review release notes for data or
+configuration migrations.
+
+This foundation does not yet provide multiple application replicas, managed
+Neo4j, zero-downtime upgrades, automated restores, or an open-source OIDC
+provider. Filesystem Auth0 sessions are intentionally scoped to one frontend
+replica; a multi-replica deployment needs a shared session store.

--- a/docs/self-hosting-quickstart.md
+++ b/docs/self-hosting-quickstart.md
@@ -102,9 +102,9 @@ only when you need them.
 Local development authentication is intentionally restricted by the backend to
 `NODE_ENV=development`. Its shared bootstrap password is not a production
 identity system. Do not expose this Compose configuration to the public
-internet; use the production self-hosting path with Auth0 (or a future supported
-OIDC provider), TLS, unique secrets, backups, and an appropriately secured
-Neo4j deployment.
+internet; use the [production Compose foundation](./self-hosting-production.md)
+with Auth0 (or a future supported OIDC provider), TLS, unique secrets, backups,
+and an appropriately secured Neo4j deployment.
 
 ## Troubleshooting
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,7 @@ import { config } from './config';
 import path from 'path';
 import { inMemoryCacheOptions } from './cache';
 import { DORMANT_AUTH0_CONFIG } from './utils/auth0RuntimeConfig';
+import { getAuthStorageConfig } from './utils/authStorageConfig';
 
 const isMockedE2E = process.env.VITE_E2E_MOCK_MODE === 'true';
 const browserGraphqlUrl = config?.graphqlUrl || 'http://localhost:4000';
@@ -16,9 +17,7 @@ const runtimeGraphqlFetch: typeof globalThis.fetch = (input, init) => {
       ? process.env.NUXT_BACKEND_GRAPHQL_URL?.trim()
       : '';
   const target =
-    typeof window === 'undefined'
-      ? runtimeBackendUrl || input
-      : input;
+    typeof window === 'undefined' ? runtimeBackendUrl || input : input;
   return globalThis.fetch(target, init);
 };
 const ignoredDevWatchPatterns = [
@@ -306,28 +305,14 @@ export default defineNuxtConfig({
     // silently logged out. A persistent, shared store survives restarts and (on
     // serverless) is shared across function instances, avoiding that cascade.
     //
-    // Production (Vercel) uses Upstash Redis over its REST API — no persistent
-    // TCP connections, so it fits the serverless model. The driver reads
-    // UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN from the environment at
-    // runtime (set these in the Vercel project). `ttl` (seconds) bounds orphaned
-    // entries: each session refresh re-`set`s the key and resets its TTL, so
-    // active sessions stay alive while abandoned ones expire after 30 days.
-    storage: {
-      auth0Sessions: {
-        driver: 'upstash',
-        base: 'auth0Sessions',
-        ttl: 60 * 60 * 24 * 30, // 30 days
-      },
-      // Per-email cache of the stable auth profile (username / mod name /
-      // avatar), so server/middleware/2.auth-session.ts doesn't re-run the full
-      // backend lookup on every authenticated request. Entries are written with
-      // a per-item TTL (PROFILE_CACHE_TTL_SECONDS); the unread-notification
-      // count is never cached here (fetched fresh per request).
-      authProfileCache: {
-        driver: 'upstash',
-        base: 'authProfileCache',
-      },
-    },
+    // Vercel uses Upstash Redis over its REST API so sessions are shared across
+    // function instances. The official node-server container keeps Auth0
+    // sessions under /app/data and uses a bounded in-process profile cache,
+    // avoiding an external Redis service for one frontend replica.
+    storage: getAuthStorageConfig({
+      nitroPreset: process.env.NITRO_PRESET,
+      dataDir: process.env.MULTIFORUM_DATA_DIR,
+    }),
     // Local dev keeps filesystem-backed mounts (no Upstash creds needed) that
     // still survive `nuxt dev` restarts. devStorage overrides the production
     // mounts above only during development.
@@ -337,8 +322,9 @@ export default defineNuxtConfig({
         base: './.auth0-sessions',
       },
       authProfileCache: {
-        driver: 'upstash',
-        base: 'authProfileCache',
+        driver: 'lru-cache',
+        max: 1000,
+        ttl: 60 * 60 * 1000,
       },
     },
     // Enable server-side caching
@@ -407,7 +393,7 @@ export default defineNuxtConfig({
     localAuthTokenEndpoint: '',
     // SPIKE (auth0-nuxt server-session migration): server-only Auth0 config.
     // These are overridden by NUXT_AUTH0_* env vars at runtime (see
-    // .env.auth0-nuxt.example). clientSecret + sessionSecret mean this is a
+    // .env.production.example). clientSecret + sessionSecret mean this is a
     // CONFIDENTIAL "Regular Web Application" in Auth0 — a different app type
     // than the current SPA.
     auth0: {

--- a/server/utils/session-store-factory.ts
+++ b/server/utils/session-store-factory.ts
@@ -10,14 +10,13 @@
 // only a small session id in the cookie and stores the tokens server-side.
 //
 // The 'auth0Sessions' storage mount is configured in nuxt.config (nitro):
-// Upstash Redis in production (a shared, persistent store across serverless
-// function instances) and a filesystem driver in local dev (nitro.devStorage).
-// Both survive restarts. With in-memory storage, every restart orphaned the
-// browser's session cookie (its id no longer in the store), which the SDK then
-// deleted on the resulting store miss, silently logging the user out — a shared
-// persistent store avoids that cascade. This store implementation is driver-
-// agnostic: it only talks to the unstorage interface, so the driver can change
-// without touching this file.
+// Upstash Redis is shared across serverless function instances, while local
+// development and the single-node container use a persistent filesystem mount.
+// With in-memory storage, every restart orphaned the browser's session cookie
+// (its id no longer in the store), which the SDK then deleted on the resulting
+// store miss, silently logging the user out. This implementation is driver-
+// agnostic: it only talks to unstorage, so the driver can change without
+// touching this file.
 import type {
   SessionStore,
   StateData,

--- a/tests/unit/utils/authStorageConfig.spec.ts
+++ b/tests/unit/utils/authStorageConfig.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getAuthStorageConfig } from '@/utils/authStorageConfig';
+
+describe('getAuthStorageConfig', () => {
+  it.each([
+    [
+      { nitroPreset: 'node-server' },
+      {
+        auth0Sessions: {
+          driver: 'fs',
+          base: '.data/auth0-sessions',
+        },
+        authProfileCache: {
+          driver: 'lru-cache',
+          max: 1000,
+          ttl: 3_600_000,
+        },
+      },
+    ],
+    [
+      { nitroPreset: 'node-server', dataDir: '/app/data' },
+      {
+        auth0Sessions: {
+          driver: 'fs',
+          base: '/app/data/auth0-sessions',
+        },
+        authProfileCache: {
+          driver: 'lru-cache',
+          max: 1000,
+          ttl: 3_600_000,
+        },
+      },
+    ],
+    [
+      { nitroPreset: 'vercel' },
+      {
+        auth0Sessions: {
+          driver: 'upstash',
+          base: 'auth0Sessions',
+          ttl: 2_592_000,
+        },
+        authProfileCache: {
+          driver: 'upstash',
+          base: 'authProfileCache',
+        },
+      },
+    ],
+    [
+      { nitroPreset: undefined },
+      {
+        auth0Sessions: {
+          driver: 'upstash',
+          base: 'auth0Sessions',
+          ttl: 2_592_000,
+        },
+        authProfileCache: {
+          driver: 'upstash',
+          base: 'authProfileCache',
+        },
+      },
+    ],
+  ])('returns the expected mounts for options %o', (options, expected) => {
+    expect(getAuthStorageConfig(options)).toEqual(expected);
+  });
+});

--- a/utils/authStorageConfig.ts
+++ b/utils/authStorageConfig.ts
@@ -1,0 +1,38 @@
+const SESSION_TTL_SECONDS = 60 * 60 * 24 * 30;
+const PROFILE_CACHE_TTL_MS = 60 * 60 * 1000;
+
+type AuthStorageConfigOptions = {
+  nitroPreset: string | undefined;
+  dataDir?: string;
+};
+
+export const getAuthStorageConfig = ({
+  nitroPreset,
+  dataDir = '.data',
+}: AuthStorageConfigOptions) => {
+  if (nitroPreset === 'node-server') {
+    return {
+      auth0Sessions: {
+        driver: 'fs' as const,
+        base: `${dataDir}/auth0-sessions`,
+      },
+      authProfileCache: {
+        driver: 'lru-cache' as const,
+        max: 1000,
+        ttl: PROFILE_CACHE_TTL_MS,
+      },
+    };
+  }
+
+  return {
+    auth0Sessions: {
+      driver: 'upstash' as const,
+      base: 'auth0Sessions',
+      ttl: SESSION_TTL_SECONDS,
+    },
+    authProfileCache: {
+      driver: 'upstash' as const,
+      base: 'authProfileCache',
+    },
+  };
+};


### PR DESCRIPTION
## Summary

- add a production Compose overlay with Auth0 wiring, fail-fast secrets, persistent frontend sessions, and a pinned Caddy TLS proxy
- make the official node-server image use filesystem Auth0 sessions plus a bounded one-hour in-process profile cache, removing the Upstash requirement for a single replica
- add a production environment template that keeps required secrets empty and optional capabilities disabled
- document DNS, Auth0 callbacks, TLS startup, health checks, cold backups, updates, and single-host limitations
- require production operators to opt into trusted application CIDRs rather than inheriting local-development assumptions

## Stack

- Depends on #478
- Transitively depends on #477 and #476
- Base: `codex/self-hosting-16-terraform-images`

## Validation

- full unit suite: 799 files and 7,604 tests passed
- targeted storage selector coverage: 100% statements, branches, functions, and lines
- `pnpm run tsc`
- ESLint on changed TypeScript configuration and tests
- full `NITRO_PRESET=node-server MULTIFORUM_DATA_DIR=/app/data pnpm run build`
- generated Nitro bundle inspection confirms filesystem Auth0 sessions and the one-hour LRU profile cache
- production Compose fail-fast check with empty required secrets
- resolved Compose assertions for Auth0 mode, HTTPS origin, persistent volume, public Caddy ports, and loopback-only application/database ports
- Caddyfile validation with the pinned official `caddy:2.11.4-alpine` image
- Prettier and `git diff --check`

## Coverage

The new runtime storage selector is covered at 100%. Configuration and documentation additions do not add executable frontend branches.