### PR TITLE
feat(self-hosting): consolidate production deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,10 +73,9 @@ NUXT_AUTH0_APP_BASE_URL=http://localhost:3000
 # getAccessToken() returns a JWT the backend accepts.
 NUXT_AUTH0_AUDIENCE=https://api.placeholder.app
 
-# --- Session store (production only) ---
-# Sessions are stored in Upstash Redis in production (nitro.storage in
-# nuxt.config.ts). Provision an Upstash Redis database via the Vercel
-# Marketplace and set these in the Vercel project. Local dev uses a filesystem
-# store instead (nitro.devStorage), so these can be left unset locally.
+# --- Serverless production session store ---
+# Vercel deployments store sessions in Upstash Redis. Provision a database via
+# the Vercel Marketplace and set these in the Vercel project. Local development
+# and the official single-node container use filesystem storage instead.
 UPSTASH_REDIS_REST_URL=https://placeholder.upstash.io
 UPSTASH_REDIS_REST_TOKEN=placeholder

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,36 @@
+# Copy to .env.production, set restrictive permissions, and replace every empty
+# required value before running the production Compose overlay.
+
+MULTIFORUM_DOMAIN=forum.example.com
+MULTIFORUM_INSTANCE_NAME=My Multiforum
+MULTIFORUM_BIND_ADDRESS=127.0.0.1
+CADDY_ACME_EMAIL=admin@example.com
+
+# Pin releases or immutable sha-* tags for repeatable deployments.
+MULTIFORUM_BACKEND_IMAGE=ghcr.io/gennit-project/multiforum-backend:edge
+MULTIFORUM_BACKEND_PULL_POLICY=always
+MULTIFORUM_FRONTEND_IMAGE=ghcr.io/gennit-project/multiforum-nuxt:edge
+MULTIFORUM_FRONTEND_PULL_POLICY=always
+
+# Required secrets and identity configuration.
+NEO4J_PASSWORD=
+MULTIFORUM_SUPERADMIN_EMAIL=
+PLUGIN_SECRET_ENCRYPTION_KEY=
+AUTH0_DOMAIN=
+AUTH0_CLIENT_ID=
+AUTH0_AUDIENCE=
+NUXT_AUTH0_CLIENT_SECRET=
+NUXT_AUTH0_SESSION_SECRET=
+
+# Optional uploads and email. Leave blank to keep each capability disabled.
+GCS_BUCKET_NAME=
+GCS_PRIVATE_DOWNLOAD_BUCKET_NAME=
+GOOGLE_CREDENTIALS_BASE64=
+GOOGLE_MAPS_API_KEY=
+GOOGLE_MAP_ID=
+OPEN_CAGE_API_KEY=
+EMAIL_PROVIDER=
+EMAIL_FROM=
+RESEND_API_KEY=
+SENDGRID_API_KEY=
+SENDGRID_FROM_EMAIL=

--- a/.env.production.example
+++ b/.env.production.example
@@ -7,10 +7,12 @@ MULTIFORUM_BIND_ADDRESS=127.0.0.1
 CADDY_ACME_EMAIL=admin@example.com
 
 # Pin releases or immutable sha-* tags for repeatable deployments.
+MULTIFORUM_NEO4J_IMAGE=neo4j:5.1.0
 MULTIFORUM_BACKEND_IMAGE=ghcr.io/gennit-project/multiforum-backend:edge
 MULTIFORUM_BACKEND_PULL_POLICY=always
 MULTIFORUM_FRONTEND_IMAGE=ghcr.io/gennit-project/multiforum-nuxt:edge
 MULTIFORUM_FRONTEND_PULL_POLICY=always
+MULTIFORUM_CADDY_IMAGE=caddy:2.11.4-alpine
 
 # Required secrets and identity configuration.
 NEO4J_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ logs
 .env.*
 !.env.example
 !.env.quickstart.example
+!.env.production.example
 
 # Cypress env file (contains secrets; must never be committed)
 cypress.env.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY . .
 # Deployment-specific configuration is supplied when the built server starts,
 # so this image can be promoted between environments without rebuilding.
 ENV NITRO_PRESET=node-server
+ENV MULTIFORUM_DATA_DIR=/app/data
 
 RUN NODE_OPTIONS=--max-old-space-size=4096 pnpm run build
 
@@ -37,6 +38,10 @@ ENV NODE_ENV=production
 ENV PORT=3000
 
 COPY --from=build --chown=node:node /app/.output ./.output
+
+# The node-server build persists Auth0 sessions here. Creating the mount point
+# in the image gives new named volumes the non-root runtime user's ownership.
+RUN mkdir -p /app/data && chown node:node /app/data
 
 USER node
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ client.
 Start here:
 
 - [Local self-hosting quick-start](./docs/self-hosting-quickstart.md)
+- [Production Compose foundation](./docs/self-hosting-production.md)
 - [Official frontend container image](./docs/frontend-container-image.md)
 - [Development setup](./docs/development-setup.md)
 - [AWS single-VM Terraform example](./deploy/terraform/aws-single-vm/README.md)

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -1,0 +1,15 @@
+{
+	email {$CADDY_ACME_EMAIL}
+}
+
+{$MULTIFORUM_DOMAIN} {
+	encode zstd gzip
+	reverse_proxy frontend:3000
+
+	header {
+		Strict-Transport-Security "max-age=31536000"
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		-Server
+	}
+}

--- a/deploy/terraform/aws-single-vm/README.md
+++ b/deploy/terraform/aws-single-vm/README.md
@@ -2,19 +2,22 @@
 
 This example creates one Ubuntu 24.04 EC2 instance for Multiforum, installs
 Docker and Docker Compose with cloud-init, clones the frontend repository into
-`/opt/multiforum`, and assigns a stable Elastic IP. It is deliberately a small
-operator-owned starting point, not a managed production platform.
+`/opt/multiforum` for its deployment configuration, pre-pulls the official
+backend and frontend images, and assigns a stable Elastic IP. It is deliberately
+a small operator-owned starting point, not a managed production platform.
 
-Terraform does **not** receive application secrets. Auth0 credentials, the
+Terraform does **not** receive application secrets. The bootstrap credentials,
 Neo4j password, and optional integration keys therefore stay out of Terraform
-plans and state. You add them directly on the host after provisioning.
+plans and state. The selected non-secret image references are stored in state
+and written to `/opt/multiforum/.env.quickstart`; you add secrets directly on
+the host after provisioning.
 
 ## What it creates
 
 - one EC2 instance in the account's default VPC;
 - one encrypted gp3 root volume (40 GiB by default), including Docker volumes;
 - one security group exposing SSH only to `admin_cidr`;
-- port 3000 to `application_cidrs` (public by default); and
+- port 3000 only to the explicitly configured `application_cidrs`; and
 - one Elastic IP for a stable address.
 
 Neo4j's ports (7474 and 7687) and the backend port (4000) are not admitted by
@@ -48,7 +51,9 @@ address. Terraform prints the resulting SSH command and temporary application
 URL.
 
 Cloud-init may continue installing packages for a few minutes after EC2 reports
