### PR TITLE
feat(self-hosting): add production verification

### DIFF
--- a/.github/workflows/self-hosting-contract.yml
+++ b/.github/workflows/self-hosting-contract.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/backup-self-hosting.sh'
       - 'scripts/restore-self-hosting.sh'
       - 'scripts/upgrade-self-hosting.sh'
+      - 'scripts/verify-self-hosting.sh'
       - 'scripts/self-hosting-tests/**'
       - 'scripts/validate-self-hosting-contract.sh'
   push:
@@ -29,6 +30,7 @@ on:
       - 'scripts/backup-self-hosting.sh'
       - 'scripts/restore-self-hosting.sh'
       - 'scripts/upgrade-self-hosting.sh'
+      - 'scripts/verify-self-hosting.sh'
       - 'scripts/self-hosting-tests/**'
       - 'scripts/validate-self-hosting-contract.sh'
   workflow_dispatch:

--- a/deploy/terraform/aws-single-vm/README.md
+++ b/deploy/terraform/aws-single-vm/README.md
@@ -130,8 +130,13 @@ docker compose \
   logs --tail=100 caddy frontend backend
 ```
 
-Verify `https://YOUR_DOMAIN`, the Auth0 sign-in flow, and container health.
-The full production guide covers backups, verification, and current
+Run production verification, then complete a real Auth0 sign-in:
+
+```bash
+scripts/verify-self-hosting.sh --env-file .env.production
+```
+
+The full production guide covers backups, recovery, upgrades, and current
 single-host limitations.
 
 ## Updates and destruction

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -102,16 +102,17 @@ docker compose \
   logs --tail=100 caddy frontend backend
 ```
 
-Verify the HTTPS origin, sign-in redirect, and container health:
+Run the read-only production verification command:
 
 ```bash
-curl --fail --show-error --head https://forum.example.com
-docker compose \
-  --env-file .env.production \
-  -f docker-compose.yml \
-  -f docker-compose.production.yml \
-  ps
+scripts/verify-self-hosting.sh --env-file .env.production
 ```
+
+It verifies that each running container uses the image selected by the
+environment, requires healthy database and application containers, checks the
+public HTTPS response for Caddy's security headers, and sends a harmless query
+through the same-origin GraphQL proxy. Complete a real Auth0 sign-in separately;
+the command does not accept or automate user credentials.
 
 Only Caddy publishes public ports. The frontend, backend, and Neo4j ports retain
 loopback-only bindings for host diagnostics. Caddy adds HSTS, MIME-sniffing, and
@@ -196,7 +197,8 @@ The command verifies the manifest, both SHA-256 checksums, archive paths, the
 stopped-service precondition, and the configured Neo4j image before replacing
 either volume. It never starts application services; once restoration begins,
 keep them stopped whether extraction succeeds or fails. After a successful
-restore, validate the Compose model and start the stack:
+restore, validate the Compose model, start the stack, and run production
+verification:
 
 ```bash
 docker compose \
@@ -209,6 +211,7 @@ docker compose \
   -f docker-compose.yml \
   -f docker-compose.production.yml \
   up -d
+scripts/verify-self-hosting.sh --env-file .env.production
 ```
 
 Use `--allow-database-image-mismatch` only after reviewing Neo4j's supported
@@ -250,9 +253,10 @@ Changing Neo4j is blocked unless `--allow-database-image-change` is supplied.
 Use that option only after reviewing Neo4j's supported upgrade path and testing
 the backup on a separate host.
 
-Verify HTTPS, authentication, application health, and representative reads and
-writes. Once satisfied, promote the target while retaining the old protected
-file through the rollback window:
+Run `scripts/verify-self-hosting.sh --env-file .env.production.next`, complete a
+real Auth0 sign-in, and test representative reads and writes. Once satisfied,
+promote the target while retaining the old protected file through the rollback
+window:
 
 ```bash
 mv .env.production .env.production.previous

