### PR TITLE
feat(self-hosting): add cold backup command

### DIFF
--- a/.github/workflows/self-hosting-contract.yml
+++ b/.github/workflows/self-hosting-contract.yml
@@ -11,6 +11,8 @@ on:
       - 'deploy/caddy/**'
       - 'deploy/terraform/aws-single-vm/**'
       - 'docker-compose*.yml'
+      - 'scripts/backup-self-hosting.sh'
+      - 'scripts/self-hosting-tests/**'
       - 'scripts/validate-self-hosting-contract.sh'
   push:
     branches:
@@ -22,6 +24,8 @@ on:
       - 'deploy/caddy/**'
       - 'deploy/terraform/aws-single-vm/**'
       - 'docker-compose*.yml'
+      - 'scripts/backup-self-hosting.sh'
+      - 'scripts/self-hosting-tests/**'
       - 'scripts/validate-self-hosting-contract.sh'
   workflow_dispatch:
 

--- a/deploy/terraform/aws-single-vm/README.md
+++ b/deploy/terraform/aws-single-vm/README.md
@@ -148,6 +148,9 @@ stateful host would also replace its local data disk. Apply operating-system
 security updates on the host and plan host migrations as explicit
 backup-and-restore operations.
 
-Back up Neo4j off-host before replacing or destroying the instance. The root
-volume is deleted with the instance by default, so `terraform destroy` removes
-the forum data along with the infrastructure.
+Back up Neo4j off-host before replacing or destroying the instance. From
+`/opt/multiforum`, use the production guide's
+[cold-backup command](../../../docs/self-hosting-production.md#persistent-state-and-backups),
+then encrypt and copy the completed bundle away from the VM. The root volume is
+deleted with the instance by default, so `terraform destroy` removes the forum
+data along with the infrastructure.

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -129,29 +129,31 @@ The deployment has two important persistent data sets:
 Losing `frontend-data` signs users out but does not remove forum content.
 Losing `neo4j-data` loses the forum.
 
-Configure automated, encrypted, off-host backups before inviting users. For a
-simple cold snapshot, stop the write path and database, snapshot or copy the
-Neo4j volume with your infrastructure provider's tooling, and then restart:
+Configure automated, encrypted, off-host backups before inviting users. The
+repository includes a cold-backup command that verifies the production
+services are running, stops the write path and database, archives both durable
+volumes, writes a checksum manifest, and restarts the services even when an
+archive operation fails.
 
 ```bash
-docker compose \
+sudo install -d -m 0700 -o "$(id -un)" -g "$(id -gn)" \
+  /var/backups/multiforum
+scripts/backup-self-hosting.sh \
   --env-file .env.production \
-  -f docker-compose.yml \
-  -f docker-compose.production.yml \
-  stop frontend backend database
-
-# Create and export an off-host snapshot of the neo4j-data volume here.
-
-docker compose \
-  --env-file .env.production \
-  -f docker-compose.yml \
-  -f docker-compose.production.yml \
-  up -d
+  --output-dir /var/backups/multiforum
 ```
 
-Use Neo4j's backup or dump tooling when your selected edition and operational
-requirements support it. Whichever method you choose, document retention,
-encrypt backups, monitor failures, and test restoring onto a separate host.
+Each timestamped bundle contains `neo4j-data.tar.gz`,
+`frontend-data.tar.gz`, and `manifest.json`. The manifest records the selected
+database, backend, and frontend images plus a SHA-256 checksum for each
+archive. It deliberately excludes `.env.production`; preserve that file and
+its secrets separately in encrypted secret storage.
+
+The command creates a consistent cold copy, so the site has a brief outage
+while the volumes are archived. Copy the completed bundle off the host,
+encrypt it at rest, apply a retention policy, monitor scheduled runs, and test
+restoring onto a separate host. Use Neo4j's online backup tooling instead when
+your selected edition and recovery requirements support it.
 
 ## Updates and limitations
 

--- a/scripts/backup-self-hosting.sh
+++ b/scripts/backup-self-hosting.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+backup_root=""
+env_file=".env.production"
+backup_helper_image="${MULTIFORUM_BACKUP_HELPER_IMAGE:-busybox:1.36.1}"
+script_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/backup-self-hosting.sh --output-dir PATH [--env-file PATH]
+
+Creates a consistent cold backup of the production Neo4j and frontend-session
+volumes. The frontend, backend, and database must already be running.
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "Required command not found: sha256sum or shasum" >&2
+    return 1
+  fi
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --env-file)
+      if [[ -z "${2:-}" ]]; then
+        echo "--env-file requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      env_file="$2"
+      shift 2
+      ;;
+    --output-dir)
+      if [[ -z "${2:-}" ]]; then
+        echo "--output-dir requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      backup_root="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$backup_root" ]]; then
+  echo "--output-dir is required." >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -f "$env_file" ]]; then
+  echo "Production environment file not found: $env_file" >&2
+  exit 1
+fi
+
+require_command docker
+require_command jq
+require_command awk
+
+mkdir -p "$backup_root"
+backup_root="$(cd -- "$backup_root" && pwd)"
+env_file="$(cd -- "$(dirname -- "$env_file")" && pwd)/$(basename -- "$env_file")"
+
+compose=(
+  docker compose
+  --env-file "$env_file"
+  --file "$script_root/docker-compose.yml"
+  --file "$script_root/docker-compose.production.yml"
+)
+
+compose_config="$("${compose[@]}" config --format json)"
+neo4j_volume="$(jq --raw-output '.volumes["neo4j-data"].name // empty' <<<"$compose_config")"
+frontend_volume="$(jq --raw-output '.volumes["frontend-data"].name // empty' <<<"$compose_config")"
+
+if [[ -z "$neo4j_volume" || -z "$frontend_volume" ]]; then
+  echo "Production Compose did not resolve the expected persistent volumes." >&2
+  exit 1
+fi
+
+running_services="$("${compose[@]}" ps --status running --services)"
+for required_service in database backend frontend; do
+  if ! grep --fixed-strings --line-regexp "$required_service" <<<"$running_services" >/dev/null; then
+    echo "Production service is not running: $required_service" >&2
+    exit 1
+  fi
+done
+
+backup_timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+final_dir="$backup_root/multiforum-backup-$backup_timestamp"
+
+if [[ -e "$final_dir" ]]; then
+  echo "Backup destination already exists: $final_dir" >&2
+  exit 1
+fi
+
+working_dir="$(mktemp -d "$backup_root/.multiforum-backup.XXXXXX")"
+services_stopped=false
+backup_complete=false
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+
+  if [[ "$services_stopped" == true ]]; then
+    echo "Restarting the production services..."
+    if ! "${compose[@]}" up -d database backend frontend; then
+      echo "Failed to restart one or more production services." >&2
+      if ((status == 0)); then
+        status=1
+      fi
+    fi
+  fi
+
+  if [[ "$backup_complete" != true && -d "$working_dir" ]]; then
+    rm -rf -- "$working_dir"
+  fi
+
+  exit "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+archive_volume() {
+  local volume_name="$1"
+  local destination="$2"
+
+  docker run --rm \
+    --volume "$volume_name:/source:ro" \
+    "$backup_helper_image" \
+    tar -czf - -C /source . >"$destination"
+}
+
+echo "Stopping application writes for a consistent cold backup..."
+services_stopped=true
+"${compose[@]}" stop frontend backend
+"${compose[@]}" stop database
+
+echo "Archiving Neo4j data..."
+archive_volume "$neo4j_volume" "$working_dir/neo4j-data.tar.gz"
+
+echo "Archiving frontend sessions..."
+archive_volume "$frontend_volume" "$working_dir/frontend-data.tar.gz"
+
+neo4j_sha256="$(sha256_file "$working_dir/neo4j-data.tar.gz")"
+frontend_sha256="$(sha256_file "$working_dir/frontend-data.tar.gz")"
+
+jq --null-input \
+  --arg createdAt "$created_at" \
+  --arg databaseImage "$(jq --raw-output '.services.database.image' <<<"$compose_config")" \
+  --arg backendImage "$(jq --raw-output '.services.backend.image' <<<"$compose_config")" \
+  --arg frontendImage "$(jq --raw-output '.services.frontend.image' <<<"$compose_config")" \
+  --arg neo4jSha256 "$neo4j_sha256" \
+  --arg frontendSha256 "$frontend_sha256" \
+  '{
+    formatVersion: 1,
+    createdAt: $createdAt,
+    images: {
+      database: $databaseImage,
+      backend: $backendImage,
+      frontend: $frontendImage
+    },
+    archives: {
+      "neo4j-data.tar.gz": {sha256: $neo4jSha256},
+      "frontend-data.tar.gz": {sha256: $frontendSha256}
+    }
+  }' >"$working_dir/manifest.json"
+
+mv -- "$working_dir" "$final_dir"
+backup_complete=true
+
+echo "Backup created: $final_dir"
+echo "Encrypt and copy this bundle off the host before relying on it."

