### PR TITLE
feat(self-hosting): wire Terraform to production Compose

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -7,10 +7,12 @@ MULTIFORUM_BIND_ADDRESS=127.0.0.1
 CADDY_ACME_EMAIL=admin@example.com
 
 # Pin releases or immutable sha-* tags for repeatable deployments.
+MULTIFORUM_NEO4J_IMAGE=neo4j:5.1.0
 MULTIFORUM_BACKEND_IMAGE=ghcr.io/gennit-project/multiforum-backend:edge
 MULTIFORUM_BACKEND_PULL_POLICY=always
 MULTIFORUM_FRONTEND_IMAGE=ghcr.io/gennit-project/multiforum-nuxt:edge
 MULTIFORUM_FRONTEND_PULL_POLICY=always
+MULTIFORUM_CADDY_IMAGE=caddy:2.11.4-alpine
 
 # Required secrets and identity configuration.
 NEO4J_PASSWORD=

--- a/deploy/terraform/aws-single-vm/README.md
+++ b/deploy/terraform/aws-single-vm/README.md
@@ -1,117 +1,153 @@
-# AWS single-VM Terraform example
+# AWS single-VM Terraform production example
 
-This example creates one Ubuntu 24.04 EC2 instance for Multiforum, installs
-Docker and Docker Compose with cloud-init, clones the frontend repository into
-`/opt/multiforum` for its deployment configuration, pre-pulls the official
-backend and frontend images, and assigns a stable Elastic IP. It is deliberately
-a small operator-owned starting point, not a managed production platform.
+This example provisions the AWS host for Multiforum's
+[production Compose foundation](../../../docs/self-hosting-production.md). It
+creates one Ubuntu 24.04 EC2 instance, installs Docker and Docker Compose,
+prepares `/opt/multiforum/.env.production`, pre-pulls the selected images, and
+assigns a stable Elastic IP. Caddy then serves the forum over automatic HTTPS.
 
-Terraform does **not** receive application secrets. The bootstrap credentials,
-Neo4j password, and optional integration keys therefore stay out of Terraform
-plans and state. The selected non-secret image references are stored in state
-and written to `/opt/multiforum/.env.quickstart`; you add secrets directly on
-the host after provisioning.
+This is a practical operator-owned deployment for one host and one frontend
+replica, not a high-availability platform. Neo4j and the application volumes
+remain local to the instance.
+
+Terraform intentionally does **not** receive application secrets. Auth0
+credentials, the Neo4j password, encryption keys, and optional integration
+credentials stay out of Terraform plans and state. Cloud-init writes only the
+domain, ACME email, instance name, and selected non-secret image references;
+you add secrets directly on the host before starting the stack.
 
 ## What it creates
 
 - one EC2 instance in the account's default VPC;
 - one encrypted gp3 root volume (40 GiB by default), including Docker volumes;
-- one security group exposing SSH only to `admin_cidr`;
-- port 3000 only to the explicitly configured `application_cidrs`; and
-- one Elastic IP for a stable address.
+- one security group allowing SSH only from `admin_cidr`;
+- inbound TCP 80 and 443 plus UDP 443 from `application_cidrs`; and
+- one Elastic IP and a DNS A-record output.
 
-Neo4j's ports (7474 and 7687) and the backend port (4000) are not admitted by
-the AWS security group. The instance metadata service requires IMDSv2 tokens.
+Ports 3000, 4000, 7474, and 7687 are not admitted by the AWS security group.
+They remain loopback-only host bindings in Compose. The instance metadata
+service requires IMDSv2 tokens.
 
 ## Prerequisites
 
 - Terraform 1.8 or newer;
 - AWS credentials available to Terraform;
-- an existing EC2 key pair in the selected region; and
-- a default VPC with at least one subnet.
+- an existing EC2 key pair in the selected region;
+- a default VPC with at least one subnet;
+- a domain whose DNS records you can change; and
+- an Auth0 Regular Web Application and Auth0 API.
 
 The default `t3.large` is a conservative starting size for Neo4j, the backend,
-and the frontend on one machine. Review current EC2, EBS, and Elastic IP pricing
-before applying. This example creates billable resources.
+the frontend, and Caddy on one machine. Review current EC2, EBS, data-transfer,
+and Elastic IP pricing before applying. This example creates billable resources.
 
 ## Provision the host
 
 ```bash
 cd deploy/terraform/aws-single-vm
 cp terraform.tfvars.example terraform.tfvars
-# Replace admin_cidr and ssh_key_name before continuing.
+$EDITOR terraform.tfvars
 terraform init
 terraform plan
 terraform apply
 ```
 
