### PR TITLE
feat(self-hosting): add safe upgrade command

### DIFF
--- a/.github/workflows/self-hosting-contract.yml
+++ b/.github/workflows/self-hosting-contract.yml
@@ -13,6 +13,7 @@ on:
       - 'docker-compose*.yml'
       - 'scripts/backup-self-hosting.sh'
       - 'scripts/restore-self-hosting.sh'
+      - 'scripts/upgrade-self-hosting.sh'
       - 'scripts/self-hosting-tests/**'
       - 'scripts/validate-self-hosting-contract.sh'
   push:
@@ -27,6 +28,7 @@ on:
       - 'docker-compose*.yml'
       - 'scripts/backup-self-hosting.sh'
       - 'scripts/restore-self-hosting.sh'
+      - 'scripts/upgrade-self-hosting.sh'
       - 'scripts/self-hosting-tests/**'
       - 'scripts/validate-self-hosting-contract.sh'
   workflow_dispatch:

--- a/deploy/terraform/aws-single-vm/README.md
+++ b/deploy/terraform/aws-single-vm/README.md
@@ -137,10 +137,11 @@ single-host limitations.
 ## Updates and destruction
 
 Terraform provisions infrastructure; it is deliberately not an in-place
-application updater. To update, back up Neo4j, select a repository tag and
-tested image versions, pull them, validate the merged model, and recreate the
-stack. Changing `repository_ref` or image variables in Terraform does not
-rerun cloud-init on an existing instance.
+application updater. Use the production guide's
+[safe upgrade command](../../../docs/self-hosting-production.md#updates-and-limitations)
+to pre-pull pinned images, take a safety backup, and recreate the existing
+stack. Changing `repository_ref` or image variables in Terraform does not rerun
+cloud-init on an existing instance.
 
 The Canonical SSM parameter selects the current Ubuntu 24.04 image at initial
 creation. Later AMI changes are ignored because silently replacing this

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -218,9 +218,52 @@ again.
 
 ## Updates and limitations
 
-Update one component at a time by changing its pinned image tag, pulling, and
-recreating the stack. Back up Neo4j first and review release notes for data or
-configuration migrations.
+Prepare upgrades in a separate protected environment file so the known-good
+configuration remains available for rollback:
+
+```bash
+cp -p .env.production .env.production.next
+$EDITOR .env.production.next
+```
+
+Set explicit release or immutable `sha-*` tags for Neo4j, the backend, the
+frontend, and Caddy. The upgrade command rejects `edge`, `latest`, branch-like
+tags, and untagged target images. Review release notes for data or configuration
+migrations, then run:
+
+```bash
+scripts/upgrade-self-hosting.sh \
+  --current-env-file .env.production \
+  --target-env-file .env.production.next \
+  --backup-output-dir /var/backups/multiforum \
+  --confirm-upgrade
+```
+
+The command validates both Compose models, requires the current production
+services to be running, pre-pulls every target image, creates a cold safety
+backup with the current image metadata, and then force-recreates the stack from
+the already-pulled local images in the target file. Image pull or backup
+failures happen before recreation, and Compose waits for services to become
+running or healthy. The command does not overwrite `.env.production`.
+
+Changing Neo4j is blocked unless `--allow-database-image-change` is supplied.
+Use that option only after reviewing Neo4j's supported upgrade path and testing
+the backup on a separate host.
+
+Verify HTTPS, authentication, application health, and representative reads and
+writes. Once satisfied, promote the target while retaining the old protected
+file through the rollback window:
+
+```bash
+mv .env.production .env.production.previous
+mv .env.production.next .env.production
+```
+
+If recreation fails, do not promote the target file. Stop any partially
+recreated application services, select `.env.production` and the safety backup
+created immediately before recreation, and follow the guarded restore procedure
+above. Encrypt or securely remove `.env.production.previous` after the rollback
+window because it contains production secrets.
 
 This foundation does not yet provide multiple application replicas, managed
 Neo4j, zero-downtime upgrades, unattended restores, or an open-source OIDC

--- a/scripts/self-hosting-tests/fixtures/docker
+++ b/scripts/self-hosting-tests/fixtures/docker
@@ -7,19 +7,36 @@ printf '%s\n' "$*" >>"$MULTIFORUM_FAKE_DOCKER_LOG"
 if [[ "${1:-}" == "compose" ]]; then
   case " $* " in
     *" config --format json "*)
