### PR TITLE
perf(cwv): start image delivery phase one

### DIFF
--- a/components/AvatarComponent.vue
+++ b/components/AvatarComponent.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import Identicon from 'identicon.js';
 import sha256 from 'crypto-js/sha256';
+import AppImage from '@/components/image/AppImage.vue';
 
 const props = defineProps({
   text: {
@@ -58,22 +59,43 @@ const identiconData = computed(() => {
 
   return 'data:image/svg+xml;base64,' + data;
 });
+
+const avatarDimensions = computed(() => {
+  if (props.isLarge) {
+    return { width: 192, height: 192 };
+  }
+
+  if (props.isMedium) {
+    return { width: 48, height: 48 };
+  }
+
+  if (props.isSmall) {
+    return { width: 32, height: 32 };
+  }
+
+  return { width: undefined, height: undefined };
+});
 </script>
 
 <template>
   <div>
-    <img
+    <AppImage
       v-if="src"
       :src="src"
       :alt="isDecorative ? '' : text"
       :aria-hidden="isDecorative ? 'true' : undefined"
+      :width="avatarDimensions.width"
+      :height="avatarDimensions.height"
+      :loading="isLarge ? 'eager' : 'lazy'"
+      :decoding="'async'"
+      :fetchpriority="isLarge ? 'high' : 'auto'"
       :class="[
         isLarge ? 'h-48 w-48' : '',
         isMedium ? 'h-12 w-12' : '',
         isSmall ? 'h-8 w-8' : '',
         isSquare ? 'rounded-lg' : 'rounded-full',
       ]"
-    >
+    />
     <img
       v-else
       class="border bg-white dark:border-gray-600 dark:bg-black"
@@ -83,6 +105,8 @@ const identiconData = computed(() => {
         isSmall ? 'h-8 w-8' : '',
         isSquare ? 'rounded-lg' : 'rounded-full',
       ]"
+      :width="avatarDimensions.width"
+      :height="avatarDimensions.height"
       :src="identiconData"
       :alt="isDecorative ? '' : text"
       :aria-hidden="isDecorative ? 'true' : undefined"

--- a/components/discussion/form/CreateEditDiscussionFields.vue
+++ b/components/discussion/form/CreateEditDiscussionFields.vue
@@ -407,7 +407,7 @@ onMounted(() => {
                   @update:model-value="
                     $emit('updateFormValues', {
                       selectedFlairIdsByChannel: {
-                        ...(formValues.selectedFlairIdsByChannel || {}),
+                        ...(formValues?.selectedFlairIdsByChannel || {}),
                         [flairChannel]: $event,
                       },
                     })

--- a/components/discussion/list/SitewideDiscussionListItem.vue
+++ b/components/discussion/list/SitewideDiscussionListItem.vue
@@ -19,6 +19,7 @@ import RightArrowIcon from '@/components/icons/RightArrowIcon.vue';
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import RequireAuth from '@/components/auth/RequireAuth.vue';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
+import AppImage from '@/components/image/AppImage.vue';
 import XmarkIcon from '@/components/icons/XmarkIcon.vue';
 import { stableRelativeTime } from '@/utils';
 import { useQuery } from '@vue/apollo-composable';
@@ -412,10 +413,13 @@ const revealSensitiveContent = () => {
           :to="getDetailLink()"
           class="shrink-0 lg:hidden"
         >
-          <img
+          <AppImage
             :src="thumbnailUrl"
             :alt="title"
             class="h-16 w-16 rounded-lg object-cover sm:h-20 sm:w-20"
+            :width="80"
+            :height="80"
+            sizes="(max-width: 639px) 64px, 80px"
           />
         </nuxt-link>
         <nuxt-link
@@ -423,10 +427,13 @@ const revealSensitiveContent = () => {
           :to="getDesktopSelectionLink()"
           class="hidden shrink-0 lg:block"
         >
-          <img
+          <AppImage
             :src="thumbnailUrl"
             :alt="title"
             class="h-16 w-16 rounded-lg object-cover sm:h-20 sm:w-20"
+            :width="80"
+            :height="80"
+            sizes="80px"
           />
         </nuxt-link>
         <nuxt-link

--- a/components/event/list/EventListItem.vue
+++ b/components/event/list/EventListItem.vue
@@ -13,6 +13,7 @@ import type { Event } from '@/__generated__/graphql';
 import type { SearchEventValues } from '@/types/Event';
 import { useRoute, useRouter } from 'nuxt/app';
 import { isEventSearchRoute } from '@/utils/isEventSearchRoute';
+import AppImage from '@/components/image/AppImage.vue';
 
 const props = defineProps({
   event: {
@@ -268,11 +269,14 @@ const seriesOccurrences = computed(() => {
     </div>
 
     <div class="min-w-0 flex-1">
-      <img
+      <AppImage
         v-if="event.coverImageURL"
         :src="event.coverImageURL"
         alt="Event cover image"
         class="mb-4 block max-h-48 rounded-lg md:hidden"
+        :width="640"
+        :height="360"
+        sizes="100vw"
       />
       <!-- Title and image section for medium+ screens -->
       <div class="hidden md:flex md:items-start md:gap-4">
@@ -382,10 +386,13 @@ const seriesOccurrences = computed(() => {
         </div>
 
         <div v-if="event.coverImageURL" class="shrink-0 pr-2">
-          <img
+          <AppImage
             :alt="event.title"
             :src="event.coverImageURL"
             class="h-32 w-32 rounded-lg"
+            :width="128"
+            :height="128"
+            sizes="128px"
           />
         </div>
       </div>

--- a/components/image/AppImage.vue
+++ b/components/image/AppImage.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { canOptimizeImageUrl } from '@/utils/imageOptimization';
+
+const props = withDefaults(
+  defineProps<{
+    src: string;
+    alt: string;
+    width?: number | string;
+    height?: number | string;
+    sizes?: string;
+    loading?: 'lazy' | 'eager';
+    decoding?: 'async' | 'sync' | 'auto';
+    fetchpriority?: 'high' | 'low' | 'auto';
+    class?: string;
+    ariaHidden?: string;
+  }>(),
+  {
+    width: undefined,
+    height: undefined,
+    sizes: '',
+    loading: 'lazy',
+    decoding: 'async',
+    fetchpriority: 'auto',
+    class: '',
+    ariaHidden: undefined,
+  }
+);
+
+const shouldOptimize = computed(() => canOptimizeImageUrl(props.src));
+</script>
+
+<template>
+  <NuxtImg
+    v-if="shouldOptimize"
+    :src="src"
+    :alt="alt"
+    :width="width"
+    :height="height"
+    :sizes="sizes || undefined"
+    :loading="loading"
+    :decoding="decoding"
+    :fetchpriority="fetchpriority"
+    :class="props.class"
+    :aria-hidden="ariaHidden"
+  />
+  <img
+    v-else
+    :src="src"
+    :alt="alt"
+    :width="width"
+    :height="height"
+    :loading="loading"
+    :decoding="decoding"
+    :fetchpriority="fetchpriority"
+    :class="props.class"
+    :aria-hidden="ariaHidden"
+  >
+</template>

--- a/components/image/AppImage.vue
+++ b/components/image/AppImage.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, useAttrs } from 'vue';
 import { canOptimizeImageUrl } from '@/utils/imageOptimization';
+
+defineOptions({
+  inheritAttrs: false,
+});
 
 const props = withDefaults(
   defineProps<{
@@ -12,8 +16,6 @@ const props = withDefaults(
     loading?: 'lazy' | 'eager';
     decoding?: 'async' | 'sync' | 'auto';
     fetchpriority?: 'high' | 'low' | 'auto';
-    class?: string;
-    ariaHidden?: string;
   }>(),
   {
     width: undefined,
@@ -22,17 +24,17 @@ const props = withDefaults(
     loading: 'lazy',
     decoding: 'async',
     fetchpriority: 'auto',
-    class: '',
-    ariaHidden: undefined,
   }
 );
 
+const attrs = useAttrs();
 const shouldOptimize = computed(() => canOptimizeImageUrl(props.src));
 </script>
 
 <template>
   <NuxtImg
     v-if="shouldOptimize"
+    v-bind="attrs"
     :src="src"
     :alt="alt"
     :width="width"
@@ -41,11 +43,10 @@ const shouldOptimize = computed(() => canOptimizeImageUrl(props.src));
     :loading="loading"
     :decoding="decoding"
     :fetchpriority="fetchpriority"
-    :class="props.class"
-    :aria-hidden="ariaHidden"
   />
   <img
     v-else
+    v-bind="attrs"
     :src="src"
     :alt="alt"
     :width="width"
@@ -53,7 +54,5 @@ const shouldOptimize = computed(() => canOptimizeImageUrl(props.src));
     :loading="loading"
     :decoding="decoding"
     :fetchpriority="fetchpriority"
-    :class="props.class"
-    :aria-hidden="ariaHidden"
   >
 </template>

--- a/components/user/PhotoAvatar.vue
+++ b/components/user/PhotoAvatar.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import { useQuery } from '@vue/apollo-composable';
-import gql from 'graphql-tag';
+import AppImage from '@/components/image/AppImage.vue';
 
 withDefaults(defineProps<{
   src: string;
@@ -12,33 +10,19 @@ withDefaults(defineProps<{
   isSquare: false,
   isLarge: false,
 });
-
-const GET_THEME = gql`
-  query getTheme {
-    theme @client
-  }
-`;
-
-const {
-  result: themeResult,
-  loading: themeLoading,
-  error: themeError,
-} = useQuery(GET_THEME);
-
-const _theme = computed(() => {
-  if (themeLoading.value || themeError.value) {
-    return '';
-  }
-  return themeResult.value?.theme;
-});
 </script>
 <template>
-  <img
+  <AppImage
     :class="[
       isLarge ? '' : 'h-8 w-8',
       isSquare ? 'rounded-lg' : 'rounded-full',
     ]"
     :src="src"
     :alt="alt"
-  >
+    :width="isLarge ? undefined : 32"
+    :height="isLarge ? undefined : 32"
+    :loading="isLarge ? 'eager' : 'lazy'"
+    :decoding="'async'"
+    :fetchpriority="isLarge ? 'high' : 'auto'"
+  />
 </template>

--- a/docs/image-performance-plan.md
+++ b/docs/image-performance-plan.md
@@ -1,0 +1,180 @@
+# Image Performance Plan
+
+This document is the execution plan for fixing image-related Core Web Vitals
+regressions in `multiforum-nuxt`.
+
+It complements [core-web-vitals-plan.md](./core-web-vitals-plan.md) and narrows
+the work specifically to image delivery, sizing, and rendering behavior.
+
+## Summary
+
+The current public UI still sends too many raw image URLs directly to `<img>`
+elements.
+
+That creates three recurring problems:
+
+1. small list and avatar surfaces can download oversized originals
+2. many image surfaces do not declare width, height, or `sizes`
+3. the browser has too little guidance about lazy loading, decoding, and fetch priority
+
+## Current High-Impact Surfaces
+
+### Public list surfaces
+
+- [components/discussion/list/SitewideDiscussionListItem.vue](/Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt/components/discussion/list/SitewideDiscussionListItem.vue)
+- [components/discussion/list/ChannelDiscussionListItem.vue](/Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt/components/discussion/list/ChannelDiscussionListItem.vue)
+- [components/event/list/EventListItem.vue](/Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt/components/event/list/EventListItem.vue)
+- [components/image/ImageListItem.vue](/Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt/components/image/ImageListItem.vue)
+
+### Avatar surfaces
+
+- [components/AvatarComponent.vue](/Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt/components/AvatarComponent.vue)
+- [components/user/PhotoAvatar.vue](/Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt/components/user/PhotoAvatar.vue)
+
+### Detail and gallery surfaces
+
+- [components/discussion/detail/DiscussionAlbum.vue](/Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt/components/discussion/detail/DiscussionAlbum.vue)
+- [components/discussion/detail/ImageLightbox.vue](/Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt/components/discussion/detail/ImageLightbox.vue)
+- [components/discussion/detail/LightboxImagePanel.vue](/Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt/components/discussion/detail/LightboxImagePanel.vue)
+
+## Constraints
+
+There is not yet a proper generated-thumbnail pipeline in storage/backend.
+
+That means the image work needs two phases:
+
+1. immediate frontend delivery improvements using the existing Nuxt image stack
+2. true generated variants once backend/storage can emit canonical thumbnail URLs
+
+## Goals
+
+### Phase 1
+
+- stop sending raw original URLs to the highest-traffic public list surfaces
+- add explicit dimensions or stable aspect ratios
+- apply `sizes`, `loading`, `decoding`, and selective `fetchpriority`
+- centralize the optimization decision so every component does not invent its own rules
+
+### Phase 2
+
+- generate durable storage variants for avatars, list thumbnails, and detail media
+- expose those variants through GraphQL
+- prevent regressions by making thumbnail surfaces reject raw originals
+
+## Proposed Architecture
+
+### 1. Shared optimization helper
+
+Add a small helper that decides whether a URL can safely go through the current
+Nuxt image pipeline.
+
+Initially this should optimize only URLs already supported by the current image
+configuration, especially:
+
+- same-origin paths
+- `storage.googleapis.com`
+
+Arbitrary external markdown images should continue to fall back to plain `<img>`
+until the optimization rules can be widened safely.
+
+### 2. Shared wrapper component
+
+Add one wrapper component that:
+
+- renders `NuxtImg` when the source is eligible for optimization
+- falls back to `<img>` when it is not
+- preserves width, height, `sizes`, `loading`, `decoding`, `fetchpriority`, and classes
+
+This provides a single migration point for Phase 1.
+
+### 3. Surface policies
+
+#### Avatars
+
+- target sizes: `32`, `48`, `64`, `96`
+- default to `loading="lazy"` and `decoding="async"` outside clearly critical shells
+- always declare width and height when the component controls them
+
+#### Public list thumbnails
+
+- discussion list thumb: `80x80`
+- desktop event card thumb: `128x128`
+- mobile event cover image: larger responsive width with `sizes`
+- list surfaces should not request original full-width assets when optimization is available
+
+#### Detail galleries
+
+- thumbnail strips should use thumbnail-sized variants
+- main visible image should use a medium/large variant
+- lightbox can continue to use large assets until generated variants exist
+
+## Delivery Order
+
+### Slice 1: Avatars and public list thumbnails
+
+Start with:
+
+- `AvatarComponent`
+- `PhotoAvatar`
+- `SitewideDiscussionListItem`
+- `EventListItem`
+
+These are common, public, visually small, and highly likely to be overserved today.
+
+### Slice 2: Forum discussion list and image list cards
+
+- `ChannelDiscussionListItem`
+- `ImageListItem`
+- album index and library thumbnails
+
+### Slice 3: Discussion album thumbnail surfaces
+
+- `DiscussionAlbum`
+- `CarouselThumbnail`
+- `LightgalleryAlbum`
+
+### Slice 4: Detail-page main media
+
+- main discussion album image
+- event detail cover images
+- other above-the-fold detail media
+
+### Slice 5: Markdown image rendering
+
+Markdown should be last because it is the least controlled image source and may
+include arbitrary external URLs.
+
+## Backend Follow-up
+
+When thumbnail generation becomes available, the system should evolve to:
+
+1. generate avatar/list/detail variants at upload time
+2. store intrinsic width and height for originals and variants
+3. expose variants through GraphQL
+4. move list surfaces from best-effort optimization to hard thumbnail requirements
+
+Suggested variant families:
+
+- avatar: `32`, `48`, `64`, `96`
+- list/card: `80`, `160`, `320`
+- detail content: `640`, `960`, `1280`
+
+## Verification
+
+For each slice:
+
+1. verify targeted surfaces no longer render raw originals when optimization is available
+2. confirm `loading`, `decoding`, and `sizes` are present where expected
+3. compare transferred image bytes in DevTools before and after
+4. verify no layout regressions or broken external-image fallbacks
+
+## Progress
+
+### August 8, 2026
+
+Started Phase 1 Slice 1:
+
+- introduce a shared optimized-image wrapper and URL eligibility helper
+- migrate avatar surfaces
+- migrate the sitewide discussion list thumbnail
+- migrate event list cover images

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "vue-chartjs": "^5.3.4",
     "vue-codemirror": "^6.1.1",
     "vue-easy-lightbox": "^1.19.0",
-    "vue-google-maps-community-fork": "^0.3.1",
     "vue-i18n": "^11.4.5",
     "vue-router": "^5.1.0",
     "vue3-popper": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,9 +158,6 @@ importers:
       vue-easy-lightbox:
         specifier: ^1.19.0
         version: 1.19.0(vue@3.5.40(typescript@6.0.3))
-      vue-google-maps-community-fork:
-        specifier: ^0.3.1
-        version: 0.3.1
       vue-i18n:
         specifier: ^11.4.5
         version: 11.4.6(vue@3.5.40(typescript@6.0.3))
@@ -8027,9 +8024,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-
-  vue-google-maps-community-fork@0.3.1:
-    resolution: {integrity: sha512-RcnpQZdv/aXf6Aeuq+hWdtwZaC4HRgXBY+S59QpbozgVIK4MHp23zbAQjpJ/zzG/B0e7BL91UIa8psuwbPBZQA==}
 
   vue-i18n@11.4.6:
     resolution: {integrity: sha512-l0gE7Rfy0phCa5ChKYkOq543Wgd39BCK6hkktfr1Ed4D99oRkgPK9ffShASZdeC8OJxGfdWmpYoAaAH6iLEuIg==}
@@ -16465,10 +16459,6 @@ snapshots:
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
-
-  vue-google-maps-community-fork@0.3.1:
-    dependencies:
-      '@googlemaps/markerclusterer': 2.6.2
 
   vue-i18n@11.4.6(vue@3.5.40(typescript@6.0.3)):
     dependencies:

--- a/utils/imageOptimization.spec.ts
+++ b/utils/imageOptimization.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { canOptimizeImageUrl } from './imageOptimization';
+
+describe('canOptimizeImageUrl', () => {
+  it('optimizes same-origin paths', () => {
+    expect(canOptimizeImageUrl('/images/cat.jpg')).toBe(true);
+  });
+
+  it('optimizes storage.googleapis.com URLs', () => {
+    expect(
+      canOptimizeImageUrl('https://storage.googleapis.com/bucket/cat.jpg')
+    ).toBe(true);
+  });
+
+  it('does not optimize arbitrary external hosts', () => {
+    expect(canOptimizeImageUrl('https://example.com/cat.jpg')).toBe(false);
+  });
+
+  it('does not optimize data URLs', () => {
+    expect(canOptimizeImageUrl('data:image/png;base64,abc')).toBe(false);
+  });
+
+  it('does not optimize empty strings', () => {
+    expect(canOptimizeImageUrl('')).toBe(false);
+  });
+});

--- a/utils/imageOptimization.ts
+++ b/utils/imageOptimization.ts
@@ -1,0 +1,28 @@
+export function canOptimizeImageUrl(url: string): boolean {
+  if (!url) {
+    return false;
+  }
+
+  if (
+    url.startsWith('data:') ||
+    url.startsWith('blob:') ||
+    url.startsWith('javascript:')
+  ) {
+    return false;
+  }
+
+  if (url.startsWith('/')) {
+    return true;
+  }
+
+  if (!/^https?:\/\//.test(url)) {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.hostname === 'storage.googleapis.com';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add an image delivery execution plan in `docs/image-performance-plan.md`
- introduce a shared `AppImage` wrapper and URL eligibility helper for Phase 1 optimization
- migrate the first public surfaces to responsive image delivery: avatars, sitewide discussion thumbnails, and event list cover images

## Validation
- `pnpm exec vitest run components/AvatarComponent.spec.ts components/user/PhotoAvatar.spec.ts components/discussion/list/SitewideDiscussionListItem.spec.ts components/event/list/EventListItem.spec.ts utils/imageOptimization.spec.ts`
- `pnpm exec eslint components/AvatarComponent.vue components/user/PhotoAvatar.vue components/discussion/list/SitewideDiscussionListItem.vue components/event/list/EventListItem.vue components/image/AppImage.vue utils/imageOptimization.ts utils/imageOptimization.spec.ts`