-the instance as running. Follow its progress with:
+the instance as running. It clones the selected `repository_ref`, writes the
+selected image references, and runs `docker compose pull`. Follow its progress
+with:
 
 ```bash
 ssh ubuntu@PUBLIC_IP
@@ -57,38 +62,49 @@ cloud-init status --wait
 
 ## Configure and start Multiforum
 
-On the host, create `/opt/multiforum/.env` from the repository example and fill
-in strong, real values. The current application stack requires Auth0 for login;
-maps, geocoding, mail, and storage remain optional and degrade when omitted.
+Cloud-init creates `/opt/multiforum/.env.quickstart` from the repository example
+and injects the selected image references. On the host, replace the default
+credentials with strong, unique values before starting. Maps, geocoding, mail,
+and storage remain optional and degrade when omitted.
 
 ```bash
 cd /opt/multiforum
-cp .env.example .env
-$EDITOR .env
-docker compose up -d --build
+$EDITOR .env.quickstart
+docker compose --env-file .env.quickstart up -d
 docker compose ps
 ```
 
-Do not use the placeholder Neo4j password. Keep `NEO4J_AUTH` and
-`NEO4J_PASSWORD` consistent, and configure the Auth0 callback/base URLs for the
-address users will visit.
+Do not use either placeholder password left in `.env.quickstart` by cloud-init.
 
-Port 3000 serves plain HTTP only. Before allowing public users, put a TLS
-reverse proxy or load balancer in front of the instance, configure a domain,
-and remove public port-3000 access. A future module can make that advanced path
-repeatable without coupling the basic example to a specific DNS provider.
+This stack uses Multiforum's local development authentication and is for a
+private evaluation environment only. Restrict `application_cidrs` to trusted
+addresses and do not expose this configuration as a public production forum.
+
+Port 3000 serves plain HTTP only. A public production deployment also needs a
+production identity provider, a TLS reverse proxy or load balancer, a domain,
+and removal of public port-3000 access. Those production-hardening steps remain
+outside this private evaluation example.
 
 ## Updating and destroying
 
-Application updates are explicit so an infrastructure plan cannot silently
-change the running forum:
+The image inputs select the initial installation; Terraform is deliberately not
+an in-place application updater. Update an existing host explicitly:
 
 ```bash
+ssh ubuntu@PUBLIC_IP
 cd /opt/multiforum
 git fetch --tags
 git checkout RELEASE_TAG
-docker compose up -d --build
+# Set the new backend and frontend image references.
+$EDITOR .env.quickstart
+docker compose --env-file .env.quickstart pull
+docker compose --env-file .env.quickstart up -d
 ```
+
+Cloud-init runs only when the instance is first created. Before provisioning a
+replacement host, update `repository_ref`, `backend_image`, and `frontend_image`
+in `terraform.tfvars` to match the revisions you tested. Automated in-place
+application upgrades are deliberately outside this example's current scope.
 
 The Canonical SSM parameter selects the current Ubuntu 24.04 image when the
 instance is first created. Later AMI changes are ignored because replacing this

--- a/deploy/terraform/aws-single-vm/README.md
+++ b/deploy/terraform/aws-single-vm/README.md
@@ -1,117 +1,153 @@
-# AWS single-VM Terraform example
+# AWS single-VM Terraform production example
 
-This example creates one Ubuntu 24.04 EC2 instance for Multiforum, installs
-Docker and Docker Compose with cloud-init, clones the frontend repository into
-`/opt/multiforum` for its deployment configuration, pre-pulls the official
-backend and frontend images, and assigns a stable Elastic IP. It is deliberately
-a small operator-owned starting point, not a managed production platform.
+This example provisions the AWS host for Multiforum's
+[production Compose foundation](../../../docs/self-hosting-production.md). It
+creates one Ubuntu 24.04 EC2 instance, installs Docker and Docker Compose,
+prepares `/opt/multiforum/.env.production`, pre-pulls the selected images, and
+assigns a stable Elastic IP. Caddy then serves the forum over automatic HTTPS.
 
-Terraform does **not** receive application secrets. The bootstrap credentials,
-Neo4j password, and optional integration keys therefore stay out of Terraform
-plans and state. The selected non-secret image references are stored in state
-and written to `/opt/multiforum/.env.quickstart`; you add secrets directly on
-the host after provisioning.
+This is a practical operator-owned deployment for one host and one frontend
+replica, not a high-availability platform. Neo4j and the application volumes
+remain local to the instance.
+
+Terraform intentionally does **not** receive application secrets. Auth0
+credentials, the Neo4j password, encryption keys, and optional integration
+credentials stay out of Terraform plans and state. Cloud-init writes only the
+domain, ACME email, instance name, and selected non-secret image references;
+you add secrets directly on the host before starting the stack.
 
 ## What it creates
 
 - one EC2 instance in the account's default VPC;
 - one encrypted gp3 root volume (40 GiB by default), including Docker volumes;
-- one security group exposing SSH only to `admin_cidr`;
-- port 3000 only to the explicitly configured `application_cidrs`; and
-- one Elastic IP for a stable address.
+- one security group allowing SSH only from `admin_cidr`;
+- inbound TCP 80 and 443 plus UDP 443 from `application_cidrs`; and
+- one Elastic IP and a DNS A-record output.
 
-Neo4j's ports (7474 and 7687) and the backend port (4000) are not admitted by
-the AWS security group. The instance metadata service requires IMDSv2 tokens.
+Ports 3000, 4000, 7474, and 7687 are not admitted by the AWS security group.
+They remain loopback-only host bindings in Compose. The instance metadata
+service requires IMDSv2 tokens.
 
 ## Prerequisites
 
 - Terraform 1.8 or newer;
 - AWS credentials available to Terraform;
-- an existing EC2 key pair in the selected region; and
-- a default VPC with at least one subnet.
+- an existing EC2 key pair in the selected region;
+- a default VPC with at least one subnet;
+- a domain whose DNS records you can change; and
+- an Auth0 Regular Web Application and Auth0 API.
 
 The default `t3.large` is a conservative starting size for Neo4j, the backend,
-and the frontend on one machine. Review current EC2, EBS, and Elastic IP pricing
-before applying. This example creates billable resources.
+the frontend, and Caddy on one machine. Review current EC2, EBS, data-transfer,
+and Elastic IP pricing before applying. This example creates billable resources.
 
 ## Provision the host
 
 ```bash
 cd deploy/terraform/aws-single-vm
 cp terraform.tfvars.example terraform.tfvars