-      cat <<'JSON'
+      if [[ "$*" == *"target.env"* ]]; then
+        database_image="${MULTIFORUM_FAKE_TARGET_DATABASE_IMAGE:-neo4j:test}"
+        backend_image="${MULTIFORUM_FAKE_TARGET_BACKEND_IMAGE:-ghcr.io/example/backend:1.2.3}"
+        frontend_image="${MULTIFORUM_FAKE_TARGET_FRONTEND_IMAGE:-ghcr.io/example/frontend:1.2.3}"
+        caddy_image="${MULTIFORUM_FAKE_TARGET_CADDY_IMAGE:-caddy:2.11.4-alpine}"
+      else
+        database_image="neo4j:test"
+        backend_image="ghcr.io/example/backend:test"
+        frontend_image="ghcr.io/example/frontend:test"
+        caddy_image="caddy:test"
+      fi
+      jq --null-input \
+        --arg databaseImage "$database_image" \
+        --arg backendImage "$backend_image" \
+        --arg frontendImage "$frontend_image" \
+        --arg caddyImage "$caddy_image" \
+        '
 {
   "services": {
-    "database": {"image": "neo4j:test"},
-    "backend": {"image": "ghcr.io/example/backend:test"},
-    "frontend": {"image": "ghcr.io/example/frontend:test"}
+    "database": {"image": $databaseImage},
+    "backend": {"image": $backendImage},
+    "frontend": {"image": $frontendImage},
+    "caddy": {"image": $caddyImage}
   },
   "volumes": {
     "neo4j-data": {"name": "neo4j-volume"},
     "frontend-data": {"name": "frontend-volume"}
   }
 }
-JSON
+'
       ;;
     *" ps --status running --services "*)
       if [[ -n "${MULTIFORUM_FAKE_RUNNING_SERVICES:-}" ]]; then
@@ -45,6 +62,21 @@ JSON
     *" up -d database backend frontend "*)
       if [[ "${MULTIFORUM_FAKE_FAIL_RESTART:-false}" == true ]]; then
         exit 44
+      fi
+      ;;
+    *" pull database backend frontend caddy "*)
+      if [[ "${MULTIFORUM_FAKE_FAIL_PULL:-false}" == true ]]; then
+        exit 46
+      fi
+      ;;
+    *" up -d --force-recreate --wait "*)
+      if [[ "${MULTIFORUM_BACKEND_PULL_POLICY:-}" != never ||
+        "${MULTIFORUM_FRONTEND_PULL_POLICY:-}" != never ]]; then
+        echo "Upgrade recreation must use only the pre-pulled application images." >&2
+        exit 48
+      fi
+      if [[ "${MULTIFORUM_FAKE_FAIL_UPGRADE:-false}" == true ]]; then
+        exit 47
       fi
       ;;
     *)

