### PR TITLE
perf(cwv): drop unused maps wrapper dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "vue-chartjs": "^5.3.4",
     "vue-codemirror": "^6.1.1",
     "vue-easy-lightbox": "^1.19.0",
-    "vue-google-maps-community-fork": "^0.3.1",
     "vue-i18n": "^11.4.5",
     "vue-router": "^5.1.0",
     "vue3-popper": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,9 +158,6 @@ importers:
       vue-easy-lightbox:
         specifier: ^1.19.0
         version: 1.19.0(vue@3.5.40(typescript@6.0.3))
-      vue-google-maps-community-fork:
-        specifier: ^0.3.1
-        version: 0.3.1
       vue-i18n:
         specifier: ^11.4.5
         version: 11.4.6(vue@3.5.40(typescript@6.0.3))
@@ -8027,9 +8024,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-
-  vue-google-maps-community-fork@0.3.1:
-    resolution: {integrity: sha512-RcnpQZdv/aXf6Aeuq+hWdtwZaC4HRgXBY+S59QpbozgVIK4MHp23zbAQjpJ/zzG/B0e7BL91UIa8psuwbPBZQA==}
 
   vue-i18n@11.4.6:
     resolution: {integrity: sha512-l0gE7Rfy0phCa5ChKYkOq543Wgd39BCK6hkktfr1Ed4D99oRkgPK9ffShASZdeC8OJxGfdWmpYoAaAH6iLEuIg==}
@@ -16465,10 +16459,6 @@ snapshots:
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
-
-  vue-google-maps-community-fork@0.3.1:
-    dependencies:
-      '@googlemaps/markerclusterer': 2.6.2
 
   vue-i18n@11.4.6(vue@3.5.40(typescript@6.0.3)):
     dependencies:


### PR DESCRIPTION
## Summary
- remove the unused `vue-google-maps-community-fork` dependency from the app manifest and lockfile
- keep the existing lazy event-map path intact since the app already uses `@googlemaps/js-api-loader` directly
- further reduce public-route startup/dependency surface after removing the dead global maps plugin in PR #501

## Validation
- `pnpm install --lockfile-only`
- `pnpm exec vitest run components/event/map/MapView.spec.ts components/event/map/Map.spec.ts`
- `pnpm exec eslint nuxt.config.ts`