--- a/scripts/self-hosting-tests/fixtures/curl
+++ b/scripts/self-hosting-tests/fixtures/curl
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$MULTIFORUM_FAKE_CURL_LOG"
+
+if [[ "${MULTIFORUM_FAKE_CURL_FAIL:-false}" == true ]]; then
+  exit 22
+fi
+
+if [[ "$*" == *"/api/graphql"* ]]; then
+  if [[ "${MULTIFORUM_FAKE_GRAPHQL_FAIL:-false}" == true ]]; then
+    printf '%s\n' '{"errors":[{"message":"unavailable"}]}'
+  else
+    printf '%s\n' '{"data":{"__typename":"Query"}}'
+  fi
+  exit 0
+fi
+
+printf 'HTTP/1.1 200 OK\r\n'
+if [[ "${MULTIFORUM_FAKE_MISSING_HEADER:-}" != hsts ]]; then
+  printf 'Strict-Transport-Security: max-age=31536000\r\n'
+fi
+if [[ "${MULTIFORUM_FAKE_MISSING_HEADER:-}" != content-type ]]; then
+  printf 'X-Content-Type-Options: nosniff\r\n'
+fi
+if [[ "${MULTIFORUM_FAKE_MISSING_HEADER:-}" != referrer ]]; then
+  printf 'Referrer-Policy: strict-origin-when-cross-origin\r\n'
+fi
+printf 'Content-Type: text/html\r\n\r\n<html>Multiforum</html>\n'

--- a/scripts/self-hosting-tests/fixtures/docker
+++ b/scripts/self-hosting-tests/fixtures/docker
@@ -29,7 +29,10 @@ if [[ "${1:-}" == "compose" ]]; then
     "database": {"image": $databaseImage},
     "backend": {"image": $backendImage},
     "frontend": {"image": $frontendImage},
-    "caddy": {"image": $caddyImage}
+    "caddy": {
+      "image": $caddyImage,
+      "environment": {"MULTIFORUM_DOMAIN": "forum.example.com"}
+    }
   },
   "volumes": {
     "neo4j-data": {"name": "neo4j-volume"},
@@ -50,6 +53,12 @@ if [[ "${1:-}" == "compose" ]]; then
         printf '%s\n' "$MULTIFORUM_FAKE_RUNNING_SERVICES"
       else
         printf 'database\nbackend\nfrontend\n'
+      fi
+      ;;
+    *" ps -q "*)
+      service="${!#}"
+      if [[ "${MULTIFORUM_FAKE_MISSING_SERVICE:-}" != "$service" ]]; then
+        printf '%s-container\n' "$service"
       fi
       ;;
     *" stop frontend backend "*)
@@ -84,6 +93,31 @@ if [[ "${1:-}" == "compose" ]]; then
       exit 90
       ;;
   esac
+elif [[ "${1:-}" == "inspect" ]]; then
+  container_id="${!#}"
+  service="${container_id%-container}"
+  case "$service" in
+    database) image="neo4j:test" ;;
+    backend) image="ghcr.io/example/backend:test" ;;
+    frontend) image="ghcr.io/example/frontend:test" ;;
+    caddy) image="caddy:test" ;;
+    *)
+      echo "Unexpected fake container: $container_id" >&2
+      exit 92
+      ;;
+  esac
+  if [[ "${MULTIFORUM_FAKE_IMAGE_MISMATCH_SERVICE:-}" == "$service" ]]; then
+    image="$image-mismatch"
+  fi
+  status=running
+  health=healthy
+  if [[ "$service" == caddy ]]; then
+    health=none
+  fi
+  if [[ "${MULTIFORUM_FAKE_UNHEALTHY_SERVICE:-}" == "$service" ]]; then
+    health=unhealthy
+  fi
+  printf '%s|%s|%s\n' "$image" "$status" "$health"
 elif [[ "${1:-}" == "run" ]]; then
   if [[ "$*" == *":/target"* ]]; then
     cat >/dev/null