--- a/scripts/self-hosting-tests/backup-self-hosting.test.sh
+++ b/scripts/self-hosting-tests/backup-self-hosting.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+backup_script="$repository_root/scripts/backup-self-hosting.sh"
+fixture_bin="$repository_root/scripts/self-hosting-tests/fixtures"
+
+trap 'rm -rf "$test_root"' EXIT
+
+export PATH="$fixture_bin:$PATH"
+export MULTIFORUM_FAKE_DOCKER_LOG="$test_root/docker.log"
+
+env_file="$test_root/.env.production"
+: >"$env_file"
+
+"$backup_script" --help | grep --fixed-strings -- "--output-dir PATH" >/dev/null
+
+if "$backup_script" --env-file >/dev/null 2>&1; then
+  echo "Expected a missing --env-file value to fail." >&2
+  exit 1
+fi
+
+if "$backup_script" --unknown >/dev/null 2>&1; then
+  echo "Expected an unknown argument to fail." >&2
+  exit 1
+fi
+
+if "$backup_script" --output-dir "$test_root/missing-env" \
+  --env-file "$test_root/does-not-exist" >/dev/null 2>&1; then
+  echo "Expected a missing production environment file to fail." >&2
+  exit 1
+fi
+
+success_root="$test_root/success"
+mkdir -p "$success_root"
+
+"$backup_script" --env-file "$env_file" --output-dir "$success_root"
+
+backup_dir="$(find "$success_root" -mindepth 1 -maxdepth 1 -type d -name 'multiforum-backup-*' -print)"
+if [[ -z "$backup_dir" || "$(printf '%s\n' "$backup_dir" | wc -l | tr -d ' ')" != 1 ]]; then
+  echo "Expected exactly one completed backup bundle." >&2
+  exit 1
+fi
+
+test -s "$backup_dir/neo4j-data.tar.gz"
+test -s "$backup_dir/frontend-data.tar.gz"
+jq --exit-status '
+  .formatVersion == 1 and
+  .images.database == "neo4j:test" and
+  .images.backend == "ghcr.io/example/backend:test" and
+  .images.frontend == "ghcr.io/example/frontend:test" and
+  (.archives["neo4j-data.tar.gz"].sha256 | test("^[a-f0-9]{64}$")) and
+  (.archives["frontend-data.tar.gz"].sha256 | test("^[a-f0-9]{64}$"))
+' "$backup_dir/manifest.json" >/dev/null
+grep --fixed-strings "stop frontend backend" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+grep --fixed-strings "stop database" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+grep --fixed-strings "up -d database backend frontend" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+
+failure_root="$test_root/failure"
+mkdir -p "$failure_root"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+
+if MULTIFORUM_FAKE_FAIL_FRONTEND=true \
+  "$backup_script" --env-file "$env_file" --output-dir "$failure_root"; then
+  echo "Expected a failed archive command to fail the backup." >&2
+  exit 1
+fi
+
+if find "$failure_root" -mindepth 1 -print -quit | grep --quiet .; then
+  echo "A failed backup must not leave a partial bundle." >&2
+  exit 1
+fi
+grep --fixed-strings "up -d database backend frontend" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+
+restart_failure_root="$test_root/restart-failure"
+mkdir -p "$restart_failure_root"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+
+if MULTIFORUM_FAKE_FAIL_RESTART=true \
+  "$backup_script" --env-file "$env_file" --output-dir "$restart_failure_root"; then
+  echo "Expected a failed service restart to fail the backup command." >&2
+  exit 1
+fi
+
+if ! find "$restart_failure_root" -mindepth 1 -maxdepth 1 -type d \
+  -name 'multiforum-backup-*' -print -quit | grep --quiet .; then
+  echo "A completed backup must survive a subsequent restart failure." >&2
+  exit 1
+fi
+
+stop_failure_root="$test_root/stop-failure"
+mkdir -p "$stop_failure_root"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+
+if MULTIFORUM_FAKE_FAIL_STOP=true \
+  "$backup_script" --env-file "$env_file" --output-dir "$stop_failure_root"; then
+  echo "Expected a failed stop command to fail the backup." >&2
+  exit 1
+fi
+
+if find "$stop_failure_root" -mindepth 1 -print -quit | grep --quiet .; then
+  echo "A failed stop command must not leave a partial bundle." >&2
+  exit 1
+fi
+grep --fixed-strings "up -d database backend frontend" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+
+missing_service_root="$test_root/missing-service"
+mkdir -p "$missing_service_root"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+
+if MULTIFORUM_FAKE_RUNNING_SERVICES=$'database\nbackend' \
+  "$backup_script" --env-file "$env_file" --output-dir "$missing_service_root"; then
+  echo "Expected the backup to reject a stopped frontend." >&2
+  exit 1
+fi
+
+if grep --fixed-strings "stop frontend backend" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "The backup must not stop services after a failed preflight." >&2
+  exit 1
+fi
+
+echo "Cold-backup command tests passed."

