### PR TITLE
feat(self-hosting): attest release artifacts

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -23,7 +23,10 @@ jobs:
   build-publish-smoke:
     runs-on: ubuntu-latest
     permissions:
+      artifact-metadata: write
+      attestations: write
       contents: read
+      id-token: write
       packages: write
     outputs:
       frontend-digest: ${{ steps.build.outputs.digest }}
@@ -230,12 +233,23 @@ jobs:
           trap 'rm -rf "$anonymous_docker_config"' EXIT
           DOCKER_CONFIG="$anonymous_docker_config" docker pull "$PUBLISHED_IMAGE"
 
+      - name: Attest the accepted frontend image
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
   publish-release-manifest:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build-publish-smoke
     runs-on: ubuntu-latest
     permissions:
+      artifact-metadata: write
+      attestations: write
       contents: write
+      id-token: write
 
     steps:
       - name: Check out release source
@@ -266,6 +280,11 @@ jobs:
           while IFS= read -r image; do
             DOCKER_CONFIG="$anonymous_docker_config" docker pull "$image"
           done < <(jq --raw-output '.images[]' "$RELEASE_MANIFEST")
+
+      - name: Attest the self-hosting release manifest
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ steps.release-manifest.outputs.path }}
 
       - name: Preserve the release manifest with the workflow run
         uses: actions/upload-artifact@v4

--- a/docs/frontend-container-image.md
+++ b/docs/frontend-container-image.md
@@ -59,11 +59,22 @@ backups, and appropriately secured backend and database services.
 ## Supply-chain metadata
 
 Main-branch and release publications include OCI source and revision labels,
-a software bill of materials, and build provenance. Pulling by digest provides
-an immutable reference independent of the tag policy:
+a software bill of materials, and signed GitHub artifact attestations for the
+image's build provenance. Pulling by digest provides an immutable reference
+independent of the tag policy:
 
 ```bash
 docker pull ghcr.io/gennit-project/multiforum-nuxt@sha256:DIGEST
+```
+
+With the GitHub CLI authenticated for GitHub and GHCR, verify that the digest
+was produced by Multiforum's official publishing workflow:
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/gennit-project/multiforum-nuxt@sha256:DIGEST \
+  --repo gennit-project/multiforum-nuxt \
+  --signer-workflow gennit-project/multiforum-nuxt/.github/workflows/container-image.yml
 ```
 
 The publishing workflow tests the non-root runtime, health check, runtime

--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -62,6 +62,19 @@ Download and validate the release manifest for the version you intend to run:
 scripts/download-self-hosting-release.sh --release VERSION
 ```
 
+For a high-assurance installation, install and authenticate the GitHub CLI and
+verify the manifest's signed build provenance while downloading it:
+
+```bash
+scripts/download-self-hosting-release.sh \
+  --release VERSION \
+  --verify-attestation
+```
+
+This check requires provenance signed by GitHub Actions for the requested
+release tag, from Multiforum's official container publishing workflow. A
+verification failure leaves no manifest at the requested output path.
+
 The resulting `multiforum-self-hosting-VERSION.json` is the machine-readable
 compatibility contract for the frontend, backend, Neo4j, and Caddy images. Copy
 its `release` value to

--- a/scripts/download-self-hosting-release.sh
+++ b/scripts/download-self-hosting-release.sh
@@ -5,18 +5,21 @@ set -euo pipefail
 release_version=""
 output_file=""
 replace_existing=false
+verify_attestation=false
 official_repository="gennit-project/multiforum-nuxt"
+official_signer_workflow="${official_repository}/.github/workflows/container-image.yml"
 script_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 usage() {
   cat <<'EOF'
 Usage: scripts/download-self-hosting-release.sh --release VERSION
-       [--output PATH] [--replace-existing]
+       [--output PATH] [--replace-existing] [--verify-attestation]
 
 Downloads one version-pinned self-hosting manifest from Multiforum's official
 GitHub Release, validates its schema and image references, confirms that its
 declared version matches VERSION, and writes it atomically. VERSION must be
-SemVer without a leading v.
+SemVer without a leading v. --verify-attestation additionally requires the
+GitHub CLI and verifies signed provenance from the official release workflow.
 EOF
 }
 
@@ -44,6 +47,10 @@ while (($# > 0)); do
       ;;
     --replace-existing)
       replace_existing=true
+      shift
+      ;;
+    --verify-attestation)
+      verify_attestation=true
       shift
       ;;
     --help|-h)
@@ -89,6 +96,10 @@ for required_command in curl jq; do
     exit 1
   fi
 done
+if [[ "$verify_attestation" == true ]] && ! command -v gh >/dev/null 2>&1; then
+  echo "Required command not found for attestation verification: gh" >&2
+  exit 1
+fi
 
 output_dir="$(dirname -- "$output_file")"
 mkdir -p "$output_dir"
@@ -120,6 +131,14 @@ if [[ "$downloaded_version" != "$release_version" ]]; then
   echo "Requested:  $release_version" >&2
   echo "Downloaded: $downloaded_version" >&2
   exit 1