-Use a `/32` containing only your current public IPv4 address for `admin_cidr`.
-During initial setup, consider restricting `application_cidrs` to that same
-address. Terraform prints the resulting SSH command and temporary application
-URL.
+Set `admin_cidr` to a `/32` containing only your current public IPv4 address.
+Set `application_cidrs` to `0.0.0.0/0` for a public forum and Caddy's normal
+ACME flow. Pin `repository_ref` and every image input to revisions you have
+tested together rather than relying on `main` or `edge` in production.
 
-Cloud-init may continue installing packages for a few minutes after EC2 reports
-the instance as running. It clones the selected `repository_ref`, writes the
-selected image references, and runs `docker compose pull`. Follow its progress
-with:
+Terraform prints the stable IP, HTTPS URL, SSH command, and DNS record to
+create. Add that A record at your DNS provider:
+
+```bash
+terraform output dns_a_record
+```
+
+Wait for DNS to resolve to the reported Elastic IP before starting Caddy.
+Cloud-init may continue for a few minutes after EC2 reports the instance as
+running. Follow it with:
 
 ```bash
 ssh ubuntu@PUBLIC_IP
 cloud-init status --wait
 ```
 
-## Configure and start Multiforum
+Cloud-init clones the selected repository revision, copies
+`.env.production.example` to `.env.production`, injects the non-secret Terraform
+inputs, restricts the file to mode `0600`, and pre-pulls Neo4j, backend,
+frontend, and Caddy images. It deliberately does not start Compose while the
+required secrets are empty.
 
-Cloud-init creates `/opt/multiforum/.env.quickstart` from the repository example
-and injects the selected image references. On the host, replace the default
-credentials with strong, unique values before starting. Maps, geocoding, mail,
-and storage remain optional and degrade when omitted.
+## Configure Auth0 and secrets
 