--- a/scripts/self-hosting-tests/upgrade-self-hosting.test.sh
+++ b/scripts/self-hosting-tests/upgrade-self-hosting.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+upgrade_script="$repository_root/scripts/upgrade-self-hosting.sh"
+fixture_bin="$repository_root/scripts/self-hosting-tests/fixtures"
+
+trap 'rm -rf "$test_root"' EXIT
+
+export PATH="$fixture_bin:$PATH"
+export MULTIFORUM_FAKE_DOCKER_LOG="$test_root/docker.log"
+export MULTIFORUM_FAKE_RUNNING_SERVICES=$'database\nbackend\nfrontend\ncaddy'
+
+current_env_file="$test_root/current.env"
+target_env_file="$test_root/target.env"
+: >"$current_env_file"
+: >"$target_env_file"
+
+"$upgrade_script" --help | grep --fixed-strings -- "--confirm-upgrade" >/dev/null
+
+if "$upgrade_script" \
+  --current-env-file "$current_env_file" \
+  --target-env-file "$target_env_file" \
+  --backup-output-dir "$test_root/unconfirmed" >/dev/null 2>&1; then
+  echo "Expected upgrade without explicit confirmation to fail." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+if MULTIFORUM_FAKE_TARGET_FRONTEND_IMAGE=ghcr.io/example/frontend:edge \
+  "$upgrade_script" \
+  --current-env-file "$current_env_file" \
+  --target-env-file "$target_env_file" \
+  --backup-output-dir "$test_root/floating" \
+  --confirm-upgrade >/dev/null 2>&1; then
+  echo "Expected upgrade to reject a floating target image." >&2
+  exit 1
+fi
+if grep --fixed-strings " pull " "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "A floating image must be rejected before target images are pulled." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+if MULTIFORUM_FAKE_TARGET_DATABASE_IMAGE=neo4j:6.0.0 \
+  "$upgrade_script" \
+  --current-env-file "$current_env_file" \
+  --target-env-file "$target_env_file" \
+  --backup-output-dir "$test_root/database-change" \
+  --confirm-upgrade >/dev/null 2>&1; then
+  echo "Expected upgrade to reject an unapproved database image change." >&2
+  exit 1
+fi
+if grep --fixed-strings " pull " "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "A database image change must be approved before pulling images." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+if MULTIFORUM_FAKE_RUNNING_SERVICES=$'database\nbackend\nfrontend' \
+  "$upgrade_script" \
+  --current-env-file "$current_env_file" \
+  --target-env-file "$target_env_file" \
+  --backup-output-dir "$test_root/missing-caddy" \
+  --confirm-upgrade >/dev/null 2>&1; then
+  echo "Expected upgrade to reject a partially running stack." >&2
+  exit 1
+fi
+if grep --fixed-strings " pull " "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "A service preflight failure must occur before pulling images." >&2
+  exit 1
+fi
+
+success_backup_root="$test_root/success"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+"$upgrade_script" \
+  --current-env-file "$current_env_file" \
+  --target-env-file "$target_env_file" \
+  --backup-output-dir "$success_backup_root" \
+  --confirm-upgrade
+
+pull_line="$(grep --line-number --fixed-strings "target.env" "$MULTIFORUM_FAKE_DOCKER_LOG" | grep --fixed-strings " pull " | cut -d: -f1)"
+stop_line="$(grep --line-number --fixed-strings "current.env" "$MULTIFORUM_FAKE_DOCKER_LOG" | grep --fixed-strings " stop frontend backend" | cut -d: -f1)"
+upgrade_line="$(grep --line-number --fixed-strings "target.env" "$MULTIFORUM_FAKE_DOCKER_LOG" | grep --fixed-strings "up -d --force-recreate --wait" | cut -d: -f1)"
+
+if [[ -z "$pull_line" || -z "$stop_line" || -z "$upgrade_line" ||
+  "$pull_line" -ge "$stop_line" || "$stop_line" -ge "$upgrade_line" ]]; then
+  echo "Expected pull, safety backup, and recreation to occur in that order." >&2
+  exit 1
+fi
+
+if ! find "$success_backup_root" -mindepth 1 -maxdepth 1 -type d \
+  -name 'multiforum-backup-*' -print -quit | grep --quiet .; then
+  echo "Expected the successful upgrade to create a safety backup." >&2
+  exit 1
+fi
+test -f "$target_env_file"
+
+pull_failure_root="$test_root/pull-failure"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+if MULTIFORUM_FAKE_FAIL_PULL=true \
+  "$upgrade_script" \
+  --current-env-file "$current_env_file" \
+  --target-env-file "$target_env_file" \
+  --backup-output-dir "$pull_failure_root" \
+  --confirm-upgrade >/dev/null 2>&1; then
+  echo "Expected a target image pull failure to fail the upgrade." >&2
+  exit 1
+fi
+if grep --fixed-strings " stop frontend backend" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "A pull failure must occur before the safety backup stops services." >&2
+  exit 1
+fi
+
+upgrade_failure_root="$test_root/upgrade-failure"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+if MULTIFORUM_FAKE_FAIL_UPGRADE=true \
+  "$upgrade_script" \
+  --current-env-file "$current_env_file" \
+  --target-env-file "$target_env_file" \
+  --backup-output-dir "$upgrade_failure_root" \
+  --confirm-upgrade >/dev/null 2>&1; then
+  echo "Expected a failed force-recreation to fail the upgrade." >&2
+  exit 1
+fi
+if ! find "$upgrade_failure_root" -mindepth 1 -maxdepth 1 -type d \
+  -name 'multiforum-backup-*' -print -quit | grep --quiet .; then
+  echo "A failed recreation must retain its completed safety backup." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+MULTIFORUM_FAKE_TARGET_DATABASE_IMAGE=neo4j:6.0.0 \
+  "$upgrade_script" \
+  --current-env-file "$current_env_file" \
+  --target-env-file "$target_env_file" \
+  --backup-output-dir "$test_root/approved-database-change" \
+  --confirm-upgrade \
+  --allow-database-image-change
+grep --fixed-strings "up -d --force-recreate --wait" "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null
+
+echo "Safe-upgrade command tests passed."