-# Replace admin_cidr and ssh_key_name before continuing.
+$EDITOR terraform.tfvars
 terraform init
 terraform plan
 terraform apply
 ```
 
-Use a `/32` containing only your current public IPv4 address for `admin_cidr`.
-During initial setup, consider restricting `application_cidrs` to that same
-address. Terraform prints the resulting SSH command and temporary application
-URL.
+Set `admin_cidr` to a `/32` containing only your current public IPv4 address.
+Set `application_cidrs` to `0.0.0.0/0` for a public forum and Caddy's normal
+ACME flow. Pin `repository_ref` and every image input to revisions you have
+tested together rather than relying on `main` or `edge` in production.
 
-Cloud-init may continue installing packages for a few minutes after EC2 reports
-the instance as running. It clones the selected `repository_ref`, writes the
-selected image references, and runs `docker compose pull`. Follow its progress
-with:
+Terraform prints the stable IP, HTTPS URL, SSH command, and DNS record to
+create. Add that A record at your DNS provider:
+
+```bash
+terraform output dns_a_record
+```
+
+Wait for DNS to resolve to the reported Elastic IP before starting Caddy.
+Cloud-init may continue for a few minutes after EC2 reports the instance as
+running. Follow it with:
 
 ```bash
 ssh ubuntu@PUBLIC_IP
 cloud-init status --wait
 ```
 
-## Configure and start Multiforum
+Cloud-init clones the selected repository revision, copies
+`.env.production.example` to `.env.production`, injects the non-secret Terraform
+inputs, restricts the file to mode `0600`, and pre-pulls Neo4j, backend,
+frontend, and Caddy images. It deliberately does not start Compose while the
+required secrets are empty.
 
-Cloud-init creates `/opt/multiforum/.env.quickstart` from the repository example
-and injects the selected image references. On the host, replace the default
-credentials with strong, unique values before starting. Maps, geocoding, mail,
-and storage remain optional and degrade when omitted.
+## Configure Auth0 and secrets
 
-```bash
-cd /opt/multiforum
-$EDITOR .env.quickstart
-docker compose --env-file .env.quickstart up -d
-docker compose ps
-```
+Follow the [Auth0 and secret setup](../../../docs/self-hosting-production.md#configure-auth0)
+for your domain. The Auth0 application must allow:
 
-Do not use either placeholder password left in `.env.quickstart` by cloud-init.
+- `https://YOUR_DOMAIN/auth/callback` as a callback URL; and
+- `https://YOUR_DOMAIN` as a logout URL.
 
-This stack uses Multiforum's local development authentication and is for a
-private evaluation environment only. Restrict `application_cidrs` to trusted
-addresses and do not expose this configuration as a public production forum.
-
-Port 3000 serves plain HTTP only. A public production deployment also needs a
-production identity provider, a TLS reverse proxy or load balancer, a domain,
-and removal of public port-3000 access. Those production-hardening steps remain
-outside this private evaluation example.
-
-## Updating and destroying
-
-The image inputs select the initial installation; Terraform is deliberately not
-an in-place application updater. Update an existing host explicitly:
+Then edit the protected environment file on the host and fill every required
+empty value:
 
 ```bash
 ssh ubuntu@PUBLIC_IP
 cd /opt/multiforum
-git fetch --tags
-git checkout RELEASE_TAG
-# Set the new backend and frontend image references.
-$EDITOR .env.quickstart
-docker compose --env-file .env.quickstart pull
-docker compose --env-file .env.quickstart up -d
+$EDITOR .env.production
 ```
 
-Cloud-init runs only when the instance is first created. Before provisioning a
-replacement host, update `repository_ref`, `backend_image`, and `frontend_image`
-in `terraform.tfvars` to match the revisions you tested. Automated in-place
-application upgrades are deliberately outside this example's current scope.
+Keep `.env.production` out of Git, images, Terraform variables, and Terraform
+state. Optional mail, maps, geocoding, and storage values may remain empty; the
+corresponding capabilities remain disabled.
 
-The Canonical SSM parameter selects the current Ubuntu 24.04 image when the
-instance is first created. Later AMI changes are ignored because replacing this
-stateful host as an automatic upgrade would also replace its local data disk.
-Apply operating-system security updates on the host and plan image migrations
-as explicit backup-and-restore operations.
+## Validate and start Multiforum
 
-Back up Neo4j data before replacing or destroying the instance. The root volume
-is deleted with the instance by default, so `terraform destroy` removes the
-forum data as well as the infrastructure.
+Validate the merged model before creating containers:
+
+```bash
+cd /opt/multiforum
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  config --quiet
+```
+
+Compose fails immediately if a required production value is missing. Once it
+passes, start the stack and watch Caddy obtain the certificate:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  up -d
+
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  logs --tail=100 caddy frontend backend
+```
+
+Verify `https://YOUR_DOMAIN`, the Auth0 sign-in flow, and container health.
+The full production guide covers backups, verification, and current
+single-host limitations.
+
+## Updates and destruction
+
+Terraform provisions infrastructure; it is deliberately not an in-place
+application updater. To update, back up Neo4j, select a repository tag and
+tested image versions, pull them, validate the merged model, and recreate the
+stack. Changing `repository_ref` or image variables in Terraform does not
+rerun cloud-init on an existing instance.
+
+The Canonical SSM parameter selects the current Ubuntu 24.04 image at initial
+creation. Later AMI changes are ignored because silently replacing this
+stateful host would also replace its local data disk. Apply operating-system
+security updates on the host and plan host migrations as explicit
+backup-and-restore operations.
+
+Back up Neo4j off-host before replacing or destroying the instance. The root
+volume is deleted with the instance by default, so `terraform destroy` removes
+the forum data along with the infrastructure.

--- a/deploy/terraform/aws-single-vm/cloud-init.tftpl
+++ b/deploy/terraform/aws-single-vm/cloud-init.tftpl
@@ -11,11 +11,19 @@ runcmd:
   - systemctl enable --now docker
   - usermod -aG docker ubuntu
   - git clone --branch '${repository_ref}' --depth 1 https://github.com/gennit-project/multiforum-nuxt.git /opt/multiforum
-  - cp /opt/multiforum/.env.quickstart.example /opt/multiforum/.env.quickstart
-  - sed -i 's|^MULTIFORUM_BACKEND_IMAGE=.*|MULTIFORUM_BACKEND_IMAGE=${backend_image}|' /opt/multiforum/.env.quickstart
-  - sed -i 's|^MULTIFORUM_FRONTEND_IMAGE=.*|MULTIFORUM_FRONTEND_IMAGE=${frontend_image}|' /opt/multiforum/.env.quickstart
-  - chmod 0600 /opt/multiforum/.env.quickstart
+  - cp /opt/multiforum/.env.production.example /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_DOMAIN=.*|MULTIFORUM_DOMAIN=${domain}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_INSTANCE_NAME=.*|MULTIFORUM_INSTANCE_NAME=${instance_name}|' /opt/multiforum/.env.production
+  - sed -i 's|^CADDY_ACME_EMAIL=.*|CADDY_ACME_EMAIL=${acme_email}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_NEO4J_IMAGE=.*|MULTIFORUM_NEO4J_IMAGE=${neo4j_image}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_BACKEND_IMAGE=.*|MULTIFORUM_BACKEND_IMAGE=${backend_image}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_FRONTEND_IMAGE=.*|MULTIFORUM_FRONTEND_IMAGE=${frontend_image}|' /opt/multiforum/.env.production
+  - sed -i 's|^MULTIFORUM_CADDY_IMAGE=.*|MULTIFORUM_CADDY_IMAGE=${caddy_image}|' /opt/multiforum/.env.production
+  - chmod 0600 /opt/multiforum/.env.production
   - chown -R ubuntu:ubuntu /opt/multiforum
