### PR TITLE
fix(graphql): degrade gracefully when backend is unavailable

### DIFF
--- a/server/api/graphql.spec.ts
+++ b/server/api/graphql.spec.ts
@@ -2,51 +2,143 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import handler from '@/server/api/graphql';
 
 const h = vi.hoisted(() => ({
-  proxyRequest: vi.fn(),
   backendGraphqlUrl: 'http://backend:4000/graphql',
+  getRequestHeaders: vi.fn(),
+  readRawBody: vi.fn(),
+  setResponseHeader: vi.fn(),
+  setResponseStatus: vi.fn(),
+  fetch: vi.fn(),
 }));
 
 vi.mock('h3', () => ({
   createError: (input: { statusCode: number; statusMessage: string }) =>
     Object.assign(new Error(input.statusMessage), input),
-  defineEventHandler: (handler: unknown) => handler,
-  proxyRequest: h.proxyRequest,
+  defineEventHandler: (currentHandler: unknown) => currentHandler,
+  getRequestHeaders: h.getRequestHeaders,
+  readRawBody: h.readRawBody,
+  setResponseHeader: h.setResponseHeader,
+  setResponseStatus: h.setResponseStatus,
 }));
 
 vi.stubGlobal('useRuntimeConfig', () => ({
   backendGraphqlUrl: h.backendGraphqlUrl,
 }));