+fi
+
+if [[ "$verify_attestation" == true ]]; then
+  echo "Verifying signed provenance for the release manifest"
+  gh attestation verify "$temporary_output" \
+    --repo "$official_repository" \
+    --signer-workflow "$official_signer_workflow" \
+    --source-ref "refs/tags/v${release_version}" >/dev/null
 fi
 
 chmod 644 "$temporary_output"

--- a/scripts/self-hosting-tests/download-self-hosting-release.test.sh
+++ b/scripts/self-hosting-tests/download-self-hosting-release.test.sh
@@ -11,7 +11,9 @@ trap 'rm -rf "$test_root"' EXIT
 
 export PATH="$fixture_bin:$PATH"
 export MULTIFORUM_FAKE_CURL_LOG="$test_root/curl.log"
+export MULTIFORUM_FAKE_GH_LOG="$test_root/gh.log"
 : >"$MULTIFORUM_FAKE_CURL_LOG"
+: >"$MULTIFORUM_FAKE_GH_LOG"
 
 file_mode() {
   stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
@@ -40,6 +42,7 @@ output_file="$test_root/releases/multiforum-self-hosting-1.2.3.json"
 test -f "$output_file"
 jq --exit-status '.schemaVersion == 1 and .release == "1.2.3"' "$output_file" >/dev/null
 test "$(file_mode "$output_file")" = 644
+test ! -s "$MULTIFORUM_FAKE_GH_LOG"
 grep --fixed-strings \
   'https://github.com/gennit-project/multiforum-nuxt/releases/download/v1.2.3/multiforum-self-hosting-1.2.3.json' \
   "$MULTIFORUM_FAKE_CURL_LOG" >/dev/null
@@ -122,6 +125,36 @@ if MULTIFORUM_FAKE_CURL_FAIL=true \
   exit 1
 fi
 test ! -e "$failed_output"
+
+attested_output="$test_root/attested.json"
+"$download_script" \
+  --release 1.2.3 \
+  --output "$attested_output" \
+  --verify-attestation >/dev/null
+test -f "$attested_output"
+grep --fixed-strings \
+  'attestation verify' \
+  "$MULTIFORUM_FAKE_GH_LOG" >/dev/null
+grep --fixed-strings -- \
+  '--repo gennit-project/multiforum-nuxt' \
+  "$MULTIFORUM_FAKE_GH_LOG" >/dev/null
+grep --fixed-strings -- \
+  '--signer-workflow gennit-project/multiforum-nuxt/.github/workflows/container-image.yml' \
+  "$MULTIFORUM_FAKE_GH_LOG" >/dev/null
+grep --fixed-strings -- \
+  '--source-ref refs/tags/v1.2.3' \
+  "$MULTIFORUM_FAKE_GH_LOG" >/dev/null
+
+failed_attestation_output="$test_root/failed-attestation.json"
+if MULTIFORUM_FAKE_GH_FAIL=true \
+  "$download_script" \
+  --release 1.2.3 \
+  --output "$failed_attestation_output" \
+  --verify-attestation >/dev/null 2>&1; then
+  echo "Expected release download to propagate an attestation failure." >&2
+  exit 1
+fi
+test ! -e "$failed_attestation_output"
 
 (
   cd "$test_root"

--- a/scripts/self-hosting-tests/fixtures/gh
+++ b/scripts/self-hosting-tests/fixtures/gh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$MULTIFORUM_FAKE_GH_LOG"
+
+if [[ "${MULTIFORUM_FAKE_GH_FAIL:-false}" == true ]]; then
+  exit 1
+fi
+
+if [[ "${1:-}" != attestation || "${2:-}" != verify ]]; then
+  echo "Unexpected GitHub CLI fixture command: $*" >&2
+  exit 2
+fi

--- a/scripts/validate-self-hosting-contract.sh
+++ b/scripts/validate-self-hosting-contract.sh
@@ -54,6 +54,15 @@ grep --fixed-strings \
   'scripts/smoke-self-hosting-release.sh' \
   .github/workflows/container-image.yml >/dev/null
 grep --fixed-strings \
+  'uses: actions/attest@v4' \
+  .github/workflows/container-image.yml >/dev/null
+grep --fixed-strings \
+  'subject-digest: ${{ steps.build.outputs.digest }}' \
+  .github/workflows/container-image.yml >/dev/null
+grep --fixed-strings \
+  'subject-path: ${{ steps.release-manifest.outputs.path }}' \
+  .github/workflows/container-image.yml >/dev/null
+grep --fixed-strings \
   'actions: write' \
   .github/workflows/release-please.yml >/dev/null
 grep --fixed-strings \


### PR DESCRIPTION
## Summary
- publish signed GitHub artifact attestations for accepted frontend image digests and coordinated release manifests
- add optional provenance verification to the release downloader, pinned to the official repository, tag, and workflow
- document image and manifest verification and cover success/failure-atomic downloader behavior

## Verification
- scripts/self-hosting-tests/download-self-hosting-release.test.sh
- scripts/validate-self-hosting-contract.sh
- bash -n scripts/download-self-hosting-release.sh scripts/self-hosting-tests/fixtures/gh scripts/self-hosting-tests/download-self-hosting-release.test.sh scripts/validate-self-hosting-contract.sh
- git diff --check