### PR TITLE
test(self-hosting): drill backup restoration

### DIFF
--- a/docs/self-hosting-production.md
+++ b/docs/self-hosting-production.md
@@ -291,6 +291,14 @@ failure marks the service failed but does not delete the newly completed local
 bundle. Monitor the systemd unit and configure an external alert; periodically
 run `restic check` and perform a restore drill on a separate host.
 
+Multiforum's deployment-contract CI runs the actual backup and guarded-restore
+commands against disposable Docker volumes. It removes the source volumes,
+creates clean replacements, restores both Neo4j and frontend-session data, and
+checks the original bytes while confirming that restore does not restart the
+application. This protects the mechanics of the documented procedure; it does
+not replace your own scheduled drill using your encrypted off-site repository
+and production-sized data.
+
 To retrieve the newest remote bundle for a guarded restore, load the same
 Restic configuration and restore the instance tag into an empty temporary
 directory:

--- a/scripts/self-hosting-tests/backup-restore.integration.test.sh
+++ b/scripts/self-hosting-tests/backup-restore.integration.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture_bin="$repository_root/scripts/self-hosting-tests/fixtures"
+real_docker="$(command -v docker)"
+helper_image="${MULTIFORUM_BACKUP_HELPER_IMAGE:-busybox:1.36.1}"
+volume_suffix="${RANDOM}-$$"
+neo4j_volume="multiforum-restore-drill-neo4j-$volume_suffix"
+frontend_volume="multiforum-restore-drill-frontend-$volume_suffix"
+
+cleanup() {
+  "$real_docker" volume rm --force "$neo4j_volume" "$frontend_volume" \
+    >/dev/null 2>&1 || true
+  rm -rf -- "$test_root"
+}
+trap cleanup EXIT
+
+export PATH="$fixture_bin:$PATH"
+export MULTIFORUM_FAKE_DOCKER_LOG="$test_root/docker.log"
+export MULTIFORUM_FAKE_DOCKER_REAL_VOLUME_IO=true
+export MULTIFORUM_REAL_DOCKER="$real_docker"
+export MULTIFORUM_FAKE_NEO4J_VOLUME="$neo4j_volume"
+export MULTIFORUM_FAKE_FRONTEND_VOLUME="$frontend_volume"
+export MULTIFORUM_BACKUP_HELPER_IMAGE="$helper_image"
+
+env_file="$test_root/.env.production"
+backup_root="$test_root/backups"
+: >"$env_file"
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+
+"$real_docker" volume create "$neo4j_volume" >/dev/null
+"$real_docker" volume create "$frontend_volume" >/dev/null
+
+"$real_docker" run --rm \
+  --volume "$neo4j_volume:/target" \
+  "$helper_image" \
+  sh -ec 'mkdir -p /target/databases/neo4j && printf "forum-node-data\n" > /target/databases/neo4j/neostore'
+"$real_docker" run --rm \
+  --volume "$frontend_volume:/target" \
+  "$helper_image" \
+  sh -ec 'mkdir -p /target/sessions && printf "admin-session-data\n" > /target/sessions/admin.json'
+
+"$repository_root/scripts/backup-self-hosting.sh" \
+  --env-file "$env_file" \
+  --output-dir "$backup_root" >/dev/null
+
+backup_dir="$(find "$backup_root" -mindepth 1 -maxdepth 1 -type d \
+  -name 'multiforum-backup-????????T??????Z' -print -quit)"
+if [[ -z "$backup_dir" ]]; then
+  echo "The integration drill did not create a complete backup bundle." >&2
+  exit 1
+fi
+
+jq --exit-status \
+  '.formatVersion == 1 and .images.database == "neo4j:test"' \
+  "$backup_dir/manifest.json" >/dev/null
+
+"$real_docker" volume rm "$neo4j_volume" "$frontend_volume" >/dev/null
+"$real_docker" volume create "$neo4j_volume" >/dev/null
+"$real_docker" volume create "$frontend_volume" >/dev/null
+
+"$real_docker" run --rm \
+  --volume "$neo4j_volume:/target" \
+  "$helper_image" \
+  sh -ec 'printf "replacement-only\n" > /target/replacement-marker'
+"$real_docker" run --rm \
+  --volume "$frontend_volume:/target" \
+  "$helper_image" \
+  sh -ec 'printf "replacement-only\n" > /target/replacement-marker'
+
+: >"$MULTIFORUM_FAKE_DOCKER_LOG"
+MULTIFORUM_FAKE_RUNNING_SERVICES=caddy \
+  "$repository_root/scripts/restore-self-hosting.sh" \
+  --backup-dir "$backup_dir" \
+  --env-file "$env_file" \
+  --confirm-replace-existing-data >/dev/null
+
+neo4j_data="$("$real_docker" run --rm \
+  --volume "$neo4j_volume:/source:ro" \
+  "$helper_image" \
+  cat /source/databases/neo4j/neostore)"
+frontend_data="$("$real_docker" run --rm \
+  --volume "$frontend_volume:/source:ro" \
+  "$helper_image" \
+  cat /source/sessions/admin.json)"
+
+test "$neo4j_data" = "forum-node-data"
+test "$frontend_data" = "admin-session-data"
+"$real_docker" run --rm \
+  --volume "$neo4j_volume:/source:ro" \
+  "$helper_image" \
+  test ! -e /source/replacement-marker
+"$real_docker" run --rm \
+  --volume "$frontend_volume:/source:ro" \
+  "$helper_image" \
+  test ! -e /source/replacement-marker
+
+if grep --fixed-strings ' up -d ' "$MULTIFORUM_FAKE_DOCKER_LOG" >/dev/null; then
+  echo "The restore drill unexpectedly restarted application services." >&2
+  exit 1
+fi
+
+echo "Real-volume backup and restore integration drill passed."