-  - docker compose --env-file /opt/multiforum/.env.quickstart --project-directory /opt/multiforum pull
+  - docker pull '${neo4j_image}'
+  - docker pull '${backend_image}'
+  - docker pull '${frontend_image}'
+  - docker pull '${caddy_image}'
 
-final_message: "Multiforum configuration and container images are ready. Replace the placeholder credentials before starting the stack."
+final_message: "Multiforum production configuration and container images are ready. Configure DNS, Auth0, and every required secret before starting the stack."

--- a/deploy/terraform/aws-single-vm/cloud-init.tftpl
+++ b/deploy/terraform/aws-single-vm/cloud-init.tftpl
@@ -11,6 +11,11 @@ runcmd:
   - systemctl enable --now docker
   - usermod -aG docker ubuntu
   - git clone --branch '${repository_ref}' --depth 1 https://github.com/gennit-project/multiforum-nuxt.git /opt/multiforum
+  - cp /opt/multiforum/.env.quickstart.example /opt/multiforum/.env.quickstart
+  - sed -i 's|^MULTIFORUM_BACKEND_IMAGE=.*|MULTIFORUM_BACKEND_IMAGE=${backend_image}|' /opt/multiforum/.env.quickstart
+  - sed -i 's|^MULTIFORUM_FRONTEND_IMAGE=.*|MULTIFORUM_FRONTEND_IMAGE=${frontend_image}|' /opt/multiforum/.env.quickstart
+  - chmod 0600 /opt/multiforum/.env.quickstart
   - chown -R ubuntu:ubuntu /opt/multiforum
+  - docker compose --env-file /opt/multiforum/.env.quickstart --project-directory /opt/multiforum pull
 
-final_message: "Multiforum host prerequisites are ready. Application secrets have not been installed."
+final_message: "Multiforum configuration and container images are ready. Replace the placeholder credentials before starting the stack."

--- a/deploy/terraform/aws-single-vm/main.tf
+++ b/deploy/terraform/aws-single-vm/main.tf
@@ -61,6 +61,8 @@ resource "aws_instance" "multiforum" {
   vpc_security_group_ids      = [aws_security_group.multiforum.id]
 
   user_data = templatefile("${path.module}/cloud-init.tftpl", {
+    backend_image  = var.backend_image
+    frontend_image = var.frontend_image
     repository_ref = var.repository_ref
   })
 

--- a/deploy/terraform/aws-single-vm/main.tf
+++ b/deploy/terraform/aws-single-vm/main.tf
@@ -28,10 +28,26 @@ resource "aws_security_group" "multiforum" {
   }
 
   ingress {
-    description = "Multiforum HTTP (replace with TLS before production use)"
-    from_port   = 3000
-    to_port     = 3000
+    description = "HTTP redirects and ACME validation"
+    from_port   = 80
+    to_port     = 80
     protocol    = "tcp"
+    cidr_blocks = var.application_cidrs
+  }
+
+  ingress {
+    description = "Multiforum HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.application_cidrs
+  }
+
+  ingress {
+    description = "Multiforum HTTP/3"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "udp"
     cidr_blocks = var.application_cidrs
   }
 
@@ -61,8 +77,13 @@ resource "aws_instance" "multiforum" {
   vpc_security_group_ids      = [aws_security_group.multiforum.id]
 
   user_data = templatefile("${path.module}/cloud-init.tftpl", {
+    acme_email     = var.acme_email
     backend_image  = var.backend_image
+    caddy_image    = var.caddy_image
+    domain         = var.domain
     frontend_image = var.frontend_image
+    instance_name  = var.name
+    neo4j_image    = var.neo4j_image
     repository_ref = var.repository_ref
   })
 

--- a/deploy/terraform/aws-single-vm/outputs.tf
+++ b/deploy/terraform/aws-single-vm/outputs.tf
@@ -4,8 +4,17 @@ output "public_ip" {
 }
 
 output "application_url" {
-  description = "Temporary HTTP URL. Configure a domain and TLS before production use."
-  value       = "http://${aws_eip.multiforum.public_ip}:3000"
+  description = "Public HTTPS URL served by Caddy after DNS and application configuration are complete."
+  value       = "https://${var.domain}"
+}
+
+output "dns_a_record" {
+  description = "DNS A record to create before starting the production stack."
+  value = {
+    name  = var.domain
+    type  = "A"
+    value = aws_eip.multiforum.public_ip
+  }
 }
 
 output "ssh_command" {

--- a/deploy/terraform/aws-single-vm/terraform.tfvars.example
+++ b/deploy/terraform/aws-single-vm/terraform.tfvars.example
@@ -2,8 +2,10 @@ aws_region   = "us-east-1"
 admin_cidr   = "203.0.113.10/32"
 ssh_key_name = "my-existing-ec2-key"
 
-# Pin a release tag for a repeatable production deployment.
+# Pin the deployment configuration and both images for a repeatable install.
 repository_ref = "main"
+backend_image  = "ghcr.io/gennit-project/multiforum-backend:edge"
+frontend_image = "ghcr.io/gennit-project/multiforum-nuxt:edge"
 
-# Start narrower during setup if the instance should not yet be public.
+# Keep the local-auth quick-start restricted to trusted addresses.
 application_cidrs = ["203.0.113.10/32"]

--- a/deploy/terraform/aws-single-vm/terraform.tfvars.example
+++ b/deploy/terraform/aws-single-vm/terraform.tfvars.example
@@ -1,11 +1,15 @@
 aws_region   = "us-east-1"
 admin_cidr   = "203.0.113.10/32"
 ssh_key_name = "my-existing-ec2-key"
+domain       = "forum.example.com"
+acme_email   = "admin@example.com"
 
-# Pin the deployment configuration and both images for a repeatable install.
+# Pin the deployment configuration and every image for a repeatable install.
 repository_ref = "main"
+neo4j_image     = "neo4j:5.1.0"
 backend_image  = "ghcr.io/gennit-project/multiforum-backend:edge"
 frontend_image = "ghcr.io/gennit-project/multiforum-nuxt:edge"
+caddy_image    = "caddy:2.11.4-alpine"
 
-# Keep the local-auth quick-start restricted to trusted addresses.
-application_cidrs = ["203.0.113.10/32"]
+# Public access is required for a public forum and Caddy's default ACME flow.
+application_cidrs = ["0.0.0.0/0"]

--- a/deploy/terraform/aws-single-vm/variables.tf
+++ b/deploy/terraform/aws-single-vm/variables.tf
@@ -49,11 +49,31 @@ variable "root_volume_size_gib" {
 
 variable "application_cidrs" {
   type        = list(string)
-  description = "Trusted IPv4 CIDRs allowed to reach the temporary HTTP application port (3000)."
+  description = "IPv4 CIDRs allowed to reach Caddy on HTTP, HTTPS, and HTTP/3. Use 0.0.0.0/0 for a public forum."
 
   validation {
     condition     = length(var.application_cidrs) > 0 && alltrue([for cidr in var.application_cidrs : can(cidrnetmask(cidr))])
     error_message = "application_cidrs must contain at least one valid IPv4 CIDR."
+  }
+}
+
+variable "domain" {
+  type        = string
+  description = "Public DNS hostname used by Multiforum and Caddy, for example forum.example.com."
+
+  validation {
+    condition     = length(var.domain) <= 253 && can(regex("^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$", var.domain))
+    error_message = "domain must be a lowercase fully qualified DNS hostname without a trailing dot."
+  }
+}
+
+variable "acme_email" {
+  type        = string
+  description = "Email address Caddy supplies to the ACME certificate authority."
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$", var.acme_email))
+    error_message = "acme_email must be a valid email address using ordinary DNS characters."
   }
 }
 
@@ -79,6 +99,17 @@ variable "backend_image" {
   }
 }
 
+variable "neo4j_image" {
+  type        = string
+  description = "Neo4j OCI image pulled during cloud-init. Pin a tested version or digest."
+  default     = "neo4j:5.1.0"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.neo4j_image))
+    error_message = "neo4j_image must be a valid OCI image reference without whitespace."
+  }
+}
+
 variable "frontend_image" {
   type        = string
   description = "Frontend OCI image pulled during cloud-init. Pin a release or digest for repeatable installs."
@@ -87,5 +118,16 @@ variable "frontend_image" {
   validation {
     condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.frontend_image))
     error_message = "frontend_image must be a valid OCI image reference without whitespace."
+  }
+}
+
+variable "caddy_image" {
+  type        = string
+  description = "Caddy OCI image pulled during cloud-init. Pin a tested version or digest."
+  default     = "caddy:2.11.4-alpine"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.caddy_image))
+    error_message = "caddy_image must be a valid OCI image reference without whitespace."
   }
 }

