### PR TITLE
feat(self-hosting): publish release manifests

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -25,6 +25,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      frontend-digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Check out source
@@ -192,3 +194,67 @@ jobs:
           anonymous_docker_config="$(mktemp -d)"
           trap 'rm -rf "$anonymous_docker_config"' EXIT
           DOCKER_CONFIG="$anonymous_docker_config" docker pull "$PUBLISHED_IMAGE"
+
+  publish-release-manifest:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build-publish-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+
+      - name: Create the self-hosting release manifest
+        id: release-manifest
+        env:
+          FRONTEND_DIGEST: ${{ needs.build-publish-smoke.outputs.frontend-digest }}
+        run: |
+          set -euo pipefail
+          release_version="${GITHUB_REF_NAME#v}"
+          manifest_path="$RUNNER_TEMP/multiforum-self-hosting-${release_version}.json"
+          scripts/create-self-hosting-release-manifest.sh \
+            --release "$release_version" \
+            --frontend-image "${IMAGE_NAME}@${FRONTEND_DIGEST}" \
+            --output "$manifest_path"
+          echo "path=$manifest_path" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename "$manifest_path")" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release component images are public
+        env:
+          RELEASE_MANIFEST: ${{ steps.release-manifest.outputs.path }}
+        run: |
+          set -euo pipefail
+          anonymous_docker_config="$(mktemp -d)"
+          trap 'rm -rf "$anonymous_docker_config"' EXIT
+          while IFS= read -r image; do
+            DOCKER_CONFIG="$anonymous_docker_config" docker pull "$image"
+          done < <(jq --raw-output '.images | to_entries[] | select(.key != "frontend") | .value' "$RELEASE_MANIFEST")
+
+      - name: Preserve the release manifest with the workflow run
+        uses: actions/upload-artifact@v4
+        with:
+          name: self-hosting-release-manifest
+          path: ${{ steps.release-manifest.outputs.path }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Attach the manifest to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_MANIFEST: ${{ steps.release-manifest.outputs.path }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 12); do
+            if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+              gh release upload "$GITHUB_REF_NAME" \
+                "$RELEASE_MANIFEST#Multiforum self-hosting release manifest"
+              exit 0
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "GitHub release was not available for tag: $GITHUB_REF_NAME" >&2
+              exit 1
+            fi
+            sleep 5
+          done

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,8 @@ name: Release
 # conventional commit subjects (which the squash-merge PR-title check keeps
 # valid). Nothing is released until a maintainer merges that release PR — which
 # then tags the version, updates package.json + CHANGELOG.md, and cuts a
-# GitHub Release.
+# GitHub Release. The tag-triggered container workflow publishes the frontend
+# image and attaches its validated self-hosting release manifest to that release.
 on:
   push:
     branches:

--- a/.github/workflows/self-hosting-contract.yml
+++ b/.github/workflows/self-hosting-contract.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '.env.quickstart.example'
       - '.env.production.example'
+      - '.github/workflows/container-image.yml'
       - '.github/workflows/self-hosting-contract.yml'
       - 'deploy/caddy/**'
       - 'deploy/releases/**'
@@ -15,6 +16,7 @@ on:
       - 'docker-compose*.yml'
       - 'scripts/backup-self-hosting.sh'
       - 'scripts/check-self-hosting-backups.sh'
+      - 'scripts/create-self-hosting-release-manifest.sh'
       - 'scripts/restore-self-hosting.sh'
       - 'scripts/validate-self-hosting-release.sh'
       - 'scripts/upload-self-hosting-backup.sh'
@@ -28,6 +30,7 @@ on:
     paths:
       - '.env.quickstart.example'
       - '.env.production.example'
+      - '.github/workflows/container-image.yml'
       - '.github/workflows/self-hosting-contract.yml'
       - 'deploy/caddy/**'
       - 'deploy/releases/**'
@@ -36,6 +39,7 @@ on:
       - 'docker-compose*.yml'
       - 'scripts/backup-self-hosting.sh'
       - 'scripts/check-self-hosting-backups.sh'
+      - 'scripts/create-self-hosting-release-manifest.sh'
       - 'scripts/restore-self-hosting.sh'
       - 'scripts/validate-self-hosting-release.sh'
       - 'scripts/upload-self-hosting-backup.sh'

--- a/deploy/releases/README.md
+++ b/deploy/releases/README.md
@@ -5,8 +5,9 @@ four-image set tested together for self-hosting. It is the compatibility
 contract between a Multiforum release and the production Compose stack.
 
 The repository includes an example contract, not a claim that those example
-tags have been released. Official releases can publish a manifest using the
-same schema alongside their release notes.
+tags have been released. Every `v*.*.*` frontend tag build creates a manifest,
+preserves it as a workflow artifact, verifies that every selected component is
+publicly pullable, and attaches it to the matching GitHub Release.
 
 Schema version 1 requires:
 
@@ -14,6 +15,27 @@ Schema version 1 requires:
 - the official backend and frontend repositories, pinned to exact SemVer tags,
   immutable `sha-*` tags, or SHA-256 digests; and
 - pinned Neo4j and Caddy tags or digests.
+
+## Maintainer release input
+
+`release-components.json` is the reviewed input for the next release. It pins
+the backend, Neo4j, and Caddy images. Before merging a release PR, maintainers
+should update the backend reference to an immutable `sha-*` tag whose backend
+container workflow passed. The frontend tag workflow adds its own published
+multi-architecture digest and the release version; neither is guessed in the
+curated input.
+
+The generator can be exercised locally without publishing anything:
+
+```bash
+scripts/create-self-hosting-release-manifest.sh \
+  --release 1.2.3 \
+  --frontend-image \
+    ghcr.io/gennit-project/multiforum-nuxt@sha256:REPLACE_WITH_DIGEST \
+  --output /tmp/multiforum-self-hosting-1.2.3.json
+```
+
+Generation is atomic and runs the same release validator used by operators.
 
 Validate a downloaded manifest by itself:
 

--- a/deploy/releases/release-components.json
+++ b/deploy/releases/release-components.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "images": {
+    "database": "neo4j:5.1.0",
+    "backend": "ghcr.io/gennit-project/multiforum-backend:sha-a113caa2e045fb9c462d0c16279d75b5bc25152e",
+    "caddy": "caddy:2.11.4-alpine"
+  }
+}