--- a/scripts/upgrade-self-hosting.sh
+++ b/scripts/upgrade-self-hosting.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_env_file=".env.production"
+target_env_file=""
+backup_root=""
+upgrade_confirmed=false
+allow_database_image_change=false
+script_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/upgrade-self-hosting.sh --target-env-file PATH
+       --backup-output-dir PATH [--current-env-file PATH]
+       --confirm-upgrade [--allow-database-image-change]
+
+Pre-pulls a pinned production image set, creates a cold safety backup using the
+current environment, and force-recreates the stack with the target environment.
+The target file remains separate until the operator verifies and promotes it.
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+absolute_file_path() {
+  local file_path="$1"
+  printf '%s/%s\n' "$(cd -- "$(dirname -- "$file_path")" && pwd)" "$(basename -- "$file_path")"
+}
+
+is_pinned_image() {
+  local image="$1"
+  local image_name
+  local tag
+
+  if [[ "$image" =~ @sha256:[a-fA-F0-9]{64}$ ]]; then
+    return 0
+  fi
+
+  image_name="${image##*/}"
+  if [[ "$image_name" != *:* ]]; then
+    return 1
+  fi
+
+  tag="$(tr '[:upper:]' '[:lower:]' <<<"${image_name##*:}")"
+  case "$tag" in
+    ""|edge|latest|main|master|nightly|dev|development)
+      return 1
+      ;;
+  esac
+
+  return 0
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --current-env-file)
+      if [[ -z "${2:-}" ]]; then
+        echo "--current-env-file requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      current_env_file="$2"
+      shift 2
+      ;;
+    --target-env-file)
+      if [[ -z "${2:-}" ]]; then
+        echo "--target-env-file requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      target_env_file="$2"
+      shift 2
+      ;;
+    --backup-output-dir)
+      if [[ -z "${2:-}" ]]; then
+        echo "--backup-output-dir requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      backup_root="$2"
+      shift 2
+      ;;
+    --confirm-upgrade)
+      upgrade_confirmed=true
+      shift
+      ;;
+    --allow-database-image-change)
+      allow_database_image_change=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$upgrade_confirmed" != true ]]; then
+  echo "Refusing to upgrade without --confirm-upgrade." >&2
+  exit 2
+fi
+
+if [[ -z "$target_env_file" ]]; then
+  echo "--target-env-file is required." >&2
+  exit 2
+fi
+
+if [[ -z "$backup_root" ]]; then
+  echo "--backup-output-dir is required." >&2
+  exit 2
+fi
+
+for required_file in "$current_env_file" "$target_env_file"; do
+  if [[ ! -f "$required_file" ]]; then
+    echo "Production environment file not found: $required_file" >&2
+    exit 1
+  fi
+done
+
+require_command docker
+require_command jq
+require_command grep
+require_command tr
+require_command env
+
+current_env_file="$(absolute_file_path "$current_env_file")"
+target_env_file="$(absolute_file_path "$target_env_file")"
+
+if [[ "$current_env_file" == "$target_env_file" ]]; then
+  echo "Current and target environment files must be different." >&2
+  echo "A separate current file is required for backup metadata and rollback." >&2
+  exit 1
+fi
+
+mkdir -p "$backup_root"
+backup_root="$(cd -- "$backup_root" && pwd)"
+
+current_compose=(
+  docker compose
+  --env-file "$current_env_file"
+  --file "$script_root/docker-compose.yml"
+  --file "$script_root/docker-compose.production.yml"
+)
+target_compose=(
+  docker compose
+  --env-file "$target_env_file"
+  --file "$script_root/docker-compose.yml"
+  --file "$script_root/docker-compose.production.yml"
+)
+
+current_config="$("${current_compose[@]}" config --format json)"
+target_config="$("${target_compose[@]}" config --format json)"
+
+for service in database backend frontend caddy; do
+  target_image="$(jq --raw-output --arg service "$service" '.services[$service].image // empty' <<<"$target_config")"
+  if [[ -z "$target_image" ]]; then
+    echo "Target Compose did not resolve an image for service: $service" >&2
+    exit 1
+  fi
+  if ! is_pinned_image "$target_image"; then
+    echo "Target image must use an explicit non-floating tag or SHA-256 digest: $service ($target_image)" >&2
+    exit 1
+  fi
+done
+
+current_database_image="$(jq --raw-output '.services.database.image' <<<"$current_config")"
+target_database_image="$(jq --raw-output '.services.database.image' <<<"$target_config")"
+
+if [[ "$current_database_image" != "$target_database_image" && "$allow_database_image_change" != true ]]; then
+  echo "Target configuration changes the Neo4j image." >&2
+  echo "Current: $current_database_image" >&2
+  echo "Target:  $target_database_image" >&2
+  echo "Pass --allow-database-image-change only after reviewing Neo4j's supported upgrade path." >&2
+  exit 1
+fi
+
+running_services="$("${current_compose[@]}" ps --status running --services)"
+for required_service in database backend frontend caddy; do
+  if ! grep --fixed-strings --line-regexp "$required_service" <<<"$running_services" >/dev/null; then
+    echo "Current production service is not running: $required_service" >&2
+    exit 1
+  fi
+done
+
+echo "Pre-pulling the pinned target images..."
+"${target_compose[@]}" pull database backend frontend caddy
+
+echo "Creating a cold safety backup of the current stack..."
+"$script_root/scripts/backup-self-hosting.sh" \
+  --env-file "$current_env_file" \
+  --output-dir "$backup_root"
+
+upgrade_started=false
+upgrade_complete=false
+
+report_incomplete_upgrade() {
+  local status=$?
+  trap - EXIT
+
+  if [[ "$upgrade_started" == true && "$upgrade_complete" != true ]]; then
+    echo "Upgrade did not complete. Do not promote the target environment file." >&2
+    echo "Use the current environment and the new safety backup to recover." >&2
+  fi
+
+  exit "$status"
+}
+
+trap report_incomplete_upgrade EXIT
+
+echo "Recreating the production stack with the target image set..."
+upgrade_started=true
+env \
+  MULTIFORUM_BACKEND_PULL_POLICY=never \
+  MULTIFORUM_FRONTEND_PULL_POLICY=never \
+  "${target_compose[@]}" up -d --force-recreate --wait
+upgrade_complete=true
+
+echo "Upgrade completed with target environment: $target_env_file"
+echo "Verify the forum before promoting that file as .env.production."