--- a/deploy/terraform/aws-single-vm/variables.tf
+++ b/deploy/terraform/aws-single-vm/variables.tf
@@ -49,8 +49,7 @@ variable "root_volume_size_gib" {
 
 variable "application_cidrs" {
   type        = list(string)
-  description = "IPv4 CIDRs allowed to reach the temporary HTTP application port (3000)."
-  default     = ["0.0.0.0/0"]
+  description = "Trusted IPv4 CIDRs allowed to reach the temporary HTTP application port (3000)."
 
   validation {
     condition     = length(var.application_cidrs) > 0 && alltrue([for cidr in var.application_cidrs : can(cidrnetmask(cidr))])
@@ -60,11 +59,33 @@ variable "application_cidrs" {
 
 variable "repository_ref" {
   type        = string
-  description = "Git branch or tag checked out by cloud-init. Pin a release tag for repeatable production installs."
+  description = "Git branch or tag containing the deployment configuration. Pin a release tag for repeatable installs."
   default     = "main"
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9._/-]{1,100}$", var.repository_ref))
     error_message = "repository_ref contains unsupported characters."
+  }
+}
+
+variable "backend_image" {
+  type        = string
+  description = "Backend OCI image pulled during cloud-init. Pin a release or digest for repeatable installs."
+  default     = "ghcr.io/gennit-project/multiforum-backend:edge"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.backend_image))
+    error_message = "backend_image must be a valid OCI image reference without whitespace."
+  }
+}
+
+variable "frontend_image" {
+  type        = string
+  description = "Frontend OCI image pulled during cloud-init. Pin a release or digest for repeatable installs."
+  default     = "ghcr.io/gennit-project/multiforum-nuxt:edge"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._/:@-]{0,254}$", var.frontend_image))
+    error_message = "frontend_image must be a valid OCI image reference without whitespace."
   }
 }

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -48,7 +48,7 @@ services:
       - frontend-data:/app/data
 
   caddy:
-    image: caddy:2.11.4-alpine
+    image: ${MULTIFORUM_CADDY_IMAGE:-caddy:2.11.4-alpine}
     restart: unless-stopped
     depends_on:
       frontend:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,73 @@
+# Production overlay for the image-based stack. Supply every required value in
+# .env.production and combine this file with docker-compose.yml.
+services:
+  database:
+    environment:
+      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:?Set NEO4J_PASSWORD}
+
+  backend:
+    environment:
+      NODE_ENV: production
+      ENVIRONMENT: production
+      MULTIFORUM_AUTH_PROVIDER: auth0
+      MULTIFORUM_AUTO_PROVISION: 'true'
+      SUPERADMIN_EMAIL: ${MULTIFORUM_SUPERADMIN_EMAIL:?Set MULTIFORUM_SUPERADMIN_EMAIL}
+      AUTH0_DOMAIN: ${AUTH0_DOMAIN:?Set AUTH0_DOMAIN}
+      AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID:?Set AUTH0_CLIENT_ID}
+      AUTH0_AUDIENCE: ${AUTH0_AUDIENCE:?Set AUTH0_AUDIENCE}
+      FRONTEND_URL: https://${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:?Set NEO4J_PASSWORD}
+      PLUGIN_SECRET_ENCRYPTION_KEY: ${PLUGIN_SECRET_ENCRYPTION_KEY:?Set PLUGIN_SECRET_ENCRYPTION_KEY}
+      GCS_BUCKET_NAME: ${GCS_BUCKET_NAME:-}
+      GCS_PRIVATE_DOWNLOAD_BUCKET_NAME: ${GCS_PRIVATE_DOWNLOAD_BUCKET_NAME:-}
+      GOOGLE_CREDENTIALS_BASE64: ${GOOGLE_CREDENTIALS_BASE64:-}
+      EMAIL_PROVIDER: ${EMAIL_PROVIDER:-}
+      EMAIL_FROM: ${EMAIL_FROM:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      SENDGRID_API_KEY: ${SENDGRID_API_KEY:-}
+      SENDGRID_FROM_EMAIL: ${SENDGRID_FROM_EMAIL:-}
+
+  frontend:
+    environment:
+      NODE_ENV: production
+      NUXT_PUBLIC_AUTH_PROVIDER: auth0
+      NUXT_PUBLIC_BASE_URL: https://${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}
+      NUXT_PUBLIC_ENVIRONMENT: production
+      NUXT_PUBLIC_LOGOUT_URL: https://${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}/auth/logout
+      NUXT_AUTH0_DOMAIN: ${AUTH0_DOMAIN:?Set AUTH0_DOMAIN}
+      NUXT_AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID:?Set AUTH0_CLIENT_ID}
+      NUXT_AUTH0_CLIENT_SECRET: ${NUXT_AUTH0_CLIENT_SECRET:?Set NUXT_AUTH0_CLIENT_SECRET}
+      NUXT_AUTH0_SESSION_SECRET: ${NUXT_AUTH0_SESSION_SECRET:?Set NUXT_AUTH0_SESSION_SECRET}
+      NUXT_AUTH0_APP_BASE_URL: https://${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}
+      NUXT_AUTH0_AUDIENCE: ${AUTH0_AUDIENCE:?Set AUTH0_AUDIENCE}
+      NUXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY:-}
+      NUXT_PUBLIC_GOOGLE_MAP_ID: ${GOOGLE_MAP_ID:-}
+      NUXT_PUBLIC_OPEN_CAGE_API_KEY: ${OPEN_CAGE_API_KEY:-}
+      NUXT_PUBLIC_GOOGLE_CLOUD_STORAGE_BUCKET: ${GCS_BUCKET_NAME:-}
+    volumes:
+      - frontend-data:/app/data
+
+  caddy:
+    image: caddy:2.11.4-alpine
+    restart: unless-stopped
+    depends_on:
+      frontend:
+        condition: service_healthy
+    environment:
+      CADDY_ACME_EMAIL: ${CADDY_ACME_EMAIL:?Set CADDY_ACME_EMAIL}
+      MULTIFORUM_DOMAIN: ${MULTIFORUM_DOMAIN:?Set MULTIFORUM_DOMAIN}
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+    volumes:
+      - ./deploy/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    networks:
+      - multiforum-network
+
+volumes:
+  frontend-data:
+  caddy-data:
+  caddy-config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: neo4j:5.1.0
+    image: ${MULTIFORUM_NEO4J_IMAGE:-neo4j:5.1.0}
     restart: unless-stopped
     ports:
       - '${MULTIFORUM_BIND_ADDRESS:-127.0.0.1}:7474:7474'

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Developer documentation for the Multiforum Nuxt frontend. See the
 - [Frontend runtime configuration](./frontend-runtime-configuration.md) — configure one built frontend image at container startup
 - [Frontend container image](./frontend-container-image.md) — official image tags, architectures, and runtime behavior
 - [Development setup](./development-setup.md) — local environment and tooling
