### PR TITLE
fix(image): bypass ipx for remote storage urls

### DIFF
--- a/utils/imageOptimization.spec.ts
+++ b/utils/imageOptimization.spec.ts
@@ -6,10 +6,10 @@ describe('canOptimizeImageUrl', () => {
     expect(canOptimizeImageUrl('/images/cat.jpg')).toBe(true);
   });
 
-  it('optimizes storage.googleapis.com URLs', () => {
+  it('does not optimize storage.googleapis.com URLs', () => {
     expect(
       canOptimizeImageUrl('https://storage.googleapis.com/bucket/cat.jpg')
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('does not optimize arbitrary external hosts', () => {

--- a/utils/imageOptimization.ts
+++ b/utils/imageOptimization.ts
@@ -15,14 +15,5 @@ export function canOptimizeImageUrl(url: string): boolean {
     return true;
   }
 
-  if (!/^https?:\/\//.test(url)) {
-    return false;
-  }
-
-  try {
-    const parsedUrl = new URL(url);
-    return parsedUrl.hostname === 'storage.googleapis.com';
-  } catch {
-    return false;
-  }
+  return false;
 }


### PR DESCRIPTION
## Summary
- bypass Nuxt/IPX optimization for remote Google Cloud Storage image URLs
- continue optimizing same-origin image paths
- update the image optimization test coverage to match the new fallback behavior

## Why
Production discussion thumbnails and some avatars were broken because the deployed  path was returning  for legacy storage-backed images. Loading those remote storage URLs directly restores correctness while we investigate the image proxy path.

## Validation
- 
 RUN  v4.1.9 /Users/catherineluse/.codex/worktrees/720d/multiforum-nuxt


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  03:38:17
   Duration  1.34s (transform 56ms, setup 135ms, import 17ms, tests 6ms, environment 889ms)
- 
> multiforum@0.2.0 tsc
> vue-tsc --noEmit
