### PR TITLE
fix(graphql): align image rollout branch with current schema

### DIFF
--- a/graphQLData/fragments.js
+++ b/graphQLData/fragments.js
@@ -13,11 +13,6 @@ export const AUTHOR_FIELDS = gql`
     username
     displayName
     profilePicURL
-    variantUrls
-    avatar32Url
-    avatar48Url
-    avatar64Url
-    avatar96Url
     createdAt
     discussionKarma
     commentKarma

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -163,6 +163,14 @@ const addForumToLocalStorage = (channel: Channel) => {
     uniqueName: channelId.value,
     displayName: channel.displayName,
     channelIconURL: channel.channelIconURL,
+    variantUrls:
+      channel.variantUrls && typeof channel.variantUrls === 'object'
+        ? channel.variantUrls
+        : null,
+    icon32Url: channel.icon32Url,
+    icon48Url: channel.icon48Url,
+    icon64Url: channel.icon64Url,
+    icon96Url: channel.icon96Url,
     timestamp: Date.now(),
   };
 

--- a/pages/forums/[forumId].vue
+++ b/pages/forums/[forumId].vue
@@ -163,14 +163,6 @@ const addForumToLocalStorage = (channel: Channel) => {
     uniqueName: channelId.value,
     displayName: channel.displayName,
     channelIconURL: channel.channelIconURL,
-    variantUrls:
-      channel.variantUrls && typeof channel.variantUrls === 'object'
-        ? channel.variantUrls
-        : null,
-    icon32Url: channel.icon32Url,
-    icon48Url: channel.icon48Url,
-    icon64Url: channel.icon64Url,
-    icon96Url: channel.icon96Url,
     timestamp: Date.now(),
   };
 


### PR DESCRIPTION
## Summary
- remove unsupported channel icon variant fields from the shared GraphQL channel fragment
- remove unsupported user avatar variant fields from the shared GraphQL author fragment
- keep the branch aligned with the schema currently used by the deploy smoke environment to avoid SSR 503s

## Testing
- npm run tsc
- npx vitest run components/AvatarComponent.spec.ts components/comments/LoggedInUserAvatar.spec.ts components/user/PhotoAvatar.spec.ts components/nav/ForumFinder.spec.ts components/nav/RecentForumsDrawer.spec.ts 'pages/forums/[forumId].spec.ts'
