### PR TITLE
ci(self-hosting): validate deployment contracts

### DIFF
--- a/.github/workflows/self-hosting-contract.yml
+++ b/.github/workflows/self-hosting-contract.yml
@@ -1,0 +1,45 @@
+name: Self-hosting deployment contract
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.env.quickstart.example'
+      - '.env.production.example'
+      - '.github/workflows/self-hosting-contract.yml'
+      - 'deploy/caddy/**'
+      - 'deploy/terraform/aws-single-vm/**'
+      - 'docker-compose*.yml'
+      - 'scripts/validate-self-hosting-contract.sh'
+  push:
+    branches:
+      - main
+    paths:
+      - '.env.quickstart.example'
+      - '.env.production.example'
+      - '.github/workflows/self-hosting-contract.yml'
+      - 'deploy/caddy/**'
+      - 'deploy/terraform/aws-single-vm/**'
+      - 'docker-compose*.yml'
+      - 'scripts/validate-self-hosting-contract.sh'
+  workflow_dispatch:
+
+concurrency:
+  group: self-hosting-contract-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate deployment contract
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Validate self-hosting deployment contract
+        run: scripts/validate-self-hosting-contract.sh

--- a/deploy/terraform/aws-single-vm/tests/production_contract.tftest.hcl
+++ b/deploy/terraform/aws-single-vm/tests/production_contract.tftest.hcl
@@ -1,0 +1,104 @@
+mock_provider "aws" {
+  mock_data "aws_vpc" {
+    defaults = {
+      id = "vpc-contract"
+    }
+  }
+
+  mock_data "aws_subnets" {
+    defaults = {
+      ids = ["subnet-contract-b", "subnet-contract-a"]
+    }
+  }
+
+  mock_data "aws_ssm_parameter" {
+    defaults = {
+      value = "ami-contract"
+    }
+  }
+
+  mock_resource "aws_eip" {
+    defaults = {
+      public_ip = "203.0.113.20"
+    }
+  }
+}
+
+run "production_contract" {
+  command = apply
+
+  variables {
+    admin_cidr        = "198.51.100.10/32"
+    ssh_key_name      = "multiforum-contract"
+    application_cidrs = ["0.0.0.0/0"]
+    domain            = "forum.example.com"
+    acme_email        = "admin@example.com"
+    repository_ref    = "v1.2.3"
+    neo4j_image       = "neo4j:contract"
+    backend_image     = "ghcr.io/example/backend:contract"
+    frontend_image    = "ghcr.io/example/frontend:contract"
+    caddy_image       = "caddy:contract"
+  }
+
+  assert {
+    condition     = output.application_url == "https://forum.example.com"
+    error_message = "The application URL must use the configured production domain over HTTPS."
+  }
+
+  assert {
+    condition = output.dns_a_record == {
+      name  = "forum.example.com"
+      type  = "A"
+      value = "203.0.113.20"
+    }
+    error_message = "The DNS handoff must point the configured domain at the allocated public IP."
+  }
+
+  assert {
+    condition     = length(aws_security_group.multiforum.ingress) == 4
+    error_message = "The host must expose only SSH and Caddy's three public listener rules."
+  }
+
+  assert {
+    condition = alltrue([
+      for rule in aws_security_group.multiforum.ingress :
+      rule.from_port != 3000 && rule.to_port != 3000 &&
+      rule.from_port != 4000 && rule.to_port != 4000 &&
+      rule.from_port != 7474 && rule.to_port != 7474 &&
+      rule.from_port != 7687 && rule.to_port != 7687
+    ])
+    error_message = "Frontend, backend, and Neo4j ports must not be publicly exposed by Terraform."
+  }
+
+  assert {
+    condition = alltrue([
+      for listener in [
+        { protocol = "tcp", port = 80 },
+        { protocol = "tcp", port = 443 },
+        { protocol = "udp", port = 443 }
+        ] : length([
+          for rule in aws_security_group.multiforum.ingress : rule
+          if rule.protocol == listener.protocol &&
+          rule.from_port == listener.port &&
+          rule.to_port == listener.port &&
+          contains(rule.cidr_blocks, "0.0.0.0/0")
+      ]) == 1
+    ])
+    error_message = "Caddy must receive public HTTP, HTTPS, and HTTP/3 traffic."
+  }
+
+  assert {
+    condition = alltrue([
+      strcontains(aws_instance.multiforum.user_data, "--branch 'v1.2.3'"),
+      strcontains(aws_instance.multiforum.user_data, ".env.production"),
+      strcontains(aws_instance.multiforum.user_data, "chmod 0600 /opt/multiforum/.env.production"),
+      strcontains(aws_instance.multiforum.user_data, "docker pull 'neo4j:contract'"),
+      strcontains(aws_instance.multiforum.user_data, "docker pull 'ghcr.io/example/backend:contract'"),
+      strcontains(aws_instance.multiforum.user_data, "docker pull 'ghcr.io/example/frontend:contract'"),
+      strcontains(aws_instance.multiforum.user_data, "docker pull 'caddy:contract'"),
+      !strcontains(aws_instance.multiforum.user_data, ".env.quickstart"),
+      !strcontains(aws_instance.multiforum.user_data, "docker compose up")
+    ])
+    error_message = "Cloud-init must stage the production configuration and images without starting an unconfigured stack."
+  }
+}