-```bash
-cd /opt/multiforum
-$EDITOR .env.quickstart
-docker compose --env-file .env.quickstart up -d
-docker compose ps
-```
+Follow the [Auth0 and secret setup](../../../docs/self-hosting-production.md#configure-auth0)
+for your domain. The Auth0 application must allow:
 
-Do not use either placeholder password left in `.env.quickstart` by cloud-init.
+- `https://YOUR_DOMAIN/auth/callback` as a callback URL; and
+- `https://YOUR_DOMAIN` as a logout URL.
 
-This stack uses Multiforum's local development authentication and is for a
-private evaluation environment only. Restrict `application_cidrs` to trusted
-addresses and do not expose this configuration as a public production forum.
-
-Port 3000 serves plain HTTP only. A public production deployment also needs a
-production identity provider, a TLS reverse proxy or load balancer, a domain,
-and removal of public port-3000 access. Those production-hardening steps remain
-outside this private evaluation example.
-
-## Updating and destroying
-
-The image inputs select the initial installation; Terraform is deliberately not
-an in-place application updater. Update an existing host explicitly:
+Then edit the protected environment file on the host and fill every required
+empty value:
 
 ```bash
 ssh ubuntu@PUBLIC_IP
 cd /opt/multiforum
-git fetch --tags
-git checkout RELEASE_TAG
-# Set the new backend and frontend image references.
-$EDITOR .env.quickstart
-docker compose --env-file .env.quickstart pull
-docker compose --env-file .env.quickstart up -d
+$EDITOR .env.production
 ```
 
-Cloud-init runs only when the instance is first created. Before provisioning a
-replacement host, update `repository_ref`, `backend_image`, and `frontend_image`
-in `terraform.tfvars` to match the revisions you tested. Automated in-place
-application upgrades are deliberately outside this example's current scope.
+Keep `.env.production` out of Git, images, Terraform variables, and Terraform
+state. Optional mail, maps, geocoding, and storage values may remain empty; the
+corresponding capabilities remain disabled.
 
-The Canonical SSM parameter selects the current Ubuntu 24.04 image when the
-instance is first created. Later AMI changes are ignored because replacing this
-stateful host as an automatic upgrade would also replace its local data disk.
-Apply operating-system security updates on the host and plan image migrations
-as explicit backup-and-restore operations.
+## Validate and start Multiforum
 
-Back up Neo4j data before replacing or destroying the instance. The root volume
-is deleted with the instance by default, so `terraform destroy` removes the
-forum data as well as the infrastructure.
+Validate the merged model before creating containers:
+
+```bash
+cd /opt/multiforum
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  config --quiet
+```
+
+Compose fails immediately if a required production value is missing. Once it
+passes, start the stack and watch Caddy obtain the certificate:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  up -d
+
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  logs --tail=100 caddy frontend backend
+```
+
+Verify `https://YOUR_DOMAIN`, the Auth0 sign-in flow, and container health.
+The full production guide covers backups, verification, and current
+single-host limitations.
+
+## Updates and destruction
+
+Terraform provisions infrastructure; it is deliberately not an in-place
+application updater. To update, back up Neo4j, select a repository tag and
+tested image versions, pull them, validate the merged model, and recreate the
+stack. Changing `repository_ref` or image variables in Terraform does not
+rerun cloud-init on an existing instance.
+
+The Canonical SSM parameter selects the current Ubuntu 24.04 image at initial
+creation. Later AMI changes are ignored because silently replacing this
+stateful host would also replace its local data disk. Apply operating-system
+security updates on the host and plan host migrations as explicit
+backup-and-restore operations.
+
+Back up Neo4j off-host before replacing or destroying the instance. The root
+volume is deleted with the instance by default, so `terraform destroy` removes
+the forum data along with the infrastructure.

--- a/deploy/terraform/aws-single-vm/cloud-init.tftpl
+++ b/deploy/terraform/aws-single-vm/cloud-init.tftpl
@@ -11,11 +11,19 @@ runcmd:
   - systemctl enable --now docker
   - usermod -aG docker ubuntu
   - git clone --branch '${repository_ref}' --depth 1 https://github.com/gennit-project/multiforum-nuxt.git /opt/multiforum
-  - cp /opt/multiforum/.env.quickstart.example /opt/multiforum/.env.quickstart
-  - sed -i 's|^MULTIFORUM_BACKEND_IMAGE=.*|MULTIFORUM_BACKEND_IMAGE=${backend_image}|' /opt/multiforum/.env.quickstart
-  - sed -i 's|^MULTIFORUM_FRONTEND_IMAGE=.*|MULTIFORUM_FRONTEND_IMAGE=${frontend_image}|' /opt/multiforum/.env.quickstart
-  - chmod 0600 /opt/multiforum/.env.quickstart
+  - cp /opt/multiforum/.env.production.example /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_DOMAIN=.*|MULTIFORUM_DOMAIN=${domain}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_INSTANCE_NAME=.*|MULTIFORUM_INSTANCE_NAME=${instance_name}|' /opt/multiforum/.env.production
+  - sed -i 's|^CADDY_ACME_EMAIL=.*|CADDY_ACME_EMAIL=${acme_email}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_NEO4J_IMAGE=.*|MULTIFORUM_NEO4J_IMAGE=${neo4j_image}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_BACKEND_IMAGE=.*|MULTIFORUM_BACKEND_IMAGE=${backend_image}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_FRONTEND_IMAGE=.*|MULTIFORUM_FRONTEND_IMAGE=${frontend_image}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_CADDY_IMAGE=.*|MULTIFORUM_CADDY_IMAGE=${caddy_image}|' /opt/multiforum/.env.production
+  - chmod 0600 /opt/multiforum/.env.production
   - chown -R ubuntu:ubuntu /opt/multiforum
-  - docker compose --env-file /opt/multiforum/.env.quickstart --project-directory /opt/multiforum pull
+  - docker pull '${neo4j_image}'
+  - docker pull '${backend_image}'
+  - docker pull '${frontend_image}'
+  - docker pull '${caddy_image}'
 
-final_message: "Multiforum configuration and container images are ready. Replace the placeholder credentials before starting the stack."
+final_message: "Multiforum production configuration and container images are ready. Configure DNS, Auth0, and every required secret before starting the stack."

--- a/deploy/terraform/aws-single-vm/main.tf
+++ b/deploy/terraform/aws-single-vm/main.tf
@@ -28,10 +28,26 @@ resource "aws_security_group" "multiforum" {
   }
 
   ingress {
-    description = "Multiforum HTTP (replace with TLS before production use)"
-    from_port   = 3000
-    to_port     = 3000
+    description = "HTTP redirects and ACME validation"
+    from_port   = 80
+    to_port     = 80
     protocol    = "tcp"
+    cidr_blocks = var.application_cidrs
+  }
+
+  ingress {
+    description = "Multiforum HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.application_cidrs
+  }
+
+  ingress {
+    description = "Multiforum HTTP/3"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "udp"
     cidr_blocks = var.application_cidrs
   }
 
@@ -61,8 +77,13 @@ resource "aws_instance" "multiforum" {
   vpc_security_group_ids      = [aws_security_group.multiforum.id]
 
   user_data = templatefile("${path.module}/cloud-init.tftpl", {
+    acme_email     = var.acme_email
     backend_image  = var.backend_image
+    caddy_image    = var.caddy_image
+    domain         = var.domain
     frontend_image = var.frontend_image
+    instance_name  = var.name
+    neo4j_image    = var.neo4j_image
     repository_ref = var.repository_ref
   })
 

--- a/deploy/terraform/aws-single-vm/outputs.tf
+++ b/deploy/terraform/aws-single-vm/outputs.tf
@@ -4,8 +4,17 @@ output "public_ip" {
 }
 
 output "application_url" {
-  description = "Temporary HTTP URL. Configure a domain and TLS before production use."
-  value       = "http://${aws_eip.multiforum.public_ip}:3000"
+  description = "Public HTTPS URL served by Caddy after DNS and application configuration are complete."
+  value       = "https://${var.domain}"
+}
+
+output "dns_a_record" {
+  description = "DNS A record to create before starting the production stack."
+  value = {
+    name  = var.domain
+    type  = "A"
+    value = aws_eip.multiforum.public_ip
+  }
 }
 
 output "ssh_command" {

--- a/deploy/terraform/aws-single-vm/terraform.tfvars.example
+++ b/deploy/terraform/aws-single-vm/terraform.tfvars.example
@@ -1,11 +1,15 @@
 aws_region   = "us-east-1"
 admin_cidr   = "203.0.113.10/32"
 ssh_key_name = "my-existing-ec2-key"
+domain       = "forum.example.com"
+acme_email   = "admin@example.com"
 
-# Pin the deployment configuration and both images for a repeatable install.
+# Pin the deployment configuration and every image for a repeatable install.
 repository_ref = "main"
+neo4j_image     = "neo4j:5.1.0"
 backend_image  = "ghcr.io/gennit-project/multiforum-backend:edge"
 frontend_image = "ghcr.io/gennit-project/multiforum-nuxt:edge"
+caddy_image    = "caddy:2.11.4-alpine"
 
-# Keep the local-auth quick-start restricted to trusted addresses.
-application_cidrs = ["203.0.113.10/32"]
+# Public access is required for a public forum and Caddy's default ACME flow.
+application_cidrs = ["0.0.0.0/0"]

--- a/deploy/terraform/aws-single-vm/variables.tf
+++ b/deploy/terraform/aws-single-vm/variables.tf
@@ -49,11 +49,31 @@ variable "root_volume_size_gib" {
 
 variable "application_cidrs" {
   type        = list(string)
-  description = "Trusted IPv4 CIDRs allowed to reach the temporary HTTP application port (3000)."
+  description = "IPv4 CIDRs allowed to reach Caddy on HTTP, HTTPS, and HTTP/3. Use 0.0.0.0/0 for a public forum."
 
   validation {
     condition     = length(var.application_cidrs) > 0 && alltrue([for cidr in var.application_cidrs : can(cidrnetmask(cidr))])
     error_message = "application_cidrs must contain at least one valid IPv4 CIDR."
+  }
+}
+
+variable "domain" {
+  type        = string
+  description = "Public DNS hostname used by Multiforum and Caddy, for example forum.example.com."
+
+  validation {
+    condition     = length(var.domain) <= 253 && can(regex("^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$", var.domain))
+    error_message = "domain must be a lowercase fully qualified DNS hostname without a trailing dot."
+  }
+}
+
+variable "acme_email" {
+  type        = string
+  description = "Email address Caddy supplies to the ACME certificate authority."
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$", var.acme_email))
+    error_message = "acme_email must be a valid email address using ordinary DNS characters."
   }
 }
 
@@ -79,6 +99,17 @@ variable "backend_image" {
   }
 }
 
+variable "neo4j_image" {
+  type        = string
+  description = "Neo4j OCI image pulled during cloud-init. Pin a tested version or digest."
+  default     = "neo4j:5.1.0"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.neo4j_image))
+    error_message = "neo4j_image must be a valid OCI image reference without whitespace."
+  }
+}
+
 variable "frontend_image" {
   type        = string
   description = "Frontend OCI image pulled during cloud-init. Pin a release or digest for repeatable installs."
@@ -87,5 +118,16 @@ variable "frontend_image" {
   validation {
     condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.frontend_image))
     error_message = "frontend_image must be a valid OCI image reference without whitespace."
+  }
+}
+
+variable "caddy_image" {
+  type        = string
+  description = "Caddy OCI image pulled during cloud-init. Pin a tested version or digest."
+  default     = "caddy:2.11.4-alpine"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.caddy_image))
+    error_message = "caddy_image must be a valid OCI image reference without whitespace."
   }
 }

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -48,7 +48,7 @@ services:
       - frontend-data:/app/data
 
   caddy:
