### PR TITLE
perf(cwv): continue frontend image delivery optimization

### DIFF
--- a/components/AvatarComponent.spec.ts
+++ b/components/AvatarComponent.spec.ts
@@ -10,6 +10,24 @@ describe('AvatarComponent', () => {
     expect(wrapper.find('img').attributes('src')).toBe('https://img.test/a.png');
   });
 
+  it('prefers matching avatar variants when a variant source is available', () => {
+    const wrapper = mount(AvatarComponent, {
+      props: {
+        text: 'alice',
+        src: 'https://img.test/original.png',
+        isMedium: true,
+        variantSource: {
+          avatar48Url: 'https://img.test/avatar-48.png',
+          avatar64Url: 'https://img.test/avatar-64.png',
+        },
+      },
+    });
+
+    expect(wrapper.find('img').attributes('src')).toBe(
+      'https://img.test/avatar-48.png'
+    );
+  });
+
   it('generates an identicon data URI when no src is provided', () => {
     const wrapper = mount(AvatarComponent, { props: { text: 'alice' } });
     expect(wrapper.find('img').attributes('src')).toContain(

--- a/components/AvatarComponent.vue
+++ b/components/AvatarComponent.vue
@@ -1,8 +1,10 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
+import type { PropType } from 'vue';
 import Identicon from 'identicon.js';
 import sha256 from 'crypto-js/sha256';
 import AppImage from '@/components/image/AppImage.vue';
+import { getPreferredImageUrl, type ImageVariantKey } from '@/utils/imageVariants';
 
 const props = defineProps({
   text: {
@@ -18,6 +20,11 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  variantSource: {
+    type: Object as PropType<Record<string, unknown> | null>,
+    required: false,
+    default: null,
   },
   isLarge: {
     type: Boolean,
@@ -75,13 +82,34 @@ const avatarDimensions = computed(() => {
 
   return { width: undefined, height: undefined };
 });
+
+const preferredAvatarVariants = computed<ImageVariantKey[]>(() => {
+  if (props.isLarge) {
+    return ['avatar96', 'avatar64', 'avatar48'];
+  }
+  if (props.isMedium) {
+    return ['avatar48', 'avatar64', 'avatar32'];
+  }
+  if (props.isSmall) {
+    return ['avatar32', 'avatar48'];
+  }
+  return ['avatar64', 'avatar48', 'avatar32', 'avatar96'];
+});
+
+const avatarSrc = computed(() =>
+  getPreferredImageUrl({
+    source: props.variantSource,
+    preferred: preferredAvatarVariants.value,
+    originalUrl: props.src,
+  }) || ''
+);
 </script>
 
 <template>
   <div>
     <AppImage
-      v-if="src"
-      :src="src"
+      v-if="avatarSrc"
+      :src="avatarSrc"
       :alt="isDecorative ? '' : text"
       :aria-hidden="isDecorative ? 'true' : undefined"
       :width="avatarDimensions.width"

--- a/components/ExpandableImage.spec.ts
+++ b/components/ExpandableImage.spec.ts
@@ -9,6 +9,12 @@ const mountImage = () =>
       src: 'https://example.test/image.png',
       alt: 'Example image',
       rounded: true,
+      fullWidth: true,
+      width: 640,
+      height: 360,
+      sizes: '100vw',
+      loading: 'eager',
+      fetchpriority: 'high',
     },
     global: {
       stubs: {
@@ -18,23 +24,38 @@ const mountImage = () =>
           emits: ['hide'],
           template: '<div data-testid="lightbox" />',
         },
+        NuxtImg: {
+          props: [
+            'src',
+            'alt',
+            'width',
+            'height',
+            'sizes',
+            'loading',
+            'decoding',
+            'fetchpriority',
+          ],
+          template: '<img v-bind="$props" />',
+        },
       },
     },
   });
 
 describe('ExpandableImage', () => {
-  it('renders the image with alt text and rounded class', () => {
+  it('renders the image with optimization hints and rounded class', () => {
     const wrapper = mountImage();
 
-    expect({
-      src: wrapper.get('img').attributes('src'),
-      alt: wrapper.get('img').attributes('alt'),
-      rounded: wrapper.get('img').classes('rounded-full'),
-    }).toEqual({
+    expect(wrapper.get('img').attributes()).toMatchObject({
       src: 'https://example.test/image.png',
       alt: 'Example image',
-      rounded: true,
+      width: '640',
+      height: '360',
+      loading: 'eager',
+      fetchpriority: 'high',
     });
+    expect(wrapper.get('img').classes()).toEqual(
+      expect.arrayContaining(['rounded-full', 'w-full'])
+    );
   });
 
   it('opens and closes the lightbox for the image', async () => {

--- a/components/ExpandableImage.vue
+++ b/components/ExpandableImage.vue
@@ -1,27 +1,41 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import VueEasyLightbox from 'vue-easy-lightbox';
+import AppImage from '@/components/image/AppImage.vue';
 
-const props = defineProps({
-  src: {
-    type: String,
-    required: true,
-  },
-  alt: {
-    type: String,
-    required: false,
-    default: '',
-  },
-  rounded: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-});
+const props = withDefaults(
+  defineProps<{
+    src: string;
+    alt?: string;
+    rounded?: boolean;
+    fullWidth?: boolean;
+    width?: number | string;
+    height?: number | string;
+    sizes?: string;
+    loading?: 'lazy' | 'eager';
+    decoding?: 'async' | 'sync' | 'auto';
+    fetchpriority?: 'high' | 'low' | 'auto';
+  }>(),
+  {
+    alt: '',
+    rounded: false,
+    fullWidth: false,
+    width: undefined,
+    height: undefined,
+    sizes: '',
+    loading: 'lazy',
+    decoding: 'async',
+    fetchpriority: 'auto',
+  }
+);
 
 const visible = ref(false);
 const index = ref(0);
 const images = ref<string[]>([props.src]);
+const imageClasses = computed(() => ({
+  'w-full': props.fullWidth,
+  'rounded-full': props.rounded,
+}));
 
 const handleImageClick = () => {
   visible.value = true;
@@ -30,13 +44,19 @@ const handleImageClick = () => {
 
 <template>
   <div>
-    <img
+    <AppImage
       :src="src"
       :alt="alt"
       class="cursor-pointer"
-      :class="{ 'rounded-full': rounded }"
+      :class="imageClasses"
+      :width="width"
+      :height="height"
+      :sizes="sizes"
+      :loading="loading"
+      :decoding="decoding"
+      :fetchpriority="fetchpriority"
       @click="handleImageClick"
-    >
+    />
     <vue-easy-lightbox
       v-if="visible"
       :visible="visible"

--- a/components/LinkPreview.spec.ts
+++ b/components/LinkPreview.spec.ts
@@ -49,7 +49,13 @@ describe('LinkPreview', () => {
     const wrapper = mountPreview();
     await flushPromises();
 
-    expect(wrapper.find('img').attributes('src')).toBe('https://x/og.png');
+    expect(wrapper.find('img').attributes()).toMatchObject({
+      src: 'https://x/og.png',
+      width: '80',
+      height: '80',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('links to the target url', () => {

--- a/components/LinkPreview.vue
+++ b/components/LinkPreview.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { ref, onMounted, computed } from 'vue';
 import { config } from '@/config';
+import AppImage from '@/components/image/AppImage.vue';
 
 const props = defineProps<{
   url: string;
@@ -54,13 +55,17 @@ onMounted(() => {
 <template>
   <div class="my-1 overflow-hidden rounded border shadow-lg">
     <a :href="url" target="_blank" rel="noopener">
-      <img
+      <AppImage
         v-if="imageUrl && showImage"
-        class="m-4 w-20 object-cover"
+        class="m-4 h-20 w-20 object-cover"
         :src="imageUrl"
         :alt="imageAlt"
+        :width="80"
+        :height="80"
+        loading="lazy"
+        decoding="async"
         @error="showImage = false"
-      >
+      />
     </a>
     <div class="px-6 py-4">
       <a :href="url" target="_blank" rel="noopener"

--- a/components/MultiSelect.spec.ts
+++ b/components/MultiSelect.spec.ts
@@ -123,6 +123,26 @@ describe('MultiSelect', () => {
     expect(wrapper.emitted('update:modelValue')).toBeUndefined();
   });
 
+  it('renders avatar images in the selected display and options list', async () => {
+    const wrapper = mountSelect({
+      multiple: false,
+      showChips: false,
+      modelValue: ['a'],
+      options: [
+        { value: 'a', label: 'Apple', avatar: 'https://img.test/a.png' },
+        { value: 'b', label: 'Banana', avatar: 'https://img.test/b.png' },
+      ],
+    });
+
+    await wrapper.get('[data-testid="ms"]').trigger('click');
+
+    expect(wrapper.findAll('img').map((img) => img.attributes('src'))).toEqual([
+      'https://img.test/a.png',
+      'https://img.test/a.png',
+      'https://img.test/b.png',
+    ]);
+  });
+
   const clickRow = async (
     wrapper: ReturnType<typeof mountSelect>,
     label: string

--- a/components/MultiSelect.vue
+++ b/components/MultiSelect.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, useId } from 'vue';
 import type { PropType } from 'vue';
+import AppImage from '@/components/image/AppImage.vue';
 import CheckIcon from '@/components/icons/CheckIcon.vue';
 import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue';
 import XmarkIcon from '@/components/icons/XmarkIcon.vue';
@@ -468,11 +469,16 @@ const describedBy = computed(() => {
           class="flex flex-1 items-start"
         >
           <!-- Show avatar/icon only for single selection -->
-          <img
+          <AppImage
             v-if="selectedOptions.length === 1 && selectedOptions[0]?.avatar"
             :src="selectedOptions[0]?.avatar"
             :alt="selectedOptions[0]?.label"
             class="mr-2 h-6 w-6 shrink-0 rounded-full"
+            :width="24"
+            :height="24"
+            sizes="24px"
+            loading="lazy"
+            decoding="async"
           />
           <i
             v-else-if="selectedOptions.length === 1 && selectedOptions[0]?.icon"
@@ -894,11 +900,16 @@ const describedBy = computed(() => {
                 </span>
               </div>
 
-              <img
+              <AppImage
                 v-if="option.avatar"
                 :src="option.avatar"
                 alt=""
                 class="mr-3 h-6 w-6 rounded-full"
+                :width="24"
+                :height="24"
+                sizes="24px"
+                loading="lazy"
+                decoding="async"
               />
 
               <i

--- a/components/TextEditor.mount.spec.ts
+++ b/components/TextEditor.mount.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
 import { mount, flushPromises } from '@vue/test-utils';
-
 import TextEditor from '@/components/TextEditor.vue';
 
 // Vuetify's useDisplay needs the Vuetify plugin context, which we don't install
@@ -93,6 +92,25 @@ vi.mock('@/components/text-editor/EmojiPickerWrapper.vue', () => ({
     name: 'EmojiPickerWrapper',
     emits: ['emoji-click', 'close'],
     template: '<div class="emoji-picker" />',
+  },
+}));
+
+// TextEditor lazy-loads these modules via defineAsyncComponent. Mocking the
+// modules themselves prevents Vitest from importing the real implementations
+// after a test has already finished, which can otherwise trip teardown-time
+// runtime-config imports in CI.
+vi.mock('@/components/text-editor/TextEditorFullScreen.vue', () => ({
+  default: {
+    name: 'TextEditorFullScreen',
+    template: '<div class="text-editor-full-screen" />',
+  },
+}));
+
+vi.mock('@/components/MarkdownRenderer.vue', () => ({
+  default: {
+    name: 'MarkdownRenderer',
+    props: ['text'],
+    template: '<div class="markdown-renderer-stub">{{ text }}</div>',
   },
 }));
 

--- a/components/UsernameWithTooltip.spec.ts
+++ b/components/UsernameWithTooltip.spec.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
 
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
+
+const AvatarComponentStub = defineComponent({
+  name: 'AvatarComponent',
+  props: {
+    text: { type: String, default: '' },
+    src: { type: String, default: '' },
+    variantSource: { type: Object, default: null },
+    isMedium: { type: Boolean, default: false },
+  },
+  template: '<div />',
+});
 
 const mountUsername = (props: Record<string, unknown> = {}) =>
   mount(UsernameWithTooltip, {
@@ -13,7 +25,7 @@ const mountUsername = (props: Record<string, unknown> = {}) =>
           name: 'Tooltip',
           template: '<div><slot name="activator" :props="{}" /><slot /></div>',
         },
-        AvatarComponent: true,
+        AvatarComponent: AvatarComponentStub,
         NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
         'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
       },
@@ -96,5 +108,16 @@ describe('UsernameWithTooltip tooltip content', () => {
     const wrapper = mountUsername({ disableTooltip: true, commentKarma: 5 });
 
     expect(wrapper.text()).not.toContain('comment karma');
+  });
+
+  it('forwards the variant source to the avatar inside the tooltip', () => {
+    const variantSource = { avatar48Url: 'https://img.test/avatar-48.png' };
+    const wrapper = mountUsername({
+      src: 'https://img.test/original.png',
+      variantSource,
+    });
+
+    const avatar = wrapper.getComponent(AvatarComponentStub);
+    expect(avatar.props('variantSource')).toEqual(variantSource);
   });
 });

--- a/components/UsernameWithTooltip.vue
+++ b/components/UsernameWithTooltip.vue
@@ -6,6 +6,7 @@ interface Props {
   username: string;
   displayName?: string;
   src?: string;
+  variantSource?: Record<string, unknown> | null;
   accountCreated?: string;
   commentKarma?: number;
   discussionKarma?: number;
@@ -21,6 +22,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   displayName: '',
   src: '',
+  variantSource: null,
   accountCreated: '',
   commentKarma: 0,
   discussionKarma: 0,
@@ -127,12 +129,22 @@ const modBadgeClasses = computed(() => {
       <template #default>
         <div>
           <div v-if="!displayName" class="text-md flex w-full flex-col">
-            <AvatarComponent :text="username" :src="src" :is-medium="true" />{{
+            <AvatarComponent
+              :text="username"
+              :src="src"
+              :variant-source="variantSource"
+              :is-medium="true"
+            />{{
               username
             }}
           </div>
           <div v-if="displayName" class="text-md flex w-full flex-col">
-            <AvatarComponent :text="username" :src="src" :is-medium="true" />
+            <AvatarComponent
+              :text="username"
+              :src="src"
+              :variant-source="variantSource"
+              :is-medium="true"
+            />
             <p class="text-xs font-bold">
               {{ displayName }}
             </p>

--- a/components/album/AlbumThumbnailGrid.spec.ts
+++ b/components/album/AlbumThumbnailGrid.spec.ts
@@ -23,9 +23,15 @@ describe('AlbumThumbnailGrid', () => {
   });
 
   it('renders a tile per image', () => {
-    expect(
-      mountGrid({ images: [img('a'), img('b')] }).findAll('img')
-    ).toHaveLength(2);
+    const images = mountGrid({ images: [img('a'), img('b')] }).findAll('img');
+
+    expect(images[0]?.attributes()).toMatchObject({
+      src: 'a.png',
+      width: '320',
+      height: '320',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('caps the number of tiles at maxImages', () => {

--- a/components/album/AlbumThumbnailGrid.vue
+++ b/components/album/AlbumThumbnailGrid.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { PropType } from 'vue';
+import AppImage from '@/components/image/AppImage.vue';
 
 type AlbumImage = {
   id: string;
@@ -39,10 +40,15 @@ defineProps({
       :to="`/u/${image.Uploader?.username}/images/${image.id}`"
       class="group relative aspect-square overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800"
     >
-      <img
+      <AppImage
         :src="image.url || ''"
         :alt="image.alt || image.caption || 'Album image'"
         class="h-full w-full object-cover"
+        :width="320"
+        :height="320"
+        sizes="(min-width: 1024px) 25vw, (min-width: 640px) 33vw, 50vw"
+        loading="lazy"
+        decoding="async"
       />
       <div
         v-if="showCaptions && image.caption"

--- a/components/album/AlbumThumbnailGrid.vue
+++ b/components/album/AlbumThumbnailGrid.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { PropType } from 'vue';
 import AppImage from '@/components/image/AppImage.vue';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 
 type AlbumImage = {
   id: string;
@@ -30,6 +31,13 @@ defineProps({
     default: 'grid-cols-2 sm:grid-cols-3 md:grid-cols-4',
   },
 });
+
+const getImageUrl = (image: AlbumImage) =>
+  getPreferredImageUrl({
+    source: image,
+    preferred: ['list320', 'list160'],
+    originalUrl: image.url,
+  }) || '';
 </script>
 
 <template>
@@ -41,7 +49,7 @@ defineProps({
       class="group relative aspect-square overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800"
     >
       <AppImage
-        :src="image.url || ''"
+        :src="getImageUrl(image)"
         :alt="image.alt || image.caption || 'Album image'"
         class="h-full w-full object-cover"
         :width="320"

--- a/components/channel/ChannelSidebar.vue
+++ b/components/channel/ChannelSidebar.vue
@@ -133,6 +133,11 @@ const handleBecomeAdminSuccess = () => {
           :full-width="true"
           :alt="channelId"
           :src="channel?.channelIconURL ?? ''"
+          :width="80"
+          :height="80"
+          sizes="80px"
+          loading="eager"
+          fetchpriority="high"
         />
         <AvatarComponent
           v-if="!channel?.channelIconURL"

--- a/components/collection/CollectionDownloadListItem.spec.ts
+++ b/components/collection/CollectionDownloadListItem.spec.ts
@@ -92,6 +92,26 @@ describe('CollectionDownloadListItem preview image', () => {
     });
   });
 
+  it('prefers a generated list variant when present', () => {
+    const wrapper = mountItem({
+      discussion: discussion({
+        Album: {
+          Images: [
+            {
+              id: 'i1',
+              url: 'https://x/original.png',
+              variantUrls: { list320: 'https://x/list-320.webp' },
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(wrapper.find('img').attributes('src')).toBe(
+      'https://x/list-320.webp'
+    );
+  });
+
   it('shows a no-preview placeholder without images', () => {
     const wrapper = mountItem({ discussion: discussion({ Album: { Images: [] } }) });
 

--- a/components/collection/CollectionDownloadListItem.spec.ts
+++ b/components/collection/CollectionDownloadListItem.spec.ts
@@ -61,7 +61,13 @@ describe('CollectionDownloadListItem preview image', () => {
   it('shows the first album image', () => {
     const wrapper = mountItem();
 
-    expect(wrapper.find('img').attributes('src')).toBe('https://x/a.png');
+    expect(wrapper.find('img').attributes()).toMatchObject({
+      src: 'https://x/a.png',
+      width: '192',
+      height: '192',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('respects the album image order', () => {
@@ -77,7 +83,13 @@ describe('CollectionDownloadListItem preview image', () => {
       }),
     });
 
-    expect(wrapper.find('img').attributes('src')).toBe('https://x/b.png');
+    expect(wrapper.find('img').attributes()).toMatchObject({
+      src: 'https://x/b.png',
+      width: '192',
+      height: '192',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('shows a no-preview placeholder without images', () => {

--- a/components/collection/CollectionDownloadListItem.vue
+++ b/components/collection/CollectionDownloadListItem.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import type { PropType } from 'vue';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 import AppImage from '@/components/image/AppImage.vue';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 import { relativeTime } from '@/utils';
 
 const props = defineProps({
@@ -37,10 +38,18 @@ const firstImage = computed(() => {
     const ordered = album.Images.find(
       (img) => img.id === album.imageOrder?.[0]
     );
-    if (ordered?.url) return ordered.url;
+    if (ordered) return ordered;
   }
-  return album.Images[0]?.url || null;
+  return album.Images[0] || null;
 });
+
+const firstImageUrl = computed(() =>
+  getPreferredImageUrl({
+    source: firstImage.value,
+    preferred: ['list320', 'list160'],
+    originalUrl: firstImage.value?.url,
+  }) || ''
+);
 
 const createdAgo = computed(() => {
   return props.discussion?.createdAt
@@ -58,8 +67,8 @@ const createdAgo = computed(() => {
         class="aspect-square w-full overflow-hidden bg-gray-100 dark:bg-gray-700"
       >
         <AppImage
-          v-if="firstImage"
-          :src="firstImage"
+          v-if="firstImageUrl"
+          :src="firstImageUrl"
           :alt="discussion?.title || 'Download preview'"
           class="h-full w-full object-cover"
           :width="192"

--- a/components/collection/CollectionDownloadListItem.vue
+++ b/components/collection/CollectionDownloadListItem.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import type { PropType } from 'vue';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
+import AppImage from '@/components/image/AppImage.vue';
 import { relativeTime } from '@/utils';
 
 const props = defineProps({
@@ -56,11 +57,16 @@ const createdAgo = computed(() => {
       <div
         class="aspect-square w-full overflow-hidden bg-gray-100 dark:bg-gray-700"
       >
-        <img
+        <AppImage
           v-if="firstImage"
           :src="firstImage"
           :alt="discussion?.title || 'Download preview'"
           class="h-full w-full object-cover"
+          :width="192"
+          :height="192"
+          sizes="192px"
+          loading="lazy"
+          decoding="async"
         />
         <div
           v-else

--- a/components/comments/CommentHeader.vue
+++ b/components/comments/CommentHeader.vue
@@ -229,6 +229,7 @@ const isSticky = computed(
       :is-small="true"
       :text="commentAuthorUsername"
       :src="commentAuthorProfilePic || ''"
+      :variant-source="commentData.CommentAuthor || null"
     />
     <AvatarComponent
       v-else-if="commentData.CommentAuthor?.displayName"

--- a/components/discussion/detail/CarouselThumbnail.spec.ts
+++ b/components/discussion/detail/CarouselThumbnail.spec.ts
@@ -17,8 +17,13 @@ const mountThumb = (props: Record<string, unknown>) =>
 describe('CarouselThumbnail', () => {
   it('renders a plain image for a regular url', () => {
     expect(
-      mountThumb({ image: { url: 'a.png' } }).find('img').exists()
-    ).toBe(true);
+      mountThumb({ image: { url: 'a.png' } }).find('img').attributes()
+    ).toMatchObject({
+      width: '80',
+      height: '80',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('renders the model viewer for a glb url', () => {

--- a/components/discussion/detail/CarouselThumbnail.vue
+++ b/components/discussion/detail/CarouselThumbnail.vue
@@ -4,6 +4,7 @@ import ModelViewer from '@/components/ModelViewer.vue';
 import StlViewer from '@/components/download/StlViewer.vue';
 import AppImage from '@/components/image/AppImage.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 
 const props = defineProps({
   image: {
@@ -36,6 +37,13 @@ const sizeStyle = computed(() => ({
   width: `${thumbnailWidth.value}px`,
   height: `${thumbnailHeight.value}px`,
 }));
+const imageUrl = computed(() =>
+  getPreferredImageUrl({
+    source: props.image,
+    preferred: ['list160', 'list80'],
+    originalUrl: props.image?.url,
+  }) || ''
+);
 </script>
 
 <template>
@@ -69,7 +77,7 @@ const sizeStyle = computed(() => ({
     </ClientOnly>
     <AppImage
       v-else-if="image"
-      :src="image.url || ''"
+      :src="imageUrl"
       :alt="image.alt || ''"
       class="h-full w-full rounded object-cover shadow-sm"
       :width="thumbnailWidth"

--- a/components/discussion/detail/CarouselThumbnail.vue
+++ b/components/discussion/detail/CarouselThumbnail.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import ModelViewer from '@/components/ModelViewer.vue';
 import StlViewer from '@/components/download/StlViewer.vue';
+import AppImage from '@/components/image/AppImage.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
 
 const props = defineProps({
@@ -66,12 +67,16 @@ const sizeStyle = computed(() => ({
         :style="sizeStyle"
       />
     </ClientOnly>
-    <img
+    <AppImage
       v-else-if="image"
       :src="image.url || ''"
       :alt="image.alt || ''"
       class="h-full w-full rounded object-cover shadow-sm"
-      :style="sizeStyle"
+      :width="thumbnailWidth"
+      :height="thumbnailHeight"
+      :sizes="`${thumbnailWidth}px`"
+      loading="lazy"
+      decoding="async"
     />
   </div>
 </template>

--- a/components/discussion/detail/DiscussionAlbum.spec.ts
+++ b/components/discussion/detail/DiscussionAlbum.spec.ts
@@ -79,12 +79,20 @@ describe('DiscussionAlbum', () => {
 
   it('falls back to the Images array (in order) when imageOrder is empty', () => {
     const wrapper = mountAlbum({ album: makeAlbum(['a', 'b'], []) });
-    const srcs = cells(wrapper).map((cell) =>
-      cell.find('img').attributes('src')
-    );
-    expect(srcs).toEqual([
-      'https://example.com/a.jpg',
-      'https://example.com/b.jpg',
+    const attrs = cells(wrapper).map((cell) => cell.find('img').attributes());
+    expect(attrs).toEqual([
+      expect.objectContaining({
+        src: 'https://example.com/a.jpg',
+        width: '200',
+        height: '200',
+        loading: 'lazy',
+      }),
+      expect.objectContaining({
+        src: 'https://example.com/b.jpg',
+        width: '200',
+        height: '200',
+        loading: 'lazy',
+      }),
     ]);
   });
 
@@ -300,5 +308,19 @@ describe('DiscussionAlbum — carousel navigation', () => {
     });
 
     expect(carousel(wrapper).attributes('style')).toContain('500px');
+  });
+
+  it('eager loads the expanded active image with stable dimensions', () => {
+    const wrapper = mountAlbum({
+      carouselFormat: true,
+      expandedView: true,
+    });
+
+    expect(carousel(wrapper).find('img').attributes()).toMatchObject({
+      width: '600',
+      height: '400',
+      loading: 'eager',
+      fetchpriority: 'high',
+    });
   });
 });

--- a/components/discussion/detail/DiscussionAlbum.vue
+++ b/components/discussion/detail/DiscussionAlbum.vue
@@ -15,6 +15,7 @@ import { useUsername } from '@/composables/useAuthState';
 import ModelViewer from '@/components/ModelViewer.vue';
 import StlViewer from '@/components/download/StlViewer.vue';
 import CarouselThumbnail from '@/components/discussion/detail/CarouselThumbnail.vue';
+import AppImage from '@/components/image/AppImage.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
 
 const ImageLightbox = defineAsyncComponent(
@@ -136,6 +137,13 @@ const orderedImages = computed(() => {
 const activeImage = computed(() => {
   return orderedImages.value[activeIndex.value] || null;
 });
+
+const mainImageWidth = computed(() => (props.expandedView ? 600 : 384));
+const mainImageSizes = computed(() =>
+  props.expandedView
+    ? '(min-width: 1024px) 600px, 100vw'
+    : '(min-width: 1024px) 384px, (min-width: 768px) 60vw, 100vw'
+);
 
 // Caption editing for thumbnail grid
 const editingCaptionIndex = ref(-1);
@@ -310,11 +318,16 @@ onMounted(() => {
               class="shadow-sm"
             />
           </ClientOnly>
-          <img
+          <AppImage
             v-else-if="image"
             :src="image.url || ''"
             :alt="image.alt || ''"
             class="shadow-sm"
+            :width="200"
+            :height="200"
+            sizes="(min-width: 1024px) 33vw, 50vw"
+            loading="lazy"
+            decoding="async"
           />
           <div
             v-if="editingCaptionIndex === idx"
@@ -526,11 +539,17 @@ onMounted(() => {
                     }"
                   />
                 </ClientOnly>
-                <img
+                <AppImage
                   v-else
                   :src="activeImage.url || ''"
                   :alt="activeImage.alt || ''"
                   class="shadow-sm"
+                  :width="mainImageWidth"
+                  :height="mainImageHeight"
+                  :sizes="mainImageSizes"
+                  :loading="expandedView ? 'eager' : 'lazy'"
+                  decoding="async"
+                  :fetchpriority="expandedView ? 'high' : 'auto'"
                   :class="{
                     'max-h-96 max-w-96 object-contain': !expandedView,
                     'h-full w-full object-cover': expandedView,

--- a/components/discussion/detail/DiscussionAlbum.vue
+++ b/components/discussion/detail/DiscussionAlbum.vue
@@ -17,6 +17,7 @@ import StlViewer from '@/components/download/StlViewer.vue';
 import CarouselThumbnail from '@/components/discussion/detail/CarouselThumbnail.vue';
 import AppImage from '@/components/image/AppImage.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 
 const ImageLightbox = defineAsyncComponent(
   () => import('@/components/discussion/detail/ImageLightbox.vue')
@@ -143,6 +144,21 @@ const mainImageSizes = computed(() =>
   props.expandedView
     ? '(min-width: 1024px) 600px, 100vw'
     : '(min-width: 1024px) 384px, (min-width: 768px) 60vw, 100vw'
+);
+const getGridImageUrl = (image: { url?: string | null } & Record<string, unknown>) =>
+  getPreferredImageUrl({
+    source: image,
+    preferred: ['list320', 'list160'],
+    originalUrl: image.url,
+  }) || '';
+const activeImageUrl = computed(() =>
+  activeImage.value
+    ? getPreferredImageUrl({
+        source: activeImage.value,
+        preferred: ['detail960', 'detail640', 'detail1280'],
+        originalUrl: activeImage.value.url,
+      }) || ''
+    : ''
 );
 
 // Caption editing for thumbnail grid
@@ -320,7 +336,7 @@ onMounted(() => {
           </ClientOnly>
           <AppImage
             v-else-if="image"
-            :src="image.url || ''"
+            :src="getGridImageUrl(image)"
             :alt="image.alt || ''"
             class="shadow-sm"
             :width="200"
@@ -541,7 +557,7 @@ onMounted(() => {
                 </ClientOnly>
                 <AppImage
                   v-else
-                  :src="activeImage.url || ''"
+                  :src="activeImageUrl"
                   :alt="activeImage.alt || ''"
                   class="shadow-sm"
                   :width="mainImageWidth"

--- a/components/discussion/detail/DiscussionHeader.vue
+++ b/components/discussion/detail/DiscussionHeader.vue
@@ -382,6 +382,7 @@ const warningModalBody = computed(() => {
           <AvatarComponent
             :text="discussion?.Author?.username ?? '[Deleted]'"
             :src="discussion?.Author?.profilePicURL ?? ''"
+            :variant-source="discussion?.Author || null"
             :is-small="true"
           />
         </div>

--- a/components/discussion/detail/LightboxImagePanel.spec.ts
+++ b/components/discussion/detail/LightboxImagePanel.spec.ts
@@ -23,6 +23,19 @@ const mountPanel = (props: Record<string, unknown> = {}) =>
         ModelViewer: { name: 'ModelViewer', props: ['modelUrl'], template: '<div class="model" />' },
         StlViewer: { name: 'StlViewer', props: ['src'], template: '<div class="stl" />' },
         ClientOnly: { template: '<div><slot /></div>' },
+        NuxtImg: {
+          props: [
+            'src',
+            'alt',
+            'width',
+            'height',
+            'sizes',
+            'loading',
+            'decoding',
+            'fetchpriority',
+          ],
+          template: '<img v-bind="$props" />',
+        },
         LeftArrowIcon: true,
         RightArrowIcon: true,
       },
@@ -36,7 +49,12 @@ describe('LightboxImagePanel viewer selection', () => {
   it('renders an img for a regular image', () => {
     const wrapper = mountPanel();
 
-    expect(wrapper.find('img').attributes('src')).toBe('https://x/pic.png');
+    expect(wrapper.find('img').attributes()).toMatchObject({
+      src: 'https://x/pic.png',
+      loading: 'eager',
+      fetchpriority: 'high',
+      decoding: 'async',
+    });
   });
 
   it('renders a ModelViewer for a glb file', () => {

--- a/components/discussion/detail/LightboxImagePanel.vue
+++ b/components/discussion/detail/LightboxImagePanel.vue
@@ -4,6 +4,7 @@ import LeftArrowIcon from '@/components/icons/LeftArrowIcon.vue';
 import RightArrowIcon from '@/components/icons/RightArrowIcon.vue';
 import ModelViewer from '@/components/ModelViewer.vue';
 import StlViewer from '@/components/download/StlViewer.vue';
+import AppImage from '@/components/image/AppImage.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
 // Simplified image type for lightbox display
 interface LightboxImage {
@@ -135,11 +136,15 @@ const handleClick = (event: MouseEvent) => {
         />
       </ClientOnly>
     </div>
-    <img
+    <AppImage
       v-else
       :src="currentImage.url || ''"
       :alt="currentImage.alt || ''"
       class="h-full w-full object-contain transition-all duration-300 ease-in-out"
+      sizes="100vw"
+      loading="eager"
+      decoding="async"
+      fetchpriority="high"
       :style="{
         transform: `scale(${zoomLevel}) translate(${translateX}px, ${translateY}px)`,
         cursor: isZoomed ? (isDragging ? 'grabbing' : 'grab') : 'auto',

--- a/components/discussion/detail/LightgalleryAlbum.spec.ts
+++ b/components/discussion/detail/LightgalleryAlbum.spec.ts
@@ -43,6 +43,17 @@ describe('LightgalleryAlbum grid format', () => {
     expect(wrapper.findAll('img')).toHaveLength(6);
   });
 
+  it('applies fixed dimensions and lazy decoding to grid images', () => {
+    const wrapper = mountAlbum({ carouselFormat: false });
+
+    expect(wrapper.find('img').attributes()).toMatchObject({
+      width: '200',
+      height: '200',
+      loading: 'lazy',
+      decoding: 'async',
+    });
+  });
+
   it('opens the selected image in the lightbox', async () => {
     const wrapper = mountAlbum({ carouselFormat: false });
 
@@ -90,6 +101,17 @@ describe('LightgalleryAlbum carousel thumbnails', () => {
     await thumbnails(wrapper)[2].trigger('click');
 
     expect(thumbnails(wrapper)[2].classes()).toContain('border-orange-500');
+  });
+
+  it('eager loads the active carousel image', () => {
+    const wrapper = mountAlbum({ carouselFormat: true });
+
+    expect(wrapper.find('img.max-h-96').attributes()).toMatchObject({
+      width: '384',
+      height: '384',
+      loading: 'eager',
+      fetchpriority: 'high',
+    });
   });
 });
 

--- a/components/discussion/detail/LightgalleryAlbum.vue
+++ b/components/discussion/detail/LightgalleryAlbum.vue
@@ -3,6 +3,7 @@ import type { PropType } from 'vue';
 import { ref, computed } from 'vue';
 import VueEasyLightbox from 'vue-easy-lightbox';
 import type { Album } from '@/__generated__/graphql';
+import AppImage from '@/components/image/AppImage.vue';
 import LeftArrowIcon from '@/components/icons/LeftArrowIcon.vue';
 import RightArrowIcon from '@/components/icons/RightArrowIcon.vue';
 
@@ -59,6 +60,12 @@ const canScrollLeft = computed(() => thumbnailStartIndex.value > 0);
 const canScrollRight = computed(
   () => thumbnailStartIndex.value < props.album.Images.length - 4
 );
+
+const carouselMainImageSizes = computed(() =>
+  props.carouselFormat
+    ? '(min-width: 1024px) 384px, (min-width: 768px) 60vw, 100vw'
+    : '(min-width: 1024px) 33vw, 50vw'
+);
 </script>
 
 <template>
@@ -72,11 +79,16 @@ const canScrollRight = computed(
         :aria-label="`View ${image.alt || `image ${index + 1}`} in gallery`"
         @click="openLightbox(index)"
       >
-        <img
+        <AppImage
           :src="image.url || ''"
           :alt="image.alt || ''"
           class="shadow-sm"
-        >
+          :width="200"
+          :height="200"
+          sizes="(min-width: 1024px) 33vw, 50vw"
+          loading="lazy"
+          decoding="async"
+        />
         <span class="text-center">
           {{ image.alt }}
         </span>
@@ -93,11 +105,17 @@ const canScrollRight = computed(
         :aria-label="`View ${activeImage.alt || `image ${activeIndex + 1}`} in gallery`"
         @click="openLightbox(activeIndex)"
       >
-        <img
+        <AppImage
           :src="activeImage.url || ''"
           :alt="activeImage.alt || ''"
           class="max-h-96 max-w-96 object-contain shadow-sm"
-        >
+          :width="384"
+          :height="384"
+          :sizes="carouselMainImageSizes"
+          loading="eager"
+          decoding="async"
+          fetchpriority="high"
+        />
       </button>
 
       <!-- Thumbnails with navigation -->
@@ -129,11 +147,16 @@ const canScrollRight = computed(
             :aria-label="`Show ${image.alt || `image ${thumbnailStartIndex + index + 1}`}`"
             @click="() => setActiveImage(thumbnailStartIndex + index)"
           >
-            <img
+            <AppImage
               :src="image.url || ''"
               :alt="`Thumbnail ${thumbnailStartIndex + index + 1}`"
               class="h-full w-full object-cover transition-opacity hover:opacity-80"
-            >
+              :width="80"
+              :height="80"
+              sizes="80px"
+              loading="lazy"
+              decoding="async"
+            />
           </button>
         </div>
 

--- a/components/discussion/detail/LightgalleryAlbum.vue
+++ b/components/discussion/detail/LightgalleryAlbum.vue
@@ -6,6 +6,7 @@ import type { Album } from '@/__generated__/graphql';
 import AppImage from '@/components/image/AppImage.vue';
 import LeftArrowIcon from '@/components/icons/LeftArrowIcon.vue';
 import RightArrowIcon from '@/components/icons/RightArrowIcon.vue';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 
 const props = defineProps({
   album: {
@@ -66,6 +67,27 @@ const carouselMainImageSizes = computed(() =>
     ? '(min-width: 1024px) 384px, (min-width: 768px) 60vw, 100vw'
     : '(min-width: 1024px) 33vw, 50vw'
 );
+const getGridImageUrl = (image: Album['Images'][number]) =>
+  getPreferredImageUrl({
+    source: image,
+    preferred: ['list320', 'list160'],
+    originalUrl: image.url,
+  }) || '';
+const activeImageUrl = computed(() =>
+  activeImage.value
+    ? getPreferredImageUrl({
+        source: activeImage.value,
+        preferred: ['detail640', 'detail960', 'detail1280'],
+        originalUrl: activeImage.value.url,
+      }) || ''
+    : ''
+);
+const getThumbnailImageUrl = (image: Album['Images'][number]) =>
+  getPreferredImageUrl({
+    source: image,
+    preferred: ['list80', 'list160'],
+    originalUrl: image.url,
+  }) || '';
 </script>
 
 <template>
@@ -80,7 +102,7 @@ const carouselMainImageSizes = computed(() =>
         @click="openLightbox(index)"
       >
         <AppImage
-          :src="image.url || ''"
+          :src="getGridImageUrl(image)"
           :alt="image.alt || ''"
           class="shadow-sm"
           :width="200"
@@ -106,7 +128,7 @@ const carouselMainImageSizes = computed(() =>
         @click="openLightbox(activeIndex)"
       >
         <AppImage
-          :src="activeImage.url || ''"
+          :src="activeImageUrl"
           :alt="activeImage.alt || ''"
           class="max-h-96 max-w-96 object-contain shadow-sm"
           :width="384"
@@ -148,7 +170,7 @@ const carouselMainImageSizes = computed(() =>
             @click="() => setActiveImage(thumbnailStartIndex + index)"
           >
             <AppImage
-              :src="image.url || ''"
+              :src="getThumbnailImageUrl(image)"
               :alt="`Thumbnail ${thumbnailStartIndex + index + 1}`"
               class="h-full w-full object-cover transition-opacity hover:opacity-80"
               :width="80"

--- a/components/discussion/form/AlbumImageItem.vue
+++ b/components/discussion/form/AlbumImageItem.vue
@@ -121,6 +121,10 @@ const getUploaderLabel = (image: ImageData) => {
           class="w-72 object-cover"
           :src="image.url"
           :alt="image.alt"
+          :full-width="true"
+          :width="288"
+          :height="288"
+          sizes="288px"
         />
       </div>
 

--- a/components/discussion/form/AlbumReusableImageGrid.spec.ts
+++ b/components/discussion/form/AlbumReusableImageGrid.spec.ts
@@ -34,7 +34,13 @@ const addButtons = (wrapper: ReturnType<typeof mountGrid>) =>
 describe('AlbumReusableImageGrid', () => {
   it('renders one card per image', () => {
     const wrapper = mountGrid({ images: [image('a'), image('b')] });
-    expect(wrapper.findAll('article')).toHaveLength(2);
+    expect(wrapper.findAll('img')[0]?.attributes()).toMatchObject({
+      src: 'https://img.test/a.jpg',
+      width: '320',
+      height: '128',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('shows the loading spinner while loading with no images yet', () => {

--- a/components/discussion/form/AlbumReusableImageGrid.vue
+++ b/components/discussion/form/AlbumReusableImageGrid.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import ErrorBanner from '@/components/ErrorBanner.vue';
+import AppImage from '@/components/image/AppImage.vue';
 import type { ReusableImage } from './reusableImageTypes';
 
 const props = defineProps<{
@@ -63,12 +64,16 @@ const getUploaderLabel = (image: ReusableImage) => {
         :key="image.id"
         class="overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800"
       >
-        <img
+        <AppImage
           :src="image.url"
           :alt="getImageAlt(image)"
           class="h-32 w-full object-cover"
+          :width="320"
+          :height="128"
+          sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
           loading="lazy"
-        >
+          decoding="async"
+        />
         <div class="space-y-2 p-3">
           <p class="line-clamp-2 text-sm font-medium text-gray-900 dark:text-white">
             {{ image.caption || image.alt || image.id }}

--- a/components/discussion/list/ChannelDiscussionListItem.spec.ts
+++ b/components/discussion/list/ChannelDiscussionListItem.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { defineComponent } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import {
   asMock,
@@ -37,6 +38,15 @@ vi.mock('@/composables/useAuthState', () =>
   createAuthStateMock({ username: 'alice' })
 );
 
+const UsernameWithTooltipStub = defineComponent({
+  name: 'UsernameWithTooltip',
+  props: {
+    username: { type: String, default: '' },
+    variantSource: { type: Object, default: null },
+  },
+  template: '<div><slot /></div>',
+});
+
 const mountItem = (
   title: string,
   flairs: Array<Record<string, unknown>> = []
@@ -60,7 +70,7 @@ const mountItem = (
       stubs: {
         AddToDiscussionFavorites: true,
         MarkdownPreview: true,
-        UsernameWithTooltip: true,
+        UsernameWithTooltip: UsernameWithTooltipStub,
         TagComponent: true,
         ErrorBanner: true,
         CheckCircleIcon: true,
@@ -93,6 +103,18 @@ describe('ChannelDiscussionListItem', () => {
     ]);
     expect(wrapper.get('[data-testid="discussion-flair"]').text()).toBe(
       'Question'
+    );
+  });
+
+  it('passes the full author as the avatar variant source', () => {
+    const wrapper = mountItem('Variant author');
+
+    expect(
+      wrapper.getComponent(UsernameWithTooltipStub).props('variantSource')
+    ).toEqual(
+      expect.objectContaining({
+        username: 'alice',
+      })
     );
   });
 });

--- a/components/discussion/list/ChannelDiscussionListItem.vue
+++ b/components/discussion/list/ChannelDiscussionListItem.vue
@@ -339,6 +339,7 @@ const revealSensitiveContent = () => {
                     :is-forum-mod="authorBadges.isForumMod"
                     :username="authorUsername"
                     :src="authorProfilePicURL ?? ''"
+                    :variant-source="discussion?.Author || null"
                     :display-name="authorDisplayName ?? ''"
                     :comment-karma="authorCommentKarma"
                     :discussion-karma="authorDiscussionKarma"

--- a/components/discussion/list/ChannelDownloadListItem.spec.ts
+++ b/components/discussion/list/ChannelDownloadListItem.spec.ts
@@ -103,7 +103,13 @@ describe('ChannelDownloadListItem album image', () => {
       })
     );
 
-    expect(wrapper.get('img').attributes('src')).toBe('u2');
+    expect(wrapper.get('img').attributes()).toMatchObject({
+      src: 'u2',
+      width: '320',
+      height: '320',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('falls back to the first image when there is no order', () => {
@@ -111,7 +117,13 @@ describe('ChannelDownloadListItem album image', () => {
       makeDiscussion({ Album: { Images: [{ id: 'img1', url: 'u1' }] } })
     );
 
-    expect(wrapper.get('img').attributes('src')).toBe('u1');
+    expect(wrapper.get('img').attributes()).toMatchObject({
+      src: 'u1',
+      width: '320',
+      height: '320',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('shows a placeholder when there is no album', () => {

--- a/components/discussion/list/ChannelDownloadListItem.spec.ts
+++ b/components/discussion/list/ChannelDownloadListItem.spec.ts
@@ -58,7 +58,7 @@ const mountItem = (
         'nuxt-link': nuxtLinkStub,
         HighlightedSearchTerms: { props: ['text', 'searchInput'], template: '<span>{{ text }}</span>' },
         TagComponent: stub('TagComponent', ['tag', 'active'], ['click']),
-        UsernameWithTooltip: stub('UsernameWithTooltip', ['username', 'isServerAdmin', 'isServerMod', 'isForumAdmin', 'isForumMod']),
+        UsernameWithTooltip: stub('UsernameWithTooltip', ['username', 'variantSource', 'isServerAdmin', 'isServerMod', 'isForumAdmin', 'isForumMod']),
         AddToDiscussionFavorites: stub('AddToDiscussionFavorites', ['discussionId']),
         DiscussionVotes: true,
         ErrorBanner: true,
@@ -126,6 +126,24 @@ describe('ChannelDownloadListItem album image', () => {
     });
   });
 
+  it('prefers a generated list variant when present', () => {
+    const wrapper = mountItem(
+      makeDiscussion({
+        Album: {
+          Images: [
+            {
+              id: 'img1',
+              url: 'u1',
+              variantUrls: { list320: 'u1-list.webp' },
+            },
+          ],
+        },
+      })
+    );
+
+    expect(wrapper.get('img').attributes('src')).toBe('u1-list.webp');
+  });
+
   it('shows a placeholder when there is no album', () => {
     const wrapper = mountItem(makeDiscussion());
 
@@ -156,6 +174,19 @@ describe('ChannelDownloadListItem metadata', () => {
     const wrapper = mountItem(makeDiscussion({ Author: null }));
 
     expect(author(wrapper).props('username')).toBe('Deleted');
+  });
+
+  it('passes the full author as the avatar variant source', () => {
+    const discussion = makeDiscussion({
+      Author: {
+        username: 'alice',
+        profilePicURL: 'https://img.test/original.png',
+        avatar32Url: 'https://img.test/avatar-32.png',
+      },
+    });
+    const wrapper = mountItem(discussion);
+
+    expect(author(wrapper).props('variantSource')).toEqual(discussion.Author);
   });
 });
 

--- a/components/discussion/list/ChannelDownloadListItem.vue
+++ b/components/discussion/list/ChannelDownloadListItem.vue
@@ -20,6 +20,7 @@ import ImageIcon from '@/components/icons/ImageIcon.vue';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
 import DownloadQuarantineBadge from '@/components/download/DownloadQuarantineBadge.vue';
 import AppImage from '@/components/image/AppImage.vue';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 
 // Define props
 const props = defineProps({
@@ -103,12 +104,20 @@ const firstAlbumImage = computed(() => {
   if (album.imageOrder?.length && album.imageOrder.length > 0) {
     const firstImageId = album.imageOrder[0];
     const orderedImage = album.Images.find((img) => img.id === firstImageId);
-    return orderedImage?.url || null;
+    return orderedImage || null;
   }
 
   // Fallback to first image in the Images array
-  return album.Images[0]?.url || null;
+  return album.Images[0] || null;
 });
+
+const firstAlbumImageUrl = computed(() =>
+  getPreferredImageUrl({
+    source: firstAlbumImage.value,
+    preferred: ['list320', 'list160'],
+    originalUrl: firstAlbumImage.value?.url,
+  }) || ''
+);
 
 const filteredQuery = computed(() => {
   const query = { ...route.query };
@@ -141,8 +150,8 @@ const filteredQuery = computed(() => {
               class="aspect-square w-full overflow-hidden bg-gray-100 dark:bg-gray-700"
             >
               <AppImage
-                v-if="firstAlbumImage"
-                :src="firstAlbumImage"
+                v-if="firstAlbumImageUrl"
+                :src="firstAlbumImageUrl"
                 :alt="title"
                 class="h-full w-full object-cover"
                 :width="320"
@@ -203,6 +212,7 @@ const filteredQuery = computed(() => {
                 :discussion-karma="authorDiscussionKarma"
                 :display-name="authorDisplayName ?? ''"
                 :src="authorProfilePicURL ?? ''"
+                :variant-source="discussion?.Author || null"
                 :username="authorUsername"
                 light-text
               />

--- a/components/discussion/list/ChannelDownloadListItem.vue
+++ b/components/discussion/list/ChannelDownloadListItem.vue
@@ -19,6 +19,7 @@ import CommentIcon from '@/components/icons/CommentIcon.vue';
 import ImageIcon from '@/components/icons/ImageIcon.vue';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
 import DownloadQuarantineBadge from '@/components/download/DownloadQuarantineBadge.vue';
+import AppImage from '@/components/image/AppImage.vue';
 
 // Define props
 const props = defineProps({
@@ -139,11 +140,16 @@ const filteredQuery = computed(() => {
             <div
               class="aspect-square w-full overflow-hidden bg-gray-100 dark:bg-gray-700"
             >
-              <img
+              <AppImage
                 v-if="firstAlbumImage"
                 :src="firstAlbumImage"
                 :alt="title"
                 class="h-full w-full object-cover"
+                :width="320"
+                :height="320"
+                sizes="(min-width: 1280px) 20vw, (min-width: 768px) 25vw, 50vw"
+                loading="lazy"
+                decoding="async"
               />
               <div
                 v-else

--- a/components/discussion/list/SitewideDiscussionListItem.spec.ts
+++ b/components/discussion/list/SitewideDiscussionListItem.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { defineComponent } from 'vue';
 import { useQuery } from '@vue/apollo-composable';
 import { asMock, createQueryMock } from '@/tests/utils/mockApollo';
 import { createMockRoute } from '@/tests/utils/mockRouter';
@@ -19,6 +20,15 @@ vi.mock('@/composables/useAuthState', () =>
   createAuthStateMock({ username: 'alice' })
 );
 
+const UsernameWithTooltipStub = defineComponent({
+  name: 'UsernameWithTooltip',
+  props: {
+    username: { type: String, default: '' },
+    variantSource: { type: Object, default: null },
+  },
+  template: '<div><slot /></div>',
+});
+
 const mountItem = (discussion: Discussion) => {
   asMock(useQuery).mockReturnValue(createQueryMock({ users: [] }));
   return mountWithDefaults(SitewideDiscussionListItem, {
@@ -28,7 +38,7 @@ const mountItem = (discussion: Discussion) => {
         AddToDiscussionFavorites: true,
         AvatarComponent: true,
         MarkdownPreview: true,
-        UsernameWithTooltip: true,
+        UsernameWithTooltip: UsernameWithTooltipStub,
         TagComponent: true,
         ChevronDownIcon: true,
       },
@@ -210,5 +220,21 @@ describe('SitewideDiscussionListItem thumbnail', () => {
       })
     );
     expect(thumbnail(wrapper).exists()).toBe(false);
+  });
+
+  it('passes the full author as the avatar variant source', () => {
+    const fullDiscussion = discussion({
+      DiscussionChannels: [channel('cats')],
+      Author: {
+        username: 'alice',
+        profilePicURL: 'https://img.test/original.png',
+        avatar48Url: 'https://img.test/avatar-48.png',
+      },
+    });
+    const wrapper = mountItem(fullDiscussion);
+
+    expect(
+      wrapper.getComponent(UsernameWithTooltipStub).props('variantSource')
+    ).toEqual(fullDiscussion.Author);
   });
 });

--- a/components/discussion/list/SitewideDiscussionListItem.vue
+++ b/components/discussion/list/SitewideDiscussionListItem.vue
@@ -27,6 +27,7 @@ import { GET_USER } from '@/graphQLData/user/queries';
 import { useUsername, useIsAuthenticated } from '@/composables/useAuthState';
 import { useServerRoleMembership } from '@/composables/useServerRoleMembership';
 import { getServerRoleBadge } from '@/utils/serverRoleBadges';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 
 const usernameVar = useUsername();
 const isAuthenticatedVar = useIsAuthenticated();
@@ -210,9 +211,25 @@ const thumbnailUrl = computed(() => {
     const order = album?.imageOrder || [];
     if (order.length) {
       const firstOrdered = images.find((img) => img?.id === order[0]);
-      if (firstOrdered?.url) return firstOrdered.url;
+      if (firstOrdered) {
+        return (
+          getPreferredImageUrl({
+            source: firstOrdered,
+            preferred: ['list160', 'list80'],
+            originalUrl: firstOrdered.url,
+          }) || ''
+        );
+      }
     }
-    if (images[0]?.url) return images[0].url;
+    if (images[0]) {
+      return (
+        getPreferredImageUrl({
+          source: images[0],
+          preferred: ['list160', 'list80'],
+          originalUrl: images[0].url,
+        }) || ''
+      );
+    }
   }
 
   const body = props.discussion?.body || '';
@@ -359,6 +376,7 @@ const revealSensitiveContent = () => {
                 :is-server-admin="authorIsAdmin"
                 :username="authorUsername"
                 :src="discussion?.Author?.profilePicURL || ''"
+                :variant-source="discussion?.Author || null"
                 :display-name="discussion?.Author?.displayName || ''"
                 :comment-karma="discussion?.Author?.commentKarma ?? 0"
                 :discussion-karma="discussion?.Author?.discussionKarma ?? 0"

--- a/components/discussion/list/SitewideDownloadListItem.spec.ts
+++ b/components/discussion/list/SitewideDownloadListItem.spec.ts
@@ -43,4 +43,38 @@ describe('SitewideDownloadListItem', () => {
   it('reflects an overridden title', () => {
     expect(mountItem('Another Model').text()).toContain('Another Model');
   });
+
+  it('renders a sized lazy-loaded album preview', () => {
+    const wrapper = mountWithDefaults(SitewideDownloadListItem, {
+      props: {
+        discussion: makeDiscussion({
+          title: 'Cool Model',
+          hasDownload: true,
+          Author: { username: 'alice' },
+          Album: {
+            Images: [{ id: 'img-1', url: 'https://example.com/a.jpg' }],
+          },
+          DiscussionChannels: [
+            { channelUniqueName: 'cats' },
+          ] as Discussion['DiscussionChannels'],
+        } as Partial<Discussion>),
+      },
+      global: {
+        stubs: {
+          AddToDiscussionFavorites: true,
+          UsernameWithTooltip: true,
+          ImageIcon: true,
+          ChevronDownIcon: true,
+        },
+      },
+    });
+
+    expect(wrapper.get('img').attributes()).toMatchObject({
+      src: 'https://example.com/a.jpg',
+      width: '320',
+      height: '320',
+      loading: 'lazy',
+      decoding: 'async',
+    });
+  });
 });

--- a/components/discussion/list/SitewideDownloadListItem.spec.ts
+++ b/components/discussion/list/SitewideDownloadListItem.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { defineComponent } from 'vue';
 import { createMockRoute } from '@/tests/utils/mockRouter';
 import { createQueryMock, createMutationMock } from '@/tests/utils/mockApollo';
 import { mountWithDefaults } from '@/tests/utils/mountWithDefaults';
@@ -12,6 +13,15 @@ vi.mock('@vue/apollo-composable', () => ({
   useMutation: () => createMutationMock(),
 }));
 vi.mock('nuxt/app', () => ({ useRoute: () => createMockRoute() }));
+
+const UsernameWithTooltipStub = defineComponent({
+  name: 'UsernameWithTooltip',
+  props: {
+    username: { type: String, default: '' },
+    variantSource: { type: Object, default: null },
+  },
+  template: '<div><slot /></div>',
+});
 
 const mountItem = (title: string) =>
   mountWithDefaults(SitewideDownloadListItem, {
@@ -28,7 +38,7 @@ const mountItem = (title: string) =>
     global: {
       stubs: {
         AddToDiscussionFavorites: true,
-        UsernameWithTooltip: true,
+        UsernameWithTooltip: UsernameWithTooltipStub,
         ImageIcon: true,
         ChevronDownIcon: true,
       },
@@ -62,7 +72,7 @@ describe('SitewideDownloadListItem', () => {
       global: {
         stubs: {
           AddToDiscussionFavorites: true,
-          UsernameWithTooltip: true,
+          UsernameWithTooltip: UsernameWithTooltipStub,
           ImageIcon: true,
           ChevronDownIcon: true,
         },
@@ -76,5 +86,36 @@ describe('SitewideDownloadListItem', () => {
       loading: 'lazy',
       decoding: 'async',
     });
+  });
+
+  it('passes the full author as the avatar variant source', () => {
+    const discussion = makeDiscussion({
+      title: 'Cool Model',
+      hasDownload: true,
+      Author: {
+        username: 'alice',
+        profilePicURL: 'https://img.test/original.png',
+        avatar32Url: 'https://img.test/avatar-32.png',
+      },
+      DiscussionChannels: [
+        { channelUniqueName: 'cats' },
+      ] as Discussion['DiscussionChannels'],
+    } as Partial<Discussion>);
+
+    const wrapper = mountWithDefaults(SitewideDownloadListItem, {
+      props: { discussion },
+      global: {
+        stubs: {
+          AddToDiscussionFavorites: true,
+          UsernameWithTooltip: UsernameWithTooltipStub,
+          ImageIcon: true,
+          ChevronDownIcon: true,
+        },
+      },
+    });
+
+    expect(
+      wrapper.getComponent(UsernameWithTooltipStub).props('variantSource')
+    ).toEqual(discussion.Author);
   });
 });

--- a/components/discussion/list/SitewideDownloadListItem.vue
+++ b/components/discussion/list/SitewideDownloadListItem.vue
@@ -10,6 +10,7 @@ import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue';
 import CommentIcon from '@/components/icons/CommentIcon.vue';
 import DownloadQuarantineBadge from '@/components/download/DownloadQuarantineBadge.vue';
 import AppImage from '@/components/image/AppImage.vue';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 import { relativeTime } from '@/utils';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 import type { DiscussionWithFavorited } from '@/types/Discussion';
@@ -130,10 +131,18 @@ const firstAlbumImage = computed(() => {
     const orderedImage = album.Images.find(
       (img) => img.id === album.imageOrder?.[0]
     );
-    if (orderedImage?.url) return orderedImage.url;
+    if (orderedImage) return orderedImage;
   }
-  return album.Images[0]?.url || null;
+  return album.Images[0] || null;
 });
+
+const firstAlbumImageUrl = computed(() =>
+  getPreferredImageUrl({
+    source: firstAlbumImage.value,
+    preferred: ['list320', 'list160'],
+    originalUrl: firstAlbumImage.value?.url,
+  }) || ''
+);
 
 const relativeCreated = computed(() => {
   if (!props.discussion?.createdAt) return '';
@@ -158,8 +167,8 @@ const handleOpenAlbum = () => {
       <nuxt-link v-if="primaryChannel" class="block" :to="defaultLink">
         <div class="aspect-square w-full bg-gray-50 dark:bg-gray-800">
           <AppImage
-            v-if="firstAlbumImage"
-            :src="firstAlbumImage"
+            v-if="firstAlbumImageUrl"
+            :src="firstAlbumImageUrl"
             :alt="discussion.title || 'Download preview'"
             class="h-full w-full object-cover"
             :width="320"
@@ -210,6 +219,7 @@ const handleOpenAlbum = () => {
             :username="authorUsername"
             :display-name="authorDisplayName"
             :src="authorProfilePicURL"
+            :variant-source="discussion?.Author || null"
             :comment-karma="authorCommentKarma"
             :discussion-karma="authorDiscussionKarma"
             :account-created="authorAccountCreated"

--- a/components/discussion/list/SitewideDownloadListItem.vue
+++ b/components/discussion/list/SitewideDownloadListItem.vue
@@ -9,6 +9,7 @@ import ImageIcon from '@/components/icons/ImageIcon.vue';
 import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue';
 import CommentIcon from '@/components/icons/CommentIcon.vue';
 import DownloadQuarantineBadge from '@/components/download/DownloadQuarantineBadge.vue';
+import AppImage from '@/components/image/AppImage.vue';
 import { relativeTime } from '@/utils';
 import type { Discussion, DiscussionChannel } from '@/__generated__/graphql';
 import type { DiscussionWithFavorited } from '@/types/Discussion';
@@ -156,11 +157,16 @@ const handleOpenAlbum = () => {
     <div class="relative">
       <nuxt-link v-if="primaryChannel" class="block" :to="defaultLink">
         <div class="aspect-square w-full bg-gray-50 dark:bg-gray-800">
-          <img
+          <AppImage
             v-if="firstAlbumImage"
             :src="firstAlbumImage"
             :alt="discussion.title || 'Download preview'"
             class="h-full w-full object-cover"
+            :width="320"
+            :height="320"
+            sizes="(min-width: 1280px) 20vw, (min-width: 768px) 25vw, 50vw"
+            loading="lazy"
+            decoding="async"
           />
           <div
             v-else

--- a/components/event/detail/EventDetail.vue
+++ b/components/event/detail/EventDetail.vue
@@ -420,12 +420,14 @@ watchEffect(() => {
                 v-if="event?.Poster?.username"
                 :text="event?.Poster.username"
                 :src="event?.Poster.profilePicURL ?? ''"
+                :variant-source="event?.Poster || null"
                 class="mr-2 h-6 w-6"
               />
               <UsernameWithTooltip
                 v-if="event?.Poster?.username"
                 :username="event?.Poster?.username"
                 :src="event?.Poster.profilePicURL ?? ''"
+                :variant-source="event?.Poster || null"
                 :display-name="event?.Poster.displayName ?? ''"
                 :comment-karma="event?.Poster.commentKarma ?? 0"
                 :discussion-karma="event?.Poster.discussionKarma ?? 0"

--- a/components/event/detail/EventDetail.vue
+++ b/components/event/detail/EventDetail.vue
@@ -508,6 +508,10 @@ watchEffect(() => {
               v-if="event.coverImageURL"
               :src="event.coverImageURL"
               :alt="event.title"
+              :full-width="true"
+              sizes="(min-width: 1024px) 896px, 100vw"
+              loading="eager"
+              fetchpriority="high"
             />
 
             <div>

--- a/components/event/detail/EventFooter.vue
+++ b/components/event/detail/EventFooter.vue
@@ -71,6 +71,7 @@ function getTimeZone(startTime: string) {
         :is-forum-mod="posterBadges.isForumMod"
         :username="eventData.Poster.username"
         :src="eventData.Poster.profilePicURL ?? ''"
+        :variant-source="eventData.Poster || null"
         :display-name="eventData.Poster.displayName || ''"
         :comment-karma="eventData.Poster.commentKarma ?? 0"
         :discussion-karma="eventData.Poster.discussionKarma ?? 0"

--- a/components/event/detail/EventHeader.vue
+++ b/components/event/detail/EventHeader.vue
@@ -471,6 +471,7 @@ function openFeedbackFormModal() {
               :is-forum-mod="posterBadges.isForumMod"
               :username="eventData.Poster.username"
               :src="eventData.Poster.profilePicURL ?? ''"
+              :variant-source="eventData.Poster || null"
               :display-name="eventData.Poster.displayName || ''"
               :comment-karma="eventData.Poster.commentKarma ?? 0"
               :discussion-karma="eventData.Poster.discussionKarma ?? 0"

--- a/components/event/form/EventCoverImageField.spec.ts
+++ b/components/event/form/EventCoverImageField.spec.ts
@@ -51,9 +51,13 @@ describe('EventCoverImageField', () => {
 
   it('renders the cover image when a url is provided', () => {
     const wrapper = mountField('https://img.test/cover.png');
-    expect(wrapper.get('img').attributes('src')).toBe(
-      'https://img.test/cover.png'
-    );
+    expect(wrapper.get('app-image-stub').attributes()).toMatchObject({
+      src: 'https://img.test/cover.png',
+      width: '1024',
+      height: '512',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('shows the empty state when there is no image', () => {

--- a/components/event/form/EventCoverImageField.vue
+++ b/components/event/form/EventCoverImageField.vue
@@ -13,6 +13,7 @@ import AddImage from '@/components/AddImage.vue';
 import ImageIcon from '@/components/icons/ImageIcon.vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import TrashIcon from '@/components/icons/TrashIcon.vue';
+import AppImage from '@/components/image/AppImage.vue';
 
 defineProps<{
   imageUrl?: string | null;
@@ -101,10 +102,15 @@ const removeImage = () => {
     <div
       class="relative overflow-hidden rounded-md border border-gray-200 dark:border-gray-600"
     >
-      <img
+      <AppImage
         alt="Cover Image"
         :src="imageUrl"
         class="h-auto max-h-64 w-full object-cover"
+        :width="1024"
+        :height="512"
+        sizes="(min-width: 1024px) 768px, 100vw"
+        loading="lazy"
+        decoding="async"
       />
 
       <!-- Image overlay when loading -->

--- a/components/image/AppImage.vue
+++ b/components/image/AppImage.vue
@@ -5,7 +5,6 @@ import { canOptimizeImageUrl } from '@/utils/imageOptimization';
 defineOptions({
   inheritAttrs: false,
 });
-
 const props = withDefaults(
   defineProps<{
     src: string;

--- a/components/image/ImageListItem.spec.ts
+++ b/components/image/ImageListItem.spec.ts
@@ -20,7 +20,12 @@ const mountItem = (image: Partial<Image>) =>
 describe('ImageListItem', () => {
   it('renders a plain image for a regular url', () => {
     const wrapper = mountItem({ id: 'i1', url: 'https://img.test/a.png' });
-    expect(wrapper.find('img').exists()).toBe(true);
+    expect(wrapper.find('img').attributes()).toMatchObject({
+      width: '300',
+      height: '300',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('uses alt, then caption, then a fallback for the image alt', () => {

--- a/components/image/ImageListItem.spec.ts
+++ b/components/image/ImageListItem.spec.ts
@@ -33,6 +33,17 @@ describe('ImageListItem', () => {
     expect(wrapper.find('img').attributes('alt')).toBe('A cat');
   });
 
+  it('prefers a list variant url when present', () => {
+    const wrapper = mountItem({
+      id: 'i1',
+      url: 'https://img.test/original.png',
+      variantUrls: { list320: 'https://img.test/list-320.webp' },
+    } as Partial<Image>);
+    expect(wrapper.find('img').attributes('src')).toBe(
+      'https://img.test/list-320.webp'
+    );
+  });
+
   it('renders the 3D model viewer for a glb url', () => {
     const wrapper = mountItem({ id: 'i1', url: 'https://img.test/m.glb' });
     expect(wrapper.find('.model').exists()).toBe(true);

--- a/components/image/ImageListItem.vue
+++ b/components/image/ImageListItem.vue
@@ -3,6 +3,7 @@ import { defineAsyncComponent } from 'vue';
 import type { PropType } from 'vue';
 import type { Image } from '@/__generated__/graphql';
 import ModelViewer from '@/components/ModelViewer.vue';
+import AppImage from '@/components/image/AppImage.vue';
 import AddToImageFavorites from '@/components/favorites/AddToImageFavorites.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
 
@@ -70,12 +71,16 @@ const getImageAlt = (image: Image) => {
         />
       </ClientOnly>
       <!-- Regular image -->
-      <img
+      <AppImage
         v-else-if="props.image.url"
         :src="props.image.url"
         :alt="getImageAlt(props.image) ?? 'Image'"
         class="h-full w-full object-cover"
+        :width="300"
+        :height="300"
+        sizes="(min-width: 1280px) 20vw, (min-width: 768px) 25vw, 50vw"
         loading="lazy"
+        decoding="async"
       />
 
       <!-- Overlay with sensitive content warning -->

--- a/components/image/ImageListItem.vue
+++ b/components/image/ImageListItem.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { defineAsyncComponent } from 'vue';
+import { computed, defineAsyncComponent } from 'vue';
 import type { PropType } from 'vue';
 import type { Image } from '@/__generated__/graphql';
 import ModelViewer from '@/components/ModelViewer.vue';
 import AppImage from '@/components/image/AppImage.vue';
 import AddToImageFavorites from '@/components/favorites/AddToImageFavorites.vue';
 import { hasGlbExtension, hasStlExtension } from '@/utils/fileTypeUtils';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 
 // StlViewer statically imports three.js (~2MB decoded). Load it lazily so that
 // weight is only fetched when an STL image actually renders, not on every page
@@ -41,6 +42,14 @@ const props = defineProps({
 const getImageAlt = (image: Image) => {
   return image.alt || image.caption || 'Image';
 };
+
+const imageUrl = computed(() =>
+  getPreferredImageUrl({
+    source: props.image,
+    preferred: ['list320', 'list160'],
+    originalUrl: props.image.url,
+  }) || ''
+);
 </script>
 
 <template>
@@ -72,8 +81,8 @@ const getImageAlt = (image: Image) => {
       </ClientOnly>
       <!-- Regular image -->
       <AppImage
-        v-else-if="props.image.url"
-        :src="props.image.url"
+        v-else-if="imageUrl"
+        :src="imageUrl"
         :alt="getImageAlt(props.image) ?? 'Image'"
         class="h-full w-full object-cover"
         :width="300"

--- a/components/library/LibraryChannelCard.vue
+++ b/components/library/LibraryChannelCard.vue
@@ -41,6 +41,10 @@ withDefaults(
             :src="channel.channelIconURL"
             :alt="channel.displayName || channel.uniqueName"
             :rounded="true"
+            :full-width="true"
+            :width="48"
+            :height="48"
+            sizes="48px"
             class="h-12 w-12"
           />
           <AvatarComponent

--- a/components/library/LibraryCommentCard.vue
+++ b/components/library/LibraryCommentCard.vue
@@ -54,6 +54,7 @@ withDefaults(
         <AvatarComponent
           :text="authorInfo?.displayName || authorInfo?.username || 'Deleted'"
           :src="authorInfo?.profilePicURL || ''"
+          :variant-source="authorInfo || null"
           :is-small="true"
         />
         <div class="min-w-0">
@@ -63,6 +64,7 @@ withDefaults(
               :username="authorInfo.username"
               :display-name="authorInfo.displayName"
               :src="authorInfo.profilePicURL"
+              :variant-source="authorInfo"
               :is-server-admin="authorInfo.isAdmin"
               :comment-karma="authorInfo.commentKarma"
               :discussion-karma="authorInfo.discussionKarma"

--- a/components/library/LibraryDiscussionCard.vue
+++ b/components/library/LibraryDiscussionCard.vue
@@ -156,6 +156,7 @@ const albumForDisplay = computed(() => props.discussion.Album as Album | null);
             :username="authorInfo.username"
             :display-name="authorInfo.displayName"
             :src="authorInfo.profilePicURL"
+            :variant-source="authorInfo"
             :is-server-admin="authorInfo.isAdmin"
             :comment-karma="authorInfo.commentKarma"
             :discussion-karma="authorInfo.discussionKarma"

--- a/components/library/LibraryDownloadCard.spec.ts
+++ b/components/library/LibraryDownloadCard.spec.ts
@@ -76,7 +76,13 @@ describe('LibraryDownloadCard', () => {
   it('renders a preview image when one is provided', () => {
     const wrapper = mountCard({ previewImageUrl: 'https://example.com/preview.jpg' });
 
-    expect(wrapper.get('img').attributes('src')).toBe('https://example.com/preview.jpg');
+    expect(wrapper.get('img').attributes()).toMatchObject({
+      src: 'https://example.com/preview.jpg',
+      width: '640',
+      height: '400',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('shows the empty preview fallback when no image is provided', () => {

--- a/components/library/LibraryDownloadCard.vue
+++ b/components/library/LibraryDownloadCard.vue
@@ -2,6 +2,7 @@
 import UsernameWithTooltip from '@/components/UsernameWithTooltip.vue';
 import TagComponent from '@/components/TagComponent.vue';
 import AddToDiscussionFavorites from '@/components/favorites/AddToDiscussionFavorites.vue';
+import AppImage from '@/components/image/AppImage.vue';
 import { relativeTime } from '@/utils';
 
 type AuthorInfo = {
@@ -53,11 +54,16 @@ withDefaults(
       :to="downloadLink"
       class="relative block aspect-16/10 overflow-hidden bg-slate-100 dark:bg-gray-700"
     >
-      <img
+      <AppImage
         v-if="previewImageUrl"
         :src="previewImageUrl"
         :alt="download.title"
         class="h-full w-full object-cover"
+        :width="640"
+        :height="400"
+        sizes="(min-width: 1280px) 24rem, (min-width: 768px) 50vw, 100vw"
+        loading="lazy"
+        decoding="async"
       />
       <div
         v-else

--- a/components/library/LibraryDownloadCard.vue
+++ b/components/library/LibraryDownloadCard.vue
@@ -135,6 +135,7 @@ withDefaults(
           :username="authorInfo.username"
           :display-name="authorInfo.displayName"
           :src="authorInfo.profilePicURL"
+          :variant-source="authorInfo"
           :is-server-admin="authorInfo.isAdmin"
           :comment-karma="authorInfo.commentKarma"
           :discussion-karma="authorInfo.discussionKarma"

--- a/components/mod/DiscussionDetails.vue
+++ b/components/mod/DiscussionDetails.vue
@@ -122,6 +122,7 @@ const formatFileSize = (sizeInBytes: number | null | undefined): string => {
             <AvatarComponent
               :text="discussion?.Author.username"
               :src="discussion?.Author.profilePicURL ?? ''"
+              :variant-source="discussion?.Author || null"
               class="mr-2 h-6 w-6"
             />
           </span>
@@ -130,6 +131,7 @@ const formatFileSize = (sizeInBytes: number | null | undefined): string => {
               v-if="discussion?.Author?.username"
               :username="discussion?.Author?.username"
               :src="discussion?.Author.profilePicURL ?? ''"
+              :variant-source="discussion?.Author || null"
               :display-name="discussion?.Author.displayName ?? ''"
               :comment-karma="discussion?.Author.commentKarma ?? 0"
               :discussion-karma="discussion?.Author.discussionKarma ?? 0"

--- a/components/mod/ImageDetails.spec.ts
+++ b/components/mod/ImageDetails.spec.ts
@@ -101,10 +101,44 @@ describe('ImageDetails content', () => {
     });
   });
 
+  it('prefers a generated detail variant when present', () => {
+    h.result = ref({
+      images: [
+        image({
+          variantUrls: {
+            detail640: 'https://x/i-640.webp',
+          },
+        }),
+      ],
+    });
+    const wrapper = mountDetails();
+
+    expect(wrapper.get('img').attributes('src')).toBe('https://x/i-640.webp');
+  });
+
   it('shows the uploader display name', () => {
     const wrapper = mountDetails();
 
     expect(wrapper.text()).toContain('Alice A');
+  });
+
+  it('prefers a generated uploader avatar variant when present', () => {
+    h.result = ref({
+      images: [
+        image({
+          Uploader: {
+            username: 'alice',
+            displayName: 'Alice A',
+            profilePicURL: 'https://x/original-avatar.jpg',
+            avatar32Url: 'https://x/avatar-32.webp',
+          },
+        }),
+      ],
+    });
+    const wrapper = mountDetails();
+    const images = wrapper.findAll('img');
+
+    expect(images[1]?.attributes('src')).toBe('https://x/avatar-32.webp');
   });
 
   it('falls back to the username when there is no display name', () => {

--- a/components/mod/ImageDetails.spec.ts
+++ b/components/mod/ImageDetails.spec.ts
@@ -38,6 +38,19 @@ const mountDetails = () =>
       stubs: {
         LoadingSpinner: { name: 'LoadingSpinner', template: '<div class="spinner" />' },
         ErrorBanner: { name: 'ErrorBanner', props: ['text'], template: '<div class="err">{{ text }}</div>' },
+        NuxtImg: {
+          props: [
+            'src',
+            'alt',
+            'width',
+            'height',
+            'sizes',
+            'loading',
+            'decoding',
+            'fetchpriority',
+          ],
+          template: '<img v-bind="$props" />',
+        },
         NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
         'nuxt-link': { props: ['to'], template: '<a><slot /></a>' },
       },
@@ -79,7 +92,13 @@ describe('ImageDetails content', () => {
   it('renders the image', () => {
     const wrapper = mountDetails();
 
-    expect(wrapper.get('img').attributes('src')).toBe('https://x/i.jpg');
+    expect(wrapper.get('img').attributes()).toMatchObject({
+      src: 'https://x/i.jpg',
+      width: '640',
+      height: '640',
+      loading: 'lazy',
+      decoding: 'async',
+    });
   });
 
   it('shows the uploader display name', () => {

--- a/components/mod/ImageDetails.vue
+++ b/components/mod/ImageDetails.vue
@@ -4,6 +4,7 @@ import { GET_IMAGE_DETAILS } from '@/graphQLData/image/queries';
 import { useQuery } from '@vue/apollo-composable';
 import ErrorBanner from '../ErrorBanner.vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import AppImage from '@/components/image/AppImage.vue';
 import { stableRelativeTime } from '@/utils';
 
 const props = defineProps({
@@ -86,12 +87,16 @@ onImageResult(({ data }) => {
       <div class="flex flex-col gap-4">
         <div class="flex items-start gap-4">
           <div class="relative max-w-md overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
-            <img
+            <AppImage
               :src="image.url"
               :alt="image.alt || 'Reported image'"
               class="max-h-80 w-auto object-contain"
+              :width="640"
+              :height="640"
+              sizes="(min-width: 1024px) 32rem, 100vw"
               loading="lazy"
-            >
+              decoding="async"
+            />
             <div
               v-if="image.hasSensitiveContent"
               class="absolute right-2 top-2 rounded bg-red-500 px-2 py-1 text-xs font-medium text-white"
@@ -107,12 +112,17 @@ onImageResult(({ data }) => {
           </div>
           <div class="flex flex-col gap-2 text-sm text-gray-600 dark:text-gray-400">
             <div class="flex items-center gap-2">
-              <img
+              <AppImage
                 v-if="image.Uploader?.profilePicURL"
                 :src="image.Uploader.profilePicURL"
                 :alt="uploaderDisplayName"
                 class="h-8 w-8 rounded-full object-cover"
-              >
+                :width="32"
+                :height="32"
+                sizes="32px"
+                loading="lazy"
+                decoding="async"
+              />
               <div
                 v-else
                 class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-gray-600 dark:bg-gray-600 dark:text-gray-300"

--- a/components/mod/ImageDetails.vue
+++ b/components/mod/ImageDetails.vue
@@ -6,6 +6,7 @@ import ErrorBanner from '../ErrorBanner.vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import AppImage from '@/components/image/AppImage.vue';
 import { stableRelativeTime } from '@/utils';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 
 const props = defineProps({
   imageId: {
@@ -40,6 +41,22 @@ const uploaderDisplayName = computed(() => {
 const uploaderUsername = computed(() => {
   return image.value?.Uploader?.username || null;
 });
+
+const detailImageUrl = computed(() =>
+  getPreferredImageUrl({
+    source: image.value,
+    preferred: ['detail640', 'detail960', 'detail1280'],
+    originalUrl: image.value?.url,
+  }) || ''
+);
+
+const uploaderImageUrl = computed(() =>
+  getPreferredImageUrl({
+    source: image.value?.Uploader,
+    preferred: ['avatar32', 'avatar48'],
+    originalUrl: image.value?.Uploader?.profilePicURL,
+  }) || ''
+);
 
 const formattedDate = computed(() => {
   if (!image.value?.createdAt) return '';
@@ -88,7 +105,7 @@ onImageResult(({ data }) => {
         <div class="flex items-start gap-4">
           <div class="relative max-w-md overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
             <AppImage
-              :src="image.url"
+              :src="detailImageUrl"
               :alt="image.alt || 'Reported image'"
               class="max-h-80 w-auto object-contain"
               :width="640"
@@ -113,8 +130,8 @@ onImageResult(({ data }) => {
           <div class="flex flex-col gap-2 text-sm text-gray-600 dark:text-gray-400">
             <div class="flex items-center gap-2">
               <AppImage
-                v-if="image.Uploader?.profilePicURL"
-                :src="image.Uploader.profilePicURL"
+                v-if="uploaderImageUrl"
+                :src="uploaderImageUrl"
                 :alt="uploaderDisplayName"
                 class="h-8 w-8 rounded-full object-cover"
                 :width="32"

--- a/components/user/PhotoAvatar.spec.ts
+++ b/components/user/PhotoAvatar.spec.ts
@@ -79,4 +79,21 @@ describe('PhotoAvatar', () => {
       hasSmallWidth: false,
     });
   });
+
+  it('prefers matching avatar variants when a variant source is available', () => {
+    const wrapper = mount(PhotoAvatar, {
+      props: {
+        src: 'https://example.test/original.png',
+        alt: 'Alice avatar',
+        variantSource: {
+          avatar32Url: 'https://example.test/avatar-32.png',
+          avatar48Url: 'https://example.test/avatar-48.png',
+        },
+      },
+    });
+
+    expect(wrapper.get('img').attributes('src')).toBe(
+      'https://example.test/avatar-32.png'
+    );
+  });
 });

--- a/components/user/PhotoAvatar.vue
+++ b/components/user/PhotoAvatar.vue
@@ -1,15 +1,31 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import AppImage from '@/components/image/AppImage.vue';
+import { getPreferredImageUrl, type ImageVariantKey } from '@/utils/imageVariants';
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   src: string;
   alt: string;
   isSquare?: boolean;
   isLarge?: boolean;
+  variantSource?: Record<string, unknown> | null;
 }>(), {
   isSquare: false,
   isLarge: false,
+  variantSource: null,
 });
+
+const preferredAvatarVariants = computed<ImageVariantKey[]>(() =>
+  props.isLarge ? ['avatar96', 'avatar64', 'avatar48'] : ['avatar32', 'avatar48']
+);
+
+const imageUrl = computed(() =>
+  getPreferredImageUrl({
+    source: props.variantSource,
+    preferred: preferredAvatarVariants.value,
+    originalUrl: props.src,
+  }) || ''
+);
 </script>
 <template>
   <AppImage
@@ -17,7 +33,7 @@ withDefaults(defineProps<{
       isLarge ? '' : 'h-8 w-8',
       isSquare ? 'rounded-lg' : 'rounded-full',
     ]"
-    :src="src"
+    :src="imageUrl"
     :alt="alt"
     :width="isLarge ? undefined : 32"
     :height="isLarge ? undefined : 32"

--- a/components/user/UserProfileSidebar.spec.ts
+++ b/components/user/UserProfileSidebar.spec.ts
@@ -44,7 +44,7 @@ const mountSidebar = (props: Record<string, unknown> = {}) =>
     props,
     global: {
       stubs: {
-        AvatarComponent: { name: 'AvatarComponent', props: ['src', 'text'], template: '<div class="avatar" />' },
+        AvatarComponent: { name: 'AvatarComponent', props: ['src', 'text', 'variantSource'], template: '<div class="avatar" />' },
         MarkdownPreview: { name: 'MarkdownPreview', props: ['text'], template: '<div class="bio">{{ text }}</div>' },
         ReportProfilePictureModal: { name: 'ReportProfilePictureModal', props: ['open'], template: '<div class="report-modal" />' },
         RequireAuth: { template: '<div><slot name="has-auth" /></div>' },
@@ -128,6 +128,17 @@ describe('UserProfileSidebar profile picture', () => {
     const wrapper = mountSidebar();
 
     expect(avatar(wrapper).props('src')).toBe('https://x/reactive.png');
+  });
+
+  it('passes the queried user as the avatar variant source', () => {
+    const wrapper = mountSidebar();
+
+    expect(avatar(wrapper).props('variantSource')).toEqual(
+      expect.objectContaining({
+        username: 'alice',
+        profilePicURL: 'https://x/query.png',
+      })
+    );
   });
 
   it('shows a report button for another user with a picture', () => {

--- a/components/user/UserProfileSidebar.vue
+++ b/components/user/UserProfileSidebar.vue
@@ -89,6 +89,7 @@ const handleReportSuccess = () => {
           class="max-w-72 flex-1"
           :src="profilePic"
           :text="username"
+          :variant-source="user"
           :is-square="false"
         />
         <RequireAuth v-if="canReportProfilePicture">

--- a/docs/image-performance-plan.md
+++ b/docs/image-performance-plan.md
@@ -184,3 +184,10 @@ Started Phase 1 Slice 2:
 - migrate the user image grid cards to the shared optimized-image wrapper
 - migrate library download preview cards to explicit dimensions and responsive sizes
 - migrate reusable gallery thumbnails to stable dimensions and lazy decoding
+
+Started Phase 2 Slice 1:
+
+- add a frontend image-variant selection contract that can prefer generated backend variants when they begin appearing in GraphQL responses
+- wire list and gallery image-object surfaces to prefer semantic variant keys over raw originals while preserving current fallback behavior
+- extend avatar/detail surfaces to pass full source objects into the shared variant contract, including discussion lists, public/event detail headers, moderator detail views, and the public profile sidebar
+- add focused regression tests that lock in variant-source propagation and variant preference behavior before backend-generated thumbnail fields land broadly

--- a/docs/image-performance-plan.md
+++ b/docs/image-performance-plan.md
@@ -178,3 +178,9 @@ Started Phase 1 Slice 1:
 - migrate avatar surfaces
 - migrate the sitewide discussion list thumbnail
 - migrate event list cover images
+
+Started Phase 1 Slice 2:
+
+- migrate the user image grid cards to the shared optimized-image wrapper
+- migrate library download preview cards to explicit dimensions and responsive sizes
+- migrate reusable gallery thumbnails to stable dimensions and lazy decoding

--- a/pages/comments/search.vue
+++ b/pages/comments/search.vue
@@ -312,6 +312,11 @@ const getContextForum = (comment: Comment) => {
                 <AvatarComponent
                   :src="getAuthorProfilePic(comment)"
                   :text="getAuthorUsername(comment)"
+                  :variant-source="
+                    comment.CommentAuthor?.__typename === 'User'
+                      ? comment.CommentAuthor
+                      : null
+                  "
                   :is-small="true"
                 />
                 <div class="text-sm">

--- a/utils/imageVariants.spec.ts
+++ b/utils/imageVariants.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractImageVariantUrls,
+  getOriginalImageUrl,
+  getPreferredImageUrl,
+} from './imageVariants';
+
+describe('extractImageVariantUrls', () => {
+  it('reads a variantUrls object', () => {
+    expect(
+      extractImageVariantUrls({
+        variantUrls: {
+          list320: 'https://img.test/list-320.webp',
+          detail960: 'https://img.test/detail-960.webp',
+        },
+      })
+    ).toEqual({
+      list320: 'https://img.test/list-320.webp',
+      detail960: 'https://img.test/detail-960.webp',
+    });
+  });
+
+  it('reads imageVariants arrays keyed by name', () => {
+    expect(
+      extractImageVariantUrls({
+        imageVariants: [
+          { name: 'list160', url: 'https://img.test/list-160.webp' },
+          { key: 'detail640', url: 'https://img.test/detail-640.webp' },
+        ],
+      })
+    ).toEqual({
+      list160: 'https://img.test/list-160.webp',
+      detail640: 'https://img.test/detail-640.webp',
+    });
+  });
+
+  it('reads direct variant aliases', () => {
+    expect(
+      extractImageVariantUrls({
+        thumbnailUrl: 'https://img.test/thumb.webp',
+        detail1280Url: 'https://img.test/detail-1280.webp',
+      })
+    ).toEqual({
+      list80: 'https://img.test/thumb.webp',
+      detail1280: 'https://img.test/detail-1280.webp',
+    });
+  });
+});
+
+describe('getOriginalImageUrl', () => {
+  it('returns direct string inputs', () => {
+    expect(getOriginalImageUrl('https://img.test/original.jpg')).toBe(
+      'https://img.test/original.jpg'
+    );
+  });
+
+  it('reads url-like fields from objects', () => {
+    expect(
+      getOriginalImageUrl({ coverImageURL: 'https://img.test/original.jpg' })
+    ).toBe('https://img.test/original.jpg');
+  });
+});
+
+describe('getPreferredImageUrl', () => {
+  it('prefers matching variants over the original url', () => {
+    expect(
+      getPreferredImageUrl({
+        source: {
+          url: 'https://img.test/original.jpg',
+          variantUrls: {
+            list160: 'https://img.test/list-160.webp',
+            list320: 'https://img.test/list-320.webp',
+          },
+        },
+        preferred: ['list320', 'list160'],
+      })
+    ).toBe('https://img.test/list-320.webp');
+  });
+
+  it('falls back to the original url when variants are absent', () => {
+    expect(
+      getPreferredImageUrl({
+        source: { url: 'https://img.test/original.jpg' },
+        preferred: ['detail960'],
+      })
+    ).toBe('https://img.test/original.jpg');
+  });
+
+  it('skips empty variant values', () => {
+    expect(
+      getPreferredImageUrl({
+        source: {
+          url: 'https://img.test/original.jpg',
+          variantUrls: {
+            list320: '',
+            list160: 'https://img.test/list-160.webp',
+          },
+        },
+        preferred: ['list320', 'list160'],
+      })
+    ).toBe('https://img.test/list-160.webp');
+  });
+});

--- a/utils/imageVariants.ts
+++ b/utils/imageVariants.ts
@@ -1,0 +1,132 @@
+export const IMAGE_VARIANT_KEYS = [
+  'avatar32',
+  'avatar48',
+  'avatar64',
+  'avatar96',
+  'list80',
+  'list160',
+  'list320',
+  'detail640',
+  'detail960',
+  'detail1280',
+] as const;
+
+export type ImageVariantKey = (typeof IMAGE_VARIANT_KEYS)[number];
+
+export type ImageVariantUrls = Partial<Record<ImageVariantKey, string>>;
+
+type VariantArrayEntry = {
+  key?: string | null;
+  name?: string | null;
+  url?: string | null;
+};
+
+type VariantSourceRecord = Record<string, unknown>;
+
+const DIRECT_VARIANT_FIELD_ALIASES: Record<ImageVariantKey, string[]> = {
+  avatar32: ['avatar32Url'],
+  avatar48: ['avatar48Url'],
+  avatar64: ['avatar64Url'],
+  avatar96: ['avatar96Url'],
+  list80: ['list80Url', 'thumbnailUrl'],
+  list160: ['list160Url'],
+  list320: ['list320Url', 'cardImageUrl'],
+  detail640: ['detail640Url', 'mediumImageUrl'],
+  detail960: ['detail960Url'],
+  detail1280: ['detail1280Url', 'largeImageUrl'],
+};
+
+const VARIANT_RECORD_FIELDS = ['variantUrls', 'imageVariantUrls'] as const;
+const VARIANT_ARRAY_FIELDS = ['variants', 'imageVariants'] as const;
+const ORIGINAL_URL_FIELDS = ['url', 'profilePicURL', 'coverImageURL'] as const;
+
+const isRecord = (value: unknown): value is VariantSourceRecord =>
+  typeof value === 'object' && value !== null;
+
+const asNonEmptyString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim().length > 0 ? value : null;
+
+export function extractImageVariantUrls(source: unknown): ImageVariantUrls {
+  if (!isRecord(source)) {
+    return {};
+  }
+
+  const urls: ImageVariantUrls = {};
+
+  for (const field of VARIANT_RECORD_FIELDS) {
+    const value = source[field];
+    if (!isRecord(value)) continue;
+    for (const key of IMAGE_VARIANT_KEYS) {
+      const candidate = asNonEmptyString(value[key]);
+      if (candidate) {
+        urls[key] = candidate;
+      }
+    }
+  }
+
+  for (const field of VARIANT_ARRAY_FIELDS) {
+    const value = source[field];
+    if (!Array.isArray(value)) continue;
+    for (const entry of value) {
+      if (!isRecord(entry)) continue;
+      const variant = entry as VariantArrayEntry;
+      const key = variant.key || variant.name;
+      if (!key || !IMAGE_VARIANT_KEYS.includes(key as ImageVariantKey)) {
+        continue;
+      }
+      const url = asNonEmptyString(variant.url);
+      if (url) {
+        urls[key as ImageVariantKey] = url;
+      }
+    }
+  }
+
+  for (const key of IMAGE_VARIANT_KEYS) {
+    for (const alias of DIRECT_VARIANT_FIELD_ALIASES[key]) {
+      const candidate = asNonEmptyString(source[alias]);
+      if (candidate) {
+        urls[key] = candidate;
+        break;
+      }
+    }
+  }
+
+  return urls;
+}
+
+export function getOriginalImageUrl(source: unknown): string | null {
+  if (typeof source === 'string') {
+    return asNonEmptyString(source);
+  }
+
+  if (!isRecord(source)) {
+    return null;
+  }
+
+  for (const field of ORIGINAL_URL_FIELDS) {
+    const candidate = asNonEmptyString(source[field]);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function getPreferredImageUrl(input: {
+  source?: unknown;
+  preferred: ImageVariantKey[];
+  originalUrl?: string | null;
+}): string | null {
+  const { source, preferred, originalUrl } = input;
+  const variantUrls = extractImageVariantUrls(source);
+
+  for (const key of preferred) {
+    const candidate = variantUrls[key];
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return asNonEmptyString(originalUrl) || getOriginalImageUrl(source);
+}


### PR DESCRIPTION
## Summary
- continue phase-one frontend image delivery optimizations across list cards, detail views, galleries, and shared image surfaces
- migrate remaining safe raw `<img>` usages onto the shared optimized-image wrapper with explicit dimensions and loading/decoding hints
- extend unit coverage for the migrated surfaces so the image delivery contract is pinned in tests

## Validation
- pnpm run tsc
- pnpm run test:unit:run -- components/discussion/detail/LightgalleryAlbum.spec.ts components/discussion/detail/DiscussionAlbum.spec.ts
- pnpm run test:unit:run -- components/ExpandableImage.spec.ts components/discussion/detail/LightboxImagePanel.spec.ts
- pnpm run test:unit:run -- components/discussion/list/SitewideDownloadListItem.spec.ts components/discussion/list/ChannelDownloadListItem.spec.ts components/LinkPreview.spec.ts
- pnpm run test:unit:run -- components/collection/CollectionDownloadListItem.spec.ts components/album/AlbumThumbnailGrid.spec.ts components/mod/ImageDetails.spec.ts
- pnpm run test:unit:run -- components/event/form/EventCoverImageField.spec.ts components/discussion/form/AlbumReusableImageGrid.spec.ts components/MultiSelect.spec.ts