### PR TITLE
fix(image): use vercel provider for remote storage images

### DIFF
--- a/components/image/AppImage.vue
+++ b/components/image/AppImage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, useAttrs } from 'vue';
 import { canOptimizeImageUrl } from '@/utils/imageOptimization';
+import { useRuntimeConfig } from 'nuxt/app';
 
 defineOptions({
   inheritAttrs: false,
@@ -27,7 +28,13 @@ const props = withDefaults(
 );
 
 const attrs = useAttrs();
-const shouldOptimize = computed(() => canOptimizeImageUrl(props.src));
+const runtimeConfig = useRuntimeConfig();
+const activeImageProvider = computed(
+  () => String(runtimeConfig.public.imageProvider || 'ipx')
+);
+const shouldOptimize = computed(() =>
+  canOptimizeImageUrl(props.src, activeImageProvider.value)
+);
 </script>
 
 <template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,6 +11,8 @@ const browserGraphqlUrl = config?.graphqlUrl || 'http://localhost:4000';
 const serverGraphqlUrl =
   process.env.NUXT_BACKEND_GRAPHQL_URL || browserGraphqlUrl;
 const frontendGraphqlProxyUrl = '/api/graphql';
+const nitroPreset = process.env.NITRO_PRESET || 'vercel';
+const activeImageProvider = nitroPreset === 'vercel' ? 'vercel' : 'ipx';
 const runtimeGraphqlFetch: typeof globalThis.fetch = (input, init) => {
   const runtimeBackendUrl =
     typeof window === 'undefined'
@@ -166,9 +168,30 @@ export default defineNuxtConfig({
         // Use WebP and AVIF formats where supported
         format: ['webp', 'avif', 'jpg', 'png'],
         // Provider for image generation
-        provider: 'ipx',
+        provider: activeImageProvider,
         // Responsive image breakpoints
         screens: {
+          icon24: 24,
+          avatar32: 32,
+          avatar48: 48,
+          avatar64: 64,
+          avatar80: 80,
+          avatar96: 96,
+          thumb128: 128,
+          thumb160: 160,
+          thumb192: 192,
+          thumb200: 200,
+          thumb256: 256,
+          thumb288: 288,
+          thumb300: 300,
+          thumb320: 320,
+          thumb384: 384,
+          thumb400: 400,
+          thumb512: 512,
+          thumb640: 640,
+          thumb768: 768,
+          thumb800: 800,
+          thumb1024: 1024,
           xs: 320,
           sm: 640,
           md: 768,
@@ -431,6 +454,7 @@ export default defineNuxtConfig({
       serverName: config.serverName,
       serverDisplayName: config.serverDisplayName,
       enableLanguagePicker: config.enableLanguagePicker,
+      imageProvider: activeImageProvider,
       authProvider:
         process.env.NUXT_PUBLIC_AUTH_PROVIDER === 'local-dev'
           ? 'local-dev'

--- a/utils/imageOptimization.spec.ts
+++ b/utils/imageOptimization.spec.ts
@@ -6,10 +6,10 @@ describe('canOptimizeImageUrl', () => {
     expect(canOptimizeImageUrl('/images/cat.jpg')).toBe(true);
   });
 
-  it('optimizes storage.googleapis.com URLs', () => {
+  it('does not optimize storage.googleapis.com URLs', () => {
     expect(
       canOptimizeImageUrl('https://storage.googleapis.com/bucket/cat.jpg')
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('does not optimize arbitrary external hosts', () => {

--- a/utils/imageOptimization.spec.ts
+++ b/utils/imageOptimization.spec.ts
@@ -6,14 +6,25 @@ describe('canOptimizeImageUrl', () => {
     expect(canOptimizeImageUrl('/images/cat.jpg')).toBe(true);
   });
 
-  it('does not optimize storage.googleapis.com URLs', () => {
+  it('optimizes storage.googleapis.com URLs when the vercel provider is active', () => {
     expect(
-      canOptimizeImageUrl('https://storage.googleapis.com/bucket/cat.jpg')
+      canOptimizeImageUrl(
+        'https://storage.googleapis.com/bucket/cat.jpg',
+        'vercel'
+      )
+    ).toBe(true);
+  });
+
+  it('does not optimize storage.googleapis.com URLs for the ipx provider', () => {
+    expect(
+      canOptimizeImageUrl('https://storage.googleapis.com/bucket/cat.jpg', 'ipx')
     ).toBe(false);
   });
 
   it('does not optimize arbitrary external hosts', () => {
-    expect(canOptimizeImageUrl('https://example.com/cat.jpg')).toBe(false);
+    expect(canOptimizeImageUrl('https://example.com/cat.jpg', 'vercel')).toBe(
+      false
+    );
   });
 
   it('does not optimize data URLs', () => {

--- a/utils/imageOptimization.ts
+++ b/utils/imageOptimization.ts
@@ -15,14 +15,5 @@ export function canOptimizeImageUrl(url: string): boolean {
     return true;
   }
 
-  if (!/^https?:\/\//.test(url)) {
-    return false;
-  }
-
-  try {
-    const parsedUrl = new URL(url);
-    return parsedUrl.hostname === 'storage.googleapis.com';
-  } catch {
-    return false;
-  }
+  return false;
 }

--- a/utils/imageOptimization.ts
+++ b/utils/imageOptimization.ts
@@ -1,4 +1,9 @@
-export function canOptimizeImageUrl(url: string): boolean {
+export type ImageOptimizationProvider = 'ipx' | 'vercel' | 'none' | string;
+
+export function canOptimizeImageUrl(
+  url: string,
+  provider: ImageOptimizationProvider = 'ipx'
+): boolean {
   if (!url) {
     return false;
   }
@@ -15,5 +20,18 @@ export function canOptimizeImageUrl(url: string): boolean {
     return true;
   }
 
-  return false;
+  if (!/^https?:\/\//.test(url)) {
+    return false;
+  }
+
+  if (provider !== 'vercel') {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.hostname === 'storage.googleapis.com';
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Summary
- switch the Nuxt image provider by deployment target instead of hardcoding ipx
- use Vercel image optimization for remote storage.googleapis.com images on Vercel deployments
- keep ipx for non-Vercel deployments, preserving the direct-image fallback there
- add explicit image widths used by the UI so Vercel sizing stays predictable

Why
The previous fix restored image correctness by bypassing the failing ipx path for remote storage-backed images. This follow-up restores remote image optimization on Vercel without re-enabling the broken ipx path on non-Vercel targets.

Validation
- npx vitest run utils/imageOptimization.spec.ts
- npm run tsc