--- a/scripts/self-hosting-tests/fixtures/docker
+++ b/scripts/self-hosting-tests/fixtures/docker
@@ -45,6 +45,8 @@ if [[ "${1:-}" == "compose" ]]; then
         --arg frontendImage "$frontend_image" \
         --arg caddyImage "$caddy_image" \
         --arg releaseVersion "${MULTIFORUM_FAKE_RELEASE_VERSION:-$release_version}" \
+        --arg neo4jVolume "${MULTIFORUM_FAKE_NEO4J_VOLUME:-neo4j-volume}" \
+        --arg frontendVolume "${MULTIFORUM_FAKE_FRONTEND_VOLUME:-frontend-volume}" \
         '
 {
   "services": {
@@ -58,8 +60,8 @@ if [[ "${1:-}" == "compose" ]]; then
     }
   },
   "volumes": {
-    "neo4j-data": {"name": "neo4j-volume"},
-    "frontend-data": {"name": "frontend-volume"}
+    "neo4j-data": {"name": $neo4jVolume},
+    "frontend-data": {"name": $frontendVolume}
   }
 }
 '
@@ -160,6 +162,9 @@ elif [[ "${1:-}" == "inspect" ]]; then
   release_version="${MULTIFORUM_FAKE_RUNNING_RELEASE_VERSION:-1.2.3}"
   printf '%s|%s|%s|%s\n' "$image" "$status" "$health" "$release_version"
 elif [[ "${1:-}" == "run" ]]; then
+  if [[ "${MULTIFORUM_FAKE_DOCKER_REAL_VOLUME_IO:-false}" == true ]]; then
+    exec "$MULTIFORUM_REAL_DOCKER" "$@"
+  fi
   if [[ "$*" == *"caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile"* ]]; then
     if [[ "${MULTIFORUM_FAKE_FAIL_CADDY_VALIDATION:-false}" == true ]]; then
       exit 50

--- a/scripts/validate-self-hosting-contract.sh
+++ b/scripts/validate-self-hosting-contract.sh
@@ -93,6 +93,9 @@ fi
 echo "Testing the guarded production restore command..."
 scripts/self-hosting-tests/restore-self-hosting.test.sh
 
+echo "Drilling backup and restore against disposable Docker volumes..."
+scripts/self-hosting-tests/backup-restore.integration.test.sh
+
 echo "Testing the safe production upgrade command..."
 scripts/self-hosting-tests/upgrade-self-hosting.test.sh
 


### PR DESCRIPTION
## Summary
- add a real-volume disaster-recovery drill to the self-hosting deployment contract
- back up representative Neo4j and frontend-session data with the production script, delete and recreate the volumes, then restore and verify the original bytes
- confirm guarded restore removes replacement data and leaves application services stopped
- document what CI proves and why operators still need off-site, production-sized restore drills

## Verification
- scripts/self-hosting-tests/backup-restore.integration.test.sh
- scripts/self-hosting-tests/backup-self-hosting.test.sh
- scripts/self-hosting-tests/restore-self-hosting.test.sh
- scripts/validate-self-hosting-contract.sh
- bash -n scripts/self-hosting-tests/backup-restore.integration.test.sh scripts/self-hosting-tests/fixtures/docker scripts/validate-self-hosting-contract.sh
- git diff --check