--- a/scripts/self-hosting-tests/fixtures/docker
+++ b/scripts/self-hosting-tests/fixtures/docker
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$MULTIFORUM_FAKE_DOCKER_LOG"
+
+if [[ "${1:-}" == "compose" ]]; then
+  case " $* " in
+    *" config --format json "*)
+      cat <<'JSON'
+{
+  "services": {
+    "database": {"image": "neo4j:test"},
+    "backend": {"image": "ghcr.io/example/backend:test"},
+    "frontend": {"image": "ghcr.io/example/frontend:test"}
+  },
+  "volumes": {
+    "neo4j-data": {"name": "neo4j-volume"},
+    "frontend-data": {"name": "frontend-volume"}
+  }
+}
+JSON
+      ;;
+    *" ps --status running --services "*)
+      if [[ -n "${MULTIFORUM_FAKE_RUNNING_SERVICES:-}" ]]; then
+        printf '%s\n' "$MULTIFORUM_FAKE_RUNNING_SERVICES"
+      else
+        printf 'database\nbackend\nfrontend\n'
+      fi
+      ;;
+    *" stop frontend backend "*)
+      if [[ "${MULTIFORUM_FAKE_FAIL_STOP:-false}" == true ]]; then
+        exit 43
+      fi
+      ;;
+    *" stop database "*)
+      ;;
+    *" up -d database backend frontend "*)
+      if [[ "${MULTIFORUM_FAKE_FAIL_RESTART:-false}" == true ]]; then
+        exit 44
+      fi
+      ;;
+    *)
+      echo "Unexpected fake Docker Compose command: $*" >&2
+      exit 90
+      ;;
+  esac
+elif [[ "${1:-}" == "run" ]]; then
+  if [[ "${MULTIFORUM_FAKE_FAIL_FRONTEND:-false}" == true && "$*" == *"frontend-volume:/source:ro"* ]]; then
+    exit 42
+  fi
+  printf 'archive:%s\n' "$*"
+else
+  echo "Unexpected fake Docker command: $*" >&2
+  exit 91
+fi