-    image: caddy:2.11.4-alpine
+    image: ${MULTIFORUM_CADDY_IMAGE:-caddy:2.11.4-alpine}
     restart: unless-stopped
     depends_on:
       frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: neo4j:5.1.0
+    image: ${MULTIFORUM_NEO4J_IMAGE:-neo4j:5.1.0}
     restart: unless-stopped
     ports:
       - '${MULTIFORUM_BIND_ADDRESS:-127.0.0.1}:7474:7474'

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Developer documentation for the Multiforum Nuxt frontend. See the
 - [Frontend runtime configuration](./frontend-runtime-configuration.md) — configure one built frontend image at container startup
 - [Frontend container image](./frontend-container-image.md) — official image tags, architectures, and runtime behavior
 - [Development setup](./development-setup.md) — local environment and tooling
-- [AWS single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md) — provision a Docker-ready self-hosting VM without storing app secrets in Terraform state
+- [AWS single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md) — provision an AWS host for the production Compose overlay without storing app secrets in Terraform state
 - [Frontend architecture and authentication](./architecture-and-auth.md)
 - [Moderation architecture](./moderation-architecture.md) — canonical reference for permissions and suspensions
 - [Performance](./performance.md) — code splitting, caching, image optimization

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -9,6 +9,13 @@ of failure.
 Start with the [local quick-start](./self-hosting-quickstart.md) before using
 this configuration. Do not reuse its credentials or local authentication mode.
 