--- a/scripts/validate-self-hosting-contract.sh
+++ b/scripts/validate-self-hosting-contract.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+contract_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+contract_tmp_dir="$(mktemp -d)"
+terraform_dir="$contract_root/deploy/terraform/aws-single-vm"
+terraform_image="hashicorp/terraform:1.8.5"
+caddy_image="caddy:2.11.4-alpine"
+
+trap 'rm -rf "$contract_tmp_dir"' EXIT
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+run_terraform() {
+  docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    --volume "$terraform_dir:/workspace" \
+    --workdir /workspace \
+    "$terraform_image" \
+    "$@"
+}
+
+require_command docker
+require_command jq
+
+cd "$contract_root"
+
+echo "Validating the image-based quick-start contract..."
+docker compose \
+  --env-file .env.quickstart.example \
+  config --format json >"$contract_tmp_dir/quickstart.json"
+
+jq --exit-status '
+  .services.database.image == "neo4j:5.1.0" and
+  .services.backend.image == "ghcr.io/gennit-project/multiforum-backend:edge" and
+  .services.frontend.image == "ghcr.io/gennit-project/multiforum-nuxt:edge" and
+  (.services.backend.build == null) and
+  (.services.frontend.build == null) and
+  .services.backend.environment.MULTIFORUM_AUTH_PROVIDER == "local-dev" and
+  .services.frontend.environment.NUXT_PUBLIC_AUTH_PROVIDER == "local-dev" and
+  (.services.caddy == null) and
+  ([
+    .services.database.ports[],
+    .services.backend.ports[],
+    .services.frontend.ports[]
+  ] | all(.host_ip == "127.0.0.1"))
+' "$contract_tmp_dir/quickstart.json" >/dev/null
+
+echo "Validating the contributor source-build override..."
+docker compose \
+  --env-file .env.quickstart.example \
+  --file docker-compose.yml \
+  --file docker-compose.source.yml \
+  config --format json >"$contract_tmp_dir/source.json"
+
+jq --exit-status '
+  .services.backend.image == "multiforum-backend:quickstart" and
+  .services.backend.pull_policy == "build" and
+  .services.backend.build.dockerfile == "docker/backend.Dockerfile" and
+  .services.backend.build.args.MULTIFORUM_BACKEND_REF == "main" and
+  .services.frontend.image == "multiforum-frontend:quickstart" and
+  .services.frontend.pull_policy == "build" and
+  .services.frontend.build.dockerfile == "Dockerfile"
+' "$contract_tmp_dir/source.json" >/dev/null
+
+echo "Confirming production configuration rejects missing secrets..."
+if env NEO4J_PASSWORD= docker compose \
+  --env-file .env.production.example \
+  --file docker-compose.yml \
+  --file docker-compose.production.yml \
+  config --quiet >"$contract_tmp_dir/missing-secrets.log" 2>&1; then
+  echo "Production Compose unexpectedly accepted an empty NEO4J_PASSWORD." >&2
+  exit 1
+fi
+
+echo "Validating the production overlay contract..."
+env \
+  NEO4J_PASSWORD=contract-neo4j \
+  MULTIFORUM_SUPERADMIN_EMAIL=admin@example.com \
+  PLUGIN_SECRET_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef \
+  AUTH0_DOMAIN=auth.example.com \
+  AUTH0_CLIENT_ID=contract-client \
+  AUTH0_AUDIENCE=https://api.example.com \
+  NUXT_AUTH0_CLIENT_SECRET=contract-client-secret \
+  NUXT_AUTH0_SESSION_SECRET=0123456789abcdef0123456789abcdef \
+  CADDY_ACME_EMAIL=admin@example.com \
+  MULTIFORUM_DOMAIN=forum.example.com \
+  MULTIFORUM_NEO4J_IMAGE=neo4j:contract \
+  MULTIFORUM_BACKEND_IMAGE=ghcr.io/example/backend:contract \
+  MULTIFORUM_FRONTEND_IMAGE=ghcr.io/example/frontend:contract \
+  MULTIFORUM_CADDY_IMAGE=caddy:contract \
+  docker compose \
+    --env-file .env.production.example \
+    --file docker-compose.yml \
+    --file docker-compose.production.yml \
+    config --format json >"$contract_tmp_dir/production.json"
+
+jq --exit-status '
+  .services.database.image == "neo4j:contract" and
+  .services.backend.image == "ghcr.io/example/backend:contract" and
+  .services.frontend.image == "ghcr.io/example/frontend:contract" and
+  .services.caddy.image == "caddy:contract" and
+  ([.services[] | .build] | all(. == null)) and
+  .services.backend.environment.NODE_ENV == "production" and
+  .services.backend.environment.MULTIFORUM_AUTH_PROVIDER == "auth0" and
+  .services.backend.environment.FRONTEND_URL == "https://forum.example.com" and
+  .services.frontend.environment.NODE_ENV == "production" and
+  .services.frontend.environment.NUXT_PUBLIC_AUTH_PROVIDER == "auth0" and
+  .services.frontend.environment.NUXT_PUBLIC_BASE_URL == "https://forum.example.com" and
+  ([
+    .services.database.ports[],
+    .services.backend.ports[],
+    .services.frontend.ports[]
+  ] | all(.host_ip == "127.0.0.1")) and
+  ([
+    .services[] | .ports[]? | select(.host_ip == null) |
+    {published: .published, protocol: .protocol}
+  ] | sort_by(.published, .protocol)) == [
+    {published: 80, protocol: "tcp"},
+    {published: 443, protocol: "tcp"},
+    {published: 443, protocol: "udp"}
+  ] and
+  any(.services.frontend.volumes[];
+    .type == "volume" and .target == "/app/data") and
+  any(.services.caddy.volumes[];
+    .type == "bind" and .target == "/etc/caddy/Caddyfile" and .read_only == true)
+' "$contract_tmp_dir/production.json" >/dev/null
+
+echo "Validating the Caddy production configuration..."
+docker run --rm \
+  --env MULTIFORUM_DOMAIN=forum.example.com \
+  --env CADDY_ACME_EMAIL=admin@example.com \
+  --volume "$contract_root/deploy/caddy/Caddyfile:/etc/caddy/Caddyfile:ro" \
+  "$caddy_image" \
+  caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+
+echo "Validating and testing the Terraform example..."
+run_terraform fmt -check -recursive
+run_terraform init -backend=false -input=false
+run_terraform validate
+run_terraform test
+
+echo "All self-hosting deployment contracts passed."