--- a/scripts/validate-self-hosting-contract.sh
+++ b/scripts/validate-self-hosting-contract.sh
@@ -31,6 +31,9 @@ require_command jq
 
 cd "$contract_root"
 
+echo "Testing the production cold-backup command..."
+scripts/self-hosting-tests/backup-self-hosting.test.sh
+
 echo "Validating the image-based quick-start contract..."
 docker compose \
   --env-file .env.quickstart.example \


### PR DESCRIPTION
## Summary

- add a production cold-backup command for Neo4j data and encrypted frontend sessions
- stop the application write path before Neo4j and always attempt service recovery on failure
- emit timestamped bundles with image metadata and SHA-256 checksums while excluding production secrets
- cover success, argument validation, archive failure, partial-stop failure, restart failure, and preflight refusal paths
- include the backup tests in deployment-contract CI and update production/Terraform operator guidance

## Validation

- `scripts/self-hosting-tests/backup-self-hosting.test.sh`
- `scripts/validate-self-hosting-contract.sh`
- ShellCheck for all affected shell scripts
- `prettier --check .github/workflows/self-hosting-contract.yml docs/self-hosting-production.md deploy/terraform/aws-single-vm/README.md`
- pinned `busybox:1.36.1` helper image and tar flags verified

## Coverage

This slice adds operational shell code rather than frontend application code, so JavaScript coverage is not applicable. The new command is exercised across its primary success path and safety-critical failure paths by deployment-contract CI.

## Follow-up

A separate restore slice should verify checksums and make its destructive target/confirmation contract explicit.