### PR TITLE
perf(image): route avatars and forum icons to generated variants

### DIFF
--- a/components/AvatarComponent.spec.ts
+++ b/components/AvatarComponent.spec.ts
@@ -28,6 +28,24 @@ describe('AvatarComponent', () => {
     );
   });
 
+  it('supports channel icon field aliases when selecting small variants', () => {
+    const wrapper = mount(AvatarComponent, {
+      props: {
+        text: 'cats',
+        src: 'https://img.test/original.png',
+        isSmall: true,
+        variantSource: {
+          icon32Url: 'https://img.test/icon-32.png',
+          icon48Url: 'https://img.test/icon-48.png',
+        },
+      },
+    });
+
+    expect(wrapper.find('img').attributes('src')).toBe(
+      'https://img.test/icon-32.png'
+    );
+  });
+
   it('generates an identicon data URI when no src is provided', () => {
     const wrapper = mount(AvatarComponent, { props: { text: 'alice' } });
     expect(wrapper.find('img').attributes('src')).toContain(

--- a/components/channel/ChannelHeaderMobile.vue
+++ b/components/channel/ChannelHeaderMobile.vue
@@ -37,6 +37,7 @@ const initialIsFavorited = computed(
         class="align-items my-2 ml-2 flex h-14 w-14 justify-center pt-2 shadow-sm"
         :text="channelId"
         :src="channel?.channelIconURL ?? ''"
+        :variant-source="channel"
         :is-square="false"
       />
       <div v-if="channel.displayName && channel.uniqueName" class="mt-4">

--- a/components/channel/ChannelListItem.vue
+++ b/components/channel/ChannelListItem.vue
@@ -46,6 +46,7 @@ defineEmits(['filterByTag']);
           <AvatarComponent
             :text="channel.uniqueName"
             :src="channel?.channelIconURL || ''"
+            :variant-source="channel"
             :is-small="false"
             :square="true"
             :is-decorative="true"

--- a/components/channel/ChannelSidebar.vue
+++ b/components/channel/ChannelSidebar.vue
@@ -271,6 +271,7 @@ const handleBecomeAdminSuccess = () => {
                 <AvatarComponent
                   :text="admin.username"
                   :src="admin.profilePicURL ?? ''"
+                  :variant-source="admin"
                   class="mr-2 h-6 w-6 shrink-0"
                 />
                 <span class="flex flex-wrap items-baseline gap-1">

--- a/components/channel/ChannelSidebar.vue
+++ b/components/channel/ChannelSidebar.vue
@@ -16,6 +16,7 @@ import RobotIcon from '@/components/icons/RobotIcon.vue';
 import TagIcon from '@/components/icons/TagIcon.vue';
 import ThumbtackIcon from '@/components/icons/ThumbtackIcon.vue';
 import { useIsAuthenticated } from '@/composables/useAuthState';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 import { getPlainWikiTitle } from '@/utils/wikiTitle';
 
 const isAuthenticatedVar = useIsAuthenticated();
@@ -67,6 +68,14 @@ const botAccounts = computed(() => {
   const channel = props.channel as Channel & { Bots?: BotSummary[] };
   return channel?.Bots ?? [];
 });
+
+const sidebarIconSrc = computed(() =>
+  getPreferredImageUrl({
+    source: props.channel,
+    preferred: ['avatar64', 'avatar96', 'avatar48'],
+    originalUrl: props.channel?.channelIconURL ?? '',
+  }) || ''
+);
 
 // Check if a bot has active suspensions
 const isBotSuspended = (bot: BotSummary): boolean => {
@@ -132,7 +141,7 @@ const handleBecomeAdminSuccess = () => {
           :rounded="true"
           :full-width="true"
           :alt="channelId"
-          :src="channel?.channelIconURL ?? ''"
+          :src="sidebarIconSrc"
           :width="80"
           :height="80"
           sizes="80px"
@@ -144,6 +153,7 @@ const handleBecomeAdminSuccess = () => {
           class="h-20 w-20 dark:border-gray-800"
           :text="channelId"
           :src="channel?.channelIconURL ?? ''"
+          :variant-source="channel"
           :full-width="true"
           :is-square="false"
         />

--- a/components/comments/LoggedInUserAvatar.spec.ts
+++ b/components/comments/LoggedInUserAvatar.spec.ts
@@ -14,7 +14,7 @@ vi.mock('@/composables/useAuthState', () => ({
 
 const AvatarStub = {
   name: 'AvatarComponent',
-  props: ['text', 'src', 'isSmall'],
+  props: ['text', 'src', 'variantSource', 'isSmall'],
   template: '<div class="avatar" />',
 };
 
@@ -38,6 +38,20 @@ describe('LoggedInUserAvatar', () => {
   it('passes the profile picture URL from the query', () => {
     query.result.value = { users: [{ profilePicURL: 'https://img/pic.png' }] };
     expect(avatar(mountAvatar()).props('src')).toBe('https://img/pic.png');
+  });
+
+  it('passes the full user object as the variant source', () => {
+    query.result.value = {
+      users: [
+        {
+          profilePicURL: 'https://img/pic.png',
+          avatar32Url: 'https://img/pic-32.png',
+        },
+      ],
+    };
+    expect(avatar(mountAvatar()).props('variantSource')).toEqual(
+      query.result.value.users[0]
+    );
   });
 
   it('falls back to an empty src when the user has no profile picture', () => {

--- a/components/comments/LoggedInUserAvatar.vue
+++ b/components/comments/LoggedInUserAvatar.vue
@@ -20,6 +20,8 @@ const { result: getUserResult } = useQuery(
 const profilePicURL = computed(() => {
   return getUserResult.value?.users?.[0]?.profilePicURL || '';
 });
+
+const user = computed(() => getUserResult.value?.users?.[0] || null);
 </script>
 
 <template>
@@ -27,6 +29,7 @@ const profilePicURL = computed(() => {
     class="h-8 w-8"
     :text="usernameVar"
     :src="profilePicURL"
+    :variant-source="user"
     :is-small="true"
   />
 </template>

--- a/components/library/LibraryChannelCard.vue
+++ b/components/library/LibraryChannelCard.vue
@@ -2,6 +2,8 @@
 import ExpandableImage from '@/components/ExpandableImage.vue';
 import TagComponent from '@/components/TagComponent.vue';
 import AddToChannelFavorites from '@/components/favorites/AddToChannelFavorites.vue';
+import { computed } from 'vue';
+import { getPreferredImageUrl } from '@/utils/imageVariants';
 
 type ChannelItem = {
   uniqueName: string;
@@ -11,7 +13,7 @@ type ChannelItem = {
   Tags?: Array<{ text?: string | null }> | null;
 };
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     channel: ChannelItem;
     showFavoriteButton?: boolean;
@@ -23,6 +25,15 @@ withDefaults(
     allowAddToList: false,
     isFavorited: false,
   }
+);
+
+const channelIconSrc = computed(
+  () =>
+    getPreferredImageUrl({
+      source: props.channel,
+      preferred: ['avatar48', 'avatar64', 'avatar32'],
+      originalUrl: props.channel.channelIconURL,
+    }) || ''
 );
 </script>
 
@@ -38,7 +49,7 @@ withDefaults(
         <div class="shrink-0">
           <ExpandableImage
             v-if="channel.channelIconURL"
-            :src="channel.channelIconURL"
+            :src="channelIconSrc"
             :alt="channel.displayName || channel.uniqueName"
             :rounded="true"
             :full-width="true"

--- a/components/nav/ForumFinder.vue
+++ b/components/nav/ForumFinder.vue
@@ -5,19 +5,12 @@ import { GET_CHANNEL_NAMES } from '@/graphQLData/channel/queries';
 import { createCaseInsensitivePattern } from '@/utils/searchUtils';
 import SearchBar from '@/components/SearchBar.vue';
 import AvatarComponent from '@/components/AvatarComponent.vue';
-import type { Channel } from '@/__generated__/graphql';
 
-type ForumOption = Pick<
-  Channel,
-  | 'uniqueName'
-  | 'displayName'
-  | 'channelIconURL'
-  | 'variantUrls'
-  | 'icon32Url'
-  | 'icon48Url'
-  | 'icon64Url'
-  | 'icon96Url'
->;
+type ForumOption = {
+  uniqueName: string;
+  displayName?: string | null;
+  channelIconURL?: string | null;
+};
 
 const emit = defineEmits<{
   select: [uniqueName: string];

--- a/components/nav/ForumFinder.vue
+++ b/components/nav/ForumFinder.vue
@@ -9,7 +9,14 @@ import type { Channel } from '@/__generated__/graphql';
 
 type ForumOption = Pick<
   Channel,
-  'uniqueName' | 'displayName' | 'channelIconURL'
+  | 'uniqueName'
+  | 'displayName'
+  | 'channelIconURL'
+  | 'variantUrls'
+  | 'icon32Url'
+  | 'icon48Url'
+  | 'icon64Url'
+  | 'icon96Url'
 >;
 
 const emit = defineEmits<{
@@ -81,6 +88,7 @@ const updateSearch = (value: string) => {
             class="h-8 w-8 shrink-0 border border-gray-200 shadow-sm dark:border-gray-800"
             :text="forum.uniqueName || ''"
             :src="forum.channelIconURL ?? ''"
+            :variant-source="forum"
             :is-small="true"
             :is-square="false"
             :is-decorative="true"

--- a/components/nav/ForumQuickSwitcherOption.vue
+++ b/components/nav/ForumQuickSwitcherOption.vue
@@ -6,6 +6,11 @@ defineProps<{
     uniqueName: string;
     displayName: string;
     channelIconURL: string;
+    variantUrls?: Record<string, string> | null;
+    icon32Url?: string | null;
+    icon48Url?: string | null;
+    icon64Url?: string | null;
+    icon96Url?: string | null;
   };
   active?: boolean;
   compact?: boolean;
@@ -29,6 +34,7 @@ const emit = defineEmits<{
       :class="compact ? 'h-6 w-6' : 'h-7 w-7'"
       :text="forum.uniqueName"
       :src="forum.channelIconURL"
+      :variant-source="forum"
       :is-small="true"
       :is-square="false"
       :is-decorative="true"

--- a/components/nav/RecentForumsList.vue
+++ b/components/nav/RecentForumsList.vue
@@ -5,6 +5,11 @@ import AvatarComponent from '@/components/AvatarComponent.vue';
 type ForumItem = {
   uniqueName: string;
   channelIconURL?: string | null;
+  variantUrls?: Record<string, string> | null;
+  icon32Url?: string | null;
+  icon48Url?: string | null;
+  icon64Url?: string | null;
+  icon96Url?: string | null;
   timestamp: number;
 };
 
@@ -62,6 +67,7 @@ const defaultLinkClasses =
               class="list-item-icon h-8 w-8 shrink-0 border border-gray-200 shadow-sm dark:border-gray-800"
               :text="forum.uniqueName || ''"
               :src="forum?.channelIconURL ?? ''"
+              :variant-source="forum"
               :is-small="true"
               :is-square="false"
               :is-decorative="true"

--- a/components/nav/SiteSidenav.vue
+++ b/components/nav/SiteSidenav.vue
@@ -371,6 +371,7 @@ const selectSearchType = (type: SearchType) => {
                   class="list-item-icon h-8 w-8 shrink-0 border border-gray-200 shadow-sm dark:border-gray-800"
                   :text="forum.uniqueName || ''"
                   :src="forum?.channelIconURL ?? ''"
+                  :variant-source="forum"
                   :is-small="true"
                   :is-square="false"
                   :is-decorative="true"
@@ -380,6 +381,7 @@ const selectSearchType = (type: SearchType) => {
                   class="list-item-icon h-8 w-8 shrink-0 border border-gray-200 shadow-sm dark:border-gray-800"
                   :text="forum.uniqueName || ''"
                   :src="forum?.channelIconURL ?? ''"
+                  :variant-source="forum"
                   :is-small="true"
                   :is-square="false"
                   :is-decorative="true"
@@ -427,6 +429,7 @@ const selectSearchType = (type: SearchType) => {
               v-if="profilePicURL"
               :text="usernameVar"
               :src="profilePicURL"
+              :variant-source="user"
               :is-small="true"
             />
             My Profile

--- a/components/nav/UserProfileDropdownMenu.spec.ts
+++ b/components/nav/UserProfileDropdownMenu.spec.ts
@@ -29,7 +29,11 @@ const mountMenu = (props: Record<string, unknown> = {}) =>
     global: {
       stubs: {
         IconButtonDropdown: dropdownStub,
-        AvatarComponent: { name: 'AvatarComponent', props: ['src', 'text'], template: '<div class="avatar" />' },
+        AvatarComponent: {
+          name: 'AvatarComponent',
+          props: ['src', 'text', 'variantSource'],
+          template: '<div class="avatar" />',
+        },
       },
     },
   });
@@ -56,6 +60,14 @@ describe('UserProfileDropdownMenu', () => {
     expect(wrapper.getComponent({ name: 'AvatarComponent' }).props('src')).toBe(
       'https://x/pic.png'
     );
+  });
+
+  it('passes the full user as the variant source', () => {
+    const wrapper = mountMenu();
+
+    expect(
+      wrapper.getComponent({ name: 'AvatarComponent' }).props('variantSource')
+    ).toEqual(h.result.value.users[0]);
   });
 
   it('falls back to an empty avatar src without a user', () => {

--- a/components/nav/UserProfileDropdownMenu.vue
+++ b/components/nav/UserProfileDropdownMenu.vue
@@ -35,6 +35,10 @@ const profilePicURL = computed(() => {
   if (!getUserResult.value?.users?.length) return '';
   return getUserResult.value.users[0]?.profilePicURL || '';
 });
+const user = computed(() => {
+  if (!getUserResult.value?.users?.length) return null;
+  return getUserResult.value.users[0] || null;
+});
 const router = useRouter();
 
 const menuItems = [
@@ -77,6 +81,7 @@ const goToUserProfile = () => {
       :key="profilePicURL"
       :is-small="true"
       :src="profilePicURL"
+      :variant-source="user"
       :text="username"
     />
   </IconButtonDropdown>

--- a/components/nav/VerticalIconNav.vue
+++ b/components/nav/VerticalIconNav.vue
@@ -303,6 +303,7 @@ const getNavLabelClasses = (isActive: boolean) =>
                 class="h-8 w-8"
                 :text="forum.uniqueName || ''"
                 :src="forum?.channelIconURL ?? ''"
+                :variant-source="forum"
                 :is-small="true"
                 :is-square="false"
               />

--- a/components/scratchpad/ScratchpadEntry.vue
+++ b/components/scratchpad/ScratchpadEntry.vue
@@ -164,6 +164,7 @@ const isLoading = computed(() => updateLoading.value || deleteLoading.value);
         <AvatarComponent
           :src="entry.Author?.profilePicURL"
           :text="entry.Author?.username || 'U'"
+          :variant-source="entry.Author || null"
           :is-square="false"
           class="h-10 w-10"
         />

--- a/graphQLData/channel/mutations.js
+++ b/graphQLData/channel/mutations.js
@@ -112,6 +112,15 @@ export const PERMANENTLY_DELETE_CHANNEL_BANNER = gql`
   }
 `;
 
+export const SET_CHANNEL_ICON = gql`
+  mutation setChannelIcon($channelUniqueName: String!, $imageUrl: String!) {
+    setChannelIcon(channelUniqueName: $channelUniqueName, imageUrl: $imageUrl) {
+      uniqueName
+      channelIconURL
+    }
+  }
+`;
+
 export const CREATE_WIKI_PAGE = gql`
   mutation createWikiPage($where: ChannelWhere!, $update: ChannelUpdateInput!) {
     updateChannels(where: $where, update: $update) {

--- a/graphQLData/channel/queries.js
+++ b/graphQLData/channel/queries.js
@@ -1,16 +1,18 @@
 import { gql } from '@apollo/client/core';
 import { DateTime } from 'luxon';
+import { AUTHOR_FIELDS, CHANNEL_ICON_FIELDS } from '../fragments';
 
 export const GET_CHANNEL_NAMES = gql`
   query getChannelNames($channelWhere: ChannelWhere) {
     channels(where: $channelWhere, options: { limit: 10 }) {
       uniqueName
       displayName
-      channelIconURL
+      ...ChannelIconFields
       description
       eventsEnabled
     }
   }
+  ${CHANNEL_ICON_FIELDS}
 `;
 
 export const GET_CHANNEL_DISCUSSION_FLAIR_CONFIG = gql`
@@ -87,7 +89,7 @@ export const GET_CHANNEL = gql`
       uniqueName
       displayName
       description
-      channelIconURL
+      ...ChannelIconFields
       channelBannerURL
       isFavorited(username: $loggedInUsername)
       rules
@@ -146,12 +148,7 @@ export const GET_CHANNEL = gql`
         text
       }
       Admins {
-        username
-        displayName
-        profilePicURL
-        commentKarma
-        discussionKarma
-        createdAt
+        ...AuthorFields
       }
       Bots {
         username
@@ -286,6 +283,8 @@ export const GET_CHANNEL = gql`
       }
     }
   }
+  ${AUTHOR_FIELDS}
+  ${CHANNEL_ICON_FIELDS}
 `;
 
 export const GET_CHANNEL_RULES = gql`

--- a/graphQLData/fragments.js
+++ b/graphQLData/fragments.js
@@ -13,8 +13,24 @@ export const AUTHOR_FIELDS = gql`
     username
     displayName
     profilePicURL
+    variantUrls
+    avatar32Url
+    avatar48Url
+    avatar64Url
+    avatar96Url
     createdAt
     discussionKarma
     commentKarma
+  }
+`;
+
+export const CHANNEL_ICON_FIELDS = gql`
+  fragment ChannelIconFields on Channel {
+    channelIconURL
+    variantUrls
+    icon32Url
+    icon48Url
+    icon64Url
+    icon96Url
   }
 `;

--- a/graphQLData/fragments.js
+++ b/graphQLData/fragments.js
@@ -27,10 +27,5 @@ export const AUTHOR_FIELDS = gql`
 export const CHANNEL_ICON_FIELDS = gql`
   fragment ChannelIconFields on Channel {
     channelIconURL
-    variantUrls
-    icon32Url
-    icon48Url
-    icon64Url
-    icon96Url
   }
 `;

--- a/graphQLData/user/queries.js
+++ b/graphQLData/user/queries.js
@@ -1,15 +1,11 @@
 import { gql } from '@apollo/client/core';
+import { AUTHOR_FIELDS, CHANNEL_ICON_FIELDS } from '../fragments';
 
 export const GET_USER = gql`
   query getBasicUserInfo($username: String!) {
     getUserWikiEditsCount(username: $username)
     users(where: { username: $username }) {
-      username
-      commentKarma
-      discussionKarma
-      createdAt
-      displayName
-      profilePicURL
+      ...AuthorFields
       location
       pronouns
       bio
@@ -58,6 +54,7 @@ export const GET_USER = gql`
       }
     }
   }
+  ${AUTHOR_FIELDS}
 `;
 
 // Public profile data only. Keep owner-only account fields (email, notification
@@ -67,12 +64,7 @@ export const GET_PUBLIC_USER_PROFILE = gql`
   query getPublicUserProfile($username: String!) {
     getUserWikiEditsCount(username: $username)
     users(where: { username: $username }) {
-      username
-      commentKarma
-      discussionKarma
-      createdAt
-      displayName
-      profilePicURL
+      ...AuthorFields
       location
       pronouns
       bio
@@ -107,6 +99,7 @@ export const GET_PUBLIC_USER_PROFILE = gql`
       }
     }
   }
+  ${AUTHOR_FIELDS}
 `;
 
 export const GET_USER_COMMENTS = gql`
@@ -451,13 +444,14 @@ export const GET_USER_FAVORITE_CHANNELS = gql`
         uniqueName
         displayName
         description
-        channelIconURL
+        ...ChannelIconFields
         Tags {
           text
         }
       }
     }
   }
+  ${CHANNEL_ICON_FIELDS}
 `;
 
 export const GET_MODDED_CHANNELS = gql`
@@ -468,7 +462,7 @@ export const GET_MODDED_CHANNELS = gql`
       ModOfChannels {
         uniqueName
         description
-        channelIconURL
+        ...ChannelIconFields
         Tags {
           text
         }
@@ -484,6 +478,7 @@ export const GET_MODDED_CHANNELS = gql`
       }
     }
   }
+  ${CHANNEL_ICON_FIELDS}
 `;
 
 export const GET_OWNED_CHANNELS = gql`
@@ -494,7 +489,7 @@ export const GET_OWNED_CHANNELS = gql`
       AdminOfChannels {
         uniqueName
         description
-        channelIconURL
+        ...ChannelIconFields
         Tags {
           text
         }
@@ -510,6 +505,7 @@ export const GET_OWNED_CHANNELS = gql`
       }
     }
   }
+  ${CHANNEL_ICON_FIELDS}
 `;
 
 export const GET_USER_CONTRIBUTIONS = gql`

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -163,6 +163,14 @@ const addForumToLocalStorage = (channel: Channel) => {
     uniqueName: channelId.value,
     displayName: channel.displayName,
     channelIconURL: channel.channelIconURL,
+    variantUrls:
+      channel.variantUrls && typeof channel.variantUrls === 'object'
+        ? channel.variantUrls
+        : null,
+    icon32Url: channel.icon32Url,
+    icon48Url: channel.icon48Url,
+    icon64Url: channel.icon64Url,
+    icon96Url: channel.icon96Url,
     timestamp: Date.now(),
   };
 

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -163,14 +163,6 @@ const addForumToLocalStorage = (channel: Channel) => {
     uniqueName: channelId.value,
     displayName: channel.displayName,
     channelIconURL: channel.channelIconURL,
-    variantUrls:
-      channel.variantUrls && typeof channel.variantUrls === 'object'
-        ? channel.variantUrls
-        : null,
-    icon32Url: channel.icon32Url,
-    icon48Url: channel.icon48Url,
-    icon64Url: channel.icon64Url,
-    icon96Url: channel.icon96Url,
     timestamp: Date.now(),
   };
 

--- a/pages/forums/[forumId]/edit/basic.spec.ts
+++ b/pages/forums/[forumId]/edit/basic.spec.ts
@@ -7,6 +7,7 @@ import type * as UtilsIndexModule from '@/utils/index';
 
 const h = vi.hoisted(() => ({
   createSignedStorageUrl: vi.fn(),
+  setChannelIcon: vi.fn(),
   removeForumOwner: vi.fn(),
   permanentlyDeleteChannelBanner: vi.fn(),
   uploadAndGetEmbeddedLink: vi.fn(),
@@ -55,6 +56,7 @@ vi.mock('@/utils/index', async (importOriginal) => {
 
 vi.mock('@/graphQLData/channel/mutations', () => ({
   PERMANENTLY_DELETE_CHANNEL_BANNER: 'PERMANENTLY_DELETE_CHANNEL_BANNER',
+  SET_CHANNEL_ICON: 'SET_CHANNEL_ICON',
 }));
 
 vi.mock('@/graphQLData/mod/mutations', () => ({
@@ -71,6 +73,8 @@ vi.mock('@vue/apollo-composable', () => ({
       mutate:
         operation === 'PERMANENTLY_DELETE_CHANNEL_BANNER'
           ? h.permanentlyDeleteChannelBanner
+          : operation === 'SET_CHANNEL_ICON'
+            ? h.setChannelIcon
           : operation === 'REMOVE_FORUM_OWNER'
             ? h.removeForumOwner
             : h.createSignedStorageUrl,
@@ -169,6 +173,7 @@ beforeEach(() => {
       },
     },
   });
+  h.setChannelIcon.mockResolvedValue({ data: { setChannelIcon: {} } });
   h.permanentlyDeleteChannelBanner.mockResolvedValue({ data: {} });
 });
 
@@ -209,19 +214,23 @@ describe('forum basic settings page', () => {
     });
   });
 
-  it('uploads an image and submits the resulting field update', async () => {
+  it('uploads a forum icon through the dedicated channel icon mutation', async () => {
     const wrapper = await buildWrapper({});
     emitImage(
       wrapper,
       new File(['banner'], 'banner.png', { type: 'image/png' })
     );
     await flushPromises();
+    expect(h.setChannelIcon).toHaveBeenCalledWith({
+      channelUniqueName: 'cats',
+      imageUrl: 'https://cdn.example.com/new.png',
+    });
     expect(wrapper.emitted()).toMatchObject({
       updateFormValues: [
         [{ channelIconURL: 'https://cdn.example.com/new.png' }],
       ],
-      submit: [[]],
     });
+    expect(wrapper.emitted('submit')).toBeUndefined();
   });
 
   it('does not upload when no user is signed in', async () => {

--- a/pages/forums/[forumId]/edit/basic.vue
+++ b/pages/forums/[forumId]/edit/basic.vue
@@ -17,7 +17,10 @@ import {
 import { useUsername } from '@/composables/useAuthState';
 import { ref, nextTick, computed } from 'vue';
 import { CREATE_SIGNED_STORAGE_URL } from '@/graphQLData/discussion/mutations';
-import { PERMANENTLY_DELETE_CHANNEL_BANNER } from '@/graphQLData/channel/mutations';
+import {
+  PERMANENTLY_DELETE_CHANNEL_BANNER,
+  SET_CHANNEL_ICON,
+} from '@/graphQLData/channel/mutations';
 import { REMOVE_FORUM_OWNER } from '@/graphQLData/mod/mutations';
 import { useMutation } from '@vue/apollo-composable';
 import { isFileSizeValid } from '@/utils/index';
@@ -94,6 +97,8 @@ const {
   error: permanentlyDeleteChannelBannerError,
 } = useMutation(PERMANENTLY_DELETE_CHANNEL_BANNER);
 
+const { mutate: setChannelIcon } = useMutation(SET_CHANNEL_ICON);
+
 const {
   mutate: removeForumOwner,
   loading: removeForumOwnerLoading,
@@ -169,6 +174,15 @@ const handleImageChange = async (input: FileChangeInput) => {
   if (selectedFile) {
     const embeddedLink = await upload(selectedFile);
     if (!embeddedLink) return;
+
+    if (fieldName === 'channelIconURL' && forumId.value) {
+      await setChannelIcon({
+        channelUniqueName: forumId.value,
+        imageUrl: embeddedLink,
+      });
+      emit('updateFormValues', { channelIconURL: embeddedLink });
+      return;
+    }
 
     emit('updateFormValues', { [fieldName]: embeddedLink });
     emit('submit');

--- a/types/forum.ts
+++ b/types/forum.ts
@@ -1,6 +1,11 @@
 export type ForumItem = {
   uniqueName: string;
   channelIconURL?: string | null;
+  variantUrls?: Record<string, string> | null;
+  icon32Url?: string | null;
+  icon48Url?: string | null;
+  icon64Url?: string | null;
+  icon96Url?: string | null;
   displayName?: string | null;
   timestamp: number;
 };

--- a/utils/imageVariants.ts
+++ b/utils/imageVariants.ts
@@ -24,10 +24,10 @@ type VariantArrayEntry = {
 type VariantSourceRecord = Record<string, unknown>;
 
 const DIRECT_VARIANT_FIELD_ALIASES: Record<ImageVariantKey, string[]> = {
-  avatar32: ['avatar32Url'],
-  avatar48: ['avatar48Url'],
-  avatar64: ['avatar64Url'],
-  avatar96: ['avatar96Url'],
+  avatar32: ['avatar32Url', 'icon32Url'],
+  avatar48: ['avatar48Url', 'icon48Url'],
+  avatar64: ['avatar64Url', 'icon64Url'],
+  avatar96: ['avatar96Url', 'icon96Url'],
   list80: ['list80Url', 'thumbnailUrl'],
   list160: ['list160Url'],
   list320: ['list320Url', 'cardImageUrl'],
@@ -38,7 +38,12 @@ const DIRECT_VARIANT_FIELD_ALIASES: Record<ImageVariantKey, string[]> = {
 
 const VARIANT_RECORD_FIELDS = ['variantUrls', 'imageVariantUrls'] as const;
 const VARIANT_ARRAY_FIELDS = ['variants', 'imageVariants'] as const;
-const ORIGINAL_URL_FIELDS = ['url', 'profilePicURL', 'coverImageURL'] as const;
+const ORIGINAL_URL_FIELDS = [
+  'url',
+  'profilePicURL',
+  'channelIconURL',
+  'coverImageURL',
+] as const;
 
 const isRecord = (value: unknown): value is VariantSourceRecord =>
   typeof value === 'object' && value !== null;


### PR DESCRIPTION
## Summary
- route forum icon uploads through the dedicated `setChannelIcon` mutation
- extend shared avatar/forum icon variant selection to understand backend icon fields and prefer generated variants
- propagate variant-aware user and channel objects through shared nav, sidebar, header, and recent-forum surfaces

## Validation
- `npm run test:unit:run -- components/AvatarComponent.spec.ts components/comments/LoggedInUserAvatar.spec.ts components/nav/UserProfileDropdownMenu.spec.ts 'pages/forums/[forumId]/edit/basic.spec.ts'`
- `npm run test:unit:run -- components/channel/ChannelSidebar.spec.ts components/channel/ChannelHeaderMobile.spec.ts components/channel/ChannelListItem.spec.ts components/nav/ForumFinder.spec.ts components/nav/RecentForumsList.spec.ts components/nav/ForumQuickSwitcher.spec.ts components/nav/SiteSidenav.spec.ts components/nav/VerticalIconNav.spec.ts components/library/LibraryChannelCard.spec.ts`
- `npm run test:unit:run -- components/discussion/detail/DiscussionHeader.spec.ts components/event/detail/EventDetail.spec.ts components/scratchpad/ScratchpadEntry.spec.ts`

## Notes
- `npm run compile` still requires a live backend GraphQL endpoint at `http://localhost:4000/graphql`.