-- [AWS single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md) — provision a Docker-ready self-hosting VM without storing app secrets in Terraform state
+- [AWS single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md) — provision an AWS host for the production Compose overlay without storing app secrets in Terraform state
 - [Frontend architecture and authentication](./architecture-and-auth.md)
 - [Moderation architecture](./moderation-architecture.md) — canonical reference for permissions and suspensions
 - [Performance](./performance.md) — code splitting, caching, image optimization

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Developer documentation for the Multiforum Nuxt frontend. See the
 ## Getting started & architecture
 
 - [Local self-hosting quick-start](./self-hosting-quickstart.md) — start a usable instance with one Docker Compose command
+- [Production Compose foundation](./self-hosting-production.md) — run the official images with Auth0, persistent sessions, and automatic TLS
 - [Frontend runtime configuration](./frontend-runtime-configuration.md) — configure one built frontend image at container startup
 - [Frontend container image](./frontend-container-image.md) — official image tags, architectures, and runtime behavior
 - [Development setup](./development-setup.md) — local environment and tooling

--- a/docs/architecture-and-auth.md
+++ b/docs/architecture-and-auth.md
@@ -82,9 +82,10 @@ small backend-for-frontend under [`server/`](../server):
   session access token and profile to the client (used by the embedded-browser
   token fallback).
 - **Caching** is configured in [`nuxt.config.ts`](../nuxt.config.ts) via Nitro
-  `routeRules` and storage mounts (Upstash Redis in production, filesystem in
-  dev). Auth-personalized forum detail pages are deliberately **not** route
-  cached — a shared cache would leak one user's personalized render to others.
+  `routeRules` and storage mounts (Upstash Redis on serverless deployments,
+  persistent filesystem storage for development and the single-node image).
+  Auth-personalized forum detail pages are deliberately **not** route cached —
+  a shared cache would leak one user's personalized render to others.
 
 ### Rendering — Nuxt SSR + hydration
 

--- a/docs/frontend-container-image.md
+++ b/docs/frontend-container-image.md
@@ -46,6 +46,12 @@ The same image supports Auth0 when the corresponding server-only
 [frontend runtime configuration](./frontend-runtime-configuration.md) for the
 complete variable list and security boundaries.
 
+The `node-server` image stores Auth0 sessions below `/app/data`. Mount persistent
+storage there for production use. This filesystem store supports one frontend
+replica; horizontally scaled deployments require a shared session store. The
+[production Compose foundation](./self-hosting-production.md) configures the
+volume and TLS proxy.
+
 The local-development provider must not be exposed to the public internet.
 Production deployments require TLS, production authentication, unique secrets,
 backups, and appropriately secured backend and database services.

--- a/docs/frontend-runtime-configuration.md
+++ b/docs/frontend-runtime-configuration.md
@@ -27,8 +27,8 @@ variables below.
 
 Nuxt exposes every `NUXT_PUBLIC_*` value to the browser. Do not put secrets in
 these variables. Auth0 client secrets and session secrets belong in the
-server-only `NUXT_AUTH0_*` variables described by
-[`.env.auth0-nuxt.example`](../.env.auth0-nuxt.example).
+server-only `NUXT_AUTH0_*` variables demonstrated by
+[`.env.production.example`](../.env.production.example).
 
 The image contains inert Auth0 placeholders solely because the Auth0 module
 validates its shape even in `local-dev` mode. Selecting `auth0` without real

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -9,6 +9,13 @@ of failure.
 Start with the [local quick-start](./self-hosting-quickstart.md) before using
 this configuration. Do not reuse its credentials or local authentication mode.
 
+If you need an AWS host, the
+[single-VM Terraform example](../deploy/terraform/aws-single-vm/README.md)
+provisions the production ports, stable IP, Docker runtime, protected
+environment template, and pinned images used by this overlay. It leaves DNS,
+Auth0 configuration, application secrets, startup, and backups under operator
+control so secrets never enter Terraform state.
+
 ## Requirements
 
 - a Linux host with Docker Engine and Docker Compose v2;
