### PR TITLE
feat(self-hosting): add guarded restore command

### DIFF
--- a/.github/workflows/self-hosting-contract.yml
+++ b/.github/workflows/self-hosting-contract.yml
@@ -12,6 +12,7 @@ on:
       - 'deploy/terraform/aws-single-vm/**'
       - 'docker-compose*.yml'
       - 'scripts/backup-self-hosting.sh'
+      - 'scripts/restore-self-hosting.sh'
       - 'scripts/self-hosting-tests/**'
       - 'scripts/validate-self-hosting-contract.sh'
   push:
@@ -25,6 +26,7 @@ on:
       - 'deploy/terraform/aws-single-vm/**'
       - 'docker-compose*.yml'
       - 'scripts/backup-self-hosting.sh'
+      - 'scripts/restore-self-hosting.sh'
       - 'scripts/self-hosting-tests/**'
       - 'scripts/validate-self-hosting-contract.sh'
   workflow_dispatch:

--- a/deploy/terraform/aws-single-vm/README.md
+++ b/deploy/terraform/aws-single-vm/README.md
@@ -153,4 +153,6 @@ Back up Neo4j off-host before replacing or destroying the instance. From
 [cold-backup command](../../../docs/self-hosting-production.md#persistent-state-and-backups),
 then encrypt and copy the completed bundle away from the VM. The root volume is
 deleted with the instance by default, so `terraform destroy` removes the forum
-data along with the infrastructure.
+data along with the infrastructure. The same guide documents the
+[guarded restore procedure](../../../docs/self-hosting-production.md#restore-a-cold-backup)
+for a replacement host.

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -155,6 +155,67 @@ encrypt it at rest, apply a retention policy, monitor scheduled runs, and test
 restoring onto a separate host. Use Neo4j's online backup tooling instead when
 your selected edition and recovery requirements support it.
 
+### Restore a cold backup
+
+Restore onto a separate host first whenever possible. Before replacing the
+current volumes, create a fresh safety backup and preserve the original
+`.env.production` in encrypted secret storage. Inspect the selected image
+versions recorded in the bundle:
+
+```bash
+jq .images /var/backups/multiforum/BACKUP_DIR/manifest.json
+```
+
+Configure the recorded Neo4j image before restoring. Neo4j stores are not
+generally portable across arbitrary database versions. Then stop the write
+path before the database:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  stop frontend backend
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  stop database
+```
+
+Run the guarded restore with its explicit destructive confirmation:
+
+```bash
+scripts/restore-self-hosting.sh \
+  --backup-dir /var/backups/multiforum/BACKUP_DIR \
+  --env-file .env.production \
+  --confirm-replace-existing-data
+```
+
+The command verifies the manifest, both SHA-256 checksums, archive paths, the
+stopped-service precondition, and the configured Neo4j image before replacing
+either volume. It never starts application services; once restoration begins,
+keep them stopped whether extraction succeeds or fails. After a successful
+restore, validate the Compose model and start the stack:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  config --quiet
+docker compose \
+  --env-file .env.production \
+  -f docker-compose.yml \
+  -f docker-compose.production.yml \
+  up -d
+```
+
+Use `--allow-database-image-mismatch` only after reviewing Neo4j's supported
+upgrade and restore paths. Restoring the original Auth0 session secret lets
+the frontend read restored sessions; otherwise users may need to sign in
+again.
+
 ## Updates and limitations
 
 Update one component at a time by changing its pinned image tag, pulling, and
@@ -162,6 +223,6 @@ recreating the stack. Back up Neo4j first and review release notes for data or
 configuration migrations.
 
 This foundation does not yet provide multiple application replicas, managed
-Neo4j, zero-downtime upgrades, automated restores, or an open-source OIDC
+Neo4j, zero-downtime upgrades, unattended restores, or an open-source OIDC
 provider. Filesystem Auth0 sessions are intentionally scoped to one frontend
 replica; a multi-replica deployment needs a shared session store.

--- a/scripts/restore-self-hosting.sh
+++ b/scripts/restore-self-hosting.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+backup_dir=""
+env_file=".env.production"
+restore_confirmed=false
+allow_database_image_mismatch=false
+restore_helper_image="${MULTIFORUM_BACKUP_HELPER_IMAGE:-busybox:1.36.1}"
+script_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/restore-self-hosting.sh --backup-dir PATH [--env-file PATH]
+       --confirm-replace-existing-data [--allow-database-image-mismatch]
+
+Replaces the production Neo4j and frontend-session volumes with a verified
+cold-backup bundle. The frontend, backend, and database must already be stopped.
+Successful restores leave them stopped for operator verification.
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "Required command not found: sha256sum or shasum" >&2
+    return 1
+  fi
+}
+
+verify_archive() {
+  local archive_name="$1"
+  local archive_path="$backup_dir/$archive_name"
+  local expected_sha256
+  local actual_sha256
+  local archive_listing
+
+  if [[ ! -f "$archive_path" ]]; then
+    echo "Backup archive not found: $archive_path" >&2
+    return 1
+  fi
+
+  expected_sha256="$(jq --raw-output --arg archive "$archive_name" \
+    '.archives[$archive].sha256' "$manifest_path")"
+  actual_sha256="$(sha256_file "$archive_path")"
+
+  if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+    echo "Backup checksum mismatch: $archive_name" >&2
+    return 1
+  fi
+
+  archive_listing="$(tar -tzf "$archive_path")"
+  if grep --extended-regexp '(^/|(^|/)\.\.(/|$))' <<<"$archive_listing" >/dev/null; then
+    echo "Backup archive contains an unsafe path: $archive_name" >&2
+    return 1
+  fi
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --backup-dir)
+      if [[ -z "${2:-}" ]]; then
+        echo "--backup-dir requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      backup_dir="$2"
+      shift 2
+      ;;
+    --env-file)
+      if [[ -z "${2:-}" ]]; then
+        echo "--env-file requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      env_file="$2"
+      shift 2
+      ;;
+    --confirm-replace-existing-data)
+      restore_confirmed=true
+      shift
+      ;;
+    --allow-database-image-mismatch)
+      allow_database_image_mismatch=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$restore_confirmed" != true ]]; then
+  echo "Refusing to replace data without --confirm-replace-existing-data." >&2
+  exit 2
+fi
+
+if [[ -z "$backup_dir" || ! -d "$backup_dir" ]]; then
+  echo "Backup directory not found: ${backup_dir:-<not provided>}" >&2
+  exit 1
+fi
+
+if [[ ! -f "$env_file" ]]; then
+  echo "Production environment file not found: $env_file" >&2
+  exit 1
+fi
+
+require_command docker
+require_command jq
+require_command awk
+require_command grep
+require_command tar
+
+backup_dir="$(cd -- "$backup_dir" && pwd)"
+env_file="$(cd -- "$(dirname -- "$env_file")" && pwd)/$(basename -- "$env_file")"
+manifest_path="$backup_dir/manifest.json"
+
+if [[ ! -f "$manifest_path" ]]; then
+  echo "Backup manifest not found: $manifest_path" >&2
+  exit 1
+fi
+
+if ! jq --exit-status '
+  .formatVersion == 1 and
+  (.images.database | type == "string" and length > 0) and
+  (.archives["neo4j-data.tar.gz"].sha256 | test("^[a-f0-9]{64}$")) and
+  (.archives["frontend-data.tar.gz"].sha256 | test("^[a-f0-9]{64}$"))
+' "$manifest_path" >/dev/null; then
+  echo "Backup manifest is invalid or uses an unsupported format." >&2
+  exit 1
+fi
+
+echo "Verifying backup archives..."
+verify_archive "neo4j-data.tar.gz"
+verify_archive "frontend-data.tar.gz"
+
+compose=(
+  docker compose
+  --env-file "$env_file"
+  --file "$script_root/docker-compose.yml"
+  --file "$script_root/docker-compose.production.yml"
+)
+
+compose_config="$("${compose[@]}" config --format json)"
+neo4j_volume="$(jq --raw-output '.volumes["neo4j-data"].name // empty' <<<"$compose_config")"
+frontend_volume="$(jq --raw-output '.volumes["frontend-data"].name // empty' <<<"$compose_config")"
+
+if [[ -z "$neo4j_volume" || -z "$frontend_volume" ]]; then
+  echo "Production Compose did not resolve the expected persistent volumes." >&2
+  exit 1
+fi
+
+active_services="$("${compose[@]}" ps --services)"
+for required_service in database backend frontend; do
+  if grep --fixed-strings --line-regexp "$required_service" <<<"$active_services" >/dev/null; then
+    echo "Refusing to restore while the production service is active: $required_service" >&2
+    exit 1
+  fi
+done
+
+backup_database_image="$(jq --raw-output '.images.database' "$manifest_path")"
+current_database_image="$(jq --raw-output '.services.database.image' <<<"$compose_config")"
+
+if [[ "$backup_database_image" != "$current_database_image" && "$allow_database_image_mismatch" != true ]]; then
+  echo "Backup database image does not match the configured database image." >&2
+  echo "Backup:  $backup_database_image" >&2
+  echo "Current: $current_database_image" >&2
+  echo "Select the backup image or pass --allow-database-image-mismatch after reviewing Neo4j compatibility." >&2
+  exit 1
+fi
+
+restore_started=false
+restore_complete=false
+
+report_incomplete_restore() {
+  local status=$?
+  trap - EXIT
+
+  if [[ "$restore_started" == true && "$restore_complete" != true ]]; then
+    echo "Restore did not complete. Keep services stopped and rerun the verified restore." >&2
+  fi
+
+  exit "$status"
+}
+
+trap report_incomplete_restore EXIT
+
+restore_volume() {
+  local volume_name="$1"
+  local archive_path="$2"
+
+  docker run --rm --interactive \
+    --network none \
+    --volume "$volume_name:/target" \
+    "$restore_helper_image" \
+    sh -ec 'find /target -mindepth 1 -maxdepth 1 -exec rm -rf -- {} \; && tar -xzf - -C /target' \
+    <"$archive_path"
+}
+
+restore_started=true
+echo "Replacing Neo4j data in volume: $neo4j_volume"
+restore_volume "$neo4j_volume" "$backup_dir/neo4j-data.tar.gz"
+
+echo "Replacing frontend sessions in volume: $frontend_volume"
+restore_volume "$frontend_volume" "$backup_dir/frontend-data.tar.gz"
+restore_complete=true
+
+echo "Restore completed successfully. The application services remain stopped."
+echo "Validate the production configuration, then start database, backend, and frontend."