--- a/scripts/validate-self-hosting-contract.sh
+++ b/scripts/validate-self-hosting-contract.sh
@@ -120,7 +120,7 @@ jq --exit-status '
   ] | all(.host_ip == "127.0.0.1")) and
   ([
     .services[] | .ports[]? | select(.host_ip == null) |
-    {published: .published, protocol: .protocol}
+    {published: (.published | tonumber), protocol: .protocol}
   ] | sort_by(.published, .protocol)) == [
     {published: 80, protocol: "tcp"},
     {published: 443, protocol: "tcp"},


### PR DESCRIPTION
## Summary

- add a path-filtered GitHub Actions check for self-hosting deployment files
- validate quick-start, source-build, and production Compose contracts from one reusable script
- validate the pinned Caddy configuration and Terraform formatting/configuration
- exercise the AWS single-VM example with a mocked Terraform apply covering DNS, ingress, and cloud-init safety

## Validation

- `scripts/validate-self-hosting-contract.sh`
- `bash -n scripts/validate-self-hosting-contract.sh`
- `prettier --check .github/workflows/self-hosting-contract.yml`
- `git diff --cached --check`

## Coverage

This PR adds infrastructure and CI assertions rather than frontend application code, so JavaScript coverage is not applicable. The new deployment paths are exercised end to end by the contract script and Terraform native test.