--- a/scripts/self-hosting-tests/verify-self-hosting.test.sh
+++ b/scripts/self-hosting-tests/verify-self-hosting.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+verify_script="$repository_root/scripts/verify-self-hosting.sh"
+fixture_bin="$repository_root/scripts/self-hosting-tests/fixtures"
+
+trap 'rm -rf "$test_root"' EXIT
+
+export PATH="$fixture_bin:$PATH"
+export MULTIFORUM_FAKE_DOCKER_LOG="$test_root/docker.log"
+export MULTIFORUM_FAKE_CURL_LOG="$test_root/curl.log"
+
+env_file="$test_root/verify.env"
+: >"$env_file"
+
+"$verify_script" --help | grep --fixed-strings -- "--base-url URL" >/dev/null
+
+if "$verify_script" --env-file "$env_file" --base-url http://forum.example.com >/dev/null 2>&1; then
+  echo "Expected production verification to reject an HTTP base URL." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+: >"$MULTIFORUM_FAKE_CURL_LOG"
+"$verify_script" --env-file "$env_file"
+grep --fixed-strings "https://forum.example.com/" "$MULTIFORUM_FAKE_CURL_LOG" >/dev/null
+grep --fixed-strings "https://forum.example.com/api/graphql" "$MULTIFORUM_FAKE_CURL_LOG" >/dev/null
+
+: >"$MULTIFORUM_FAKE_CURL_LOG"
+if MULTIFORUM_FAKE_UNHEALTHY_SERVICE=backend \
+  "$verify_script" --env-file "$env_file" >/dev/null 2>&1; then
+  echo "Expected verification to reject an unhealthy backend." >&2
+  exit 1
+fi
+if [[ -s "$MULTIFORUM_FAKE_CURL_LOG" ]]; then
+  echo "Container health failures must occur before public requests." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_CURL_LOG"
+if MULTIFORUM_FAKE_IMAGE_MISMATCH_SERVICE=frontend \
+  "$verify_script" --env-file "$env_file" >/dev/null 2>&1; then
+  echo "Expected verification to reject a running image mismatch." >&2
+  exit 1
+fi
+if [[ -s "$MULTIFORUM_FAKE_CURL_LOG" ]]; then
+  echo "Image mismatches must occur before public requests." >&2
+  exit 1
+fi
+
+if MULTIFORUM_FAKE_MISSING_SERVICE=database \
+  "$verify_script" --env-file "$env_file" >/dev/null 2>&1; then
+  echo "Expected verification to reject a missing database container." >&2
+  exit 1
+fi
+
+if MULTIFORUM_FAKE_CURL_FAIL=true \
+  "$verify_script" --env-file "$env_file" >/dev/null 2>&1; then
+  echo "Expected verification to propagate a public HTTPS failure." >&2
+  exit 1
+fi
+
+if MULTIFORUM_FAKE_MISSING_HEADER=hsts \
+  "$verify_script" --env-file "$env_file" >/dev/null 2>&1; then
+  echo "Expected verification to reject a missing HSTS header." >&2
+  exit 1
+fi
+
+if MULTIFORUM_FAKE_GRAPHQL_FAIL=true \
+  "$verify_script" --env-file "$env_file" >/dev/null 2>&1; then
+  echo "Expected verification to reject a failed GraphQL proxy response." >&2
+  exit 1
+fi
+
+: >"$MULTIFORUM_FAKE_CURL_LOG"
+"$verify_script" \
+  --env-file "$env_file" \
+  --base-url https://override.example.com/
+grep --fixed-strings "https://override.example.com/api/graphql" "$MULTIFORUM_FAKE_CURL_LOG" >/dev/null
+
+echo "Production-verification command tests passed."

--- a/scripts/validate-self-hosting-contract.sh
+++ b/scripts/validate-self-hosting-contract.sh
@@ -40,6 +40,9 @@ scripts/self-hosting-tests/restore-self-hosting.test.sh
 echo "Testing the safe production upgrade command..."
 scripts/self-hosting-tests/upgrade-self-hosting.test.sh
 
+echo "Testing production verification..."
+scripts/self-hosting-tests/verify-self-hosting.test.sh
+
 echo "Validating the image-based quick-start contract..."
 docker compose \
   --env-file .env.quickstart.example \