--- a/scripts/self-hosting-tests/fixtures/docker
+++ b/scripts/self-hosting-tests/fixtures/docker
@@ -28,6 +28,13 @@ JSON
         printf 'database\nbackend\nfrontend\n'
       fi
       ;;
+    *" ps --services "*)
+      if [[ -n "${MULTIFORUM_FAKE_RUNNING_SERVICES:-}" ]]; then
+        printf '%s\n' "$MULTIFORUM_FAKE_RUNNING_SERVICES"
+      else
+        printf 'database\nbackend\nfrontend\n'
+      fi
+      ;;
     *" stop frontend backend "*)
       if [[ "${MULTIFORUM_FAKE_FAIL_STOP:-false}" == true ]]; then
         exit 43
@@ -46,6 +53,13 @@ JSON
       ;;
   esac
 elif [[ "${1:-}" == "run" ]]; then
+  if [[ "$*" == *":/target"* ]]; then
+    cat >/dev/null
+    if [[ "${MULTIFORUM_FAKE_FAIL_RESTORE_FRONTEND:-false}" == true && "$*" == *"frontend-volume:/target"* ]]; then
+      exit 45
+    fi
+    exit 0
+  fi
   if [[ "${MULTIFORUM_FAKE_FAIL_FRONTEND:-false}" == true && "$*" == *"frontend-volume:/source:ro"* ]]; then
     exit 42
   fi