+vi.stubGlobal('fetch', h.fetch);
 
 const event = { method: 'POST' };
 
 beforeEach(() => {
   vi.clearAllMocks();
   h.backendGraphqlUrl = 'http://backend:4000/graphql';
+  h.getRequestHeaders.mockReturnValue({
+    'content-type': 'application/json',
+    authorization: 'Bearer test-token',
+    host: 'frontend.test',
+    connection: 'keep-alive',
+    'content-length': '25',
+  });
+  h.readRawBody.mockResolvedValue('{"query":"{ __typename }"}');
 });
 
 describe('runtime GraphQL proxy', () => {
   it('forwards the request to the runtime-configured backend', async () => {
-    h.proxyRequest.mockResolvedValue({ data: {} });
-    await (handler as (event: unknown) => Promise<unknown>)(event);
-    expect(h.proxyRequest).toHaveBeenCalledWith(
-      event,
-      'http://backend:4000/graphql'
+    h.fetch.mockResolvedValue(
+      new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
     );
+
+    const result = await (handler as (input: unknown) => Promise<unknown>)(event);
+
+    expect(h.fetch).toHaveBeenCalledWith(
+      'http://backend:4000/graphql',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{"query":"{ __typename }"}',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer test-token',
+        },
+      })
+    );
+    expect(result).toEqual({ data: { ok: true } });
   });
 
   it('trims the configured backend URL', async () => {
     h.backendGraphqlUrl = '  http://backend:4000/graphql  ';
-    await (handler as (event: unknown) => Promise<unknown>)(event);
-    expect(h.proxyRequest).toHaveBeenCalledWith(
-      event,
-      'http://backend:4000/graphql'
+    h.fetch.mockResolvedValue(
+      new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    await (handler as (input: unknown) => Promise<unknown>)(event);
+
+    expect(h.fetch).toHaveBeenCalledWith(
+      'http://backend:4000/graphql',
+      expect.any(Object)
     );
   });
 
-  it('returns a service-unavailable error when no backend is configured', () => {
+  it('returns a service-unavailable error when no backend is configured', async () => {
     h.backendGraphqlUrl = ' ';
-    expect(() =>
-      (handler as (event: unknown) => Promise<unknown>)(event)
-    ).toThrowError('Backend GraphQL URL is not configured');
+    await expect(
+      (handler as (input: unknown) => Promise<unknown>)(event)
+    ).rejects.toThrowError('Backend GraphQL URL is not configured');
+  });
+
+  it('returns a GraphQL error payload when the backend responds with 503', async () => {
+    h.fetch.mockResolvedValue(
+      new Response('backend unavailable', {
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: { 'content-type': 'text/html' },
+      })
+    );
+
+    const result = await (handler as (input: unknown) => Promise<unknown>)(event);
+
+    expect(h.setResponseStatus).toHaveBeenCalledWith(event, 200);
+    expect(h.setResponseHeader).toHaveBeenCalledWith(
+      event,
+      'content-type',
+      'application/json; charset=utf-8'
+    );
+    expect(result).toEqual({
+      data: null,
+      errors: [
+        {
+          message:
+            'The backend service is temporarily unavailable. Please try again later.',
+          extensions: {
+            code: 'SERVICE_UNAVAILABLE',
+            upstreamStatusCode: 503,
+          },
+        },
+      ],
+    });
+  });
+
+  it('returns a GraphQL error payload when the backend cannot be reached', async () => {
+    h.fetch.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const result = await (handler as (input: unknown) => Promise<unknown>)(event);
+
+    expect(h.setResponseStatus).toHaveBeenCalledWith(event, 200);
+    expect(result).toEqual({
+      data: null,
+      errors: [
+        {
+          message:
+            'The backend service is temporarily unavailable. Please try again later.',
+          extensions: {
+            code: 'SERVICE_UNAVAILABLE',
+            upstreamStatusCode: undefined,
+          },
+        },
+      ],
+    });
   });
 });

--- a/server/api/graphql.ts
+++ b/server/api/graphql.ts
@@ -1,6 +1,38 @@
-import { createError, defineEventHandler, proxyRequest } from 'h3';
+import {
+  createError,
+  defineEventHandler,
+  getRequestHeaders,
+  readRawBody,
+  setResponseHeader,
+  setResponseStatus,
+} from 'h3';
 
-export default defineEventHandler((event) => {
+const SERVICE_UNAVAILABLE_MESSAGE =
+  'The backend service is temporarily unavailable. Please try again later.';
+
+const buildUnavailableGraphqlResponse = (
+  event: Parameters<typeof defineEventHandler>[0] extends (event: infer T) => unknown
+    ? T
+    : never,
+  upstreamStatusCode?: number
+) => {
+  setResponseStatus(event, 200);
+  setResponseHeader(event, 'content-type', 'application/json; charset=utf-8');
+  return {
+    data: null,
+    errors: [
+      {
+        message: SERVICE_UNAVAILABLE_MESSAGE,
+        extensions: {
+          code: 'SERVICE_UNAVAILABLE',
+          upstreamStatusCode,
+        },
+      },
+    ],
+  };
+};
+
+export default defineEventHandler(async (event) => {
   const target = useRuntimeConfig(event).backendGraphqlUrl?.trim();
 
   if (!target) {
@@ -10,5 +42,44 @@ export default defineEventHandler((event) => {
     });
   }
 
-  return proxyRequest(event, target);
+  const method = event.method || 'GET';
+  const headers = {
+    ...getRequestHeaders(event),
+  };
+  delete headers.host;
+  delete headers.connection;
+  delete headers['content-length'];
+
+  const body =
+    method === 'GET' || method === 'HEAD'
+      ? undefined
+      : await readRawBody(event, false);
+
+  let response: Response;
+  try {
+    response = await fetch(target, {
+      method,
+      headers,
+      body,
+    });
+  } catch {
+    return buildUnavailableGraphqlResponse(event);
+  }
+
+  if (response.status >= 500) {
+    return buildUnavailableGraphqlResponse(event, response.status);
+  }
+
+  setResponseStatus(event, response.status, response.statusText);
+
+  const contentType = response.headers.get('content-type');
+  if (contentType) {
+    setResponseHeader(event, 'content-type', contentType);
+  }
+
+  if (contentType?.includes('application/json')) {
+    return await response.json();
+  }
+
+  return await response.text();
 });


### PR DESCRIPTION
## Summary
- stop the frontend GraphQL proxy from surfacing upstream backend 5xx outages as fatal transport errors
- return a GraphQL error payload for backend 5xx and connection failures so SSR pages can render their normal error UI instead of crashing
- add focused proxy tests covering successful forwarding and degraded-backend behavior

## Production context
On Monday, August 10, 2026, topical.space was still failing after #507 merged.
- /discussions returned 500 with Response not successful: Received status code 503
- POST /api/graphql with a trivial __typename query returned Heroku application-error HTML

That indicates the live backend is currently unhealthy, and this PR is the frontend mitigation so the site can degrade gracefully instead of appearing fully crashed.

## Testing
- npx vitest run server/api/graphql.spec.ts
- npm run tsc