+If you need an AWS host, the
+[single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md)
+provisions the production ports, stable IP, Docker runtime, protected
+environment template, and pinned images used by this overlay. It leaves DNS,
+Auth0 configuration, application secrets, startup, and backups under operator
+control so secrets never enter Terraform state.
+
 ## Requirements
 
 - a Linux host with Docker Engine and Docker Compose v2;
@@ -57,10 +64,11 @@ openssl rand -hex 16 # 32-character plugin encryption key
 openssl rand -hex 64 # Auth0 session encryption secret
 ```
 
-Fill every required empty value in `.env.production`. Pin the backend and
-frontend to tested semantic-version or immutable `sha-*` tags rather than
-`edge`. Optional mail, maps, geocoding, and storage settings can remain empty;
-the instance capability status will keep those features disabled.
+Fill every required empty value in `.env.production`. Pin Neo4j, the backend,
+the frontend, and Caddy to versions tested together rather than using floating
+or `edge` tags in production. Optional mail, maps, geocoding, and storage
+settings can remain empty; the instance capability status will keep those
+features disabled.
 
 Validate the merged Compose model before starting anything:
 


### PR DESCRIPTION
## Summary

- provision Caddy-facing HTTP, HTTPS, and HTTP/3 access instead of exposing the frontend directly on port 3000
- have cloud-init prepare the protected production environment and pre-pull pinned Neo4j, backend, frontend, and Caddy images without storing application secrets in Terraform state
- output the required DNS A record and document the full DNS, Auth0, secret, validation, startup, update, and destruction workflow
- make the Neo4j and Caddy image references configurable alongside the existing application image inputs

## Stack

- stacked on #479
- base branch: `codex/self-hosting-17-production-compose`

## Validation

- `terraform fmt -check -recursive` with Terraform 1.8.5
- `terraform validate` with Terraform 1.8.5
- rendered cloud-init YAML validation and safety assertions
- production Compose image-resolution validation with representative required settings
- quick-start Compose config validation
- `npm run tsc`
- Prettier checks for changed Markdown and Compose files
- `git diff --check`