--- a/docs/frontend-container-image.md
+++ b/docs/frontend-container-image.md
@@ -70,6 +70,12 @@ The publishing workflow tests the non-root runtime, health check, runtime
 branding, same-origin GraphQL proxy, local-development mode, and rejection of
 incomplete Auth0 configuration before accepting an image publication.
 
+For semantic-version tags, the workflow also combines the published frontend
+digest with the reviewed backend, Neo4j, and Caddy pins, verifies that all four
+images are publicly pullable, and attaches a validated self-hosting release
+manifest to the GitHub Release. Production operators should use that complete
+manifest rather than selecting component versions independently.
+
 The GHCR package must be made public once by an organization owner after its
 first publication. Every subsequent publication verifies that its digest can
 be pulled with an anonymous Docker configuration.

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -56,9 +56,9 @@ cp .env.production.example .env.production
 chmod 600 .env.production
 ```
 
-Obtain the self-hosting release manifest published with the release you intend
-to run. It is the machine-readable compatibility contract for the frontend,
-backend, Neo4j, and Caddy images. Copy its `release` value to
+Download the `multiforum-self-hosting-VERSION.json` asset from the GitHub
+Release you intend to run. It is the machine-readable compatibility contract
+for the frontend, backend, Neo4j, and Caddy images. Copy its `release` value to
 `MULTIFORUM_RELEASE_VERSION` and its four image references to the corresponding
 variables in `.env.production`. The file under
 `deploy/releases/self-hosting-release.example.json` documents the format; its

--- a/scripts/create-self-hosting-release-manifest.sh
+++ b/scripts/create-self-hosting-release-manifest.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+release_version=""
+frontend_image=""
+components_file=""
+output_file=""
+script_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/create-self-hosting-release-manifest.sh --release VERSION
+       --frontend-image IMAGE --output PATH [--components PATH]
+
+Creates and validates a self-hosting release manifest by combining the curated
+backend and infrastructure image pins with one published frontend image. VERSION
+must be SemVer without a leading v. The output is replaced atomically.
+EOF
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" ]]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --release)
+      require_value "$1" "${2:-}"
+      release_version="$2"
+      shift 2
+      ;;
+    --frontend-image)
+      require_value "$1" "${2:-}"
+      frontend_image="$2"
+      shift 2
+      ;;
+    --components)
+      require_value "$1" "${2:-}"
+      components_file="$2"
+      shift 2
+      ;;
+    --output)
+      require_value "$1" "${2:-}"
+      output_file="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$release_version" || -z "$frontend_image" || -z "$output_file" ]]; then
+  echo "--release, --frontend-image, and --output are required." >&2
+  exit 2
+fi
+
+components_file="${components_file:-$script_root/deploy/releases/release-components.json}"
+if [[ ! -f "$components_file" ]]; then
+  echo "Release components file not found: $components_file" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Required command not found: jq" >&2
+  exit 1
+fi
+
+if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release version must be SemVer without a leading v." >&2
+  exit 1
+fi
+
+if ! jq --exit-status '
+  type == "object" and
+  .schemaVersion == 1 and
+  (.images | type == "object") and
+  (.images | keys | sort) == ["backend", "caddy", "database"] and
+  ([.images[] | type == "string" and length > 0] | all)
+' "$components_file" >/dev/null; then
+  echo "Release components do not satisfy schema version 1." >&2
+  exit 1
+fi
+
+output_dir="$(dirname -- "$output_file")"
+mkdir -p "$output_dir"
+output_dir="$(cd -- "$output_dir" && pwd)"
+output_file="$output_dir/$(basename -- "$output_file")"
+temporary_output="$(mktemp "$output_dir/.multiforum-release.XXXXXX")"
+trap 'rm -f "$temporary_output"' EXIT
+
+jq --sort-keys \
+  --arg release "$release_version" \
+  --arg frontend "$frontend_image" '
+    {
+      schemaVersion: .schemaVersion,
+      release: $release,
+      images: {
+        database: .images.database,
+        backend: .images.backend,
+        frontend: $frontend,
+        caddy: .images.caddy
+      }
+    }
+  ' "$components_file" >"$temporary_output"
+
+"$script_root/scripts/validate-self-hosting-release.sh" \
+  --manifest "$temporary_output" >/dev/null
+
+mv "$temporary_output" "$output_file"
+trap - EXIT
+
+echo "Self-hosting release manifest created: $output_file"

--- a/scripts/self-hosting-tests/create-self-hosting-release-manifest.test.sh
+++ b/scripts/self-hosting-tests/create-self-hosting-release-manifest.test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+creator="$repository_root/scripts/create-self-hosting-release-manifest.sh"
+validator="$repository_root/scripts/validate-self-hosting-release.sh"
+
+trap 'rm -rf "$test_root"' EXIT
+
+components_file="$test_root/components.json"
+cat >"$components_file" <<'EOF'
+{
+  "schemaVersion": 1,
+  "images": {
+    "database": "neo4j:5.1.0",
+    "backend": "ghcr.io/gennit-project/multiforum-backend:sha-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "caddy": "caddy:2.11.4-alpine"
+  }
+}
+EOF
+
+output_file="$test_root/release.json"
+frontend_digest="ghcr.io/gennit-project/multiforum-nuxt@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+"$creator" --help | grep --fixed-strings -- "--frontend-image IMAGE" >/dev/null
+"$creator" \
+  --release 1.2.3 \
+  --frontend-image "$frontend_digest" \
+  --components "$components_file" \
+  --output "$output_file" >/dev/null
+
+jq --exit-status \
+  --arg frontend "$frontend_digest" '
+    .schemaVersion == 1 and
+    .release == "1.2.3" and
+    .images.database == "neo4j:5.1.0" and
+    .images.backend == "ghcr.io/gennit-project/multiforum-backend:sha-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" and
+    .images.frontend == $frontend and
+    .images.caddy == "caddy:2.11.4-alpine"
+  ' "$output_file" >/dev/null
+"$validator" --manifest "$output_file" >/dev/null
+
+if "$creator" \
+  --release v1.2.3 \
+  --frontend-image "$frontend_digest" \
+  --components "$components_file" \
+  --output "$test_root/invalid-version.json" >/dev/null 2>&1; then
+  echo "Expected creation to reject a leading-v release version." >&2
+  exit 1
+fi
+
+if "$creator" \
+  --release 1.2.3 \
+  --frontend-image ghcr.io/gennit-project/multiforum-nuxt:edge \
+  --components "$components_file" \
+  --output "$test_root/floating.json" >/dev/null 2>&1; then
+  echo "Expected creation to reject a floating frontend image." >&2
+  exit 1
+fi
+
+invalid_components="$test_root/invalid-components.json"
+jq '.images.frontend = "unexpected"' "$components_file" >"$invalid_components"
+if "$creator" \
+  --release 1.2.3 \
+  --frontend-image "$frontend_digest" \
+  --components "$invalid_components" \
+  --output "$test_root/invalid-components-release.json" >/dev/null 2>&1; then
+  echo "Expected creation to reject an unknown curated component." >&2
+  exit 1
+fi
+
+floating_backend="$test_root/floating-backend.json"
+jq '.images.backend = "ghcr.io/gennit-project/multiforum-backend:edge"' \
+  "$components_file" >"$floating_backend"
+if "$creator" \
+  --release 1.2.3 \
+  --frontend-image "$frontend_digest" \
+  --components "$floating_backend" \
+  --output "$test_root/floating-backend-release.json" >/dev/null 2>&1; then
+  echo "Expected creation to reject a floating curated backend image." >&2
+  exit 1
+fi
+
+if [[ -e "$test_root/floating-backend-release.json" ]]; then
+  echo "Failed creation must not leave a release manifest behind." >&2
+  exit 1
+fi
+
+echo "Self-hosting release-manifest creation tests passed."

--- a/scripts/validate-self-hosting-contract.sh
+++ b/scripts/validate-self-hosting-contract.sh
@@ -33,8 +33,16 @@ cd "$contract_root"
 
 echo "Testing the production release/version contract..."
 scripts/self-hosting-tests/validate-self-hosting-release.test.sh
+scripts/self-hosting-tests/create-self-hosting-release-manifest.test.sh
 scripts/validate-self-hosting-release.sh \
   --manifest deploy/releases/self-hosting-release.example.json
+
+grep --fixed-strings \
+  'scripts/create-self-hosting-release-manifest.sh' \
+  .github/workflows/container-image.yml >/dev/null
+grep --fixed-strings \
+  'gh release upload "$GITHUB_REF_NAME"' \
+  .github/workflows/container-image.yml >/dev/null
 
 echo "Testing the production cold-backup command..."
 scripts/self-hosting-tests/backup-self-hosting.test.sh


### PR DESCRIPTION
## Summary
- generate a validated self-hosting manifest for every semantic-version frontend tag
- pin the current successfully published backend revision as reviewed release input
- use the actual frontend multi-architecture digest instead of reconstructing a tag
- anonymously pull every referenced component before publishing the contract
- retain the manifest as a workflow artifact and attach it to the matching GitHub Release
- document the maintainer and operator workflows

## Verification
- scripts/self-hosting-tests/create-self-hosting-release-manifest.test.sh
- scripts/self-hosting-tests/validate-self-hosting-release.test.sh
- scripts/self-hosting-tests/verify-self-hosting.test.sh
- scripts/self-hosting-tests/upgrade-self-hosting.test.sh
- production Compose model validation
- Prettier checks for workflows, JSON, and docs
- git diff --check

The pinned backend revision a113caa2e045fb9c462d0c16279d75b5bc25152e has a successful official container-image workflow run.