--- a/scripts/self-hosting-tests/restore-self-hosting.test.sh
+++ b/scripts/self-hosting-tests/restore-self-hosting.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+restore_script="$repository_root/scripts/restore-self-hosting.sh"
+fixture_bin="$repository_root/scripts/self-hosting-tests/fixtures"
+
+trap 'rm -rf "$test_root"' EXIT
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+create_bundle() {
+  local bundle_dir="$1"
+  local database_image="$2"
+  local source_dir="$test_root/archive-source"
+
+  rm -rf -- "$source_dir"
+  mkdir -p "$source_dir/neo4j" "$source_dir/frontend" "$bundle_dir"
+  printf 'neo4j-data\n' >"$source_dir/neo4j/store"
+  printf 'frontend-session\n' >"$source_dir/frontend/session"
+  tar -czf "$bundle_dir/neo4j-data.tar.gz" -C "$source_dir/neo4j" .
+  tar -czf "$bundle_dir/frontend-data.tar.gz" -C "$source_dir/frontend" .
+
+  jq --null-input \
+    --arg databaseImage "$database_image" \
+    --arg neo4jSha256 "$(sha256_file "$bundle_dir/neo4j-data.tar.gz")" \
+    --arg frontendSha256 "$(sha256_file "$bundle_dir/frontend-data.tar.gz")" \
+    '{
+      formatVersion: 1,
+      createdAt: "2026-08-07T00:00:00Z",
+      images: {
+        database: $databaseImage,
+        backend: "ghcr.io/example/backend:test",
+        frontend: "ghcr.io/example/frontend:test"
+      },
+      archives: {
+        "neo4j-data.tar.gz": {sha256: $neo4jSha256},
+        "frontend-data.tar.gz": {sha256: $frontendSha256}
+      }
+    }' >"$bundle_dir/manifest.json"
+}
+
+export PATH="$fixture_bin:$PATH"
+export MULTIFORUM_FAKE_DOCKER_LOG="$test_root/docker.log"
+
+env_file="$test_root/.env.production"
+: >"$env_file"
+bundle_dir="$test_root/bundle"
+create_bundle "$bundle_dir" "neo4j:test"
+
+"$restore_script" --help | grep --fixed-strings -- "--confirm-replace-existing-data" >/dev/null
+
+if "$restore_script" --backup-dir "$bundle_dir" --env-file "$env_file" >/dev/null 2>&1; then
+  echo "Expected restore without destructive confirmation to fail." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+MULTIFORUM_FAKE_RUNNING_SERVICES=caddy \
+  "$restore_script" \
+  --backup-dir "$bundle_dir" \
+  --env-file "$env_file" \
+  --confirm-replace-existing-data
+
+grep --fixed-strings "neo4j-volume:/target" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+grep --fixed-strings "frontend-volume:/target" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+if grep --fixed-strings "up -d" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "A restore must not restart services automatically." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+if "$restore_script" \
+  --backup-dir "$bundle_dir" \
+  --env-file "$env_file" \
+  --confirm-replace-existing-data >/dev/null 2>&1; then
+  echo "Expected restore to reject a running application stack." >&2
+  exit 1
+fi
+if grep --fixed-strings ":/target" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "A running-service preflight failure must not touch volumes." >&2
+  exit 1
+fi
+
+checksum_failure_dir="$test_root/checksum-failure"
+create_bundle "$checksum_failure_dir" "neo4j:test"
+printf 'tampered\n' >>"$checksum_failure_dir/neo4j-data.tar.gz"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+
+if MULTIFORUM_FAKE_RUNNING_SERVICES=caddy \
+  "$restore_script" \
+  --backup-dir "$checksum_failure_dir" \
+  --env-file "$env_file" \
+  --confirm-replace-existing-data >/dev/null 2>&1; then
+  echo "Expected restore to reject a checksum mismatch." >&2
+  exit 1
+fi
+if [[ -s "$MULTIFORUM_FAKE_DOCKER_LOG" ]]; then
+  echo "A checksum failure must occur before Docker is invoked." >&2
+  exit 1
+fi
+
+image_mismatch_dir="$test_root/image-mismatch"
+create_bundle "$image_mismatch_dir" "neo4j:other"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+
+if MULTIFORUM_FAKE_RUNNING_SERVICES=caddy \
+  "$restore_script" \
+  --backup-dir "$image_mismatch_dir" \
+  --env-file "$env_file" \
+  --confirm-replace-existing-data >/dev/null 2>&1; then
+  echo "Expected restore to reject a Neo4j image mismatch." >&2
+  exit 1
+fi
+if grep --fixed-strings ":/target" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "An image mismatch must not touch volumes." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+MULTIFORUM_FAKE_RUNNING_SERVICES=caddy \
+  "$restore_script" \
+  --backup-dir "$image_mismatch_dir" \
+  --env-file "$env_file" \
+  --confirm-replace-existing-data \
+  --allow-database-image-mismatch
+grep --fixed-strings "neo4j-volume:/target" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+if MULTIFORUM_FAKE_RUNNING_SERVICES=caddy MULTIFORUM_FAKE_FAIL_RESTORE_FRONTEND=true \
+  "$restore_script" \
+  --backup-dir "$bundle_dir" \
+  --env-file "$env_file" \
+  --confirm-replace-existing-data >/dev/null 2>&1; then
+  echo "Expected an archive extraction failure to fail the restore." >&2
+  exit 1
+fi
+grep --fixed-strings "neo4j-volume:/target" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+grep --fixed-strings "frontend-volume:/target" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+if grep --fixed-strings "up -d" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "A failed restore must leave services stopped." >&2
+  exit 1
+fi
+
+echo "Guarded-restore command tests passed."