--- a/scripts/validate-self-hosting-contract.sh
+++ b/scripts/validate-self-hosting-contract.sh
@@ -37,6 +37,9 @@ scripts/self-hosting-tests/backup-self-hosting.test.sh
 echo "Testing the guarded production restore command..."
 scripts/self-hosting-tests/restore-self-hosting.test.sh
 
+echo "Testing the safe production upgrade command..."
+scripts/self-hosting-tests/upgrade-self-hosting.test.sh
+
 echo "Validating the image-based quick-start contract..."
 docker compose \
   --env-file .env.quickstart.example \


### PR DESCRIPTION
## Summary

- add a confirmed upgrade command using separate current and target production environment files
- reject untagged and floating target images and require explicit approval for Neo4j image changes
- pre-pull every target image before downtime, then create a cold safety backup
- force-recreate from the pre-pulled local image set and wait for services to become running or healthy
- retain the current environment and safety backup for rollback until the operator verifies and promotes the target
- cover confirmation, pinning, service preflight, pull failure, recreation failure, ordering, and database-change approval

## Validation

- `scripts/self-hosting-tests/backup-self-hosting.test.sh`
- `scripts/self-hosting-tests/restore-self-hosting.test.sh`
- `scripts/self-hosting-tests/upgrade-self-hosting.test.sh`
- `scripts/validate-self-hosting-contract.sh`
- ShellCheck for all affected self-hosting scripts
- `prettier --check .github/workflows/self-hosting-contract.yml docs/self-hosting-production.md deploy/terraform/aws-single-vm/README.md`

## Coverage

This slice adds operational shell code rather than frontend application code, so JavaScript coverage is not applicable. Deployment-contract CI exercises the upgrade success path and all safety-critical preflight and failure paths.

## Safety

The command requires `--confirm-upgrade`, never overwrites the active environment file, prevents registry pulls after the backup point, and retains a completed safety backup when recreation fails.