--- a/scripts/verify-self-hosting.sh
+++ b/scripts/verify-self-hosting.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+env_file=".env.production"
+base_url=""
+script_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/verify-self-hosting.sh [--env-file PATH] [--base-url URL]
+
+Verifies the selected production images, container health, public HTTPS
+security headers, and the same-origin GraphQL proxy. This command is read-only.
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --env-file)
+      if [[ -z "${2:-}" ]]; then
+        echo "--env-file requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      env_file="$2"
+      shift 2
+      ;;
+    --base-url)
+      if [[ -z "${2:-}" ]]; then
+        echo "--base-url requires an HTTPS URL." >&2
+        usage >&2
+        exit 2
+      fi
+      base_url="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$env_file" ]]; then
+  echo "Production environment file not found: $env_file" >&2
+  exit 1
+fi
+
+if [[ -n "$base_url" && "$base_url" != https://* ]]; then
+  echo "Production verification requires an HTTPS base URL." >&2
+  exit 1
+fi
+
+require_command docker
+require_command jq
+require_command curl
+require_command grep
+require_command tr
+
+env_file="$(cd -- "$(dirname -- "$env_file")" && pwd)/$(basename -- "$env_file")"
+compose=(
+  docker compose
+  --env-file "$env_file"
+  --file "$script_root/docker-compose.yml"
+  --file "$script_root/docker-compose.production.yml"
+)
+
+compose_config="$("${compose[@]}" config --format json)"
+
+if [[ -z "$base_url" ]]; then
+  configured_domain="$(jq --raw-output '.services.caddy.environment.MULTIFORUM_DOMAIN // empty' <<<"$compose_config")"
+  if [[ -z "$configured_domain" ]]; then
+    echo "Production Compose did not resolve MULTIFORUM_DOMAIN." >&2
+    exit 1
+  fi
+  base_url="https://$configured_domain"
+fi
+base_url="${base_url%/}"
+
+echo "Verifying configured images and container health..."
+for service in database backend frontend caddy; do
+  expected_image="$(jq --raw-output --arg service "$service" '.services[$service].image // empty' <<<"$compose_config")"
+  container_id="$("${compose[@]}" ps -q "$service")"
+
+  if [[ -z "$container_id" || "$container_id" == *$'\n'* ]]; then
+    echo "Expected exactly one container for production service: $service" >&2
+    exit 1
+  fi
+
+  inspect_result="$(docker inspect \
+    --format '{{.Config.Image}}|{{.State.Status}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+    "$container_id")"
+  IFS='|' read -r running_image container_status health_status <<<"$inspect_result"
+
+  if [[ "$running_image" != "$expected_image" ]]; then
+    echo "Running image does not match the selected configuration: $service" >&2
+    echo "Configured: $expected_image" >&2
+    echo "Running:    $running_image" >&2
+    exit 1
+  fi
+
+  if [[ "$container_status" != running ]]; then
+    echo "Production container is not running: $service ($container_status)" >&2
+    exit 1
+  fi
+
+  if [[ "$health_status" != none && "$health_status" != healthy ]]; then
+    echo "Production container is not healthy: $service ($health_status)" >&2
+    exit 1
+  fi
+
+  if [[ "$service" != caddy && "$health_status" != healthy ]]; then
+    echo "Production container has no healthy status: $service ($health_status)" >&2
+    exit 1
+  fi
+done
+
+echo "Verifying public HTTPS and Caddy security headers..."
+home_response="$(curl \
+  --fail \
+  --silent \
+  --show-error \
+  --include \
+  --max-time 30 \
+  "$base_url/")"
+home_response="$(tr -d '\r' <<<"$home_response")"
+
+if ! grep --ignore-case --extended-regexp '^strict-transport-security:.*max-age=31536000' <<<"$home_response" >/dev/null; then
+  echo "Public response is missing the expected Strict-Transport-Security header." >&2
+  exit 1
+fi
+if ! grep --ignore-case --extended-regexp '^x-content-type-options:[[:space:]]*nosniff' <<<"$home_response" >/dev/null; then
+  echo "Public response is missing the expected X-Content-Type-Options header." >&2
+  exit 1
+fi
+if ! grep --ignore-case --extended-regexp '^referrer-policy:[[:space:]]*strict-origin-when-cross-origin' <<<"$home_response" >/dev/null; then
+  echo "Public response is missing the expected Referrer-Policy header." >&2
+  exit 1
+fi
+
+echo "Verifying the public GraphQL proxy..."
+graphql_response="$(curl \
+  --fail \
+  --silent \
+  --show-error \
+  --max-time 30 \
+  --header 'content-type: application/json' \
+  --data '{"query":"query SelfHostingVerification { __typename }"}' \
+  "$base_url/api/graphql")"
+
+if ! jq --exit-status '
+  .data.__typename == "Query" and
+  ((.errors // []) | length == 0)
+' <<<"$graphql_response" >/dev/null; then
+  echo "The public GraphQL proxy did not return the expected read-only response." >&2
+  exit 1
+fi
+
+echo "Production verification passed: $base_url"


### PR DESCRIPTION
## Summary
- add a read-only production verification command for selected images and container health
- verify public HTTPS security headers and the same-origin GraphQL proxy
- cover success and diagnostic failures in deployment-contract CI
- document verification after installation, restore, upgrade, and Terraform provisioning

## Validation
- scripts/self-hosting-tests/backup-self-hosting.test.sh
- scripts/self-hosting-tests/restore-self-hosting.test.sh
- scripts/self-hosting-tests/upgrade-self-hosting.test.sh
- scripts/self-hosting-tests/verify-self-hosting.test.sh
- node_modules/.bin/prettier --check .github/workflows/self-hosting-contract.yml docs/self-hosting-production.md deploy/terraform/aws-single-vm/README.md
- git diff --check
- scripts/validate-self-hosting-contract.sh (all shell tests passed; local run reached the Docker-backed Caddy validation and stopped because Docker Desktop is not running)

## Coverage
The new shell command has contract coverage for its successful path and operational failure modes. JavaScript coverage is not applicable to this deployment-only change.