--- a/scripts/validate-self-hosting-contract.sh
+++ b/scripts/validate-self-hosting-contract.sh
@@ -34,6 +34,9 @@ cd "$contract_root"
 echo "Testing the production cold-backup command..."
 scripts/self-hosting-tests/backup-self-hosting.test.sh
 
+echo "Testing the guarded production restore command..."
+scripts/self-hosting-tests/restore-self-hosting.test.sh
+
 echo "Validating the image-based quick-start contract..."
 docker compose \
   --env-file .env.quickstart.example \


### PR DESCRIPTION
## Summary

- add an explicitly confirmed restore command for cold-backup bundles
- verify manifest format, SHA-256 checksums, and archive paths before touching Docker volumes
- refuse active application services and incompatible Neo4j images by default
- leave services stopped after both successful and failed extraction attempts
- cover confirmation, success, active-service refusal, checksum corruption, image mismatch/override, and extraction failure
- add the restore runbook to production and Terraform documentation and deployment-contract CI

## Validation

- `scripts/self-hosting-tests/backup-self-hosting.test.sh`
- `scripts/self-hosting-tests/restore-self-hosting.test.sh`
- `scripts/validate-self-hosting-contract.sh`
- ShellCheck for all affected self-hosting scripts
- isolated anonymous-volume execution of the pinned BusyBox clear-and-extract command
- `prettier --check .github/workflows/self-hosting-contract.yml docs/self-hosting-production.md deploy/terraform/aws-single-vm/README.md`

## Coverage

This slice adds operational shell code rather than frontend application code, so JavaScript coverage is not applicable. Deployment-contract CI exercises the restore success path and its safety-critical refusal and failure paths.

## Safety

The command requires `--confirm-replace-existing-data`, never stops or starts services itself, and requires the database, backend, and frontend to be inactive before replacing either volume.