@@ -57,10 +64,11 @@ openssl rand -hex 16 # 32-character plugin encryption key
 openssl rand -hex 64 # Auth0 session encryption secret
 ```
 
-Fill every required empty value in `.env.production`. Pin the backend and
-frontend to tested semantic-version or immutable `sha-*` tags rather than
-`edge`. Optional mail, maps, geocoding, and storage settings can remain empty;
-the instance capability status will keep those features disabled.
+Fill every required empty value in `.env.production`. Pin Neo4j, the backend,
+the frontend, and Caddy to versions tested together rather than using floating
+or `edge` tags in production. Optional mail, maps, geocoding, and storage
+settings can remain empty; the instance capability status will keep those
+features disabled.
 
 Validate the merged Compose model before starting anything:
 

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -1,0 +1,157 @@
+# Production Compose foundation
+
+This deployment path runs the official Multiforum images behind Caddy with
+automatic HTTPS and Auth0 authentication. It is intended for one host and one
+frontend replica. It is a practical production foundation, not a high-
+availability platform: the host and its local Neo4j volume remain single points
+of failure.
+
+Start with the [local quick-start](./self-hosting-quickstart.md) before using
+this configuration. Do not reuse its credentials or local authentication mode.
+
+## Requirements
+
+- a Linux host with Docker Engine and Docker Compose v2;
+- a domain with its `A` and, when applicable, `AAAA` records pointing to the
+  host;
+- inbound TCP ports 80 and 443 plus UDP port 443 allowed by the host and cloud
+  firewalls;
+- an Auth0 Regular Web Application and Auth0 API; and
+- an off-host backup destination for the Neo4j data.
+
+Caddy obtains and renews certificates automatically. Port 80 must remain
+reachable for HTTP-to-HTTPS redirects and ACME validation unless you configure
+another supported Caddy challenge method.
+
+## Configure Auth0
+
+Create a Regular Web Application for the Nuxt server and a dedicated Auth0 API
+for the GraphQL backend. In the application settings for `forum.example.com`,
+configure:
+
+- Allowed Callback URL: `https://forum.example.com/auth/callback`
+- Allowed Logout URL: `https://forum.example.com`
+
+Use the API identifier as `AUTH0_AUDIENCE`. The same domain, client ID, and API
+audience are supplied to the frontend and backend so the access tokens issued
+by the server-side Auth0 session are accepted by GraphQL.
+
+Set `MULTIFORUM_SUPERADMIN_EMAIL` to a tightly controlled, verified Auth0
+account. It is the backend's break-glass root identity and bypasses normal role
+checks.
+
+## Prepare the environment
+
+Copy the production template and restrict it before adding secrets:
+
+```bash
+cp .env.production.example .env.production
+chmod 600 .env.production
+```
+
+Generate independent secrets rather than reusing passwords:
+
+```bash
+openssl rand -hex 32 # Neo4j password
+openssl rand -hex 16 # 32-character plugin encryption key
+openssl rand -hex 64 # Auth0 session encryption secret
+```
+
+Fill every required empty value in `.env.production`. Pin the backend and
+frontend to tested semantic-version or immutable `sha-*` tags rather than
+`edge`. Optional mail, maps, geocoding, and storage settings can remain empty;
+the instance capability status will keep those features disabled.
+
+Validate the merged Compose model before starting anything:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  config --quiet
+```
+
+Compose fails immediately when a required Auth0 or encryption value is empty.
+The environment file contains secrets: do not commit it, copy it into images,
+or make it world-readable.
+
+## Start and verify
+
+Start the stack and follow Caddy while it obtains the certificate:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  up -d
+
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  logs --tail=100 caddy frontend backend
+```
+
+Verify the HTTPS origin, sign-in redirect, and container health:
+
+```bash
+curl --fail --show-error --head https://forum.example.com
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  ps
+```
+
+Only Caddy publishes public ports. The frontend, backend, and Neo4j ports retain
+loopback-only bindings for host diagnostics. Caddy adds HSTS, MIME-sniffing, and
+referrer-policy headers and proxies traffic to the frontend over the private
+Compose network.
+
+## Persistent state and backups
+
+The deployment has two important persistent data sets:
+
+- `neo4j-data` contains the forum database; and
+- `frontend-data` contains encrypted Auth0 sessions for this single frontend
+  replica.
+
+Losing `frontend-data` signs users out but does not remove forum content.
+Losing `neo4j-data` loses the forum.
+
+Configure automated, encrypted, off-host backups before inviting users. For a
+simple cold snapshot, stop the write path and database, snapshot or copy the
+Neo4j volume with your infrastructure provider's tooling, and then restart:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  stop frontend backend database
+
+# Create and export an off-host snapshot of the neo4j-data volume here.
+
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  up -d
+```
+
+Use Neo4j's backup or dump tooling when your selected edition and operational
+requirements support it. Whichever method you choose, document retention,
+encrypt backups, monitor failures, and test restoring onto a separate host.
+
+## Updates and limitations
+
+Update one component at a time by changing its pinned image tag, pulling, and
+recreating the stack. Back up Neo4j first and review release notes for data or
+configuration migrations.
+
+This foundation does not yet provide multiple application replicas, managed
+Neo4j, zero-downtime upgrades, automated restores, or an open-source OIDC
+provider. Filesystem Auth0 sessions are intentionally scoped to one frontend
+replica; a multi-replica deployment needs a shared session store.

--- a/docs/self-hosting-quickstart.md
+++ b/docs/self-hosting-quickstart.md
@@ -102,9 +102,9 @@ only when you need them.
 Local development authentication is intentionally restricted by the backend to
 `NODE_ENV=development`. Its shared bootstrap password is not a production
 identity system. Do not expose this Compose configuration to the public
-internet; use the production self-hosting path with Auth0 (or a future supported
-OIDC provider), TLS, unique secrets, backups, and an appropriately secured
-Neo4j deployment.
+internet; use the [production Compose foundation](./self-hosting-production.md)
+with Auth0 (or a future supported OIDC provider), TLS, unique secrets, backups,
+and an appropriately secured Neo4j deployment.
 
 ## Troubleshooting
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,7 @@ import { config } from './config';
 import path from 'path';
 import { inMemoryCacheOptions } from './cache';
 import { DORMANT_AUTH0_CONFIG } from './utils/auth0RuntimeConfig';
+import { getAuthStorageConfig } from './utils/authStorageConfig';
 
 const isMockedE2E = process.env.VITE_E2E_MOCK_MODE === 'true';
 const browserGraphqlUrl = config?.graphqlUrl || 'http://localhost:4000';
@@ -16,9 +17,7 @@ const runtimeGraphqlFetch: typeof globalThis.fetch = (input, init) => {
       ? process.env.NUXT_BACKEND_GRAPHQL_URL?.trim()
       : '';
   const target =
-    typeof window === 'undefined'
-      ? runtimeBackendUrl || input
-      : input;
+    typeof window === 'undefined' ? runtimeBackendUrl || input : input;
   return globalThis.fetch(target, init);
 };
 const ignoredDevWatchPatterns = [
@@ -306,28 +305,14 @@ export default defineNuxtConfig({
     // silently logged out. A persistent, shared store survives restarts and (on
     // serverless) is shared across function instances, avoiding that cascade.
     //
-    // Production (Vercel) uses Upstash Redis over its REST API — no persistent
-    // TCP connections, so it fits the serverless model. The driver reads
-    // UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN from the environment at
-    // runtime (set these in the Vercel project). `ttl` (seconds) bounds orphaned
-    // entries: each session refresh re-`set`s the key and resets its TTL, so
-    // active sessions stay alive while abandoned ones expire after 30 days.
-    storage: {
-      auth0Sessions: {
-        driver: 'upstash',
-        base: 'auth0Sessions',
-        ttl: 60 * 60 * 24 * 30, // 30 days
-      },
-      // Per-email cache of the stable auth profile (username / mod name /
-      // avatar), so server/middleware/2.auth-session.ts doesn't re-run the full
-      // backend lookup on every authenticated request. Entries are written with
-      // a per-item TTL (PROFILE_CACHE_TTL_SECONDS); the unread-notification
-      // count is never cached here (fetched fresh per request).
-      authProfileCache: {
-        driver: 'upstash',
-        base: 'authProfileCache',
-      },
-    },
+    // Vercel uses Upstash Redis over its REST API so sessions are shared across
+    // function instances. The official node-server container keeps Auth0
+    // sessions under /app/data and uses a bounded in-process profile cache,
+    // avoiding an external Redis service for one frontend replica.
+    storage: getAuthStorageConfig({
+      nitroPreset: process.env.NITRO_PRESET,
+      dataDir: process.env.MULTIFORUM_DATA_DIR,
+    }),
     // Local dev keeps filesystem-backed mounts (no Upstash creds needed) that
     // still survive `nuxt dev` restarts. devStorage overrides the production
     // mounts above only during development.
@@ -337,8 +322,9 @@ export default defineNuxtConfig({
         base: './.auth0-sessions',
       },
       authProfileCache: {
-        driver: 'upstash',
-        base: 'authProfileCache',
+        driver: 'lru-cache',
+        max: 1000,
+        ttl: 60 * 60 * 1000,
       },
     },
     // Enable server-side caching
@@ -407,7 +393,7 @@ export default defineNuxtConfig({
     localAuthTokenEndpoint: '',
     // SPIKE (auth0-nuxt server-session migration): server-only Auth0 config.
     // These are overridden by NUXT_AUTH0_* env vars at runtime (see
-    // .env.auth0-nuxt.example). clientSecret + sessionSecret mean this is a
+    // .env.production.example). clientSecret + sessionSecret mean this is a
     // CONFIDENTIAL "Regular Web Application" in Auth0 — a different app type
     // than the current SPA.
     auth0: {

--- a/server/utils/session-store-factory.ts
+++ b/server/utils/session-store-factory.ts
@@ -10,14 +10,13 @@
 // only a small session id in the cookie and stores the tokens server-side.
 //
 // The 'auth0Sessions' storage mount is configured in nuxt.config (nitro):
-// Upstash Redis in production (a shared, persistent store across serverless
-// function instances) and a filesystem driver in local dev (nitro.devStorage).
-// Both survive restarts. With in-memory storage, every restart orphaned the
-// browser's session cookie (its id no longer in the store), which the SDK then
-// deleted on the resulting store miss, silently logging the user out — a shared
-// persistent store avoids that cascade. This store implementation is driver-
-// agnostic: it only talks to the unstorage interface, so the driver can change
-// without touching this file.
+// Upstash Redis is shared across serverless function instances, while local
+// development and the single-node container use a persistent filesystem mount.
+// With in-memory storage, every restart orphaned the browser's session cookie
+// (its id no longer in the store), which the SDK then deleted on the resulting
+// store miss, silently logging the user out. This implementation is driver-
+// agnostic: it only talks to unstorage, so the driver can change without
+// touching this file.
 import type {
   SessionStore,
   StateData,

--- a/tests/unit/utils/authStorageConfig.spec.ts
+++ b/tests/unit/utils/authStorageConfig.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getAuthStorageConfig } from '@/utils/authStorageConfig';
+
+describe('getAuthStorageConfig', () => {
+  it.each([
+    [
+      { nitroPreset: 'node-server' },
+      {
+        auth0Sessions: {
+          driver: 'fs',
+          base: '.data/auth0-sessions',
+        },
+        authProfileCache: {
+          driver: 'lru-cache',
+          max: 1000,
+          ttl: 3_600_000,
+        },
+      },
+    ],
+    [
+      { nitroPreset: 'node-server', dataDir: '/app/data' },
+      {
+        auth0Sessions: {
+          driver: 'fs',
+          base: '/app/data/auth0-sessions',
+        },
+        authProfileCache: {
+          driver: 'lru-cache',
+          max: 1000,
+          ttl: 3_600_000,
+        },
+      },
+    ],
+    [
+      { nitroPreset: 'vercel' },
+      {
+        auth0Sessions: {
+          driver: 'upstash',
+          base: 'auth0Sessions',
+          ttl: 2_592_000,
+        },
+        authProfileCache: {
+          driver: 'upstash',
+          base: 'authProfileCache',
+        },
+      },
+    ],
+    [
+      { nitroPreset: undefined },
+      {
+        auth0Sessions: {
+          driver: 'upstash',
+          base: 'auth0Sessions',
+          ttl: 2_592_000,
+        },
+        authProfileCache: {
+          driver: 'upstash',
+          base: 'authProfileCache',
+        },
+      },
+    ],
+  ])('returns the expected mounts for options %o', (options, expected) => {
+    expect(getAuthStorageConfig(options)).toEqual(expected);
+  });
+});

--- a/utils/authStorageConfig.ts
+++ b/utils/authStorageConfig.ts
@@ -1,0 +1,38 @@
+const SESSION_TTL_SECONDS = 60 * 60 * 24 * 30;
+const PROFILE_CACHE_TTL_MS = 60 * 60 * 1000;
+
+type AuthStorageConfigOptions = {
+  nitroPreset: string | undefined;
+  dataDir?: string;
+};
+
+export const getAuthStorageConfig = ({
+  nitroPreset,
+  dataDir = '.data',
+}: AuthStorageConfigOptions) => {
+  if (nitroPreset === 'node-server') {
+    return {
+      auth0Sessions: {
+        driver: 'fs' as const,
+        base: `${dataDir}/auth0-sessions`,
+      },
+      authProfileCache: {
+        driver: 'lru-cache' as const,
+        max: 1000,
+        ttl: PROFILE_CACHE_TTL_MS,
+      },
+    };
+  }
+
+  return {
+    auth0Sessions: {
+      driver: 'upstash' as const,
+      base: 'auth0Sessions',
+      ttl: SESSION_TTL_SECONDS,
+    },
+    authProfileCache: {
+      driver: 'upstash' as const,
+      base: 'authProfileCache',
+    },
+  };
+};


### PR DESCRIPTION
## Summary

- land the Terraform image deployment from #478 directly on current `main`
- land the production Compose, Caddy, persistent Auth0 session, and runtime configuration work from #479
- land the Terraform-to-production-overlay integration from #480
- preserve the 4 GB frontend container build heap fix already merged through #476

## Why this PR exists

PRs #478, #479, and #480 were marked merged into their intermediate feature-branch bases after the native GitHub stack was removed. Their changes therefore did not reach `main`. This recovery branch starts at current `main` and applies only those three missing commits.

## Validation

- targeted auth storage tests: 4 passing, 100% statements/branches/functions/lines
- `npm run tsc`
- `npm run lint -- --no-fix`
- 4 GB `node-server` production build
- quick-start and production Compose configuration
- Terraform 1.8.5 formatting and validation
- rendered cloud-init YAML and safety assertions
- Caddy 2.11.4 configuration validation
- Prettier on changed supported deployment/docs files
- `git diff --check`